### PR TITLE
Add interview request flow on homepage

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/index.html
+++ b/LongevityWorldCup.Website/wwwroot/index.html
@@ -663,6 +663,13 @@
             padding-inline: 1.1rem;
         }
 
+        .lwc-interview-email-drop .shared-email-button.is-loading {
+            cursor: wait;
+            opacity: 0.9;
+            transform: none;
+            box-shadow: none;
+        }
+
         /* mobile: stack the cards */
         @media (max-width: 991px) {
             .lwc-highlights-countdown-wrapper {
@@ -1104,7 +1111,7 @@
                             </p>
                             <form class="lwc-interview-email-drop" id="interview-email-drop-form" aria-label="Interview request email form">
                                 <input type="email" id="interviewEmailInput" class="shared-email-input" placeholder="your_email@domain.com" autocomplete="email" required>
-                                <button type="button" class="shared-email-button" aria-label="Share your email for interview contact">
+                                <button type="submit" class="shared-email-button" aria-label="Share your email for interview contact">
                                     <i class="fas fa-paper-plane"></i> Let’s connect
                                 </button>
                             </form>
@@ -1374,6 +1381,59 @@
             } else {
                 customAlert('Please enter a valid email address.');
             }
+        });
+
+        document.getElementById('interview-email-drop-form').addEventListener('submit', function (e) {
+            e.preventDefault();
+
+            const emailInputElement = document.getElementById('interviewEmailInput');
+            const submitButton = this.querySelector('button[type="submit"]');
+            const emailInput = emailInputElement.value.trim();
+            emailInputElement.blur();
+            if (!submitButton || submitButton.disabled) {
+                return;
+            }
+
+            if (!validator.isEmail(emailInput)) {
+                customAlert('Please enter a valid email address.');
+                return;
+            }
+
+            const originalButtonHtml = submitButton.innerHTML;
+            submitButton.disabled = true;
+            submitButton.classList.add('is-loading');
+            submitButton.innerHTML = '<i class="fas fa-spinner fa-spin" aria-hidden="true"></i> Sending...';
+
+            fetchWithTimeout('/api/application/interview-request', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ email: emailInput })
+            }, 10000)
+                .then(response => {
+                    if (response.ok) {
+                        return response.json();
+                    }
+
+                    if (response.status === 400) {
+                        return response.text().then(text => { throw new Error(text || 'Invalid request.'); });
+                    }
+
+                    throw new Error('Failed to send interview request. Please try again.');
+                })
+                .then(() => {
+                    customAlert(`Thanks! We'll reach out at ${emailInput}.`);
+                    document.getElementById('interview-email-drop-form').reset();
+                })
+                .catch(error => {
+                    customAlert(error.message || 'Failed to send interview request. Please try again.');
+                })
+                .finally(() => {
+                    submitButton.disabled = false;
+                    submitButton.classList.remove('is-loading');
+                    submitButton.innerHTML = originalButtonHtml;
+                });
         });
 
         function adjustBitcoinAddressDisplay() {

--- a/LongevityWorldCup.Website/wwwroot/index.html
+++ b/LongevityWorldCup.Website/wwwroot/index.html
@@ -320,20 +320,47 @@
                 color: #2d3748;
             }
 
-            .newsletter-section input[type="email"] {
+            .shared-email-input {
                 color: var(--dark-text-color);
                 border: 2px solid var(--primary-color);
                 transition: border-color 0.3s ease;
                 outline: none;
                 padding: 0.6rem 1rem;
-                width: 250px;
                 border-radius: 25px;
-                margin-right: 1rem;
                 box-sizing: border-box;
             }
 
-                .newsletter-section input[type="email"]:focus {
+                .shared-email-input:focus {
                     border-color: var(--secondary-color);
+                }
+
+            .newsletter-section .shared-email-input {
+                width: 250px;
+                margin-right: 1rem;
+            }
+
+            .shared-email-button {
+                padding: 0.6rem 1.5rem;
+                font-size: 1rem;
+                background: linear-gradient(135deg, var(--primary-color, #3498db), #4fa3e8);
+                color: var(--light-text-color);
+                border: none;
+                border-radius: 25px;
+                cursor: pointer;
+                transition: background 0.3s ease, transform 0.2s ease, box-shadow 0.3s ease;
+                max-width: 350px;
+                box-sizing: border-box;
+                white-space: nowrap;
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                gap: 0.45rem;
+            }
+
+                .shared-email-button:hover {
+                    background: linear-gradient(135deg, #4fa3e8, #5eb2f2);
+                    transform: scale(1.05);
+                    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.2);
                 }
 
         .btc-status {
@@ -533,12 +560,12 @@
 
         /* body styling */
         .lwc-countdown-body {
-            padding: 18px 20px 20px;
+            padding: 20px 20px 22px;
             display: flex;
             flex-direction: column;
             align-items: center;
             text-align: center;
-            gap: 0.65rem;
+            gap: 0.7rem;
             flex: 1 1 auto;
             justify-content: center;
         }
@@ -548,7 +575,7 @@
             margin-bottom: 0;
             font-size: clamp(1.03rem, 1.05vw, 1.28rem);
             line-height: 1.35;
-            max-width: 25em;
+            max-width: 27ch;
             padding: 0 0.4rem;
             margin-left: auto;
             margin-right: auto;
@@ -564,75 +591,78 @@
 
         .lwc-interview-cta-text {
             margin: 0;
-            font-size: 0.9rem;
+            font-size: 0.93rem;
             line-height: 1.45;
             color: #506176;
-            max-width: 31em;
+            max-width: none;
+            margin-left: auto;
+            margin-right: auto;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 0.04rem;
+        }
+
+        .lwc-interview-cta-line {
+            display: block;
+            width: fit-content;
+            max-width: 100%;
+            text-align: center;
+            white-space: nowrap;
+        }
+
+        .lwc-interview-cta-line--question {
+            font-size: inherit;
+            line-height: inherit;
+        }
+
+        .lwc-copy-mobile {
+            display: none;
+        }
+
+        .lwc-interview-contact-wrap {
+            width: min(100%, 31em);
+            margin-left: auto;
+            margin-right: auto;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            text-align: center;
+            gap: 0.4rem;
         }
 
         .lwc-interview-email-drop {
             width: 100%;
-            max-width: 620px;
-            margin-top: 0.25rem;
+            max-width: 100%;
+            margin-top: 0.35rem;
             display: grid;
             grid-template-columns: minmax(0, 1fr) auto;
-            gap: 0.7rem;
-            align-items: stretch;
-        }
-
-        .lwc-interview-email-drop input[type="email"] {
-            min-width: 0;
-            height: 56px;
-            box-sizing: border-box;
-            border-radius: 13px;
-            border: 1px solid rgba(0, 188, 212, 0.32);
-            background: #ffffff;
-            color: #2d3748;
-            font-size: 1rem;
-            padding: 0.72rem 0.9rem;
-            box-shadow: 0 4px 14px rgba(15, 23, 42, 0.06);
-            transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
-        }
-
-        .lwc-interview-email-drop input[type="email"]:focus {
-            outline: none;
-            border-color: rgba(0, 188, 212, 0.72);
-            box-shadow: 0 0 0 4px rgba(0, 188, 212, 0.16);
-            transform: translateY(-1px);
-        }
-
-        .lwc-interview-email-drop button {
-            height: 56px;
-            box-sizing: border-box;
-            display: inline-flex;
+            gap: 0.65rem;
             align-items: center;
-            justify-content: center;
-            border: none;
-            border-radius: 13px;
-            background: linear-gradient(180deg, #00bed3 0%, #00a7bd 100%);
-            color: #fff;
-            font-weight: 700;
+        }
+
+        .lwc-interview-email-drop .shared-email-input {
+            min-width: 0;
+            background: #ffffff;
+            height: 3rem;
             font-size: 1rem;
-            padding: 0.72rem 1.15rem;
-            cursor: pointer;
-            transition: background-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
-            box-shadow: 0 10px 18px rgba(0, 167, 189, 0.3);
-            white-space: nowrap;
+            border-width: 2px;
+            border-radius: 999px;
+            padding-inline: 1.1rem;
         }
 
-        .lwc-interview-email-drop button:hover {
-            background: linear-gradient(180deg, #01b2c6 0%, #009bb0 100%);
-            transform: translateY(-2px);
-            box-shadow: 0 12px 20px rgba(0, 159, 181, 0.34);
+        .lwc-interview-email-drop .shared-email-input::placeholder {
+            color: #6b7280;
         }
 
-        .lwc-interview-email-drop button:active {
-            transform: translateY(0);
-        }
-
-        .lwc-interview-email-drop button:focus-visible {
-            outline: none;
-            box-shadow: 0 0 0 4px rgba(0, 188, 212, 0.22), 0 10px 18px rgba(0, 167, 189, 0.3);
+        .lwc-interview-email-drop .shared-email-button {
+            height: 3rem;
+            min-width: 12rem;
+            border-radius: 999px;
+            font-size: 0.95rem;
+            font-weight: 700;
+            letter-spacing: 0;
+            padding-inline: 1.1rem;
         }
 
         /* mobile: stack the cards */
@@ -675,6 +705,41 @@
             .lwc-interview-email-drop input[type="email"],
             .lwc-interview-email-drop button {
                 width: 100%;
+            }
+
+            .lwc-interview-cta-text {
+                max-width: 44ch;
+                font-size: 0.86rem;
+                line-height: 1.38;
+            }
+
+            .lwc-interview-cta-line--question {
+                font-size: 0.93rem;
+                line-height: 1.45;
+            }
+
+            .lwc-copy-desktop {
+                display: none;
+            }
+
+            .lwc-copy-mobile {
+                display: inline;
+            }
+
+            .lwc-interview-cta-line {
+                white-space: normal;
+            }
+        }
+
+        @media (max-width: 400px) {
+            .lwc-interview-cta-text {
+                font-size: 0.8rem;
+                line-height: 1.34;
+            }
+
+            .lwc-interview-cta-line--question {
+                font-size: 0.93rem;
+                line-height: 1.45;
             }
         }
 
@@ -1028,14 +1093,24 @@
                             The 2026 season is live with<br>
                             <strong>Professional&nbsp;and&nbsp;Amateur</strong> tracks.
                         </p>
-                        <p class="lwc-interview-cta-text">
-                            Want to interview the host of the Longevity&nbsp;World&nbsp;Cup?<br>
-                            Drop your email below and I'll reach out.
-                        </p>
-                        <form class="lwc-interview-email-drop" id="interview-email-drop-form" aria-label="Interview request email form">
-                            <input type="email" id="interviewEmailInput" placeholder="your_email@domain.com" autocomplete="email" required>
-                            <button type="button" aria-label="Share your email for interview contact">Let’s connect</button>
-                        </form>
+                        <div class="lwc-interview-contact-wrap">
+                            <p class="lwc-interview-cta-text">
+                                <span class="lwc-interview-cta-line lwc-interview-cta-line--question">
+                                    <span class="lwc-copy-desktop">Wanna interview the host of the Longevity&nbsp;World&nbsp;Cup?</span>
+                                    <span class="lwc-copy-mobile">Wanna interview the host of the LWC?</span>
+                                </span>
+                                <span class="lwc-interview-cta-line">
+                                    <span class="lwc-copy-desktop">Drop your email below and I'll personally reach out to setup a time.</span>
+                                    <span class="lwc-copy-mobile">Drop your email below and I'll personally reach out.</span>
+                                </span>
+                            </p>
+                            <form class="lwc-interview-email-drop" id="interview-email-drop-form" aria-label="Interview request email form">
+                                <input type="email" id="interviewEmailInput" class="shared-email-input" placeholder="your_email@domain.com" autocomplete="email" required>
+                                <button type="button" class="shared-email-button" aria-label="Share your email for interview contact">
+                                    <i class="fas fa-paper-plane"></i> Let’s connect
+                                </button>
+                            </form>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -1167,8 +1242,8 @@
             </p>
 
             <form id="newsletter-form">
-                <input type="email" id="emailInput" placeholder="why_am_i_doing_this@help.com" required>
-                <button type="submit" class="enhanced-subscribe-btn" aria-label="Subscribe to the Longevity World&nbsp;Cup newsletter">
+                <input type="email" id="emailInput" class="shared-email-input" placeholder="why_am_i_doing_this@help.com" required>
+                <button type="submit" class="enhanced-subscribe-btn shared-email-button" aria-label="Subscribe to the Longevity World&nbsp;Cup newsletter">
                     <i class="fas fa-paper-plane"></i> Subscribe
                 </button>
             </form>

--- a/LongevityWorldCup.Website/wwwroot/index.html
+++ b/LongevityWorldCup.Website/wwwroot/index.html
@@ -460,6 +460,10 @@
                     width: 100%;
                 }
 
+                .section-container .shared-email-button {
+                    flex-direction: row;
+                }
+
             #newsletter-form {
                 flex-direction: column;
                 width: 100%; /* Ensure the container doesn't cause layout issues */
@@ -644,8 +648,6 @@
         .lwc-interview-email-drop .shared-email-input {
             min-width: 0;
             background: #ffffff;
-            height: 3rem;
-            font-size: 1rem;
             border-width: 2px;
             border-radius: 999px;
             padding-inline: 1.1rem;
@@ -656,11 +658,7 @@
         }
 
         .lwc-interview-email-drop .shared-email-button {
-            height: 3rem;
-            min-width: 12rem;
             border-radius: 999px;
-            font-size: 0.95rem;
-            font-weight: 700;
             letter-spacing: 0;
             padding-inline: 1.1rem;
         }

--- a/LongevityWorldCup.Website/wwwroot/index.html
+++ b/LongevityWorldCup.Website/wwwroot/index.html
@@ -532,6 +532,68 @@
             white-space: nowrap;
         }
 
+        .lwc-interview-cta-text {
+            margin: 1rem 0 0;
+            font-size: 0.95rem;
+            line-height: 1.55;
+            color: #4a5568;
+            max-width: 32em;
+        }
+
+        .lwc-interview-email-drop {
+            width: 100%;
+            max-width: 500px;
+            margin-top: 0.85rem;
+            display: flex;
+            gap: 0.65rem;
+            align-items: center;
+            justify-content: center;
+            flex-wrap: wrap;
+        }
+
+        .lwc-interview-email-drop input[type="email"] {
+            flex: 1 1 260px;
+            min-width: 220px;
+            border-radius: 10px;
+            border: 1px solid rgba(0, 188, 212, 0.35);
+            background: #ffffff;
+            color: #2d3748;
+            font-size: 0.95rem;
+            padding: 0.7rem 0.9rem;
+            box-shadow: 0 2px 6px rgba(45, 55, 72, 0.08);
+            transition: border-color 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        .lwc-interview-email-drop input[type="email"]:focus {
+            outline: none;
+            border-color: rgba(0, 188, 212, 0.7);
+            box-shadow: 0 0 0 3px rgba(0, 188, 212, 0.18);
+        }
+
+        .lwc-interview-email-drop button {
+            border: none;
+            border-radius: 10px;
+            background: var(--primary-color);
+            color: #fff;
+            font-weight: 700;
+            font-size: 0.9rem;
+            padding: 0.72rem 1rem;
+            cursor: pointer;
+            transition: background-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+            box-shadow: 0 3px 10px rgba(0, 188, 212, 0.25);
+            white-space: nowrap;
+        }
+
+        .lwc-interview-email-drop button:hover {
+            background: #00a3b8;
+            transform: translateY(-1px);
+            box-shadow: 0 5px 12px rgba(0, 188, 212, 0.3);
+        }
+
+        .lwc-interview-email-drop button:active {
+            transform: translateY(0);
+        }
+
         /* mobile: stack the cards */
         @media (max-width: 991px) {
             .lwc-highlights-countdown-wrapper {
@@ -562,6 +624,16 @@
 
             .lwc-countdown-body {
                 padding: 18px 14px 20px;
+            }
+
+            .lwc-interview-email-drop {
+                flex-direction: column;
+                gap: 0.55rem;
+            }
+
+            .lwc-interview-email-drop input[type="email"],
+            .lwc-interview-email-drop button {
+                width: 100%;
             }
         }
 
@@ -914,6 +986,13 @@
                         <p class="lwc-countdown-details-text">
                             The 2026 season begins, featuring <strong>Professional and Amateur</strong> tracks.
                         </p>
+                        <p class="lwc-interview-cta-text">
+                            Want to interview the host of the Longevity World Cup? Drop your email and I'll reach out.
+                        </p>
+                        <form class="lwc-interview-email-drop" id="interview-email-drop-form" aria-label="Interview request email form">
+                            <input type="email" id="interviewEmailInput" placeholder="your_email@domain.com" autocomplete="email" required>
+                            <button type="button" aria-label="Share your email for interview contact">Drop email</button>
+                        </form>
                     </div>
                 </div>
             </div>

--- a/LongevityWorldCup.Website/wwwroot/index.html
+++ b/LongevityWorldCup.Website/wwwroot/index.html
@@ -385,6 +385,15 @@
                 color: var(--secondary-color);
             }
 
+        /* Keep the donation copy button transparent */
+        .section-container .copy-btn,
+        .section-container .copy-btn:hover,
+        .section-container .copy-btn:focus-visible {
+            background: transparent;
+            box-shadow: none;
+            transform: none;
+        }
+
         .qr-code-container {
             text-align: center;
             margin: 1rem auto;
@@ -436,7 +445,7 @@
             max-width: 1250px;
             margin: 2rem auto;
             display: flex;
-            gap: 1.5rem;
+            gap: 1.75rem;
             align-items: stretch;
         }
 
@@ -446,17 +455,30 @@
                 flex: 1 1 0;
             }
 
+            .lwc-highlights-countdown-wrapper > #events-root-index {
+                display: flex;
+            }
+
+            .lwc-highlights-countdown-wrapper > #events-root-index > .events-board {
+                flex: 1 1 auto;
+                height: 100%;
+            }
+
         /* modifier so we don't mess with the table board */
         .events-board--timer {
             display: flex;
             align-items: stretch;
             padding: 0; /* spacing handled inside */
-            margin-bottom: 28px; /* same visual rhythm as board */
+            margin-bottom: 0;
+            background-color: var(--card-bg);
+            border-radius: 20px;
+            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+            overflow: hidden;
         }
 
         @media (min-width: 992px) {
             .events-board--timer {
-                margin-bottom: 36px;
+                margin-bottom: 0;
             }
         }
 
@@ -465,13 +487,16 @@
             flex-direction: column;
             width: 100%;
             flex: 1 1 auto;
+            height: 100%;
         }
 
         /* header matches HIGHLIGHTS header bar */
         .lwc-countdown-header-row {
-            background: rgba(0, 188, 212, 0.12);
+            background:
+                linear-gradient(rgba(0, 188, 212, 0.12), rgba(0, 188, 212, 0.12)),
+                var(--card-bg);
             color: var(--primary-color);
-            padding: 12px 20px;
+            padding: 15px 20px;
             display: flex;
             align-items: center;
             justify-content: space-between;
@@ -485,28 +510,35 @@
 
         .lwc-countdown-title {
             white-space: nowrap;
+            font-size: inherit;
         }
 
         .lwc-countdown-chip {
-            padding: 4px 12px;
+            padding: 0 10px;
             border-radius: 999px;
-            font-size: 0.7rem;
+            font-size: 0.66rem;
             text-transform: uppercase;
             letter-spacing: 0.08em;
-            border: 1px solid rgba(0, 188, 212, 0.4);
+            border: 1px solid rgba(0, 188, 212, 0.3);
             background: rgba(255, 255, 255, 0.7);
             color: var(--primary-color);
             white-space: nowrap;
+            font-weight: 700;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            height: 16px;
+            line-height: 1;
         }
 
         /* body styling */
         .lwc-countdown-body {
-            padding: 24px 24px 26px;
+            padding: 18px 20px 20px;
             display: flex;
             flex-direction: column;
             align-items: center;
             text-align: center;
-            gap: 0rem;
+            gap: 0.65rem;
             flex: 1 1 auto;
             justify-content: center;
         }
@@ -514,84 +546,93 @@
         .lwc-countdown-details-text {
             margin-top: 0;
             margin-bottom: 0;
-            font-size: 1.125rem;
-            line-height: 1.6;
-            max-width: 28em;
-            padding: 0 1rem;
+            font-size: clamp(1.03rem, 1.05vw, 1.28rem);
+            line-height: 1.35;
+            max-width: 25em;
+            padding: 0 0.4rem;
             margin-left: auto;
             margin-right: auto;
-            color: #4a5568;
-            font-weight: 400;
+            color: #3a4758;
+            font-weight: 500;
             letter-spacing: 0.005em;
         }
 
         .lwc-countdown-details-text strong {
-            font-weight: 600;
-            color: #2d3748;
-            position: relative;
-            white-space: nowrap;
+            font-weight: 700;
+            color: #243446;
         }
 
         .lwc-interview-cta-text {
-            margin: 1rem 0 0;
-            font-size: 0.95rem;
-            line-height: 1.55;
-            color: #4a5568;
-            max-width: 32em;
+            margin: 0;
+            font-size: 0.9rem;
+            line-height: 1.45;
+            color: #506176;
+            max-width: 31em;
         }
 
         .lwc-interview-email-drop {
             width: 100%;
-            max-width: 500px;
-            margin-top: 0.85rem;
-            display: flex;
-            gap: 0.65rem;
-            align-items: center;
-            justify-content: center;
-            flex-wrap: wrap;
+            max-width: 620px;
+            margin-top: 0.25rem;
+            display: grid;
+            grid-template-columns: minmax(0, 1fr) auto;
+            gap: 0.7rem;
+            align-items: stretch;
         }
 
         .lwc-interview-email-drop input[type="email"] {
-            flex: 1 1 260px;
-            min-width: 220px;
-            border-radius: 10px;
-            border: 1px solid rgba(0, 188, 212, 0.35);
+            min-width: 0;
+            height: 56px;
+            box-sizing: border-box;
+            border-radius: 13px;
+            border: 1px solid rgba(0, 188, 212, 0.32);
             background: #ffffff;
             color: #2d3748;
-            font-size: 0.95rem;
-            padding: 0.7rem 0.9rem;
-            box-shadow: 0 2px 6px rgba(45, 55, 72, 0.08);
-            transition: border-color 0.2s ease, box-shadow 0.2s ease;
+            font-size: 1rem;
+            padding: 0.72rem 0.9rem;
+            box-shadow: 0 4px 14px rgba(15, 23, 42, 0.06);
+            transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
         }
 
         .lwc-interview-email-drop input[type="email"]:focus {
             outline: none;
-            border-color: rgba(0, 188, 212, 0.7);
-            box-shadow: 0 0 0 3px rgba(0, 188, 212, 0.18);
+            border-color: rgba(0, 188, 212, 0.72);
+            box-shadow: 0 0 0 4px rgba(0, 188, 212, 0.16);
+            transform: translateY(-1px);
         }
 
         .lwc-interview-email-drop button {
+            height: 56px;
+            box-sizing: border-box;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
             border: none;
-            border-radius: 10px;
-            background: var(--primary-color);
+            border-radius: 13px;
+            background: linear-gradient(180deg, #00bed3 0%, #00a7bd 100%);
             color: #fff;
             font-weight: 700;
-            font-size: 0.9rem;
-            padding: 0.72rem 1rem;
+            font-size: 1rem;
+            padding: 0.72rem 1.15rem;
             cursor: pointer;
             transition: background-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
-            box-shadow: 0 3px 10px rgba(0, 188, 212, 0.25);
+            box-shadow: 0 10px 18px rgba(0, 167, 189, 0.3);
             white-space: nowrap;
         }
 
         .lwc-interview-email-drop button:hover {
-            background: #00a3b8;
-            transform: translateY(-1px);
-            box-shadow: 0 5px 12px rgba(0, 188, 212, 0.3);
+            background: linear-gradient(180deg, #01b2c6 0%, #009bb0 100%);
+            transform: translateY(-2px);
+            box-shadow: 0 12px 20px rgba(0, 159, 181, 0.34);
         }
 
         .lwc-interview-email-drop button:active {
             transform: translateY(0);
+        }
+
+        .lwc-interview-email-drop button:focus-visible {
+            outline: none;
+            box-shadow: 0 0 0 4px rgba(0, 188, 212, 0.22), 0 10px 18px rgba(0, 167, 189, 0.3);
         }
 
         /* mobile: stack the cards */
@@ -608,11 +649,11 @@
                 }
 
             .lwc-countdown-body {
-                padding: 20px 18px 22px;
+                padding: 18px 16px 20px;
             }
 
             .lwc-countdown-details-text {
-                font-size: 1.05rem;
+                font-size: 1.03rem;
             }
         }
 
@@ -627,7 +668,7 @@
             }
 
             .lwc-interview-email-drop {
-                flex-direction: column;
+                grid-template-columns: 1fr;
                 gap: 0.55rem;
             }
 
@@ -984,14 +1025,16 @@
 
                     <div class="lwc-countdown-body">
                         <p class="lwc-countdown-details-text">
-                            The 2026 season begins, featuring <strong>Professional and Amateur</strong> tracks.
+                            The 2026 season is live with<br>
+                            <strong>Professional&nbsp;and&nbsp;Amateur</strong> tracks.
                         </p>
                         <p class="lwc-interview-cta-text">
-                            Want to interview the host of the Longevity World Cup? Drop your email and I'll reach out.
+                            Want to interview the host of the Longevity&nbsp;World&nbsp;Cup?<br>
+                            Drop your email below and I'll reach out.
                         </p>
                         <form class="lwc-interview-email-drop" id="interview-email-drop-form" aria-label="Interview request email form">
                             <input type="email" id="interviewEmailInput" placeholder="your_email@domain.com" autocomplete="email" required>
-                            <button type="button" aria-label="Share your email for interview contact">Drop email</button>
+                            <button type="button" aria-label="Share your email for interview contact">Let’s connect</button>
                         </form>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- add an interview-request section on the homepage with improved email input and CTA styling
- wire the new form submission to backend email handling so requests are delivered to organizers
- refactor application email-sending logic to support the new interview request pathway

## Test plan
- [ ] run `dotnet build LongevityWorldCup.sln`
- [ ] submit the interview request form from `wwwroot/index.html`
- [ ] verify the request email is sent with expected content