### PR TITLE
Improved performance on mobile (fixes #313)

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -37,11 +37,9 @@
     /* Scope table styles to the leaderboard table only */
     .leaderboard > table{ flex-grow:1; width:auto; border-collapse:separate; border-spacing:0; align-self:flex-start; }
 
-    .leaderboard td{ text-align:center; }
-
     /* Scoped header styles – do NOT affect the modal info table */
     .leaderboard table th{
-        padding:1rem 1rem; text-align:center; background-color:rgba(0,188,212,.1);
+        padding:1rem 0; text-align:center; background-color:rgba(0,188,212,.1);
         color:var(--primary-color); font-weight:700; text-transform:uppercase; font-size:.9rem; letter-spacing:1px;
     }
     .leaderboard table th:nth-child(2){ text-align:left; }
@@ -258,12 +256,11 @@
        8) Table row bits
        ========================= */
     .rank{ font-weight:700; font-size:1.2rem; color:var(--primary-color); }
-    .age-reduction{ font-weight:700; color:#4caf50; text-align:left; }
-    .athlete-td{ display:flex; align-items:center; text-align:left; gap:.5rem; }
+    .age-reduction{ font-weight:700; color:#4caf50; }
 
     .athlete-name{
         color:var(--primary-color); text-decoration:underline; text-align:left; cursor:pointer; transition:color .2s ease-in-out;
-        display:inline-block; padding:.5rem .2rem .5rem .5rem; white-space:pre-wrap;
+        padding:.5rem .1rem .5rem 0; white-space:pre-wrap; overflow-wrap: break-word;
     }
     .athlete-name:hover{ color:var(--secondary-color); background-color:rgba(0,0,0,.05); border-radius:8px; font-size:1.1em; }
     .podium .athlete-name{ font-size:1.1rem; padding-bottom:.2rem; }
@@ -280,6 +277,10 @@
 
     .leaderboard table tbody tr{ scroll-margin-top:0; }
     .leaderboard table tbody tr:target{ background:rgba(255,255,0,.35); transition:background-color 1.2s ease; }
+
+    .age-reduction-td {
+        text-align: center;
+    }
 
     /* =========================
        10) Modal
@@ -543,7 +544,7 @@
                 <thead>
                 <tr>
                     <th>Rank</th>
-                    <th>Athlete</th>
+                    <th colspan="2">Athlete</th>
                     <th>
                         Sponsor<br />
                         <a href="https://github.com/nopara73/LongevityWorldCup/issues/74" target="_blank" rel="noopener" style="color: #999; text-decoration: underline; cursor: pointer;"
@@ -558,7 +559,7 @@
                         <a href="https://github.com/nopara73/LongevityWorldCup/blob/master/LongevityWorldCup.Documentation/Ruleset.md#point-system" target="_blank" rel="noopener" style="color: var(--primary-color); text-decoration: underline; cursor: pointer;"
                            onmouseover="this.style.color='var(--secondary-color)';"
                            onmouseout="this.style.color='var(--primary-color)';">
-                            Age Reduction
+                           Years Reduced
                         </a>
                     </th>
                     <th>Media Contact</th>
@@ -698,12 +699,13 @@
         <td data-label="Rank" class="rank-td">
             <span class="rank"></span>
         </td>
-        <td data-label="Athlete" class="athlete-td">
+        <td data-label="Athlete Portrait" class="athlete-portrait-td">
             <img src="" alt="" class="portrait" loading="lazy">
+        </td>
+        <td data-label="Athlete" class="athlete-td" colspan="2">
             <span class="athlete-name" title="View stats"></span>
             <div class="badge-section"></div>
         </td>
-        <td data-label="Sponsor" class="sponsor-td"></td>
         <td data-label="Age Reduction" class="age-reduction-td">
             <span class="age-reduction"></span>
         </td>
@@ -1294,9 +1296,6 @@
                                         });
                                     });
 
-                                    applyCamelCaseNewlines();
-                                    autoshrinkPodiumNames();
-
                                     addClickListenerToImages('.portrait, #modalProfilePic', function () {
                                         openEnlargedView(this);
                                     });
@@ -1329,7 +1328,8 @@
 
                     row.querySelector('.rank').textContent = athlete.rank;
                     const athleteCell = row.querySelector('.athlete-td');
-                    const portraitImg = athleteCell.querySelector('img.portrait');
+                    const athletePortraitCell = row.querySelector('.athlete-portrait-td');
+                    const portraitImg = athletePortraitCell.querySelector('img.portrait');
                     portraitImg.src = athlete.profilePic;
                     portraitImg.alt = `${athlete.displayName} portrait`;
                     if (athlete.isNew) {
@@ -1348,7 +1348,7 @@
                     window.setBadges(athlete, athleteCell);
 
                     const ageReductionSpan = row.querySelector('.age-reduction');
-                    ageReductionSpan.textContent = (athlete.ageReduction > 0 ? '+' : '') + athlete.ageReduction.toFixed(1) + ' years';
+                    ageReductionSpan.textContent = (athlete.ageReduction > 0 ? '+' : '') + athlete.ageReduction.toFixed(1);
 
                     const mediaContactCell = row.querySelector('.media-contact-td');
                     mediaContactCell.innerHTML = renderMediaContact(athlete.mediaContact, false, athlete.displayName);
@@ -1371,7 +1371,6 @@
                     }
 
                     attachAthleteNameClickListeners();
-                    applyCamelCaseNewlines();
                     addClickListenerToImages('#modalProfilePic', function () {
                         openEnlargedView(this);
                     });
@@ -1800,7 +1799,6 @@
 
         if (typeof AOS !== 'undefined') {
             AOS.refresh();
-            applyCamelCaseNewlines(); // Reapply the camelCase fix AFTER AOS refresh
         }
 
         const url = new URL(window.location.href);
@@ -2182,16 +2180,6 @@
         addFadeInEffectToElements();
     });
 
-    function applyCamelCaseNewlines() {
-        if (window.innerWidth < 480) {
-            document.querySelectorAll('.athlete-name').forEach(el => {
-                if (el.closest('.podium')) return;
-                const txt = el.textContent;
-                el.innerHTML = txt.replace(/([a-z])([A-Z](?=[a-z]))/g, '$1<br>$2');
-            });
-        }
-    }
-
     function fitTextToWidth(el, minPx = 12, maxPx = null) {
         // reset to CSS default first
         el.style.fontSize = '';
@@ -2207,13 +2195,6 @@
         el.style.fontSize = best + 'px';
     }
 
-    function autoshrinkPodiumNames() {
-        document.querySelectorAll('.podium .athlete-name').forEach(el => fitTextToWidth(el, 12));
-    }
-
-    // run after podium render and on resize
-    window.addEventListener('resize', debounce(autoshrinkPodiumNames, 150));
-    window.addEventListener('load', autoshrinkPodiumNames);
     document.addEventListener('keydown', function (event) {
         if (event.key === 'Escape' || event.key === 'Esc') {
             closeOpenComponents();


### PR DESCRIPTION
The improvements are described in #313.

I also fixed the table layout that was allowing text overflows (e.g. Vishwamithra Shashishekara, see screenshots) and made the headings less squashed and more consistently aligned

I did 2 sets of before/after screenshots. One at the top of the leaderboard to show the header, and then a hard area with HealthOptimisers and Vishwamithra Shashishekara.

First set:
<p align="center">
<img width="45%"  alt="lwc-before" src="https://github.com/user-attachments/assets/c22041f9-b16e-48cf-afc9-d7ca4fc4b9f2" />
<img width="45%"  alt="lwc-after" src="https://github.com/user-attachments/assets/524b79e0-8e4b-4555-ac08-81070355e9dc" />
</p>

Second set:
<p align="center">
<img width="45%" alt="lwc-before-2" src="https://github.com/user-attachments/assets/fe866b27-8fc9-4070-9606-9496e8fe9c76" />
<img width="45%"  alt="lwc-after-2" src="https://github.com/user-attachments/assets/384e9df5-8238-453e-a81d-16b8639c639d" />
</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves mobile layout/perf and clarifies the leaderboard table.
> 
> - Restructures the table: splits `Athlete` into a dedicated portrait column plus name/badges cell; updates row template and JS to target `.athlete-portrait-td`
> - Header/labels/alignments: adjusts `th` padding, renames `Age Reduction` → `Years Reduced`, centers `.age-reduction-td`, and drops the "years" unit from table values
> - Row template removes the `Sponsor` cell (header still has a placeholder link), potentially changing column alignment
> - Removes camelCase newline and podium autoshrink helpers (and their calls) to reduce JS work; small CSS tweaks to wrapping/hover for `.athlete-name`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 525447506ea15fdb9d1a91fa78b09de05a7db073. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->