### PR TITLE
Caching fix for better performance

### DIFF
--- a/LongevityWorldCup.Website/Middleware/HtmlInjectionMiddleware.cs
+++ b/LongevityWorldCup.Website/Middleware/HtmlInjectionMiddleware.cs
@@ -1,14 +1,16 @@
 using System.Text.Json;
 using System.Globalization;
 using LongevityWorldCup.Website.Business;
+using LongevityWorldCup.Website.Tools;
 
 namespace LongevityWorldCup.Website.Middleware
 {
-    public class HtmlInjectionMiddleware(RequestDelegate next, AthleteOgImageService athleteOgImages, LeagueOgImageService leagueOgImages)
+    public class HtmlInjectionMiddleware(RequestDelegate next, AthleteOgImageService athleteOgImages, LeagueOgImageService leagueOgImages, AssetVersionProvider assetVersionProvider)
     {
         private readonly RequestDelegate _next = next;
         private readonly AthleteOgImageService _athleteOgImages = athleteOgImages;
         private readonly LeagueOgImageService _leagueOgImages = leagueOgImages;
+        private readonly AssetVersionProvider _assetVersionProvider = assetVersionProvider;
         private const string SiteBaseUrl = "https://longevityworldcup.com";
         private const string DefaultOgImage = "https://longevityworldcup.com/assets/og-image.png";
         private static readonly HashSet<string> IndexableRoutes = new(StringComparer.OrdinalIgnoreCase)
@@ -61,6 +63,7 @@ namespace LongevityWorldCup.Website.Middleware
                         .Replace("{{SEO_OG_URL}}", EncodeMeta(seo.CanonicalUrl))
                         .Replace("{{SEO_OG_IMAGE}}", EncodeMeta(seo.OgImageUrl))
                         .Replace("{{SEO_STRUCTURED_DATA}}", BuildStructuredDataJson(seo));
+                    head = ApplyAssetVersions(head);
 
                     // Replace placeholders within leaderboardContent first (since it contains nested placeholders)
                     leaderboardContent = leaderboardContent.Replace("<!--AGE-VISUALIZATION-->", ageVisualization);
@@ -99,6 +102,20 @@ namespace LongevityWorldCup.Website.Middleware
 
             // For all other requests, continue down the pipeline
             await _next(context);
+        }
+
+        private string ApplyAssetVersions(string html)
+        {
+            return html
+                .Replace("{{ASSET_BADGES_CSS}}", _assetVersionProvider.AppendVersion("/css/badges.css"))
+                .Replace("{{ASSET_MISC_JS}}", _assetVersionProvider.AppendVersion("/js/misc.js"))
+                .Replace("{{ASSET_LEAGUE_ICONS_JS}}", _assetVersionProvider.AppendVersion("/js/leagueIcons.js"))
+                .Replace("{{ASSET_PHENO_AGE_JS}}", _assetVersionProvider.AppendVersion("/js/pheno-age.js"))
+                .Replace("{{ASSET_BORTZ_AGE_JS}}", _assetVersionProvider.AppendVersion("/js/bortz-age.js"))
+                .Replace("{{ASSET_BADGES_JS}}", _assetVersionProvider.AppendVersion("/js/badges.js"))
+                .Replace("{{ASSET_PRO_DISCOUNTS_JS}}", _assetVersionProvider.AppendVersion("/js/pro-discounts.js"))
+                .Replace("{{ASSET_PROOF_HELPERS_JS}}", _assetVersionProvider.AppendVersion("/js/proof-helpers.js"))
+                .Replace("{{ASSET_AGE_VISUALIZATION_JS}}", _assetVersionProvider.AppendVersion("/js/age-visualization.js"));
         }
 
         private SeoMeta GetSeoMeta(HttpContext context)

--- a/LongevityWorldCup.Website/Program.cs
+++ b/LongevityWorldCup.Website/Program.cs
@@ -48,6 +48,7 @@ namespace LongevityWorldCup.Website
             builder.Services.AddHttpClient();
             builder.Services.AddMemoryCache();
 
+            builder.Services.AddSingleton<AssetVersionProvider>();
             builder.Services.AddSingleton<DatabaseManager>();
             builder.Services.AddSingleton<AthleteDataService>();
             builder.Services.AddSingleton<EventDataService>();

--- a/LongevityWorldCup.Website/Tools/AssetVersionProvider.cs
+++ b/LongevityWorldCup.Website/Tools/AssetVersionProvider.cs
@@ -1,0 +1,56 @@
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+
+namespace LongevityWorldCup.Website.Tools;
+
+public sealed class AssetVersionProvider
+{
+    private readonly string _webRootPath;
+    private readonly ConcurrentDictionary<string, CacheEntry> _cache = new(StringComparer.OrdinalIgnoreCase);
+
+    public AssetVersionProvider(IWebHostEnvironment environment)
+    {
+        _webRootPath = environment.WebRootPath;
+    }
+
+    public string AppendVersion(string assetPath)
+    {
+        if (string.IsNullOrWhiteSpace(assetPath) || !assetPath.StartsWith('/'))
+        {
+            return assetPath;
+        }
+
+        var queryIndex = assetPath.IndexOf('?');
+        var cleanPath = queryIndex >= 0 ? assetPath[..queryIndex] : assetPath;
+        var relativePath = cleanPath.TrimStart('/').Replace('/', Path.DirectorySeparatorChar);
+        var fullPath = Path.Combine(_webRootPath, relativePath);
+
+        if (!File.Exists(fullPath))
+        {
+            return assetPath;
+        }
+
+        var lastWriteUtc = File.GetLastWriteTimeUtc(fullPath);
+        var version = _cache.AddOrUpdate(
+            fullPath,
+            _ => new CacheEntry(lastWriteUtc, ComputeHash(fullPath)),
+            (_, existing) => existing.LastWriteUtc == lastWriteUtc
+                ? existing
+                : new CacheEntry(lastWriteUtc, ComputeHash(fullPath)))
+            .Version;
+
+        return queryIndex >= 0
+            ? $"{assetPath}&v={version}"
+            : $"{assetPath}?v={version}";
+    }
+
+    private static string ComputeHash(string fullPath)
+    {
+        using var stream = File.OpenRead(fullPath);
+        using var sha256 = SHA256.Create();
+        var hash = sha256.ComputeHash(stream);
+        return Convert.ToHexString(hash[..8]).ToLowerInvariant();
+    }
+
+    private sealed record CacheEntry(DateTime LastWriteUtc, string Version);
+}

--- a/LongevityWorldCup.Website/wwwroot/partials/head.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/head.html
@@ -42,9 +42,7 @@
 <!-- AOS JS -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js" defer></script>
 
-<script>
-(function(){var v=Date.now();window.__v=v;document.write('<link rel="stylesheet" href="/css/badges.css?v='+v+'">');})();
-</script>
+<link rel="stylesheet" href="{{ASSET_BADGES_CSS}}">
 
 <!--
 Monkey-patch DOMContentLoaded to delay all handlers until modulesReady resolves.
@@ -100,20 +98,18 @@ Must appear before any other script that initializes or relies on AOS.
 </script>
 
 <script type="module">
-    const __v = window.__v || Date.now();
-
     // kick off dynamic imports (they run in module scope,
     // so nothing leaks global except what each module explicitly
     // assigns to window, e.g. window.PhenoAge)
     window.modulesReady = Promise.all([
-        import(`/js/misc.js?v=${__v}`),
-        import(`/js/leagueIcons.js?v=${__v}`),
-        import(`/js/pheno-age.js?v=${__v}`),
-        import(`/js/bortz-age.js?v=${__v}`),
-        import(`/js/badges.js?v=${__v}`),
-        import(`/js/pro-discounts.js?v=${__v}`),
-        import(`/js/proof-helpers.js?v=${__v}`),
-        import(`/js/age-visualization.js?v=${__v}`)
+        import(`{{ASSET_MISC_JS}}`),
+        import(`{{ASSET_LEAGUE_ICONS_JS}}`),
+        import(`{{ASSET_PHENO_AGE_JS}}`),
+        import(`{{ASSET_BORTZ_AGE_JS}}`),
+        import(`{{ASSET_BADGES_JS}}`),
+        import(`{{ASSET_PRO_DISCOUNTS_JS}}`),
+        import(`{{ASSET_PROOF_HELPERS_JS}}`),
+        import(`{{ASSET_AGE_VISUALIZATION_JS}}`)
     ]);
 </script>
 


### PR DESCRIPTION
part of https://github.com/nopara73/LongevityWorldCup/issues/313

So the problem with the current JS file caching is that we add a versioning every time (current date), thus the browser thinks it is a new file every time, thus caching does not exist for these.

This PR uses the middleware and computes the version based on the file's content, meaning the version won't change until the content changes. So the browser can actually cache it.