### PR TITLE
Specify charset in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,6 @@
 ﻿[*.cs]
 
+charset = utf-8
+
 # CA1860: Avoid using 'Enumerable.Any()' extension method
 dotnet_diagnostic.CA1860.severity = none


### PR DESCRIPTION
This was needed for Rider's AI Assistant to not make mistakes around charsets.