### PR TITLE
Fix fallback for BTC price

### DIFF
--- a/LongevityWorldCup.Website/Controllers/BitcoinController.cs
+++ b/LongevityWorldCup.Website/Controllers/BitcoinController.cs
@@ -42,6 +42,9 @@ namespace LongevityWorldCup.Website.Controllers
 
                     return Ok(new { btcToUsdRate = usdRate });
                 }
+
+                // If primary API response is not successful, trigger fallback
+                throw new HttpRequestException($"Primary API returned status {response.StatusCode}");
             }
             catch
             {


### PR DESCRIPTION
## Summary
- trigger fallback API when primary BTC price call returns non-success status

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe1b7fafc833195bed17a69d7722b