### PR TITLE
Allow shared VS Code launch profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,5 @@ AppData
 *.iml
 
 # VS Code
-.vscode/
+.vscode/*
+!.vscode/launch.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,35 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+
+        {
+            "name": ".NET Core Launch (web)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/LongevityWorldCup.Website/bin/Debug/net8.0/LongevityWorldCup.Website.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/LongevityWorldCup.Website",
+            "stopAtEntry": false,
+            "serverReadyAction": {
+                "action": "openExternally",
+                "pattern": "\\bNow listening on:\\s+(https?://\\S+)"
+            },
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development",
+                "ASPNETCORE_URLS": "https://localhost:7080"
+            },
+            "sourceFileMap": {
+                "/Views": "${workspaceFolder}/LongevityWorldCup.Website/Views"
+            }
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach"
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- Keep most `.vscode` files ignored, but explicitly track `.vscode/launch.json`
- Add a shared .NET launch profile for `LongevityWorldCup.Website`
- Standardize local debug startup on `https://localhost:7080` with external browser auto-open

## Test plan
- [x] Start debug with `.NET Core Launch (web)` in Cursor
- [x] Confirm app binds to `https://localhost:7080`
- [x] Confirm browser opens automatically after startup
- [x] Confirm only `.vscode/launch.json` is tracked under `.vscode`

@RolandUI please review and approve when you have a moment.