### PR TITLE
missing tasks.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ AppData
 # VS Code
 .vscode/*
 !.vscode/launch.json
+!.vscode/tasks.json

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,19 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/LongevityWorldCup.sln"
+            ],
+            "problemMatcher": "$msCompile",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Continuation of https://github.com/nopara73/LongevityWorldCup/pull/378, the shared launch profile was referencing a task that was not shared.

I will not merge this, maybe it conflicts with your version @nopara73. Please check and merge, or commit your version.