### PR TITLE
Athlete info layout fix

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -534,8 +534,21 @@
 
         /* table portraits smaller on mobile */
         .leaderboard .portrait{ width:40px; height:40px; }
-    }
 
+        /* =========================
+           Athlete info table tweaks
+           ========================= */
+        .athlete-info-table {
+            font-size: 0.9rem;
+            border-spacing: 0.2rem .08rem;
+        }
+        .athlete-info-table th {
+            padding-right: 0.1rem;
+        }
+        .athlete-info-table td {
+            padding-left: 0.4rem;
+        }
+    }
 
     .athlete-info-table th > strong{
         display:inline-block;


### PR DESCRIPTION
Fixes https://github.com/nopara73/LongevityWorldCup/issues/234

Before:
<img width="926" height="321" alt="image" src="https://github.com/user-attachments/assets/7e02b15f-d65e-452f-9942-6f638cf8f22b" />

After:
<img width="1377" height="518" alt="image" src="https://github.com/user-attachments/assets/c1bc7dea-6b8f-4af8-b49a-57ded85888e0" />

