### PR TITLE
Donation Received event

### DIFF
--- a/LongevityWorldCup.Website/Business/BitcoinDataService.cs
+++ b/LongevityWorldCup.Website/Business/BitcoinDataService.cs
@@ -1,0 +1,234 @@
+using System.Text.Json;
+using Microsoft.Extensions.Caching.Memory;
+using LongevityWorldCup.Website.Business;
+
+namespace LongevityWorldCup.Website.Business
+{
+    public sealed class BitcoinDataService
+    {
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly IMemoryCache _cache;
+        private readonly EventDataService _events;
+        private readonly Config _config;
+        private readonly ILogger<BitcoinDataService> _log;
+
+        public BitcoinDataService(IHttpClientFactory httpClientFactory, IMemoryCache cache, EventDataService events, Config config, ILogger<BitcoinDataService> log)
+        {
+            _httpClientFactory = httpClientFactory;
+            _cache = cache;
+            _events = events;
+            _config = config;
+            _log = log;
+        }
+
+        public async Task<decimal> GetBtcUsdAsync()
+        {
+            const string cacheKey = "btcToUsdRate";
+            if (_cache.TryGetValue(cacheKey, out decimal cachedUsdRate))
+                return cachedUsdRate;
+
+            var client = _httpClientFactory.CreateClient();
+            try
+            {
+                var response = await client.GetAsync("https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd");
+                if (response.IsSuccessStatusCode)
+                {
+                    var jsonString = await response.Content.ReadAsStringAsync();
+                    using var doc = JsonDocument.Parse(jsonString);
+                    var usd = doc.RootElement.GetProperty("bitcoin").GetProperty("usd").GetDecimal();
+                    _cache.Set(cacheKey, usd, TimeSpan.FromMinutes(1));
+                    return usd;
+                }
+                throw new HttpRequestException($"Primary API returned status {response.StatusCode}");
+            }
+            catch
+            {
+                try
+                {
+                    var fallbackResponse = await client.GetAsync("https://blockchain.info/ticker");
+                    if (fallbackResponse.IsSuccessStatusCode)
+                    {
+                        var jsonString = await fallbackResponse.Content.ReadAsStringAsync();
+                        using var doc = JsonDocument.Parse(jsonString);
+                        var usd = doc.RootElement.GetProperty("USD").GetProperty("last").GetDecimal();
+                        _cache.Set(cacheKey, usd, TimeSpan.FromMinutes(1));
+                        return usd;
+                    }
+                }
+                catch { }
+            }
+
+            throw new InvalidOperationException("Both primary and fallback APIs failed for BTC to USD rate.");
+        }
+
+        public async Task<long> GetTotalReceivedSatoshisAsync(string address)
+        {
+            var cacheExpiration = TimeSpan.FromMinutes(3);
+            var cacheKey = $"totalReceived_{address}";
+            if (_cache.TryGetValue(cacheKey, out long cachedTotal))
+                return cachedTotal;
+
+            var client = _httpClientFactory.CreateClient();
+
+            async Task<long?> TryFallbackAsync()
+            {
+                var resp = await client.GetAsync($"https://blockchain.info/rawaddr/{address}");
+                if (!resp.IsSuccessStatusCode) return null;
+                var jsonString = await resp.Content.ReadAsStringAsync();
+                using var doc = JsonDocument.Parse(jsonString);
+                return doc.RootElement.GetProperty("total_received").GetInt64();
+            }
+
+            try
+            {
+                var response = await client.GetAsync($"https://api.blockcypher.com/v1/btc/main/addrs/{address}");
+                if (response.IsSuccessStatusCode)
+                {
+                    var jsonString = await response.Content.ReadAsStringAsync();
+                    using var doc = JsonDocument.Parse(jsonString);
+                    var total = doc.RootElement.GetProperty("total_received").GetInt64();
+                    _cache.Set(cacheKey, total, cacheExpiration);
+                    return total;
+                }
+                else
+                {
+                    var fb = await TryFallbackAsync();
+                    if (fb is null) throw new InvalidOperationException();
+                    _cache.Set(cacheKey, fb.Value, cacheExpiration);
+                    return fb.Value;
+                }
+            }
+            catch
+            {
+                var fb = await TryFallbackAsync();
+                if (fb is null) throw new InvalidOperationException("Both primary and fallback APIs failed for total received.");
+                _cache.Set(cacheKey, fb.Value, cacheExpiration);
+                return fb.Value;
+            }
+        }
+
+        public async Task<int> CheckDonationAddressAndCreateEventsAsync(CancellationToken ct = default)
+        {
+            var address = _config.DonationBitcoinAddress;
+            if (string.IsNullOrWhiteSpace(address))
+                return 0;
+
+            var txs = await FetchAddressDonationTransactionsAsync(address, ct);
+            if (txs.Count == 0) return 0;
+
+            var items = txs
+                .Where(t => t.AmountSatoshis > 0)
+                .Select(t => (t.TxId, t.OccurredAtUtc, t.AmountSatoshis))
+                .OrderBy(t => t.OccurredAtUtc)
+                .ToList();
+
+            _events.CreateDonationReceivedEvents(items, skipIfExists: true);
+            return items.Count;
+        }
+
+        private async Task<IReadOnlyList<DonationTx>> FetchAddressDonationTransactionsAsync(string address, CancellationToken ct)
+        {
+            var client = _httpClientFactory.CreateClient();
+
+            try
+            {
+                var resp = await client.GetAsync($"https://blockchain.info/rawaddr/{address}?limit=50", ct);
+                if (resp.IsSuccessStatusCode)
+                {
+                    var json = await resp.Content.ReadAsStringAsync(ct);
+                    return ParseBlockchainInfoRawAddr(json, address);
+                }
+            }
+            catch (Exception ex)
+            {
+                _log.LogDebug(ex, "Blockchain.info primary failed");
+            }
+
+            try
+            {
+                var resp = await client.GetAsync($"https://api.blockcypher.com/v1/btc/main/addrs/{address}/full?limit=50&txlimit=50", ct);
+                if (resp.IsSuccessStatusCode)
+                {
+                    var json = await resp.Content.ReadAsStringAsync(ct);
+                    return ParseBlockCypherFull(json, address);
+                }
+            }
+            catch (Exception ex)
+            {
+                _log.LogDebug(ex, "BlockCypher fallback failed");
+            }
+
+            return Array.Empty<DonationTx>();
+        }
+
+        private static IReadOnlyList<DonationTx> ParseBlockchainInfoRawAddr(string json, string address)
+        {
+            var list = new List<DonationTx>();
+            using var doc = JsonDocument.Parse(json);
+            if (!doc.RootElement.TryGetProperty("txs", out var txs)) return list;
+
+            foreach (var tx in txs.EnumerateArray())
+            {
+                var hash = tx.GetProperty("hash").GetString() ?? "";
+                var time = tx.TryGetProperty("time", out var t) ? t.GetInt64() : 0;
+                var dt = DateTimeOffset.FromUnixTimeSeconds(time).UtcDateTime;
+
+                long amountToAddress = 0;
+                if (tx.TryGetProperty("out", out var outputs))
+                {
+                    foreach (var o in outputs.EnumerateArray())
+                    {
+                        var addr = o.TryGetProperty("addr", out var a) ? a.GetString() : null;
+                        if (string.Equals(addr, address, StringComparison.OrdinalIgnoreCase))
+                        {
+                            amountToAddress += o.GetProperty("value").GetInt64();
+                        }
+                    }
+                }
+
+                if (amountToAddress > 0)
+                    list.Add(new DonationTx(hash, amountToAddress, dt));
+            }
+            return list;
+        }
+
+        private static IReadOnlyList<DonationTx> ParseBlockCypherFull(string json, string address)
+        {
+            var list = new List<DonationTx>();
+            using var doc = JsonDocument.Parse(json);
+            if (!doc.RootElement.TryGetProperty("txs", out var txs)) return list;
+
+            foreach (var tx in txs.EnumerateArray())
+            {
+                var hash = tx.GetProperty("hash").GetString() ?? "";
+                DateTime occurredUtc;
+                if (tx.TryGetProperty("confirmed", out var conf) && conf.ValueKind == JsonValueKind.String && DateTime.TryParse(conf.GetString(), out var confDt))
+                    occurredUtc = DateTime.SpecifyKind(confDt, DateTimeKind.Utc);
+                else if (tx.TryGetProperty("received", out var rec) && rec.ValueKind == JsonValueKind.String && DateTime.TryParse(rec.GetString(), out var recDt))
+                    occurredUtc = DateTime.SpecifyKind(recDt, DateTimeKind.Utc);
+                else
+                    occurredUtc = DateTime.UtcNow;
+
+                long amountToAddress = 0;
+                if (tx.TryGetProperty("outputs", out var outputs))
+                {
+                    foreach (var o in outputs.EnumerateArray())
+                    {
+                        if (o.TryGetProperty("addresses", out var addrs))
+                        {
+                            var matches = addrs.EnumerateArray().Any(a => string.Equals(a.GetString(), address, StringComparison.OrdinalIgnoreCase));
+                            if (matches)
+                                amountToAddress += o.GetProperty("value").GetInt64();
+                        }
+                    }
+                }
+
+                if (amountToAddress > 0)
+                    list.Add(new DonationTx(hash, amountToAddress, occurredUtc));
+            }
+            return list;
+        }
+
+        private readonly record struct DonationTx(string TxId, long AmountSatoshis, DateTime OccurredAtUtc);
+    }
+}

--- a/LongevityWorldCup.Website/Config.cs
+++ b/LongevityWorldCup.Website/Config.cs
@@ -21,21 +21,23 @@ namespace LongevityWorldCup.Website
         public string? GmailRefreshToken { get; set; }
         public string? SlackWebhookUrl { get; set; }
 
-        public string? DonationBitcoinAddress { get; set; }
-
+        // Load configuration from the file
         public static async Task<Config> LoadAsync()
         {
             if (!File.Exists(ConfigFilePath))
                 throw new FileNotFoundException("Configuration file not found.");
 
             string json = await File.ReadAllTextAsync(ConfigFilePath);
+
+            // Ensure deserialization doesn't return null
             var config = JsonSerializer.Deserialize<Config>(json);
             return config ?? throw new InvalidDataException("Configuration file content is invalid.");
         }
 
+        // Save configuration to the file
         public async Task SaveAsync()
         {
-            string json = JsonSerializer.Serialize(this, JsonOptions);
+            string json = JsonSerializer.Serialize(this, JsonOptions); // Use cached options
             await File.WriteAllTextAsync(ConfigFilePath, json);
         }
     }

--- a/LongevityWorldCup.Website/Config.cs
+++ b/LongevityWorldCup.Website/Config.cs
@@ -21,23 +21,21 @@ namespace LongevityWorldCup.Website
         public string? GmailRefreshToken { get; set; }
         public string? SlackWebhookUrl { get; set; }
 
-        // Load configuration from the file
+        public string? DonationBitcoinAddress { get; set; }
+
         public static async Task<Config> LoadAsync()
         {
             if (!File.Exists(ConfigFilePath))
                 throw new FileNotFoundException("Configuration file not found.");
 
             string json = await File.ReadAllTextAsync(ConfigFilePath);
-
-            // Ensure deserialization doesn't return null
             var config = JsonSerializer.Deserialize<Config>(json);
             return config ?? throw new InvalidDataException("Configuration file content is invalid.");
         }
 
-        // Save configuration to the file
         public async Task SaveAsync()
         {
-            string json = JsonSerializer.Serialize(this, JsonOptions); // Use cached options
+            string json = JsonSerializer.Serialize(this, JsonOptions);
             await File.WriteAllTextAsync(ConfigFilePath, json);
         }
     }

--- a/LongevityWorldCup.Website/Controllers/BitcoinController.cs
+++ b/LongevityWorldCup.Website/Controllers/BitcoinController.cs
@@ -1,139 +1,43 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Caching.Memory;
-using System;
-using System.Net.Http;
-using System.Text.Json;
 using System.Threading.Tasks;
+using LongevityWorldCup.Website.Business;
 
 namespace LongevityWorldCup.Website.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]
-    public class BitcoinController(IHttpClientFactory httpClientFactory, IMemoryCache cache) : Controller
+    public class BitcoinController : Controller
     {
-        private readonly IHttpClientFactory _httpClientFactory = httpClientFactory;
-        private readonly IMemoryCache _cache = cache;
+        private readonly BitcoinDataService _btc;
+
+        public BitcoinController(BitcoinDataService btc)
+        {
+            _btc = btc;
+        }
 
         [HttpGet("btcusd")]
         public async Task<IActionResult> GetBtcUsd()
         {
-            const string cacheKey = "btcToUsdRate";
-            if (_cache.TryGetValue(cacheKey, out decimal cachedUsdRate))
-            {
-                return Ok(new { btcToUsdRate = cachedUsdRate });
-            }
-
-            var client = _httpClientFactory.CreateClient();
-            decimal usdRate;
-
-            try
-            {
-                // Primary API
-                var response = await client.GetAsync("https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd");
-                if (response.IsSuccessStatusCode)
-                {
-                    var jsonString = await response.Content.ReadAsStringAsync();
-                    using var doc = JsonDocument.Parse(jsonString);
-                    var btcElement = doc.RootElement.GetProperty("bitcoin");
-                    usdRate = btcElement.GetProperty("usd").GetDecimal();
-
-                    // Cache the result for 1 minute
-                    _cache.Set(cacheKey, usdRate, TimeSpan.FromMinutes(1));
-
-                    return Ok(new { btcToUsdRate = usdRate });
-                }
-
-                // If primary API response is not successful, trigger fallback
-                throw new HttpRequestException($"Primary API returned status {response.StatusCode}");
-            }
-            catch
-            {
-                // Fallback API
-                try
-                {
-                    var fallbackResponse = await client.GetAsync("https://blockchain.info/ticker");
-                    if (fallbackResponse.IsSuccessStatusCode)
-                    {
-                        var jsonString = await fallbackResponse.Content.ReadAsStringAsync();
-                        using var doc = JsonDocument.Parse(jsonString);
-                        usdRate = doc.RootElement.GetProperty("USD").GetProperty("last").GetDecimal();
-
-                        // Cache the result for 1 minute
-                        _cache.Set(cacheKey, usdRate, TimeSpan.FromMinutes(1));
-
-                        return Ok(new { btcToUsdRate = usdRate });
-                    }
-                }
-                catch
-                {
-                    return StatusCode(500, "Both primary and fallback APIs failed for BTC to USD rate.");
-                }
-            }
-
-            return StatusCode(500, "Error fetching BTC to USD rate.");
+            var usdRate = await _btc.GetBtcUsdAsync();
+            return Ok(new { btcToUsdRate = usdRate });
         }
 
         [HttpGet("total-received")]
         public async Task<IActionResult> GetTotalReceived(string address)
         {
-            var cacheExpiration = TimeSpan.FromMinutes(3);
+            if (string.IsNullOrWhiteSpace(address))
+                return BadRequest("address is required");
 
-            var cacheKey = $"totalReceived_{address}";
-            if (_cache.TryGetValue(cacheKey, out long cachedTotalReceived))
-            {
-                return Ok(new { totalReceivedSatoshis = cachedTotalReceived });
-            }
+            var totalReceivedSatoshis = await _btc.GetTotalReceivedSatoshisAsync(address);
+            return Ok(new { totalReceivedSatoshis });
+        }
 
-            var client = _httpClientFactory.CreateClient();
-
-            async Task<long?> TryFallbackAsync()
-            {
-                var fallbackResponse = await client.GetAsync($"https://blockchain.info/rawaddr/{address}");
-                if (!fallbackResponse.IsSuccessStatusCode)
-                {
-                    return null;
-                }
-
-                var jsonString = await fallbackResponse.Content.ReadAsStringAsync();
-                using var doc = JsonDocument.Parse(jsonString);
-                return doc.RootElement.GetProperty("total_received").GetInt64();
-            }
-
-            try
-            {
-                var response = await client.GetAsync($"https://api.blockcypher.com/v1/btc/main/addrs/{address}");
-                if (response.IsSuccessStatusCode)
-                {
-                    var jsonString = await response.Content.ReadAsStringAsync();
-                    using var doc = JsonDocument.Parse(jsonString);
-                    var totalReceivedSatoshis = doc.RootElement.GetProperty("total_received").GetInt64();
-
-                    _cache.Set(cacheKey, totalReceivedSatoshis, cacheExpiration);
-                    return Ok(new { totalReceivedSatoshis });
-                }
-                else
-                {
-                    var fallbackResult = await TryFallbackAsync();
-                    if (fallbackResult == null)
-                    {
-                        return StatusCode(500, "Both primary and fallback APIs failed for total received.");
-                    }
-
-                    _cache.Set(cacheKey, fallbackResult.Value, cacheExpiration);
-                    return Ok(new { totalReceivedSatoshis = fallbackResult.Value });
-                }
-            }
-            catch
-            {
-                var fallbackResult = await TryFallbackAsync();
-                if (fallbackResult == null)
-                {
-                    return StatusCode(500, "Both primary and fallback APIs failed for total received.");
-                }
-
-                _cache.Set(cacheKey, fallbackResult.Value, cacheExpiration);
-                return Ok(new { totalReceivedSatoshis = fallbackResult.Value });
-            }
+        [HttpPost("check-donations")]
+        public async Task<IActionResult> CheckDonations()
+        {
+            var created = await _btc.CheckDonationAddressAndCreateEventsAsync();
+            return Ok(new { created });
         }
     }
 }

--- a/LongevityWorldCup.Website/Controllers/BitcoinController.cs
+++ b/LongevityWorldCup.Website/Controllers/BitcoinController.cs
@@ -1,6 +1,4 @@
 ﻿using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Caching.Memory;
-using System.Threading.Tasks;
 using LongevityWorldCup.Website.Business;
 
 namespace LongevityWorldCup.Website.Controllers
@@ -24,20 +22,18 @@ namespace LongevityWorldCup.Website.Controllers
         }
 
         [HttpGet("total-received")]
-        public async Task<IActionResult> GetTotalReceived(string address)
+        public async Task<IActionResult> GetTotalReceived()
         {
-            if (string.IsNullOrWhiteSpace(address))
-                return BadRequest("address is required");
-
-            var totalReceivedSatoshis = await _btc.GetTotalReceivedSatoshisAsync(address);
+            var totalReceivedSatoshis = await _btc.GetTotalReceivedSatoshisAsync();
             return Ok(new { totalReceivedSatoshis });
         }
 
-        [HttpPost("check-donations")]
-        public async Task<IActionResult> CheckDonations()
+        [HttpGet("donation-address")]
+        public IActionResult GetDonationAddress()
         {
-            var created = await _btc.CheckDonationAddressAndCreateEventsAsync();
-            return Ok(new { created });
+            var address = _btc.GetDonationAddress();
+            if (string.IsNullOrWhiteSpace(address)) return NoContent();
+            return Ok(new { address });
         }
     }
 }

--- a/LongevityWorldCup.Website/Jobs/BitcoinDonationCheckJob.cs
+++ b/LongevityWorldCup.Website/Jobs/BitcoinDonationCheckJob.cs
@@ -1,0 +1,24 @@
+using LongevityWorldCup.Website.Business;
+using Quartz;
+
+namespace LongevityWorldCup.Website.Jobs
+{
+    public class BitcoinDonationCheckJob : IJob
+    {
+        private readonly BitcoinDataService _btc;
+
+        public BitcoinDonationCheckJob(BitcoinDataService btc)
+        {
+            _btc = btc;
+        }
+
+        public async Task Execute(IJobExecutionContext context)
+        {
+            try
+            {
+                await _btc.CheckDonationAddressAndCreateEventsAsync(context.CancellationToken);
+            }
+            catch { }
+        }
+    }
+}

--- a/LongevityWorldCup.Website/Program.cs
+++ b/LongevityWorldCup.Website/Program.cs
@@ -74,17 +74,15 @@ namespace LongevityWorldCup.Website
                     .WithIdentity("YearlyTrigger")
                     .WithSchedule(CronScheduleBuilder.CronSchedule("0 0 0 1 1 ?").InTimeZone(TimeZoneInfo.Utc)));
 
-                // Every 10 minutes
+                // Every on start and 10 minutes
                 q.AddJob<BitcoinDonationCheckJob>(o => o.WithIdentity(donationKey));
                 q.AddTrigger(t => t.ForJob(donationKey)
                     .WithIdentity("BitcoinDonationCheckTrigger")
                     .WithSchedule(CronScheduleBuilder.CronSchedule("0 0/10 * * * ?").InTimeZone(TimeZoneInfo.Utc)));
-                
-                // // FOR TESTING
-                // q.AddTrigger(t => t.ForJob(donationKey)
-                //     .WithIdentity("BitcoinDonationCheckTrigger_Immediate")
-                //     .StartNow()
-                //     .WithSimpleSchedule(x => x.WithRepeatCount(0)));
+                q.AddTrigger(t => t.ForJob(donationKey) // on start
+                    .WithIdentity("BitcoinDonationCheckTrigger_Immediate")
+                    .StartNow()
+                    .WithSimpleSchedule(x => x.WithRepeatCount(0)));
             });
             builder.Services.AddQuartzHostedService(o => o.WaitForJobsToComplete = true);
 

--- a/LongevityWorldCup.Website/Program.cs
+++ b/LongevityWorldCup.Website/Program.cs
@@ -34,6 +34,7 @@ namespace LongevityWorldCup.Website
 
             builder.Services.AddSingleton<AthleteDataService>();
             builder.Services.AddSingleton<EventDataService>();
+            builder.Services.AddSingleton<BitcoinDataService>();
 
             var appConfig = Config.LoadAsync().GetAwaiter().GetResult();
             builder.Services.AddSingleton(appConfig);
@@ -47,6 +48,7 @@ namespace LongevityWorldCup.Website
                 var weeklyKey = new JobKey("WeeklyJob");
                 var monthlyKey = new JobKey("MonthlyJob");
                 var yearlyKey = new JobKey("YearlyJob");
+                var donationKey = new JobKey("BitcoinDonationCheckJob");
 
                 // Every day 00:00
                 q.AddJob<DailyJob>(o => o.WithIdentity(dailyKey));
@@ -71,6 +73,18 @@ namespace LongevityWorldCup.Website
                 q.AddTrigger(t => t.ForJob(yearlyKey)
                     .WithIdentity("YearlyTrigger")
                     .WithSchedule(CronScheduleBuilder.CronSchedule("0 0 0 1 1 ?").InTimeZone(TimeZoneInfo.Utc)));
+
+                // Every 10 minutes
+                q.AddJob<BitcoinDonationCheckJob>(o => o.WithIdentity(donationKey));
+                q.AddTrigger(t => t.ForJob(donationKey)
+                    .WithIdentity("BitcoinDonationCheckTrigger")
+                    .WithSchedule(CronScheduleBuilder.CronSchedule("0 0/10 * * * ?").InTimeZone(TimeZoneInfo.Utc)));
+                
+                // // FOR TESTING
+                // q.AddTrigger(t => t.ForJob(donationKey)
+                //     .WithIdentity("BitcoinDonationCheckTrigger_Immediate")
+                //     .StartNow()
+                //     .WithSimpleSchedule(x => x.WithRepeatCount(0)));
             });
             builder.Services.AddQuartzHostedService(o => o.WaitForJobsToComplete = true);
 
@@ -153,7 +167,8 @@ namespace LongevityWorldCup.Website
                 EmailTo = "longevityworldcup@gmail.com",
                 SmtpServer = "smtp.gmail.com",
                 SmtpPort = 587,
-                SmtpUser = "longevityworldcup@gmail.com"
+                SmtpUser = "longevityworldcup@gmail.com",
+                DonationBitcoinAddress = ""
             };
 
             // Serialize to JSON and save to file

--- a/LongevityWorldCup.Website/wwwroot/index.html
+++ b/LongevityWorldCup.Website/wwwroot/index.html
@@ -635,7 +635,21 @@
     <!--FOOTER-->
 
     <script>
-        window.bitcoinDonationAddress = "bc1qphwpd3mc9rts7vt4lrxxlxzs5jm3wh33w7hxz7";
+        let bitcoinDonationAddress = '';
+
+        fetch('/api/bitcoin/donation-address')
+            .then(r => r.ok ? r.json() : Promise.reject())
+            .then(({ address }) => {
+                bitcoinDonationAddress = address || '';
+                const link = document.getElementById('btcAddressLink');
+                if (link && bitcoinDonationAddress) {
+                    link.href = `https://mempool.space/address/${bitcoinDonationAddress}`;
+                    adjustBitcoinAddressDisplay();
+                }
+            })
+            .catch(() => {
+                // If address cannot be loaded, we simply skip rendering it.
+            });
 
         if (!window.callScoped) {
             window.callScoped = function (root, fn) {
@@ -784,7 +798,7 @@
         }
 
         // Fetch actual BTC data and update the progress
-        fetch(`/api/bitcoin/total-received?address=${bitcoinDonationAddress}`)
+        fetch('/api/bitcoin/total-received')
             .then(response => response.json())
             .then(data => {
                 const totalReceivedSatoshis = data.totalReceivedSatoshis;

--- a/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
@@ -4,9 +4,6 @@
         --row-stagger-step:40ms;
         --row-stagger-group-size:8;
         --row-delay: 0ms;
-        --btc-orange: #f7931a;
-        --donation-icon: var(--btc-orange);
-        --donation-bg: #fff4e8; /* light BTC orange wash */
         --donation-gift: #10b981;
     }
     @keyframes fadeInBoard{
@@ -168,7 +165,6 @@
     .avatar-disabled:hover .avatar,.avatar-disabled:focus .avatar,
     .avatar-disabled:hover .avatar-fallback,.avatar-disabled:focus .avatar-fallback{transform:none;box-shadow:0 1px 3px rgba(0,0,0,.12)}
 
-    .celebrate-icon{ margin-left:.35rem; color:var(--secondary-color,#ff4f87); }
     .donation-amount{ color: var(--secondary-color, #ff4f87); }
     .donation-gift-avatar{
         --gift: var(--donation-gift, #10b981);
@@ -183,12 +179,11 @@
         box-sizing: content-box;
     }
 
-    .donation-gift-avatar i{
+    .donation-gift-avatar i{    
         color: #fff !important;
         display: block;                /* avoids inline font metrics */
         font-size: .95rem;
         line-height: 1;
-        transform: translateY(var(--icon-nudge-y));
     }
 </style>
 

--- a/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
@@ -4,6 +4,9 @@
         --row-stagger-step:40ms;
         --row-stagger-group-size:8;
         --row-delay: 0ms;
+        --btc-orange: #f7931a;
+        --donation-icon: var(--btc-orange);
+        --donation-bg: #fff4e8; /* light BTC orange wash */
     }
     @keyframes fadeInBoard{
         from{opacity:0; transform:translateY(10px)}
@@ -163,6 +166,31 @@
     .avatar-disabled .avatar,.avatar-disabled .avatar-fallback{transition:none;transform:none;box-shadow:0 1px 3px rgba(0,0,0,.12)}
     .avatar-disabled:hover .avatar,.avatar-disabled:focus .avatar,
     .avatar-disabled:hover .avatar-fallback,.avatar-disabled:focus .avatar-fallback{transform:none;box-shadow:0 1px 3px rgba(0,0,0,.12)}
+
+    .celebrate-icon{ margin-left:.35rem; color:var(--secondary-color,#ff4f87); }
+    .donation-amount{ color: var(--secondary-color, #ff4f87); }
+    /* Full BTC-orange disk, no ring */
+    .donation-avatar{
+        --btc-orange: #f7931a;
+        width: 24px;
+        height: 24px;
+        border-radius: 50%;
+        background: var(--btc-orange);
+        border: 2px solid var(--btc-orange) !important; /* same size as others */
+        box-shadow: 0 1px 2px rgba(0,0,0,.06);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        box-sizing: content-box;
+    }
+
+    /* White glyph, slightly larger, tilted like the official BTC mark */
+    .donation-avatar .btc-tilt{
+        color: #fff !important;
+        font-size: 1.05rem;     /* tweak 1.0–1.1rem as you like */
+        line-height: 1;
+        transform: rotate(14deg);
+    }
 </style>
 
 <div id="events-root" class="events-board fade-in-board">
@@ -449,7 +477,7 @@
                             : `<span class="avatar-disabled" aria-label="${esc(name)}">${fallback}</span>`;
                     }
                 } else if (r.type === EVENT_TYPE.DonationReceived) {
-                    avatarHtml = `<div class="avatar-fallback" title="Donation">₿</div>`;
+                    avatarHtml = `<div class="avatar-fallback donation-avatar" title="Donation" aria-label="Donation"><i class="fa-brands fa-btc btc-tilt" aria-hidden="true"></i></div>`;
                 } else {
                     avatarHtml = `<div class="avatar-fallback" title="Event">★</div>`;
                 }
@@ -486,8 +514,8 @@
                 } else if (r.type === EVENT_TYPE.DonationReceived) {
                     const amount = Number.isFinite(r.sats) ? r.sats : 0;
                     const btc = amount / 100000000;
-                    const amountText = new Intl.NumberFormat(undefined, { maximumFractionDigits: 8 }).format(btc) + ' BTC';
-                    msgHtml = `${esc(amountText)} donation received`;
+                    const amountFormatted = new Intl.NumberFormat(undefined, { maximumFractionDigits: 8 }).format(btc);
+                    msgHtml = `Donation of <strong class="donation-amount">${esc(amountFormatted)} BTC</strong> received`;
                 } else {
                     const tokenHtml = renderTextWithSlugLinks(
                         r.text,

--- a/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
@@ -515,7 +515,7 @@
                     const amount = Number.isFinite(r.sats) ? r.sats : 0;
                     const btc = amount / 100000000;
                     const amountFormatted = new Intl.NumberFormat(undefined, { maximumFractionDigits: 8 }).format(btc);
-                    msgHtml = `Donation of <strong class="donation-amount">${esc(amountFormatted)} BTC</strong> received`;
+                    msgHtml = `Donation of <strong class="donation-amount">${esc(amountFormatted)} BTC</strong> added to the prize pool`;
                 } else {
                     const tokenHtml = renderTextWithSlugLinks(
                         r.text,

--- a/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
@@ -7,6 +7,7 @@
         --btc-orange: #f7931a;
         --donation-icon: var(--btc-orange);
         --donation-bg: #fff4e8; /* light BTC orange wash */
+        --donation-gift: #10b981;
     }
     @keyframes fadeInBoard{
         from{opacity:0; transform:translateY(10px)}
@@ -169,27 +170,25 @@
 
     .celebrate-icon{ margin-left:.35rem; color:var(--secondary-color,#ff4f87); }
     .donation-amount{ color: var(--secondary-color, #ff4f87); }
-    /* Full BTC-orange disk, no ring */
-    .donation-avatar{
-        --btc-orange: #f7931a;
-        width: 24px;
-        height: 24px;
+    .donation-gift-avatar{
+        --gift: var(--donation-gift, #10b981);
+        width: 24px; height: 24px;
         border-radius: 50%;
-        background: var(--btc-orange);
-        border: 2px solid var(--btc-orange) !important; /* same size as others */
+        background: var(--gift);
+        border: 2px solid var(--gift) !important;
         box-shadow: 0 1px 2px rgba(0,0,0,.06);
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
+        display: grid;                 /* perfectly center contents */
+        place-items: center;
+        line-height: 0;                /* kill baseline alignment */
         box-sizing: content-box;
     }
 
-    /* White glyph, slightly larger, tilted like the official BTC mark */
-    .donation-avatar .btc-tilt{
+    .donation-gift-avatar i{
         color: #fff !important;
-        font-size: 1.05rem;     /* tweak 1.0–1.1rem as you like */
+        display: block;                /* avoids inline font metrics */
+        font-size: .95rem;
         line-height: 1;
-        transform: rotate(14deg);
+        transform: translateY(var(--icon-nudge-y));
     }
 </style>
 
@@ -477,7 +476,7 @@
                             : `<span class="avatar-disabled" aria-label="${esc(name)}">${fallback}</span>`;
                     }
                 } else if (r.type === EVENT_TYPE.DonationReceived) {
-                    avatarHtml = `<div class="avatar-fallback donation-avatar" title="Donation" aria-label="Donation"><i class="fa-brands fa-btc btc-tilt" aria-hidden="true"></i></div>`;
+                    avatarHtml = `<div class="avatar-fallback donation-gift-avatar" title="Donation" aria-label="Donation"><i class="fa-solid fa-gift" aria-hidden="true"></i></div>`
                 } else {
                     avatarHtml = `<div class="avatar-fallback" title="Event">★</div>`;
                 }

--- a/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
@@ -185,7 +185,7 @@
 
 <script>
     (function(){
-        const EVENT_TYPE = { General: 0, Joined: 1, NewRank: 2 };
+        const EVENT_TYPE = { General: 0, Joined: 1, NewRank: 2, DonationReceived: 3 };
 
         function lowerKeyMap(o){const m={};Object.keys(o||{}).forEach(k=>m[k.toLowerCase()]=k);return m;}
         function slugifyLocal(s){return(s||"").toString().normalize("NFD").replace(/[\u0300-\u036f]/g,"").toLowerCase().replace(/[^a-z0-9]+/g,"-").replace(/^-+|-+$/g,"").replace(/-+/g,"-");}
@@ -338,8 +338,9 @@
                 const prevSlug=prevRaw?slugifyLocal(normalizeLinkId(prevRaw)):null;
                 if(prevSlug) slugTokens.push(prevSlug);
 
-                const rank=extractRank(text);
-                return { type,text,occurredAt,slugs:slugTokens,primarySlug,prevSlug,rank };
+                const rank = extractRank(text);
+                const sats = (() => { const m = /sats\[(\d+)\]/.exec(text); return m ? parseInt(m[1], 10) : 0; })();
+                return { type, text, occurredAt, slugs: slugTokens, primarySlug, prevSlug, rank, sats };
             });
         }
 
@@ -425,10 +426,8 @@
 
             rows.forEach((r, idx) => {
                 const dateLabel = r.occurredAt ? formatListDate(r.occurredAt) : "";
-                const rel = r.occurredAt
-                    ? (r.type === EVENT_TYPE.NewRank
-                        ? relativeDayLabelNoIcon(r.occurredAt, { emptyIfToday: true })
-                        : relativeDayLabel(r.occurredAt))
+                const rel = (r.type === EVENT_TYPE.Joined && r.occurredAt)
+                    ? relativeDayLabel(r.occurredAt)
                     : "";
 
                 const a = r.primarySlug ? athletesIndex.get(r.primarySlug) : null;
@@ -449,6 +448,8 @@
                             ? `<a href="${url}" class="avatar-link" title="${esc(name)}" aria-label="${esc(name)}">${fallback}</a>`
                             : `<span class="avatar-disabled" aria-label="${esc(name)}">${fallback}</span>`;
                     }
+                } else if (r.type === EVENT_TYPE.DonationReceived) {
+                    avatarHtml = `<div class="avatar-fallback" title="Donation">₿</div>`;
                 } else {
                     avatarHtml = `<div class="avatar-fallback" title="Event">★</div>`;
                 }
@@ -479,10 +480,14 @@
                         );
                     }
 
-                    const suffix = rel ? ` ${rel}` : "";
                     msgHtml = prevHtml
-                        ? `${nameWithCurrentRank} took the ${takenHtml} place from ${prevHtml}${suffix}`
-                        : `${nameWithCurrentRank} took the ${takenHtml} place${suffix}`;
+                        ? `${nameWithCurrentRank} took the ${takenHtml} place from ${prevHtml}`
+                        : `${nameWithCurrentRank} took the ${takenHtml} place`;
+                } else if (r.type === EVENT_TYPE.DonationReceived) {
+                    const amount = Number.isFinite(r.sats) ? r.sats : 0;
+                    const btc = amount / 100000000;
+                    const amountText = new Intl.NumberFormat(undefined, { maximumFractionDigits: 8 }).format(btc) + ' BTC';
+                    msgHtml = `${esc(amountText)} donation received`;
                 } else {
                     const tokenHtml = renderTextWithSlugLinks(
                         r.text,
@@ -490,7 +495,7 @@
                         athletesIndex,
                         r.type === EVENT_TYPE.Joined ? afterNameWithCurrentRankFor() : null
                     );
-                    msgHtml = r.type === EVENT_TYPE.Joined ? `${tokenHtml} joined ${rel}` : `${tokenHtml} ${rel}`;
+                    msgHtml = r.type === EVENT_TYPE.Joined ? `${tokenHtml} joined ${rel}` : `${tokenHtml}`;
                 }
 
                 const tr = document.createElement("tr");
@@ -514,7 +519,6 @@
                 tbody.querySelectorAll(".row-appear").forEach(r => r.classList.add("is-visible"));
             }
         }
-
 
         function normalizeIncomingAthleteId(id){
             if(id==null) return '';

--- a/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
@@ -509,7 +509,7 @@
                     const amount = Number.isFinite(r.sats) ? r.sats : 0;
                     const btc = amount / 100000000;
                     const amountFormatted = new Intl.NumberFormat(undefined, { maximumFractionDigits: 8 }).format(btc);
-                    msgHtml = `Donation of <strong class="donation-amount">${esc(amountFormatted)} BTC</strong> added to the prize pool`;
+                    msgHtml = `Someone has donated <strong class="donation-amount">${esc(amountFormatted)} BTC</strong>`;
                 } else {
                     const tokenHtml = renderTextWithSlugLinks(
                         r.text,


### PR DESCRIPTION
Closes https://github.com/nopara73/LongevityWorldCup/issues/256

This PR introduces a new event for donations.

What's changed:
- new class BitcoinDataService manages the Bitcoin-related logic
- Logic from BitcoinController was moved to BitcoinDataService (the controller now asks the service)
- The service checks for donations on every start and then every 10 minutes.
- It stores an entry in the DB if new donations are received.
- Donation btc address stored in the config
- Donation btc address is removed from the frontend. (Frontend asks the backend for the address)
- Donation highlight is visible both on the main screen and on the full list.

_Note: Sending event messages to Slack will be implemented in a separate PR to avoid old donation messages on merge._

Current look:
<img width="1194" height="121" alt="image" src="https://github.com/user-attachments/assets/c943e512-6546-4bfb-ae3e-013f93b25121" />
