### PR TITLE
Add leaderboard rank endpoint

### DIFF
--- a/LongevityWorldCup.Website/Business/PhenoAgeCalculator.cs
+++ b/LongevityWorldCup.Website/Business/PhenoAgeCalculator.cs
@@ -1,0 +1,39 @@
+using System;
+
+namespace LongevityWorldCup.Website.Business
+{
+    public static class PhenoAgeCalculator
+    {
+        public static double CalculateAgeFromDob(DateTime dob)
+        {
+            var today = DateTime.UtcNow.Date;
+            var totalDays = (today - dob.Date).TotalDays;
+            return Math.Round(totalDays / 365.2425, 2);
+        }
+
+        public static double CalculatePhenoAge(double[] markerValues)
+        {
+            double ageScore = markerValues[0] * 0.0804;
+            double liverScore = markerValues[1] * -0.0336 + markerValues[9] * 0.0019;
+            double kidneyScore = Math.Max(markerValues[2], 44) * 0.0095;
+            double metabolicScore = Math.Max(markerValues[3], 4.44) * 0.1953;
+            double inflammationScore = markerValues[4] * 0.0954;
+            double immuneScore =
+                Math.Max(markerValues[5], 3.5) * 0.0554 +
+                Math.Min(markerValues[6], 60) * -0.012 +
+                markerValues[7] * 0.0268 +
+                Math.Max(markerValues[8], 11.4) * 0.3306;
+
+            double totalScore = ageScore + liverScore + kidneyScore + metabolicScore + inflammationScore + immuneScore;
+
+            const double b0 = -19.9067;
+            const double gamma = 0.0076927;
+            const double tmonths = 120;
+
+            double rollingTotal = totalScore + b0;
+            double mortalityScore = 1 - Math.Exp(-Math.Exp(rollingTotal) * (Math.Exp(gamma * tmonths) - 1) / gamma);
+
+            return 141.50225 + Math.Log(-0.00553 * Math.Log(1 - mortalityScore)) / 0.090165;
+        }
+    }
+}

--- a/LongevityWorldCup.Website/Controllers/DataController.cs
+++ b/LongevityWorldCup.Website/Controllers/DataController.cs
@@ -1,5 +1,6 @@
-﻿using LongevityWorldCup.Website.Business;
+using LongevityWorldCup.Website.Business;
 using Microsoft.AspNetCore.Mvc;
+using System.Text.Json.Nodes;
 
 namespace LongevityWorldCup.Website.Controllers
 {
@@ -23,5 +24,100 @@ namespace LongevityWorldCup.Website.Controllers
 
         [HttpGet("athletes")]
         public IActionResult GetAthletes() => Ok(_svc.Athletes);
+
+        [HttpGet("leaderboard-rank")]
+        public IActionResult GetLeaderboardRank(double phenoAgeDifference)
+        {
+            var reductions = new List<double>();
+            foreach (var node in _svc.Athletes)
+            {
+                if (node is not JsonObject athlete)
+                    continue;
+
+                var reduction = CalculateAgeReduction(athlete);
+                reductions.Add(reduction);
+            }
+
+            reductions.Sort();
+            int total = reductions.Count;
+
+            int rank = reductions.TakeWhile(r => r < phenoAgeDifference).Count() + 1;
+            double percentile = 100d * (total - rank + 1) / total;
+
+            return Ok(new { rank, totalParticipants = total, percentile });
+        }
+
+        private static double CalculateAgeReduction(JsonObject athlete)
+        {
+            var dobObj = athlete["DateOfBirth"]!.AsObject();
+            int year = dobObj["Year"]!.GetValue<int>();
+            int month = dobObj["Month"]!.GetValue<int>();
+            int day = dobObj["Day"]!.GetValue<int>();
+            var dob = new DateTime(year, month, day);
+
+            double chronologicalAge = PhenoAgeCalculator.CalculateAgeFromDob(dob);
+
+            var biomarkerArray = athlete["Biomarkers"]!.AsArray();
+
+            double alb = double.NaN;
+            double creat = double.NaN;
+            double glu = double.NaN;
+            double crp = double.NaN;
+            double wbc = double.NaN;
+            double lym = double.NaN;
+            double mcv = double.NaN;
+            double rdw = double.NaN;
+            double alp = double.NaN;
+
+            foreach (var bmNode in biomarkerArray)
+            {
+                var bm = bmNode!.AsObject();
+                double val;
+
+                val = bm["AlbGL"]!.GetValue<double>();
+                if (double.IsNaN(alb) || val > alb) alb = val;
+
+                val = bm["CreatUmolL"]!.GetValue<double>();
+                if (double.IsNaN(creat) || val < creat) creat = val;
+
+                val = bm["GluMmolL"]!.GetValue<double>();
+                if (double.IsNaN(glu) || val < glu) glu = val;
+
+                val = bm["CrpMgL"]!.GetValue<double>();
+                if (double.IsNaN(crp) || val < crp) crp = val;
+
+                val = bm["Wbc1000cellsuL"]!.GetValue<double>();
+                if (double.IsNaN(wbc) || val < wbc) wbc = val;
+
+                val = bm["LymPc"]!.GetValue<double>();
+                if (double.IsNaN(lym) || val > lym) lym = val;
+
+                val = bm["McvFL"]!.GetValue<double>();
+                if (double.IsNaN(mcv) || val < mcv) mcv = val;
+
+                val = bm["RdwPc"]!.GetValue<double>();
+                if (double.IsNaN(rdw) || val < rdw) rdw = val;
+
+                val = bm["AlpUL"]!.GetValue<double>();
+                if (double.IsNaN(alp) || val < alp) alp = val;
+            }
+
+            var values = new[]
+            {
+                chronologicalAge,
+                alb,
+                creat,
+                glu,
+                Math.Log(crp / 10.0),
+                wbc,
+                lym,
+                mcv,
+                rdw,
+                alp
+            };
+
+            double phenoAge = PhenoAgeCalculator.CalculatePhenoAge(values);
+            return phenoAge - chronologicalAge;
+        }
     }
 }

--- a/LongevityWorldCup.Website/Controllers/DataController.cs
+++ b/LongevityWorldCup.Website/Controllers/DataController.cs
@@ -35,7 +35,8 @@ namespace LongevityWorldCup.Website.Controllers
                     continue;
 
                 var reduction = CalculateAgeReduction(athlete);
-                reductions.Add(reduction);
+                if (!double.IsNaN(reduction))
+                    reductions.Add(reduction);
             }
 
             reductions.Sort();
@@ -69,38 +70,57 @@ namespace LongevityWorldCup.Website.Controllers
             double rdw = double.NaN;
             double alp = double.NaN;
 
+            bool anyCompleteSet = false;
             foreach (var bmNode in biomarkerArray)
             {
                 var bm = bmNode!.AsObject();
-                double val;
 
-                val = bm["AlbGL"]!.GetValue<double>();
-                if (double.IsNaN(alb) || val > alb) alb = val;
+                if (
+                    bm.TryGetPropertyValue("AlbGL", out var albNode) &&
+                    bm.TryGetPropertyValue("CreatUmolL", out var creatNode) &&
+                    bm.TryGetPropertyValue("GluMmolL", out var gluNode) &&
+                    bm.TryGetPropertyValue("CrpMgL", out var crpNode) &&
+                    bm.TryGetPropertyValue("Wbc1000cellsuL", out var wbcNode) &&
+                    bm.TryGetPropertyValue("LymPc", out var lymNode) &&
+                    bm.TryGetPropertyValue("McvFL", out var mcvNode) &&
+                    bm.TryGetPropertyValue("RdwPc", out var rdwNode) &&
+                    bm.TryGetPropertyValue("AlpUL", out var alpNode))
+                {
+                    anyCompleteSet = true;
 
-                val = bm["CreatUmolL"]!.GetValue<double>();
-                if (double.IsNaN(creat) || val < creat) creat = val;
+                    double val;
 
-                val = bm["GluMmolL"]!.GetValue<double>();
-                if (double.IsNaN(glu) || val < glu) glu = val;
+                    val = albNode!.GetValue<double>();
+                    if (double.IsNaN(alb) || val > alb) alb = val;
 
-                val = bm["CrpMgL"]!.GetValue<double>();
-                if (double.IsNaN(crp) || val < crp) crp = val;
+                    val = creatNode!.GetValue<double>();
+                    if (double.IsNaN(creat) || val < creat) creat = val;
 
-                val = bm["Wbc1000cellsuL"]!.GetValue<double>();
-                if (double.IsNaN(wbc) || val < wbc) wbc = val;
+                    val = gluNode!.GetValue<double>();
+                    if (double.IsNaN(glu) || val < glu) glu = val;
 
-                val = bm["LymPc"]!.GetValue<double>();
-                if (double.IsNaN(lym) || val > lym) lym = val;
+                    val = crpNode!.GetValue<double>();
+                    if (double.IsNaN(crp) || val < crp) crp = val;
 
-                val = bm["McvFL"]!.GetValue<double>();
-                if (double.IsNaN(mcv) || val < mcv) mcv = val;
+                    val = wbcNode!.GetValue<double>();
+                    if (double.IsNaN(wbc) || val < wbc) wbc = val;
 
-                val = bm["RdwPc"]!.GetValue<double>();
-                if (double.IsNaN(rdw) || val < rdw) rdw = val;
+                    val = lymNode!.GetValue<double>();
+                    if (double.IsNaN(lym) || val > lym) lym = val;
 
-                val = bm["AlpUL"]!.GetValue<double>();
-                if (double.IsNaN(alp) || val < alp) alp = val;
+                    val = mcvNode!.GetValue<double>();
+                    if (double.IsNaN(mcv) || val < mcv) mcv = val;
+
+                    val = rdwNode!.GetValue<double>();
+                    if (double.IsNaN(rdw) || val < rdw) rdw = val;
+
+                    val = alpNode!.GetValue<double>();
+                    if (double.IsNaN(alp) || val < alp) alp = val;
+                }
             }
+
+            if (!anyCompleteSet)
+                return double.NaN;
 
             var values = new[]
             {


### PR DESCRIPTION
## Summary
- implement `PhenoAgeCalculator` with age and pheno age calculations
- add `leaderboard-rank` GET route in `DataController` to compute rank for an arbitrary pheno age difference

## Testing
- `dotnet build LongevityWorldCup.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6842a539731083319e841583f6704ba1