### PR TITLE
Handle ties correctly when generating Badge events

### DIFF
--- a/LongevityWorldCup.Website/Business/BadgeDataService.cs
+++ b/LongevityWorldCup.Website/Business/BadgeDataService.cs
@@ -310,9 +310,12 @@ VALUES (@bl, @lc, @lv, @p, @a, @dh, @u);";
                     if (forward) addsForward.Add(slug);
                 }
 
+                // Only 1-to-1 swap sets ReplacedSlug; otherwise null
+                var singleSwap = prevSet.Count == 1 && nextSet.Count == 1 && addsForward.Count == 1 && removes.Count == 1 && !string.Equals(addsForward.First(), removes.First(), StringComparison.OrdinalIgnoreCase);
+
                 for (int i = 0; i < addsForward.Count; i++)
                 {
-                    var replaced = i < removes.Count ? removes[i] : null;
+                    var replaced = singleSwap ? removes[0] : null;
                     items.Add(new BadgeEventItem
                     {
                         AthleteSlug = addsForward[i],
@@ -327,9 +330,12 @@ VALUES (@bl, @lc, @lv, @p, @a, @dh, @u);";
             }
             else
             {
+                // Only 1-to-1 swap sets ReplacedSlug; otherwise null
+                var singleSwap = prevSet.Count == 1 && nextSet.Count == 1 && adds.Count == 1 && removes.Count == 1 && !string.Equals(adds.First(), removes.First(), StringComparison.OrdinalIgnoreCase);
+
                 for (int i = 0; i < adds.Count; i++)
                 {
-                    var replaced = i < removes.Count ? removes[i] : null;
+                    var replaced = singleSwap ? removes[0] : null;
                     items.Add(new BadgeEventItem
                     {
                         AthleteSlug = adds[i],


### PR DESCRIPTION
Only mention the previous holder in the event message if it was a 1-to-1 swap.