### PR TITLE
Added LinAge2

### DIFF
--- a/LongevityWorldCup.Documentation/AgingClocks.md
+++ b/LongevityWorldCup.Documentation/AgingClocks.md
@@ -1,6 +1,6 @@
 # Every Commercially Available Biological Aging Clock in Existence
 
-|Created|Clock|Type|Creators (only real humans allowed)|Sellers|Availability
+|Created|Clock|Type|Creators (only real humans allowed)|Sellers|Availability|
 |-|-|-|-|-|-|
 |1960s–1970s|VO₂max Age|cardiorespiratory fitness (max oxygen uptake)|Per-Olof Åstrand|any sports lab, fitness trackers|global|
 |2004|Vascular Age|arterial stiffness (pulse wave velocity)|Thomas Münzel|smart scales, wearables, clinics|global|


### PR DESCRIPTION
LinAge2 was made by the same authors as LinAge, using the same training data, but it needs fewer inputs

What the authors say about why they made v2:
The original PCAge and LinAge both utilized some parameters that are not routinely collected. LinAge has been utilized by several clinics worldwide, and we have received informal feedback regarding its use. Common suggestions for enhancing the clock include: (i) improving handling of outliers and threshold effects, (ii) further refining the clinical parameters, especially removing serum fibrinogen due to the need for a specialized sodium citrate tube, (iii) providing additional tools to improve the interpretability of PCs, and (iv) providing specific strategies to optimize each PC to lower BA. PCs can also be sensitive to batch effects. We developed LinAge2 in response to these concerns.