### PR TITLE
Add mention feature to custom events

### DIFF
--- a/LongevityWorldCup.Documentation/CustomEvent.md
+++ b/LongevityWorldCup.Documentation/CustomEvent.md
@@ -22,7 +22,7 @@ sudo bash -lc 'cd /var/www/.longevityworldcup && bash /home/user/LongevityWorldC
 
 ## Supported formatting
 
-The renderer supports three inline formats inside both Title and Content.
+The renderer supports four inline formats inside both Title and Content.
 
 ### Link
 
@@ -71,6 +71,30 @@ Renders with bold font weight and uses the accent color.
 Example:
 ```text
 This is a [strong](major announcement) for the community.
+```
+
+### Mention
+
+Resolves an athlete slug to platform-specific mention text when posting to social media.
+
+```text
+[mention](athlete_slug)
+```
+
+- `[mention]` -> this is the keyword, won't be visible.
+- `(athlete_slug)` -> the athlete slug to resolve.
+
+Behavior:
+
+- X: if the athlete `MediaContact` points to X/Twitter, the post uses the corresponding `@handle`
+- Threads: if the athlete `MediaContact` points to Threads or Instagram, the post uses the corresponding `@handle`
+- Facebook: falls back to the athlete name
+- if no platform-specific social handle can be resolved, the fallback is always the athlete name
+
+Example:
+
+```text
+Shoutout to [mention](nopara73) for shipping this update.
 ```
 
 ## Delete an event by ID

--- a/LongevityWorldCup.Documentation/CustomEvent.md
+++ b/LongevityWorldCup.Documentation/CustomEvent.md
@@ -87,7 +87,7 @@ Resolves an athlete slug to platform-specific mention text when posting to socia
 Behavior:
 
 - X: if the athlete `MediaContact` points to X/Twitter, the post uses the corresponding `@handle`
-- Threads: if the athlete `MediaContact` points to Threads or Instagram, the post uses the corresponding `@handle`
+- Threads: if the athlete `MediaContact` points to Threads, the post uses the corresponding `@handle`
 - Facebook: falls back to the athlete name
 - if no platform-specific social handle can be resolved, the fallback is always the athlete name
 

--- a/LongevityWorldCup.Website/Business/AthleteDataService.cs
+++ b/LongevityWorldCup.Website/Business/AthleteDataService.cs
@@ -789,15 +789,15 @@ public class AthleteDataService : IDisposable
     {
         var order = GetRankingsOrder();
         var snapshot = GetAthletesSnapshot();
-        var extBySlug = new Dictionary<string, (string? PodcastLink, string? XHandle)>(StringComparer.OrdinalIgnoreCase);
+        var extBySlug = new Dictionary<string, (string? PodcastLink, string? XHandle, string? MediaContact)>(StringComparer.OrdinalIgnoreCase);
         foreach (var o in snapshot.OfType<JsonObject>())
         {
             var slug = o["AthleteSlug"]?.GetValue<string>();
             if (string.IsNullOrWhiteSpace(slug)) continue;
             var link = o["PodcastLink"]?.GetValue<string>() ?? o["podcastLink"]?.GetValue<string>();
             var media = o["MediaContact"]?.GetValue<string>();
-            var handle = ExtractXHandle(media);
-            extBySlug[slug] = (string.IsNullOrWhiteSpace(link) ? null : link.Trim(), handle);
+            var handle = SocialContactParser.TryBuildMention(media, SocialPlatform.X);
+            extBySlug[slug] = (string.IsNullOrWhiteSpace(link) ? null : link.Trim(), handle, string.IsNullOrWhiteSpace(media) ? null : media.Trim());
         }
         var list = new List<AthleteForX>();
         var rank = 0;
@@ -818,7 +818,7 @@ public class AthleteDataService : IDisposable
             double? bortzDiff = null;
             if (o["BortzAgeDiffFromBaseline"] is JsonValue bdv && bdv.TryGetValue<double>(out var bd)) bortzDiff = bd;
             extBySlug.TryGetValue(slug, out var ext);
-            list.Add(new AthleteForX(slug, name, rank, lowestPheno, lowestBortz, chrono, phenoDiff, bortzDiff, ext.PodcastLink, ext.XHandle));
+            list.Add(new AthleteForX(slug, name, rank, lowestPheno, lowestBortz, chrono, phenoDiff, bortzDiff, ext.PodcastLink, ext.XHandle, ext.MediaContact));
         }
         return list;
     }
@@ -1805,28 +1805,6 @@ public class AthleteDataService : IDisposable
         }
 
         _eventDataService.SetAthleteBio(bioList);
-    }
-
-    private static string? ExtractXHandle(string? mediaContact)
-    {
-        if (string.IsNullOrWhiteSpace(mediaContact)) return null;
-
-        if (System.Uri.TryCreate(mediaContact.Trim(), System.UriKind.Absolute, out var uri))
-        {
-            var host = uri.Host;
-            if (!host.EndsWith("x.com", StringComparison.OrdinalIgnoreCase) &&
-                !host.EndsWith("twitter.com", StringComparison.OrdinalIgnoreCase))
-                return null;
-
-            var path = uri.AbsolutePath.Trim('/');
-            if (string.IsNullOrWhiteSpace(path)) return null;
-            var parts = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
-            var handleCore = parts.Length > 0 ? parts[0] : null;
-            if (string.IsNullOrWhiteSpace(handleCore)) return null;
-            return "@" + handleCore;
-        }
-
-        return null;
     }
 
     // ===== biomarker/test signature helpers (single-column persistence) =====

--- a/LongevityWorldCup.Website/Business/AthleteDataService.cs
+++ b/LongevityWorldCup.Website/Business/AthleteDataService.cs
@@ -789,15 +789,20 @@ public class AthleteDataService : IDisposable
     {
         var order = GetRankingsOrder();
         var snapshot = GetAthletesSnapshot();
-        var extBySlug = new Dictionary<string, (string? PodcastLink, string? XHandle, string? MediaContact)>(StringComparer.OrdinalIgnoreCase);
+        var extBySlug = new Dictionary<string, (string? PodcastLink, string? XHandle, string? MediaContact, string? DisplayName)>(StringComparer.OrdinalIgnoreCase);
         foreach (var o in snapshot.OfType<JsonObject>())
         {
             var slug = o["AthleteSlug"]?.GetValue<string>();
             if (string.IsNullOrWhiteSpace(slug)) continue;
             var link = o["PodcastLink"]?.GetValue<string>() ?? o["podcastLink"]?.GetValue<string>();
             var media = o["MediaContact"]?.GetValue<string>();
+            var displayName = o["DisplayName"]?.GetValue<string>();
             var handle = SocialContactParser.TryBuildMention(media, SocialPlatform.X);
-            extBySlug[slug] = (string.IsNullOrWhiteSpace(link) ? null : link.Trim(), handle, string.IsNullOrWhiteSpace(media) ? null : media.Trim());
+            extBySlug[slug] = (
+                string.IsNullOrWhiteSpace(link) ? null : link.Trim(),
+                handle,
+                string.IsNullOrWhiteSpace(media) ? null : media.Trim(),
+                string.IsNullOrWhiteSpace(displayName) ? null : displayName.Trim());
         }
         var list = new List<AthleteForX>();
         var rank = 0;
@@ -806,7 +811,8 @@ public class AthleteDataService : IDisposable
             rank++;
             var slug = o["AthleteSlug"]?.GetValue<string>();
             if (string.IsNullOrWhiteSpace(slug)) continue;
-            var name = o["Name"]?.GetValue<string>() ?? "";
+            extBySlug.TryGetValue(slug, out var ext);
+            var name = ext.DisplayName ?? o["Name"]?.GetValue<string>() ?? "";
             double? lowestPheno = null;
             if (o["LowestPhenoAge"] is JsonValue pv && pv.TryGetValue<double>(out var p)) lowestPheno = p;
             double? lowestBortz = null;
@@ -817,7 +823,6 @@ public class AthleteDataService : IDisposable
             if (o["PhenoAgeDiffFromBaseline"] is JsonValue pdv && pdv.TryGetValue<double>(out var pd)) phenoDiff = pd;
             double? bortzDiff = null;
             if (o["BortzAgeDiffFromBaseline"] is JsonValue bdv && bdv.TryGetValue<double>(out var bd)) bortzDiff = bd;
-            extBySlug.TryGetValue(slug, out var ext);
             list.Add(new AthleteForX(slug, name, rank, lowestPheno, lowestBortz, chrono, phenoDiff, bortzDiff, ext.PodcastLink, ext.XHandle, ext.MediaContact));
         }
         return list;

--- a/LongevityWorldCup.Website/Business/AthleteForX.cs
+++ b/LongevityWorldCup.Website/Business/AthleteForX.cs
@@ -10,4 +10,5 @@ public record AthleteForX(
     double? PhenoAgeDiffFromBaseline,
     double? BortzAgeDiffFromBaseline,
     string? PodcastLink,
-    string? XHandle);
+    string? XHandle,
+    string? MediaContact);

--- a/LongevityWorldCup.Website/Business/CustomEventImageService.cs
+++ b/LongevityWorldCup.Website/Business/CustomEventImageService.cs
@@ -67,7 +67,7 @@ public sealed class CustomEventImageService
         File.Exists(_regularFontPath) &&
         File.Exists(_boldFontPath);
 
-    public async Task<(string FullPath, string PublicUrl)?> RenderAsync(string eventId, string rawText)
+    public async Task<(string FullPath, string PublicUrl)?> RenderAsync(string eventId, string rawText, Func<string, string>? mentionResolver = null)
     {
         if (string.IsNullOrWhiteSpace(eventId) || !IsConfigured)
             return null;
@@ -81,7 +81,7 @@ public sealed class CustomEventImageService
             var fileName = $"{SanitizeFileName(eventId)}.png";
             var outputPath = IOPath.Combine(_outputDir, fileName);
 
-            using (var image = await BuildImageAsync(rawText))
+            using (var image = await BuildImageAsync(rawText, mentionResolver))
                 await image.SaveAsPngAsync(outputPath);
 
             return (outputPath, $"{SiteBaseUrl}/generated/custom-events/{Uri.EscapeDataString(fileName)}");
@@ -97,7 +97,7 @@ public sealed class CustomEventImageService
         }
     }
 
-    public async Task<MemoryStream?> RenderToStreamAsync(string rawText)
+    public async Task<MemoryStream?> RenderToStreamAsync(string rawText, Func<string, string>? mentionResolver = null)
     {
         if (!IsConfigured)
             return null;
@@ -106,7 +106,7 @@ public sealed class CustomEventImageService
         try
         {
             EnsureFontsLoaded();
-            using var image = await BuildImageAsync(rawText);
+            using var image = await BuildImageAsync(rawText, mentionResolver);
             var stream = new MemoryStream();
             await image.SaveAsPngAsync(stream);
             stream.Position = 0;
@@ -123,11 +123,11 @@ public sealed class CustomEventImageService
         }
     }
 
-    private async Task<Image<Rgba32>> BuildImageAsync(string rawText)
+    private async Task<Image<Rgba32>> BuildImageAsync(string rawText, Func<string, string>? mentionResolver)
     {
         var (_, contentRaw) = CustomEventMarkup.SplitTitleAndContent(rawText);
         var contentSource = string.IsNullOrWhiteSpace(contentRaw) ? rawText : contentRaw;
-        var segments = CustomEventMarkup.ParseSegments(contentSource, keepHyperlinkLabels: true);
+        var segments = CustomEventMarkup.ParseSegments(contentSource, keepHyperlinkLabels: true, mentionResolver);
         var layout = FindBestLayout(segments);
 
         var image = await Image.LoadAsync<Rgba32>(_templatePath);

--- a/LongevityWorldCup.Website/Business/FacebookEventService.cs
+++ b/LongevityWorldCup.Website/Business/FacebookEventService.cs
@@ -96,7 +96,7 @@ public class FacebookEventService
             return false;
         }
 
-        var plan = CustomEventSocialComposer.BuildPlan(eventId, rawText, 63206);
+        var plan = CustomEventSocialComposer.BuildPlan(eventId, rawText, 63206, ResolveMention);
         if (plan.Mode == CustomEventPostMode.Text)
             return await TrySendAsync(plan.PostText);
 
@@ -106,7 +106,7 @@ public class FacebookEventService
             return false;
         }
 
-        var imageAsset = await _customEventImages.RenderAsync(eventId, rawText);
+        var imageAsset = await _customEventImages.RenderAsync(eventId, rawText, ResolveMention);
         if (imageAsset is null)
         {
             _log.LogWarning("Facebook custom event image render returned no asset for event {EventId}.", eventId);
@@ -155,7 +155,7 @@ public class FacebookEventService
         if (type != EventType.CustomEvent || string.IsNullOrWhiteSpace(eventId))
             return null;
 
-        return CustomEventSocialComposer.BuildPlan(eventId, rawText, 63206).PostText;
+        return CustomEventSocialComposer.BuildPlan(eventId, rawText, 63206, ResolveMention).PostText;
     }
 
     public string? TryBuildFillerMessage(FillerType fillerType, string payloadText)
@@ -175,5 +175,16 @@ public class FacebookEventService
 
         var spaced = slug.Replace('_', '-').Replace('-', ' ');
         return CultureInfo.InvariantCulture.TextInfo.ToTitleCase(spaced);
+    }
+
+    private string ResolveMention(string slug)
+    {
+        lock (_lockObj)
+        {
+            if (_bySlug.TryGetValue(slug, out var athlete) && !string.IsNullOrWhiteSpace(athlete.Name))
+                return athlete.Name;
+        }
+
+        return SlugToName(slug);
     }
 }

--- a/LongevityWorldCup.Website/Business/ThreadsEventService.cs
+++ b/LongevityWorldCup.Website/Business/ThreadsEventService.cs
@@ -105,7 +105,7 @@ public class ThreadsEventService
             if (string.IsNullOrWhiteSpace(eventId))
                 return null;
 
-            return CustomEventSocialComposer.BuildPlan(eventId, rawText, 500).PostText;
+            return CustomEventSocialComposer.BuildPlan(eventId, rawText, 500, ResolveMention).PostText;
         }
 
         var message = ThreadsMessageBuilder.ForEventText(
@@ -169,7 +169,7 @@ public class ThreadsEventService
             return false;
         }
 
-        var plan = CustomEventSocialComposer.BuildPlan(eventId, rawText, 500);
+        var plan = CustomEventSocialComposer.BuildPlan(eventId, rawText, 500, ResolveMention);
         if (plan.Mode == CustomEventPostMode.Text)
             return await TrySendAsync(plan.PostText);
 
@@ -179,7 +179,7 @@ public class ThreadsEventService
             return false;
         }
 
-        var imageAsset = await _customEventImages.RenderAsync(eventId, rawText);
+        var imageAsset = await _customEventImages.RenderAsync(eventId, rawText, ResolveMention);
         if (imageAsset is null)
         {
             _log.LogWarning("Threads custom event image render returned no asset for event {EventId}.", eventId);
@@ -234,6 +234,24 @@ public class ThreadsEventService
         }
         var spaced = slug.Replace('_', '-').Replace('-', ' ');
         return CultureInfo.InvariantCulture.TextInfo.ToTitleCase(spaced);
+    }
+
+    private string ResolveMention(string slug)
+    {
+        lock (_lockObj)
+        {
+            if (_bySlug.TryGetValue(slug, out var athlete))
+            {
+                var mention = SocialContactParser.TryBuildMention(athlete.MediaContact, SocialPlatform.Threads);
+                if (!string.IsNullOrWhiteSpace(mention))
+                    return mention;
+
+                if (!string.IsNullOrWhiteSpace(athlete.Name))
+                    return athlete.Name;
+            }
+        }
+
+        return SlugToName(slug);
     }
 
     private string? GetPodcast(string slug)

--- a/LongevityWorldCup.Website/Business/XEventService.cs
+++ b/LongevityWorldCup.Website/Business/XEventService.cs
@@ -115,7 +115,7 @@ public class XEventService
             if (string.IsNullOrWhiteSpace(eventId))
                 return null;
 
-            return CustomEventSocialComposer.BuildPlan(eventId, rawText, 280).PostText;
+            return CustomEventSocialComposer.BuildPlan(eventId, rawText, 280, ResolveMention).PostText;
         }
 
         var message = XMessageBuilder.ForEventText(
@@ -179,7 +179,7 @@ public class XEventService
             return false;
         }
 
-        var plan = CustomEventSocialComposer.BuildPlan(eventId, rawText, 280);
+        var plan = CustomEventSocialComposer.BuildPlan(eventId, rawText, 280, ResolveMention);
         if (plan.Mode == CustomEventPostMode.Text)
             return await TrySendAsync(plan.PostText);
 
@@ -189,7 +189,7 @@ public class XEventService
             return false;
         }
 
-        using var imageStream = await _customEventImages.RenderToStreamAsync(rawText);
+        using var imageStream = await _customEventImages.RenderToStreamAsync(rawText, ResolveMention);
         if (imageStream is null)
         {
             _log.LogWarning("X custom event image render returned no stream for event {EventId}.", eventId);
@@ -218,6 +218,24 @@ public class XEventService
         }
         var spaced = slug.Replace('_', '-').Replace('-', ' ');
         return CultureInfo.InvariantCulture.TextInfo.ToTitleCase(spaced);
+    }
+
+    private string ResolveMention(string slug)
+    {
+        lock (_lockObj)
+        {
+            if (_bySlug.TryGetValue(slug, out var athlete))
+            {
+                var mention = SocialContactParser.TryBuildMention(athlete.MediaContact, SocialPlatform.X);
+                if (!string.IsNullOrWhiteSpace(mention))
+                    return mention;
+
+                if (!string.IsNullOrWhiteSpace(athlete.Name))
+                    return athlete.Name;
+            }
+        }
+
+        return SlugToName(slug);
     }
 
     private string? GetPodcast(string slug)

--- a/LongevityWorldCup.Website/Scripts/custom_event.sh
+++ b/LongevityWorldCup.Website/Scripts/custom_event.sh
@@ -246,6 +246,11 @@ render() {
   prev=""
   while [[ "$prev" != "$s" ]]; do
     prev="$s"
+    s="$(printf '%s' "$s" | sed -E "s/\[mention\]\(([^()]*)\)/\1/g")"
+  done
+  prev=""
+  while [[ "$prev" != "$s" ]]; do
+    prev="$s"
     s="$(printf '%s' "$s" | sed -E "s/\[([^][]+)\]\((https?:[^)]+)\)/${esc}]8;;\2${bel}\1${esc}]8;;${bel}/g")"
   done
   printf '%s' "$s"

--- a/LongevityWorldCup.Website/Tools/CustomEventMarkup.cs
+++ b/LongevityWorldCup.Website/Tools/CustomEventMarkup.cs
@@ -36,16 +36,17 @@ public static class CustomEventMarkup
         return ContainsHyperlinkCore(text, 0, text.Length);
     }
 
-    public static IReadOnlyList<CustomEventSegment> ParseSegments(string? text, bool keepHyperlinkLabels)
+    public static IReadOnlyList<CustomEventSegment> ParseSegments(string? text, bool keepHyperlinkLabels, Func<string, string>? mentionResolver = null)
     {
         var output = new List<CustomEventSegment>();
-        ParseInto(output, NormalizeNewlines(text), 0, NormalizeNewlines(text).Length, CustomEventTextStyle.Regular, keepHyperlinkLabels);
+        var normalized = NormalizeNewlines(text);
+        ParseInto(output, normalized, 0, normalized.Length, CustomEventTextStyle.Regular, keepHyperlinkLabels, mentionResolver);
         return MergeAdjacent(output);
     }
 
-    public static string ToPlainText(string? text, bool keepHyperlinkLabels = true)
+    public static string ToPlainText(string? text, bool keepHyperlinkLabels = true, Func<string, string>? mentionResolver = null)
     {
-        var segments = ParseSegments(text, keepHyperlinkLabels);
+        var segments = ParseSegments(text, keepHyperlinkLabels, mentionResolver);
         var sb = new StringBuilder();
         foreach (var segment in segments)
             sb.Append(segment.Text);
@@ -99,7 +100,7 @@ public static class CustomEventMarkup
         return false;
     }
 
-    private static void ParseInto(List<CustomEventSegment> output, string text, int start, int length, CustomEventTextStyle inheritedStyle, bool keepHyperlinkLabels)
+    private static void ParseInto(List<CustomEventSegment> output, string text, int start, int length, CustomEventTextStyle inheritedStyle, bool keepHyperlinkLabels, Func<string, string>? mentionResolver)
     {
         var end = start + length;
         var i = start;
@@ -144,11 +145,15 @@ public static class CustomEventMarkup
             var key = label.Trim().ToLowerInvariant();
             if (key == "bold")
             {
-                ParseInto(output, inner, 0, inner.Length, CustomEventTextStyle.Bold, keepHyperlinkLabels);
+                ParseInto(output, inner, 0, inner.Length, CustomEventTextStyle.Bold, keepHyperlinkLabels, mentionResolver);
             }
             else if (key == "strong")
             {
-                ParseInto(output, inner, 0, inner.Length, CustomEventTextStyle.Strong, keepHyperlinkLabels);
+                ParseInto(output, inner, 0, inner.Length, CustomEventTextStyle.Strong, keepHyperlinkLabels, mentionResolver);
+            }
+            else if (key == "mention")
+            {
+                Append(output, ResolveMentionText(inner, mentionResolver), inheritedStyle);
             }
             else if (IsSafeHttpUrl(inner))
             {
@@ -176,6 +181,30 @@ public static class CustomEventMarkup
             return;
 
         output.Add(new CustomEventSegment(text, style));
+    }
+
+    private static string ResolveMentionText(string? slug, Func<string, string>? mentionResolver)
+    {
+        var normalizedSlug = (slug ?? string.Empty).Trim();
+        if (string.IsNullOrWhiteSpace(normalizedSlug))
+            return string.Empty;
+
+        var resolved = mentionResolver?.Invoke(normalizedSlug);
+        if (!string.IsNullOrWhiteSpace(resolved))
+            return resolved;
+
+        return HumanizeSlug(normalizedSlug);
+    }
+
+    private static string HumanizeSlug(string slug)
+    {
+        var spaced = slug.Replace('_', ' ').Replace('-', ' ').Trim();
+        if (string.IsNullOrWhiteSpace(spaced))
+            return slug;
+
+        return string.Join(' ', spaced
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries)
+            .Select(part => char.ToUpperInvariant(part[0]) + part[1..]));
     }
 
     private static IReadOnlyList<CustomEventSegment> MergeAdjacent(List<CustomEventSegment> segments)

--- a/LongevityWorldCup.Website/Tools/CustomEventSocialComposer.cs
+++ b/LongevityWorldCup.Website/Tools/CustomEventSocialComposer.cs
@@ -26,9 +26,14 @@ public static class CustomEventSocialComposer
 
     public static CustomEventSocialPlan BuildPlan(string eventId, string rawText, int maxTextLength)
     {
+        return BuildPlan(eventId, rawText, maxTextLength, mentionResolver: null);
+    }
+
+    public static CustomEventSocialPlan BuildPlan(string eventId, string rawText, int maxTextLength, Func<string, string>? mentionResolver)
+    {
         var (titleRaw, contentRaw) = CustomEventMarkup.SplitTitleAndContent(rawText);
-        var titleText = CollapseWhitespace(CustomEventMarkup.ToPlainText(titleRaw, keepHyperlinkLabels: true)).Trim();
-        var bodyText = CustomEventMarkup.ToPlainText(contentRaw, keepHyperlinkLabels: true).Trim();
+        var titleText = CollapseWhitespace(CustomEventMarkup.ToPlainText(titleRaw, keepHyperlinkLabels: true, mentionResolver)).Trim();
+        var bodyText = CustomEventMarkup.ToPlainText(contentRaw, keepHyperlinkLabels: true, mentionResolver).Trim();
         var eventUrl = BuildEventUrl(eventId);
         var hasHyperlinks = CustomEventMarkup.ContainsHyperlink(rawText);
 

--- a/LongevityWorldCup.Website/Tools/SlackMessageBuilder.cs
+++ b/LongevityWorldCup.Website/Tools/SlackMessageBuilder.cs
@@ -21,8 +21,8 @@ public static class SlackMessageBuilder
             EventType.DonationReceived => BuildDonation(rawText),
             EventType.AthleteCountMilestone => BuildAthleteCountMilestone(rawText),
             EventType.BadgeAward => BuildBadgeAward(rawText, getPodcastLinkForSlug),
-            EventType.CustomEvent => BuildCustomEvent(rawText),
-            EventType.General => BuildCustomEvent(rawText),
+            EventType.CustomEvent => BuildCustomEvent(rawText, slugToName),
+            EventType.General => BuildCustomEvent(rawText, slugToName),
             _ => Escape(rawText)
         };
     }
@@ -440,7 +440,7 @@ public static class SlackMessageBuilder
     private static string MedalOrTrend(int n) =>
         n switch { 1 => " 🥇", 2 => " 🥈", 3 => " 🥉", _ => "" };
 
-    private static string BuildCustomEvent(string rawText)
+    private static string BuildCustomEvent(string rawText, Func<string, string> slugToName)
     {
         if (string.IsNullOrEmpty(rawText)) return "";
 
@@ -450,16 +450,16 @@ public static class SlackMessageBuilder
         var title = (idx >= 0 ? s.Substring(0, idx) : s).Trim();
         var content = (idx >= 0 ? s.Substring(idx + 2) : "").TrimEnd();
 
-        var titleEsc = ApplyCustomMarkupToSlack(Escape(title));
+        var titleEsc = ApplyCustomMarkupToSlack(Escape(title), slugToName);
 
         if (string.IsNullOrWhiteSpace(content))
             return titleEsc;
 
-        var contentEsc = ApplyCustomMarkupToSlack(Escape(content));
+        var contentEsc = ApplyCustomMarkupToSlack(Escape(content), slugToName);
         return titleEsc + "\n\n" + contentEsc;
     }
 
-    private static string ApplyCustomMarkupToSlack(string s)
+    private static string ApplyCustomMarkupToSlack(string s, Func<string, string> slugToName)
     {
         if (string.IsNullOrEmpty(s)) return s;
 
@@ -473,6 +473,19 @@ public static class SlackMessageBuilder
             s,
             @"\[bold\]\(([^()]*)\)",
             m => $"*{m.Groups[1].Value}*",
+            RegexOptions.CultureInvariant);
+
+        s = Regex.Replace(
+            s,
+            @"\[mention\]\(([^()]*)\)",
+            m =>
+            {
+                var slug = m.Groups[1].Value.Trim();
+                if (string.IsNullOrWhiteSpace(slug))
+                    return "";
+
+                return Link(AthleteUrl(slug), slugToName(slug));
+            },
             RegexOptions.CultureInvariant);
 
         s = Regex.Replace(

--- a/LongevityWorldCup.Website/Tools/SocialContactParser.cs
+++ b/LongevityWorldCup.Website/Tools/SocialContactParser.cs
@@ -46,7 +46,7 @@ public static class SocialContactParser
         if (trimmed.StartsWith('@'))
             return NormalizeHandle(trimmed[1..]);
 
-        if (!Uri.TryCreate(trimmed, UriKind.Absolute, out var uri))
+        if (!TryCreateContactUri(trimmed, out var uri))
             return null;
 
         if (!isSupportedHost(uri.Host))
@@ -61,6 +61,14 @@ public static class SocialContactParser
             return null;
 
         return NormalizeHandle(firstSegment.TrimStart('@'));
+    }
+
+    private static bool TryCreateContactUri(string value, out Uri uri)
+    {
+        if (Uri.TryCreate(value, UriKind.Absolute, out uri!))
+            return true;
+
+        return Uri.TryCreate("https://" + value, UriKind.Absolute, out uri!);
     }
 
     private static string? NormalizeHandle(string? value)

--- a/LongevityWorldCup.Website/Tools/SocialContactParser.cs
+++ b/LongevityWorldCup.Website/Tools/SocialContactParser.cs
@@ -1,0 +1,78 @@
+namespace LongevityWorldCup.Website.Tools;
+
+public enum SocialPlatform
+{
+    X,
+    Threads,
+    Facebook
+}
+
+public static class SocialContactParser
+{
+    public static string? TryBuildMention(string? mediaContact, SocialPlatform platform)
+    {
+        var handle = platform switch
+        {
+            SocialPlatform.X => TryExtractXHandle(mediaContact),
+            SocialPlatform.Threads => TryExtractThreadsHandle(mediaContact),
+            SocialPlatform.Facebook => null,
+            _ => null
+        };
+
+        return string.IsNullOrWhiteSpace(handle)
+            ? null
+            : "@" + handle;
+    }
+
+    public static string? TryExtractXHandle(string? mediaContact)
+    {
+        return TryExtractHandle(mediaContact, isSupportedHost: host =>
+            host.EndsWith("x.com", StringComparison.OrdinalIgnoreCase) ||
+            host.EndsWith("twitter.com", StringComparison.OrdinalIgnoreCase));
+    }
+
+    public static string? TryExtractThreadsHandle(string? mediaContact)
+    {
+        return TryExtractHandle(mediaContact, isSupportedHost: host =>
+            host.EndsWith("threads.com", StringComparison.OrdinalIgnoreCase) ||
+            host.EndsWith("instagram.com", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string? TryExtractHandle(string? mediaContact, Func<string, bool> isSupportedHost)
+    {
+        if (string.IsNullOrWhiteSpace(mediaContact))
+            return null;
+
+        var trimmed = mediaContact.Trim();
+        if (trimmed.StartsWith('@'))
+            return NormalizeHandle(trimmed[1..]);
+
+        if (!Uri.TryCreate(trimmed, UriKind.Absolute, out var uri))
+            return null;
+
+        if (!isSupportedHost(uri.Host))
+            return null;
+
+        var path = uri.AbsolutePath.Trim('/');
+        if (string.IsNullOrWhiteSpace(path))
+            return null;
+
+        var firstSegment = path.Split('/', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+        if (string.IsNullOrWhiteSpace(firstSegment))
+            return null;
+
+        return NormalizeHandle(firstSegment.TrimStart('@'));
+    }
+
+    private static string? NormalizeHandle(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+
+        var normalized = value.Trim().TrimStart('@');
+        if (string.IsNullOrWhiteSpace(normalized))
+            return null;
+
+        return normalized;
+    }
+}

--- a/LongevityWorldCup.Website/Tools/SocialContactParser.cs
+++ b/LongevityWorldCup.Website/Tools/SocialContactParser.cs
@@ -34,8 +34,7 @@ public static class SocialContactParser
     public static string? TryExtractThreadsHandle(string? mediaContact)
     {
         return TryExtractHandle(mediaContact, isSupportedHost: host =>
-            host.EndsWith("threads.com", StringComparison.OrdinalIgnoreCase) ||
-            host.EndsWith("instagram.com", StringComparison.OrdinalIgnoreCase));
+            host.EndsWith("threads.com", StringComparison.OrdinalIgnoreCase));
     }
 
     private static string? TryExtractHandle(string? mediaContact, Func<string, bool> isSupportedHost)

--- a/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
+++ b/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
@@ -477,7 +477,7 @@
 
             <label>
                 <span>Content</span>
-                <textarea id="contentInput">We have added an expandable CustomEvent row in Highlights. This update highlights one [bold](important) change, includes a [strong](major announcement), and links to [Longevity World Cup](https://longevityworldcup.com/) for the latest details.</textarea>
+                <textarea id="contentInput">We have added an expandable CustomEvent row in Highlights. This update highlights one [bold](important) change, includes a [strong](major announcement), gives a shoutout to [mention](nopara73), and links to [Longevity World Cup](https://longevityworldcup.com/) for the latest details.</textarea>
             </label>
 
             <div>
@@ -523,54 +523,11 @@
             </div>
 
             <div class="panel preview-block">
-                <div class="preview-title">
-                    <h2>Text Post Preview</h2>
-                    <div id="textPreviewPlatforms" class="preview-platforms"></div>
-                </div>
-                <div class="preview-surface fit-content" style="border:0;background:transparent;padding:0;">
-                    <div class="x-post">
-                        <div class="x-avatar">LW</div>
-                        <div class="x-main">
-                            <div class="x-head">
-                                <span class="x-name">Longevity World Cup</span>
-                                <span class="x-handle">@longevitywc</span>
-                                <span class="x-meta">now</span>
-                            </div>
-                            <div id="textPostPreview" class="x-text"></div>
-                            <div class="x-actions"><span>Reply</span><span>Repost</span><span>Like</span><span>View</span></div>
-                        </div>
-                    </div>
-                </div>
+                <div id="textPreviewList" class="preview-stack"></div>
             </div>
 
             <div class="panel preview-block">
-                <div class="preview-title">
-                    <h2>Image Post Preview</h2>
-                    <div id="imagePreviewPlatforms" class="preview-platforms"></div>
-                </div>
-                <div class="preview-surface fit-content" style="border:0;background:transparent;padding:0;">
-                    <div class="x-post">
-                        <div class="x-avatar">LW</div>
-                        <div class="x-main">
-                            <div class="x-head">
-                                <span class="x-name">Longevity World Cup</span>
-                                <span class="x-handle">@longevitywc</span>
-                                <span class="x-meta">now</span>
-                            </div>
-                            <div id="imagePostPreview" class="x-text"></div>
-                            <div class="x-media">
-                                <div id="imageStageFrame" class="image-stage-frame">
-                                    <div id="imageStage" class="image-stage">
-                                        <div id="imageCard" class="image-card">
-                                            <div id="imageTextPreview" class="image-text formatted"></div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="x-actions"><span>Reply</span><span>Repost</span><span>Like</span><span>View</span></div>
-                        </div>
-                    </div>
-                </div>
+                <div id="imagePreviewList" class="preview-stack"></div>
             </div>
         </div>
     </div>
@@ -592,10 +549,8 @@
         const insertStrongBtn = document.getElementById("insertStrongBtn");
         const insertLinkBtn = document.getElementById("insertLinkBtn");
         const insertMentionBtn = document.getElementById("insertMentionBtn");
-        const imageStageFrame = document.getElementById("imageStageFrame");
-        const imageStage = document.getElementById("imageStage");
-        const textPreviewPlatforms = document.getElementById("textPreviewPlatforms");
-        const imagePreviewPlatforms = document.getElementById("imagePreviewPlatforms");
+        const textPreviewList = document.getElementById("textPreviewList");
+        const imagePreviewList = document.getElementById("imagePreviewList");
         let activeEditor = contentInput;
         let athleteMentionIndex = new Map();
 
@@ -604,6 +559,11 @@
             { key: "threads", label: "Threads", checkbox: sendThreads, limit: LIMITS.threads },
             { key: "facebook", label: "Facebook", checkbox: sendFacebook, limit: 63206 }
         ];
+        const PLATFORM_PREVIEW_META = {
+            x: { name: "Longevity World Cup", handle: "@longevitywc", avatar: "LW", label: "X" },
+            threads: { name: "Longevity World Cup", handle: "@longevityworldcup", avatar: "LW", label: "Threads" },
+            facebook: { name: "Longevity World Cup", handle: "Facebook Page", avatar: "LW", label: "Facebook" }
+        };
 
         function escapeHtml(value) {
             return (value ?? "")
@@ -722,7 +682,7 @@
                     return `@${normalizedSegment}`;
                 }
 
-                if (platformKey === "threads" && (host.endsWith("threads.com") || host.endsWith("instagram.com"))) {
+                if (platformKey === "threads" && host.endsWith("threads.com")) {
                     return `@${normalizedSegment}`;
                 }
             } catch {
@@ -915,38 +875,97 @@
                     const plan = platform.fixedMode
                         ? { mode: platform.fixedMode, postText: buildTextPost(collapseWhitespace(plainTextWithLabels(titleRaw, slug => resolveMentionSlug(slug, platform.key))), plainTextWithLabels(contentRaw, slug => resolveMentionSlug(slug, platform.key)), null) }
                         : buildPlan(titleRaw, contentRaw, platform.limit, platform.key);
-                    return { label: platform.label, ...plan };
+                    return { key: platform.key, label: platform.label, limit: platform.limit, ...plan };
                 });
         }
 
-        function updateImagePreview(contentRaw) {
-            const card = document.getElementById("imageCard");
-            const text = document.getElementById("imageTextPreview");
-            text.innerHTML = renderImageMarkupWithBreaks(contentRaw || titleInput.value.trim());
-
-            const length = plainTextWithLabels(contentRaw || titleInput.value.trim(), slug => resolveMentionSlug(slug, "x")).length;
+        function getImagePreviewLayout(contentRaw, platformKey) {
+            const resolvedContent = contentRaw || titleInput.value.trim();
+            const textHtml = window.CustomEventMarkup.renderMarkupWithBreaks(resolvedContent, {
+                mentionResolver: slug => resolveMentionSlug(slug, platformKey)
+            });
+            const length = plainTextWithLabels(resolvedContent, slug => resolveMentionSlug(slug, platformKey)).length;
+            const settings = {};
             if (length > 420) {
-                card.style.width = "1060px";
-                card.style.height = "520px";
-                card.style.padding = "40px 38px";
-                text.style.fontSize = "18px";
-                text.style.lineHeight = "1.42";
+                settings.cardWidth = 1060;
+                settings.cardHeight = 520;
+                settings.padding = "40px 38px";
+                settings.fontSize = "18px";
+                settings.lineHeight = "1.42";
             } else if (length > 280) {
-                card.style.width = "1000px";
-                card.style.height = "455px";
-                card.style.padding = "40px 30px";
-                text.style.fontSize = "22px";
-                text.style.lineHeight = "1.42";
+                settings.cardWidth = 1000;
+                settings.cardHeight = 455;
+                settings.padding = "40px 30px";
+                settings.fontSize = "22px";
+                settings.lineHeight = "1.42";
             } else {
-                card.style.width = "920px";
-                card.style.height = "360px";
-                card.style.padding = "40px 20px";
-                text.style.fontSize = "30px";
-                text.style.lineHeight = "1.36";
+                settings.cardWidth = 920;
+                settings.cardHeight = 360;
+                settings.padding = "40px 20px";
+                settings.fontSize = "30px";
+                settings.lineHeight = "1.36";
             }
 
-            const scale = imageStageFrame.clientWidth / 1200;
-            imageStage.style.transform = `scale(${scale})`;
+            settings.textHtml = textHtml;
+            return settings;
+        }
+
+        function renderTextPreviewCard(platformKey, postText) {
+            const meta = PLATFORM_PREVIEW_META[platformKey] || PLATFORM_PREVIEW_META.x;
+            return `
+                <div class="preview-surface fit-content" style="border:0;background:transparent;padding:0;">
+                    <div class="preview-title" style="margin-bottom:8px;">
+                        <h2>${escapeHtml(meta.label)} Preview</h2>
+                    </div>
+                    <div class="x-post">
+                        <div class="x-avatar">${escapeHtml(meta.avatar)}</div>
+                        <div class="x-main">
+                            <div class="x-head">
+                                <span class="x-name">${escapeHtml(meta.name)}</span>
+                                <span class="x-handle">${escapeHtml(meta.handle)}</span>
+                                <span class="x-meta">now</span>
+                            </div>
+                            <div class="x-text">${formatPlainPostTextToHtml(postText)}</div>
+                            <div class="x-actions"><span>Reply</span><span>Repost</span><span>Like</span><span>View</span></div>
+                        </div>
+                    </div>
+                </div>`;
+        }
+
+        function renderImagePreviewCard(platformKey, postText, contentRaw) {
+            const meta = PLATFORM_PREVIEW_META[platformKey] || PLATFORM_PREVIEW_META.x;
+            const layout = getImagePreviewLayout(contentRaw, platformKey);
+            const frameWidth = 560;
+            const scale = frameWidth / 1200;
+            const frameHeight = 675 * scale;
+
+            return `
+                <div class="preview-surface fit-content" style="border:0;background:transparent;padding:0;">
+                    <div class="preview-title" style="margin-bottom:8px;">
+                        <h2>${escapeHtml(meta.label)} Preview</h2>
+                    </div>
+                    <div class="x-post">
+                        <div class="x-avatar">${escapeHtml(meta.avatar)}</div>
+                        <div class="x-main">
+                            <div class="x-head">
+                                <span class="x-name">${escapeHtml(meta.name)}</span>
+                                <span class="x-handle">${escapeHtml(meta.handle)}</span>
+                                <span class="x-meta">now</span>
+                            </div>
+                            <div class="x-text">${formatPlainPostTextToHtml(postText)}</div>
+                            <div class="x-media">
+                                <div class="image-stage-frame" style="height:${frameHeight}px;">
+                                    <div class="image-stage" style="transform:scale(${scale});">
+                                        <div class="image-card" style="width:${layout.cardWidth}px;height:${layout.cardHeight}px;padding:${layout.padding};">
+                                            <div class="image-text formatted" style="font-size:${layout.fontSize};line-height:${layout.lineHeight};">${layout.textHtml}</div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="x-actions"><span>Reply</span><span>Repost</span><span>Like</span><span>View</span></div>
+                        </div>
+                    </div>
+                </div>`;
         }
 
         function update() {
@@ -975,26 +994,28 @@
             const bodyText = plainTextWithLabels(contentRaw, slug => resolveMentionSlug(slug, "x"));
             const eventUrl = containsHyperlink(combinedRaw) ? buildPreviewEventUrl(titleRaw, contentRaw) : null;
 
-            const textPreviewBlock = textPreviewPlatforms.closest(".panel");
-            const imagePreviewBlock = imagePreviewPlatforms.closest(".panel");
+            const textPreviewBlock = textPreviewList.closest(".panel");
+            const imagePreviewBlock = imagePreviewList.closest(".panel");
 
             if (textPlans.length > 0) {
                 textPreviewBlock.style.display = "";
-                textPreviewPlatforms.textContent = textPlans.map(x => x.label).join(", ");
-                document.getElementById("textPostPreview").innerHTML = formatPlainPostTextToHtml(textPlans[0].postText || buildTextPost(titleText, bodyText, eventUrl));
+                textPreviewList.innerHTML = textPlans.map(plan =>
+                    renderTextPreviewCard(plan.key, plan.postText || buildTextPost(titleText, bodyText, eventUrl))
+                ).join("");
             } else {
                 textPreviewBlock.style.display = "none";
+                textPreviewList.innerHTML = "";
             }
 
             if (imagePlans.length > 0) {
                 imagePreviewBlock.style.display = "";
-                imagePreviewPlatforms.textContent = imagePlans.map(x => x.label).join(", ");
-                document.getElementById("imagePostPreview").innerHTML = formatPlainPostTextToHtml(imagePlans[0].postText || buildImageCaption(titleText, eventUrl ?? "", LIMITS.x));
+                imagePreviewList.innerHTML = imagePlans.map(plan =>
+                    renderImagePreviewCard(plan.key, plan.postText || buildImageCaption(titleText, eventUrl ?? "", LIMITS.x), contentRaw)
+                ).join("");
             } else {
                 imagePreviewBlock.style.display = "none";
+                imagePreviewList.innerHTML = "";
             }
-
-            updateImagePreview(contentRaw);
 
             const payloadJsonText = JSON.stringify(payload);
             const payloadToken = base64UrlEncodeUtf8(payloadJsonText);

--- a/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
+++ b/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
@@ -467,6 +467,7 @@
                 <button id="insertBoldBtn" class="tool-btn" type="button">Bold</button>
                 <button id="insertStrongBtn" class="tool-btn" type="button">Strong</button>
                 <button id="insertLinkBtn" class="tool-btn" type="button">Link</button>
+                <button id="insertMentionBtn" class="tool-btn" type="button">Mention</button>
             </div>
 
             <label>
@@ -590,11 +591,13 @@
         const insertBoldBtn = document.getElementById("insertBoldBtn");
         const insertStrongBtn = document.getElementById("insertStrongBtn");
         const insertLinkBtn = document.getElementById("insertLinkBtn");
+        const insertMentionBtn = document.getElementById("insertMentionBtn");
         const imageStageFrame = document.getElementById("imageStageFrame");
         const imageStage = document.getElementById("imageStage");
         const textPreviewPlatforms = document.getElementById("textPreviewPlatforms");
         const imagePreviewPlatforms = document.getElementById("imagePreviewPlatforms");
         let activeEditor = contentInput;
+        let athleteMentionIndex = new Map();
 
         const PLATFORM_CONFIGS = [
             { key: "x", label: "X", checkbox: sendX, limit: LIMITS.x },
@@ -618,34 +621,43 @@
             return /\[[^\]]+\]\((https?:\/\/[^)\s]+)\)/i.test(value ?? "");
         }
 
-        function plainTextWithLabels(value) {
-            let text = (value ?? "").replace(/\r\n/g, "\n").replace(/\r/g, "\n");
-            text = text.replace(/\[bold\]\(([\s\S]*?)\)/gi, "$1");
-            text = text.replace(/\[strong\]\(([\s\S]*?)\)/gi, "$1");
-            text = text.replace(/\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)/gi, "$1");
-            return text.trim();
-        }
-
         function normalizeNewlines(value) { return window.CustomEventMarkup.normalizeNewlines(value); }
-        function renderCustomMarkup(text) { return window.CustomEventMarkup.renderMarkup(text); }
-        function renderCustomMarkupWithBreaks(text) { return window.CustomEventMarkup.renderMarkupWithBreaks(text); }
-
-        function formatMarkupToHtml(value) {
-            let html = escapeHtml((value ?? "").replace(/\r\n/g, "\n").replace(/\r/g, "\n"));
-            html = html.replace(/\[bold\]\(([\s\S]*?)\)/gi, "<strong>$1</strong>");
-            html = html.replace(/\[strong\]\(([\s\S]*?)\)/gi, "<span class=\"strong\">$1</span>");
-            html = html.replace(/\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)/gi, '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>');
-            html = html.replace(/\n/g, "<br>");
-            return html;
+        function renderCustomMarkup(text) {
+            return window.CustomEventMarkup.renderMarkup(text, { mentionResolver: resolveMentionDisplayName });
         }
-
-        function formatImageMarkupToHtml(value) {
-            let html = escapeHtml((value ?? "").replace(/\r\n/g, "\n").replace(/\r/g, "\n"));
-            html = html.replace(/\[bold\]\(([\s\S]*?)\)/gi, "<strong>$1</strong>");
-            html = html.replace(/\[strong\]\(([\s\S]*?)\)/gi, "<span class=\"strong\">$1</span>");
-            html = html.replace(/\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)/gi, "$1");
-            html = html.replace(/\n/g, "<br>");
-            return html;
+        function renderCustomMarkupWithBreaks(text) {
+            return window.CustomEventMarkup.renderMarkupWithBreaks(text, { mentionResolver: resolveMentionDisplayName });
+        }
+        function normalizeAthleteSlugForUrl(slug) {
+            return String(slug || "").trim().toLowerCase().replace(/_/g, "-");
+        }
+        function buildAthleteProfileUrl(slug) {
+            return `/athlete/${encodeURIComponent(normalizeAthleteSlugForUrl(slug))}`;
+        }
+        function hasKnownMentionSlug(slug) {
+            const key = String(slug || "").trim().toLowerCase();
+            return !!key && athleteMentionIndex.has(key);
+        }
+        function renderWebpageMarkup(text) {
+            return window.CustomEventMarkup.renderWebpageMarkup(text, {
+                mentionResolver: resolveMentionDisplayName,
+                mentionHrefResolver: slug => hasKnownMentionSlug(slug) ? buildAthleteProfileUrl(slug) : ""
+            });
+        }
+        function renderWebpageMarkupWithBreaks(text) {
+            return window.CustomEventMarkup.renderWebpageMarkupWithBreaks(text, {
+                mentionResolver: resolveMentionDisplayName,
+                mentionHrefResolver: slug => hasKnownMentionSlug(slug) ? buildAthleteProfileUrl(slug) : ""
+            });
+        }
+        function renderImageMarkupWithBreaks(text) {
+            return window.CustomEventMarkup.renderMarkupWithBreaks(text, { mentionResolver: slug => resolveMentionSlug(slug, "x") });
+        }
+        function plainTextWithLabels(value, mentionResolver) {
+            return window.CustomEventMarkup.toPlainText(value, {
+                keepHyperlinkLabels: true,
+                mentionResolver: mentionResolver
+            }).trim();
         }
 
         function formatPlainPostTextToHtml(value) {
@@ -654,6 +666,98 @@
             html = html.replace(/(^|[\s(>])((?:[a-z0-9-]+\.)+[a-z]{2,}(?:\/[^\s<]*)?)/gim, '$1<a href="https://$2" target="_blank" rel="noopener noreferrer">$2</a>');
             html = html.replace(/\n/g, "<br>");
             return html;
+        }
+
+        function humanizeSlug(value) {
+            return String(value ?? "")
+                .replace(/[_-]+/g, " ")
+                .trim()
+                .split(/\s+/)
+                .filter(Boolean)
+                .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+                .join(" ");
+        }
+
+        function buildAthleteMentionIndex(athletes) {
+            const index = new Map();
+            (athletes || []).forEach(athlete => {
+                const slug = String(athlete?.AthleteSlug || athlete?.Slug || "").trim().toLowerCase();
+                if (!slug) {
+                    return;
+                }
+
+                index.set(slug, {
+                    name: String(athlete?.Name || "").trim(),
+                    mediaContact: String(athlete?.MediaContact || "").trim()
+                });
+            });
+            return index;
+        }
+
+        function extractMentionHandle(mediaContact, platformKey) {
+            const value = String(mediaContact || "").trim();
+            if (!value) {
+                return "";
+            }
+
+            if (value.startsWith("@")) {
+                return value;
+            }
+
+            try {
+                const url = new URL(value.startsWith("http") ? value : `https://${value}`);
+                const host = url.hostname.toLowerCase();
+                const path = url.pathname.replace(/^\/+|\/+$/g, "");
+                if (!path) {
+                    return "";
+                }
+
+                const firstSegment = path.split("/").find(Boolean) || "";
+                const normalizedSegment = firstSegment.replace(/^@+/, "");
+                if (!normalizedSegment) {
+                    return "";
+                }
+
+                if (platformKey === "x" && (host.endsWith("x.com") || host.endsWith("twitter.com"))) {
+                    return `@${normalizedSegment}`;
+                }
+
+                if (platformKey === "threads" && (host.endsWith("threads.com") || host.endsWith("instagram.com"))) {
+                    return `@${normalizedSegment}`;
+                }
+            } catch {
+            }
+
+            return "";
+        }
+
+        function resolveMentionSlug(slug, platformKey) {
+            const key = String(slug || "").trim().toLowerCase();
+            if (!key) {
+                return "";
+            }
+
+            const athlete = athleteMentionIndex.get(key);
+            if (!athlete) {
+                return humanizeSlug(key) || key;
+            }
+
+            const mention = extractMentionHandle(athlete.mediaContact, platformKey);
+            if (mention) {
+                return mention;
+            }
+
+            return athlete.name || humanizeSlug(key) || key;
+        }
+
+        function resolveMentionDisplayName(slug) {
+            const key = String(slug || "").trim().toLowerCase();
+            if (!key) {
+                return "";
+            }
+
+            const athlete = athleteMentionIndex.get(key);
+            return athlete?.name || humanizeSlug(key) || key;
         }
 
         function fnv1a(text) {
@@ -690,10 +794,11 @@
             return finalTitle ? `${finalTitle}\n\n${eventUrl}` : eventUrl;
         }
 
-        function buildPlan(titleRaw, contentRaw, maxLength) {
+        function buildPlan(titleRaw, contentRaw, maxLength, platformKey) {
             const rawText = contentRaw ? `${titleRaw}\n\n${contentRaw}` : titleRaw;
-            const titleText = collapseWhitespace(plainTextWithLabels(titleRaw));
-            const bodyText = plainTextWithLabels(contentRaw);
+            const mentionResolver = slug => resolveMentionSlug(slug, platformKey);
+            const titleText = collapseWhitespace(plainTextWithLabels(titleRaw, mentionResolver));
+            const bodyText = plainTextWithLabels(contentRaw, mentionResolver);
             const eventUrl = buildPreviewEventUrl(titleRaw, contentRaw);
             const hasHyperlinks = containsHyperlink(rawText);
             const textWithoutUrl = buildTextPost(titleText, bodyText, null);
@@ -799,13 +904,17 @@
             update();
         }
 
+        function insertMention() {
+            insertSnippet("[mention](", "athlete_slug", ")", (prefix) => prefix.length, (prefix, innerText) => prefix.length + innerText.length);
+        }
+
         function getSelectedPlatformPlans(titleRaw, contentRaw) {
             return PLATFORM_CONFIGS
                 .filter(platform => platform.checkbox.checked)
                 .map(platform => {
                     const plan = platform.fixedMode
-                        ? { mode: platform.fixedMode, postText: buildTextPost(collapseWhitespace(plainTextWithLabels(titleRaw)), plainTextWithLabels(contentRaw), null) }
-                        : buildPlan(titleRaw, contentRaw, platform.limit);
+                        ? { mode: platform.fixedMode, postText: buildTextPost(collapseWhitespace(plainTextWithLabels(titleRaw, slug => resolveMentionSlug(slug, platform.key))), plainTextWithLabels(contentRaw, slug => resolveMentionSlug(slug, platform.key)), null) }
+                        : buildPlan(titleRaw, contentRaw, platform.limit, platform.key);
                     return { label: platform.label, ...plan };
                 });
         }
@@ -813,9 +922,9 @@
         function updateImagePreview(contentRaw) {
             const card = document.getElementById("imageCard");
             const text = document.getElementById("imageTextPreview");
-            text.innerHTML = formatImageMarkupToHtml(contentRaw || titleInput.value.trim());
+            text.innerHTML = renderImageMarkupWithBreaks(contentRaw || titleInput.value.trim());
 
-            const length = plainTextWithLabels(contentRaw || titleInput.value.trim()).length;
+            const length = plainTextWithLabels(contentRaw || titleInput.value.trim(), slug => resolveMentionSlug(slug, "x")).length;
             if (length > 420) {
                 card.style.width = "1060px";
                 card.style.height = "520px";
@@ -855,18 +964,15 @@
                 sendToFacebook: sendFacebook.checked
             };
 
-            document.getElementById("eventTitlePreview").innerHTML = renderCustomMarkup(normalizeNewlines(titleRaw).replace(/\n+/g, " ").trim());
-            document.getElementById("eventContentPreview").innerHTML = contentRaw ? renderCustomMarkupWithBreaks(contentRaw) : "";
+            document.getElementById("eventTitlePreview").innerHTML = renderWebpageMarkup(normalizeNewlines(titleRaw).replace(/\n+/g, " ").trim());
+            document.getElementById("eventContentPreview").innerHTML = contentRaw ? renderWebpageMarkupWithBreaks(contentRaw) : "";
 
-            const xPlan = buildPlan(titleRaw, contentRaw, LIMITS.x);
-            const threadsPlan = buildPlan(titleRaw, contentRaw, LIMITS.threads);
-            const facebookPlan = buildPlan(titleRaw, contentRaw, 63206);
             const selectedPlans = getSelectedPlatformPlans(titleRaw, contentRaw);
             const textPlans = selectedPlans.filter(x => x.mode === "text");
             const imagePlans = selectedPlans.filter(x => x.mode === "image");
 
-            const titleText = collapseWhitespace(plainTextWithLabels(titleRaw));
-            const bodyText = plainTextWithLabels(contentRaw);
+            const titleText = collapseWhitespace(plainTextWithLabels(titleRaw, slug => resolveMentionSlug(slug, "x")));
+            const bodyText = plainTextWithLabels(contentRaw, slug => resolveMentionSlug(slug, "x"));
             const eventUrl = containsHyperlink(combinedRaw) ? buildPreviewEventUrl(titleRaw, contentRaw) : null;
 
             const textPreviewBlock = textPreviewPlatforms.closest(".panel");
@@ -918,11 +1024,23 @@
         insertBoldBtn.addEventListener("click", insertBold);
         insertStrongBtn.addEventListener("click", insertStrong);
         insertLinkBtn.addEventListener("click", insertLink);
+        insertMentionBtn.addEventListener("click", insertMention);
         copyCommandBtn.addEventListener("click", async () => copyText(commandOutput.value, "Command copied."));
         window.addEventListener("resize", update);
 
-        loadSendToSettings();
-        update();
+        fetch("/api/data/athletes", { headers: { accept: "application/json" } })
+            .then(response => response.ok ? response.json() : Promise.reject(response.status))
+            .then(athletes => {
+                athleteMentionIndex = buildAthleteMentionIndex(athletes);
+            })
+            .catch(() => {
+                athleteMentionIndex = new Map();
+            })
+            .finally(() => {
+                window.CustomEventMarkup.setMentionResolver(resolveMentionDisplayName);
+                loadSendToSettings();
+                update();
+            });
     </script>
 </body>
 </html>

--- a/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
+++ b/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
@@ -47,6 +47,7 @@
             display: grid;
             grid-template-columns: minmax(340px, 430px) minmax(600px, 1fr);
             gap: 18px;
+            align-items: start;
         }
 
         .panel {
@@ -57,6 +58,7 @@
             padding: 16px;
             display: grid;
             gap: 12px;
+            align-content: start;
         }
 
         h1, h2 {
@@ -111,6 +113,62 @@
 
         .tool-btn:hover {
             background: rgba(255,255,255,0.1);
+        }
+
+        .mention-suggestions {
+            position: static;
+            z-index: 20;
+            border: 1px solid rgba(255,255,255,0.12);
+            border-radius: 14px;
+            background: rgba(9,9,9,0.96);
+            box-shadow: 0 10px 30px rgba(0,0,0,0.35);
+            max-height: 220px;
+            overflow-y: auto;
+            padding: 6px;
+            margin-top: 6px;
+            width: 100%;
+        }
+
+        .mention-suggestions[hidden] {
+            display: none;
+        }
+
+        .mention-option {
+            width: 100%;
+            border: 0;
+            border-radius: 10px;
+            background: transparent;
+            color: var(--text);
+            padding: 8px 10px;
+            display: grid;
+            grid-template-columns: minmax(0, 1fr) auto;
+            align-items: center;
+            gap: 12px;
+            text-align: left;
+            cursor: pointer;
+        }
+
+        .mention-option:hover,
+        .mention-option.is-active {
+            background: rgba(255,255,255,0.1);
+        }
+
+        .mention-option-slug {
+            font-size: 12px;
+            font-weight: 700;
+            color: var(--text);
+            text-align: left;
+            min-width: 0;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .mention-option-name {
+            font-size: 11px;
+            color: var(--muted);
+            text-align: right;
+            white-space: nowrap;
         }
 
         .checks {
@@ -472,13 +530,19 @@
 
             <label>
                 <span>Title</span>
-                <input id="titleInput" type="text" value="New community update is live" />
+                <div class="editor-wrap">
+                    <input id="titleInput" type="text" value="New community update is live" />
+                </div>
             </label>
 
             <label>
                 <span>Content</span>
-                <textarea id="contentInput">We have added an expandable CustomEvent row in Highlights. This update highlights one [bold](important) change, includes a [strong](major announcement), gives a shoutout to [mention](nopara73), and links to [Longevity World Cup](https://longevityworldcup.com/) for the latest details.</textarea>
+                <div class="editor-wrap">
+                    <textarea id="contentInput">We have added an expandable CustomEvent row in Highlights. This update highlights one [bold](important) change, includes a [strong](major announcement), gives a shoutout to [mention](nopara73), and links to [Longevity World Cup](https://longevityworldcup.com/) for the latest details.</textarea>
+                </div>
             </label>
+
+            <div id="mentionSuggestions" class="mention-suggestions" hidden></div>
 
             <div>
                 <div style="margin-bottom:6px;font-size:13px;">Send to</div>
@@ -549,10 +613,14 @@
         const insertStrongBtn = document.getElementById("insertStrongBtn");
         const insertLinkBtn = document.getElementById("insertLinkBtn");
         const insertMentionBtn = document.getElementById("insertMentionBtn");
+        const mentionSuggestions = document.getElementById("mentionSuggestions");
         const textPreviewList = document.getElementById("textPreviewList");
         const imagePreviewList = document.getElementById("imagePreviewList");
         let activeEditor = contentInput;
         let athleteMentionIndex = new Map();
+        let athleteMentionItems = [];
+        let activeMentionContext = null;
+        let activeMentionIndex = 0;
 
         const PLATFORM_CONFIGS = [
             { key: "x", label: "X", checkbox: sendX, limit: LIMITS.x },
@@ -640,18 +708,157 @@
 
         function buildAthleteMentionIndex(athletes) {
             const index = new Map();
+            athleteMentionItems = [];
             (athletes || []).forEach(athlete => {
                 const slug = String(athlete?.AthleteSlug || athlete?.Slug || "").trim().toLowerCase();
                 if (!slug) {
                     return;
                 }
 
-                index.set(slug, {
-                    name: String(athlete?.Name || "").trim(),
+                const item = {
+                    name: String(athlete?.DisplayName || athlete?.Name || "").trim(),
                     mediaContact: String(athlete?.MediaContact || "").trim()
+                };
+                index.set(slug, item);
+                athleteMentionItems.push({ slug, name: item.name });
+            });
+            athleteMentionItems.sort((a, b) => a.slug.localeCompare(b.slug));
+            return index;
+        }
+
+        function escapeRegExp(value) {
+            return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        }
+
+        function getMentionContext(target) {
+            if (!target) {
+                return null;
+            }
+
+            const value = target.value || "";
+            const caret = target.selectionStart ?? value.length;
+            const beforeCaret = value.slice(0, caret);
+            const marker = "[mention](";
+            const markerIndex = beforeCaret.lastIndexOf(marker);
+            if (markerIndex < 0) {
+                return null;
+            }
+
+            const mentionStart = markerIndex + marker.length;
+            const closingParenIndex = value.indexOf(")", mentionStart);
+            const mentionEnd = closingParenIndex >= 0 ? closingParenIndex : caret;
+            const mentionValue = value.slice(mentionStart, mentionEnd);
+            if (!/^[a-z0-9_-]*$/i.test(mentionValue)) {
+                return null;
+            }
+
+            if (caret < mentionStart || caret > mentionEnd) {
+                return null;
+            }
+
+            const query = value.slice(mentionStart, caret);
+            return { target, query: query.toLowerCase(), start: mentionStart, end: mentionEnd };
+        }
+
+        function getMentionMatches(query) {
+            const normalized = String(query || "").trim().toLowerCase();
+            const starts = [];
+            const contains = [];
+
+            athleteMentionItems.forEach(item => {
+                const slug = item.slug;
+                const name = (item.name || "").toLowerCase();
+                if (!normalized || slug.startsWith(normalized)) {
+                    starts.push(item);
+                    return;
+                }
+
+                if (slug.includes(normalized) || name.includes(normalized)) {
+                    contains.push(item);
+                }
+            });
+
+            return starts.concat(contains).slice(0, 8);
+        }
+
+        function closeMentionSuggestions() {
+            mentionSuggestions.hidden = true;
+            mentionSuggestions.innerHTML = "";
+            activeMentionContext = null;
+            activeMentionIndex = 0;
+        }
+
+        function positionMentionSuggestions(target) {
+            if (!target) {
+                return;
+            }
+            const wrap = target.closest(".editor-wrap");
+            if (wrap && mentionSuggestions.parentElement !== wrap) {
+                wrap.appendChild(mentionSuggestions);
+            }
+            mentionSuggestions.style.maxHeight = "220px";
+        }
+
+        function applyMentionSuggestion(item) {
+            if (!activeMentionContext || !item) {
+                return;
+            }
+
+            const target = activeMentionContext.target;
+            const value = target.value || "";
+            const nextValue = `${value.slice(0, activeMentionContext.start)}${item.slug}${value.slice(activeMentionContext.end)}`;
+            target.value = nextValue;
+            const caret = activeMentionContext.start + item.slug.length;
+            target.focus();
+            target.setSelectionRange(caret, caret);
+            closeMentionSuggestions();
+            update();
+        }
+
+        function renderMentionSuggestions(matches) {
+            if (!activeMentionContext || matches.length === 0) {
+                closeMentionSuggestions();
+                return;
+            }
+
+            positionMentionSuggestions(activeMentionContext.target);
+
+            mentionSuggestions.innerHTML = matches.map((item, index) => `
+                <button type="button" class="mention-option${index === activeMentionIndex ? " is-active" : ""}" data-slug="${escapeHtml(item.slug)}">
+                    <span class="mention-option-slug">${escapeHtml(item.slug)}</span>
+                    <span class="mention-option-name">${escapeHtml(item.name || item.slug)}</span>
+                </button>
+            `).join("");
+
+            Array.from(mentionSuggestions.querySelectorAll(".mention-option")).forEach((button, index) => {
+                button.addEventListener("mousedown", event => {
+                    event.preventDefault();
+                    applyMentionSuggestion(matches[index]);
                 });
             });
-            return index;
+
+            const activeButton = mentionSuggestions.querySelector(".mention-option.is-active");
+            if (activeButton) {
+                activeButton.scrollIntoView({ block: "nearest" });
+            }
+
+            mentionSuggestions.hidden = false;
+        }
+
+        function updateMentionSuggestions(target) {
+            const context = getMentionContext(target);
+            if (!context) {
+                closeMentionSuggestions();
+                return;
+            }
+
+            activeMentionContext = context;
+            const matches = getMentionMatches(context.query);
+            if (activeMentionIndex >= matches.length) {
+                activeMentionIndex = 0;
+            }
+
+            renderMentionSuggestions(matches);
         }
 
         function extractMentionHandle(mediaContact, platformKey) {
@@ -820,6 +1027,7 @@
         function setActiveEditor(target) {
             if (target === titleInput || target === contentInput) {
                 activeEditor = target;
+                updateMentionSuggestions(target);
             }
         }
 
@@ -1035,10 +1243,66 @@
             el.addEventListener("click", () => setActiveEditor(el));
             el.addEventListener("keyup", () => setActiveEditor(el));
             el.addEventListener("select", () => setActiveEditor(el));
+            el.addEventListener("keydown", event => {
+                if (mentionSuggestions.hidden || !activeMentionContext || activeMentionContext.target !== el) {
+                    return;
+                }
+
+                const matches = getMentionMatches(activeMentionContext.query);
+                if (matches.length === 0) {
+                    closeMentionSuggestions();
+                    return;
+                }
+
+                if (event.key === "ArrowDown") {
+                    event.preventDefault();
+                    activeMentionIndex = (activeMentionIndex + 1) % matches.length;
+                    renderMentionSuggestions(matches);
+                    return;
+                }
+
+                if (event.key === "ArrowUp") {
+                    event.preventDefault();
+                    activeMentionIndex = (activeMentionIndex - 1 + matches.length) % matches.length;
+                    renderMentionSuggestions(matches);
+                    return;
+                }
+
+                if (event.key === "Enter" || event.key === "Tab") {
+                    event.preventDefault();
+                    applyMentionSuggestion(matches[activeMentionIndex]);
+                    return;
+                }
+
+                if (event.key === "Escape") {
+                    event.preventDefault();
+                    closeMentionSuggestions();
+                }
+            });
+            el.addEventListener("blur", () => {
+                setTimeout(() => {
+                    if (document.activeElement && mentionSuggestions.contains(document.activeElement)) {
+                        return;
+                    }
+                    closeMentionSuggestions();
+                }, 0);
+            });
+        });
+
+        document.addEventListener("click", event => {
+            if (event.target === titleInput || event.target === contentInput || mentionSuggestions.contains(event.target)) {
+                return;
+            }
+            closeMentionSuggestions();
         });
 
         [titleInput, contentInput, sendSlack, sendX, sendThreads, sendFacebook].forEach(el => {
-            el.addEventListener("input", update);
+            el.addEventListener("input", event => {
+                if (event.target === titleInput || event.target === contentInput) {
+                    updateMentionSuggestions(event.target);
+                }
+                update();
+            });
             el.addEventListener("change", update);
         });
 

--- a/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
+++ b/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
@@ -679,15 +679,68 @@
             }).trim();
         }
 
-        function formatPlainPostTextToHtml(value, platformKey) {
+        function buildMentionProfileUrl(handle, platformKey) {
+            const normalized = String(handle || "").trim().replace(/^@+/, "");
+            if (!normalized) {
+                return "";
+            }
+
+            if (platformKey === "x") {
+                return `https://x.com/${encodeURIComponent(normalized)}`;
+            }
+
+            if (platformKey === "threads") {
+                return `https://www.threads.com/@${encodeURIComponent(normalized)}`;
+            }
+
+            return "";
+        }
+
+        function collectClickableMentions(rawText, platformKey) {
+            const matches = [];
+            const seen = new Set();
+            const pattern = /\[mention\]\(([^)\r\n]+)\)/gi;
+            let match;
+            while ((match = pattern.exec(String(rawText || ""))) !== null) {
+                const slug = String(match[1] || "").trim();
+                if (!slug) {
+                    continue;
+                }
+
+                const handle = resolveMentionSlug(slug, platformKey);
+                if (!handle || !handle.startsWith("@")) {
+                    continue;
+                }
+
+                const href = buildMentionProfileUrl(handle, platformKey);
+                if (!href) {
+                    continue;
+                }
+
+                const key = `${handle}|${href}`;
+                if (seen.has(key)) {
+                    continue;
+                }
+
+                seen.add(key);
+                matches.push({ handle, href });
+            }
+
+            return matches.sort((a, b) => b.handle.length - a.handle.length);
+        }
+
+        function formatPlainPostTextToHtml(value, clickableMentions) {
             let html = escapeHtml((value ?? "").replace(/\r\n/g, "\n").replace(/\r/g, "\n"));
             html = html.replace(/(https?:\/\/[^\s<]+)/gi, '<a href="$1" target="_blank" rel="noopener noreferrer">$1</a>');
             html = html.replace(/(^|[\s(>])((?:[a-z0-9-]+\.)+[a-z]{2,}(?:\/[^\s<]*)?)/gim, '$1<a href="https://$2" target="_blank" rel="noopener noreferrer">$2</a>');
-            if (platformKey === "x") {
-                html = html.replace(/(^|[\s(>])@([A-Za-z0-9_]{1,15})\b/g, '$1<a href="https://x.com/$2" target="_blank" rel="noopener noreferrer">@$2</a>');
-            } else if (platformKey === "threads") {
-                html = html.replace(/(^|[\s(>])@([A-Za-z0-9._]{1,30})\b/g, '$1<a href="https://www.threads.com/@$2" target="_blank" rel="noopener noreferrer">@$2</a>');
-            }
+            (clickableMentions || []).forEach(item => {
+                const handlePattern = escapeRegExp(item.handle);
+                const href = escapeHtml(item.href);
+                html = html.replace(
+                    new RegExp(`(^|[\\s(>])(${handlePattern})(?=$|[\\s),.!?:;<])`, "g"),
+                    `$1<a href="${href}" target="_blank" rel="noopener noreferrer">$2</a>`
+                );
+            });
             html = html.replace(/\n/g, "<br>");
             return html;
         }
@@ -1114,7 +1167,7 @@
             return settings;
         }
 
-        function renderTextPreviewCard(platformKey, postText) {
+        function renderTextPreviewCard(platformKey, postText, clickableMentions) {
             const meta = PLATFORM_PREVIEW_META[platformKey] || PLATFORM_PREVIEW_META.x;
             return `
                 <div class="panel preview-block">
@@ -1130,7 +1183,7 @@
                                     <span class="x-handle">${escapeHtml(meta.handle)}</span>
                                     <span class="x-meta">now</span>
                                 </div>
-                                <div class="x-text">${formatPlainPostTextToHtml(postText, platformKey)}</div>
+                                <div class="x-text">${formatPlainPostTextToHtml(postText, clickableMentions)}</div>
                                 <div class="x-actions"><span>Reply</span><span>Repost</span><span>Like</span><span>View</span></div>
                             </div>
                         </div>
@@ -1138,7 +1191,7 @@
                 </div>`;
         }
 
-        function renderImagePreviewCard(platformKey, postText, contentRaw) {
+        function renderImagePreviewCard(platformKey, postText, contentRaw, clickableMentions) {
             const meta = PLATFORM_PREVIEW_META[platformKey] || PLATFORM_PREVIEW_META.x;
             const layout = getImagePreviewLayout(contentRaw, platformKey);
             const frameWidth = 560;
@@ -1159,7 +1212,7 @@
                                     <span class="x-handle">${escapeHtml(meta.handle)}</span>
                                     <span class="x-meta">now</span>
                                 </div>
-                                <div class="x-text">${formatPlainPostTextToHtml(postText, platformKey)}</div>
+                                <div class="x-text">${formatPlainPostTextToHtml(postText, clickableMentions)}</div>
                                 <div class="x-media">
                                     <div class="image-stage-frame" style="height:${frameHeight}px;">
                                         <div class="image-stage" style="transform:scale(${scale});">
@@ -1176,12 +1229,12 @@
                 </div>`;
         }
 
-        function renderPlatformPreviewCard(plan, contentRaw, fallbackTextPost, fallbackImagePost) {
+        function renderPlatformPreviewCard(plan, contentRaw, fallbackTextPost, fallbackImagePost, clickableMentions) {
             if (plan.mode === "image") {
-                return renderImagePreviewCard(plan.key, plan.postText || fallbackImagePost, contentRaw);
+                return renderImagePreviewCard(plan.key, plan.postText || fallbackImagePost, contentRaw, clickableMentions);
             }
 
-            return renderTextPreviewCard(plan.key, plan.postText || fallbackTextPost);
+            return renderTextPreviewCard(plan.key, plan.postText || fallbackTextPost, clickableMentions);
         }
 
         function update() {
@@ -1213,7 +1266,8 @@
                     plan,
                     contentRaw,
                     buildTextPost(titleText, bodyText, eventUrl),
-                    buildImageCaption(titleText, eventUrl ?? "", plan.limit ?? LIMITS.x)
+                    buildImageCaption(titleText, eventUrl ?? "", plan.limit ?? LIMITS.x),
+                    collectClickableMentions(combinedRaw, plan.key)
                 )
             ).join("");
 

--- a/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
+++ b/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
@@ -638,9 +638,7 @@
             return (value ?? "").replace(/\s+/g, " ").trim();
         }
 
-        function containsHyperlink(value) {
-            return /\[[^\]]+\]\((https?:\/\/[^)\s]+)\)/i.test(value ?? "");
-        }
+        function containsHyperlink(value) { return window.CustomEventMarkup.containsHyperlink(value); }
 
         function normalizeNewlines(value) { return window.CustomEventMarkup.normalizeNewlines(value); }
         function renderCustomMarkup(text) {

--- a/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
+++ b/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
@@ -611,7 +611,7 @@
             });
         }
         function renderImageMarkupWithBreaks(text) {
-            return window.CustomEventMarkup.renderMarkupWithBreaks(text, { mentionResolver: slug => resolveMentionSlug(slug, "x") });
+            return window.CustomEventMarkup.renderImageMarkupWithBreaks(text, { mentionResolver: slug => resolveMentionSlug(slug, "x") });
         }
         function plainTextWithLabels(value, mentionResolver) {
             return window.CustomEventMarkup.toPlainText(value, {
@@ -881,7 +881,7 @@
 
         function getImagePreviewLayout(contentRaw, platformKey) {
             const resolvedContent = contentRaw || titleInput.value.trim();
-            const textHtml = window.CustomEventMarkup.renderMarkupWithBreaks(resolvedContent, {
+            const textHtml = window.CustomEventMarkup.renderImageMarkupWithBreaks(resolvedContent, {
                 mentionResolver: slug => resolveMentionSlug(slug, platformKey)
             });
             const length = plainTextWithLabels(resolvedContent, slug => resolveMentionSlug(slug, platformKey)).length;

--- a/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
+++ b/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
@@ -586,13 +586,7 @@
                 </div>
             </div>
 
-            <div class="panel preview-block">
-                <div id="textPreviewList" class="preview-stack"></div>
-            </div>
-
-            <div class="panel preview-block">
-                <div id="imagePreviewList" class="preview-stack"></div>
-            </div>
+            <div id="socialPreviewList" class="preview-stack"></div>
         </div>
     </div>
 
@@ -614,8 +608,7 @@
         const insertLinkBtn = document.getElementById("insertLinkBtn");
         const insertMentionBtn = document.getElementById("insertMentionBtn");
         const mentionSuggestions = document.getElementById("mentionSuggestions");
-        const textPreviewList = document.getElementById("textPreviewList");
-        const imagePreviewList = document.getElementById("imagePreviewList");
+        const socialPreviewList = document.getElementById("socialPreviewList");
         let activeEditor = contentInput;
         let athleteMentionIndex = new Map();
         let athleteMentionItems = [];
@@ -688,10 +681,15 @@
             }).trim();
         }
 
-        function formatPlainPostTextToHtml(value) {
+        function formatPlainPostTextToHtml(value, platformKey) {
             let html = escapeHtml((value ?? "").replace(/\r\n/g, "\n").replace(/\r/g, "\n"));
             html = html.replace(/(https?:\/\/[^\s<]+)/gi, '<a href="$1" target="_blank" rel="noopener noreferrer">$1</a>');
             html = html.replace(/(^|[\s(>])((?:[a-z0-9-]+\.)+[a-z]{2,}(?:\/[^\s<]*)?)/gim, '$1<a href="https://$2" target="_blank" rel="noopener noreferrer">$2</a>');
+            if (platformKey === "x") {
+                html = html.replace(/(^|[\s(>])@([A-Za-z0-9_]{1,15})\b/g, '$1<a href="https://x.com/$2" target="_blank" rel="noopener noreferrer">@$2</a>');
+            } else if (platformKey === "threads") {
+                html = html.replace(/(^|[\s(>])@([A-Za-z0-9._]{1,30})\b/g, '$1<a href="https://www.threads.com/@$2" target="_blank" rel="noopener noreferrer">@$2</a>');
+            }
             html = html.replace(/\n/g, "<br>");
             return html;
         }
@@ -1121,22 +1119,24 @@
         function renderTextPreviewCard(platformKey, postText) {
             const meta = PLATFORM_PREVIEW_META[platformKey] || PLATFORM_PREVIEW_META.x;
             return `
-                <div class="preview-surface fit-content" style="border:0;background:transparent;padding:0;">
+                <div class="panel preview-block">
                     <div class="preview-title" style="margin-bottom:8px;">
                         <h2>${escapeHtml(meta.label)} Preview</h2>
                     </div>
-                    <div class="x-post">
-                        <div class="x-avatar">${escapeHtml(meta.avatar)}</div>
-                        <div class="x-main">
-                            <div class="x-head">
-                                <span class="x-name">${escapeHtml(meta.name)}</span>
-                                <span class="x-handle">${escapeHtml(meta.handle)}</span>
-                                <span class="x-meta">now</span>
+                    <div class="preview-surface fit-content" style="border:0;background:transparent;padding:0;">
+                        <div class="x-post">
+                            <div class="x-avatar">${escapeHtml(meta.avatar)}</div>
+                            <div class="x-main">
+                                <div class="x-head">
+                                    <span class="x-name">${escapeHtml(meta.name)}</span>
+                                    <span class="x-handle">${escapeHtml(meta.handle)}</span>
+                                    <span class="x-meta">now</span>
+                                </div>
+                                <div class="x-text">${formatPlainPostTextToHtml(postText, platformKey)}</div>
+                                <div class="x-actions"><span>Reply</span><span>Repost</span><span>Like</span><span>View</span></div>
                             </div>
-                            <div class="x-text">${formatPlainPostTextToHtml(postText)}</div>
-                            <div class="x-actions"><span>Reply</span><span>Repost</span><span>Like</span><span>View</span></div>
                         </div>
-                    </div>
+                    </div>    
                 </div>`;
         }
 
@@ -1148,32 +1148,42 @@
             const frameHeight = 675 * scale;
 
             return `
-                <div class="preview-surface fit-content" style="border:0;background:transparent;padding:0;">
+                <div class="panel preview-block">
                     <div class="preview-title" style="margin-bottom:8px;">
                         <h2>${escapeHtml(meta.label)} Preview</h2>
                     </div>
-                    <div class="x-post">
-                        <div class="x-avatar">${escapeHtml(meta.avatar)}</div>
-                        <div class="x-main">
-                            <div class="x-head">
-                                <span class="x-name">${escapeHtml(meta.name)}</span>
-                                <span class="x-handle">${escapeHtml(meta.handle)}</span>
-                                <span class="x-meta">now</span>
-                            </div>
-                            <div class="x-text">${formatPlainPostTextToHtml(postText)}</div>
-                            <div class="x-media">
-                                <div class="image-stage-frame" style="height:${frameHeight}px;">
-                                    <div class="image-stage" style="transform:scale(${scale});">
-                                        <div class="image-card" style="width:${layout.cardWidth}px;height:${layout.cardHeight}px;padding:${layout.padding};">
-                                            <div class="image-text formatted" style="font-size:${layout.fontSize};line-height:${layout.lineHeight};">${layout.textHtml}</div>
+                    <div class="preview-surface fit-content" style="border:0;background:transparent;padding:0;">
+                        <div class="x-post">
+                            <div class="x-avatar">${escapeHtml(meta.avatar)}</div>
+                            <div class="x-main">
+                                <div class="x-head">
+                                    <span class="x-name">${escapeHtml(meta.name)}</span>
+                                    <span class="x-handle">${escapeHtml(meta.handle)}</span>
+                                    <span class="x-meta">now</span>
+                                </div>
+                                <div class="x-text">${formatPlainPostTextToHtml(postText, platformKey)}</div>
+                                <div class="x-media">
+                                    <div class="image-stage-frame" style="height:${frameHeight}px;">
+                                        <div class="image-stage" style="transform:scale(${scale});">
+                                            <div class="image-card" style="width:${layout.cardWidth}px;height:${layout.cardHeight}px;padding:${layout.padding};">
+                                                <div class="image-text formatted" style="font-size:${layout.fontSize};line-height:${layout.lineHeight};">${layout.textHtml}</div>
+                                            </div>
                                         </div>
                                     </div>
                                 </div>
+                                <div class="x-actions"><span>Reply</span><span>Repost</span><span>Like</span><span>View</span></div>
                             </div>
-                            <div class="x-actions"><span>Reply</span><span>Repost</span><span>Like</span><span>View</span></div>
                         </div>
                     </div>
                 </div>`;
+        }
+
+        function renderPlatformPreviewCard(plan, contentRaw, fallbackTextPost, fallbackImagePost) {
+            if (plan.mode === "image") {
+                return renderImagePreviewCard(plan.key, plan.postText || fallbackImagePost, contentRaw);
+            }
+
+            return renderTextPreviewCard(plan.key, plan.postText || fallbackTextPost);
         }
 
         function update() {
@@ -1195,35 +1205,19 @@
             document.getElementById("eventContentPreview").innerHTML = contentRaw ? renderWebpageMarkupWithBreaks(contentRaw) : "";
 
             const selectedPlans = getSelectedPlatformPlans(titleRaw, contentRaw);
-            const textPlans = selectedPlans.filter(x => x.mode === "text");
-            const imagePlans = selectedPlans.filter(x => x.mode === "image");
 
             const titleText = collapseWhitespace(plainTextWithLabels(titleRaw, slug => resolveMentionSlug(slug, "x")));
             const bodyText = plainTextWithLabels(contentRaw, slug => resolveMentionSlug(slug, "x"));
             const eventUrl = containsHyperlink(combinedRaw) ? buildPreviewEventUrl(titleRaw, contentRaw) : null;
 
-            const textPreviewBlock = textPreviewList.closest(".panel");
-            const imagePreviewBlock = imagePreviewList.closest(".panel");
-
-            if (textPlans.length > 0) {
-                textPreviewBlock.style.display = "";
-                textPreviewList.innerHTML = textPlans.map(plan =>
-                    renderTextPreviewCard(plan.key, plan.postText || buildTextPost(titleText, bodyText, eventUrl))
-                ).join("");
-            } else {
-                textPreviewBlock.style.display = "none";
-                textPreviewList.innerHTML = "";
-            }
-
-            if (imagePlans.length > 0) {
-                imagePreviewBlock.style.display = "";
-                imagePreviewList.innerHTML = imagePlans.map(plan =>
-                    renderImagePreviewCard(plan.key, plan.postText || buildImageCaption(titleText, eventUrl ?? "", LIMITS.x), contentRaw)
-                ).join("");
-            } else {
-                imagePreviewBlock.style.display = "none";
-                imagePreviewList.innerHTML = "";
-            }
+            socialPreviewList.innerHTML = selectedPlans.map(plan =>
+                renderPlatformPreviewCard(
+                    plan,
+                    contentRaw,
+                    buildTextPost(titleText, bodyText, eventUrl),
+                    buildImageCaption(titleText, eventUrl ?? "", plan.limit ?? LIMITS.x)
+                )
+            ).join("");
 
             const payloadJsonText = JSON.stringify(payload);
             const payloadToken = base64UrlEncodeUtf8(payloadJsonText);

--- a/LongevityWorldCup.Website/wwwroot/js/custom-event-markup.js
+++ b/LongevityWorldCup.Website/wwwroot/js/custom-event-markup.js
@@ -31,6 +31,55 @@
         return /^https?:\/\/.+/i.test(String(value || "").trim());
     }
 
+    function containsHyperlink(text) {
+        return containsHyperlinkCore(String(text || ""));
+    }
+
+    function containsHyperlinkCore(text) {
+        var s = String(text || "");
+        var i = 0;
+        while (i < s.length) {
+            var open = s.indexOf("[", i);
+            if (open < 0) {
+                return false;
+            }
+
+            var close = s.indexOf("](", open + 1);
+            if (close < 0) {
+                return false;
+            }
+
+            var label = s.slice(open + 1, close);
+            var parenStart = close + 2;
+            var depth = 1;
+            var j = parenStart;
+            while (j < s.length && depth > 0) {
+                var ch = s[j];
+                if (ch === "(") depth++;
+                else if (ch === ")") depth--;
+                j++;
+            }
+
+            if (depth !== 0) {
+                return false;
+            }
+
+            var inner = s.slice(parenStart, j - 1);
+            var key = label.trim().toLowerCase();
+            if (key === "bold" || key === "strong") {
+                if (containsHyperlinkCore(inner)) {
+                    return true;
+                }
+            } else if (isSafeHttpUrl(inner)) {
+                return true;
+            }
+
+            i = j;
+        }
+
+        return false;
+    }
+
     function humanizeSlug(value) {
         return String(value || "")
             .replace(/[_-]+/g, " ")
@@ -203,6 +252,7 @@
     window.CustomEventMarkup = {
         normalizeNewlines: normalizeNewlines,
         splitText: splitText,
+        containsHyperlink: containsHyperlink,
         renderMarkup: renderMarkup,
         renderMarkupWithBreaks: renderMarkupWithBreaks,
         renderWebpageMarkup: renderWebpageMarkup,

--- a/LongevityWorldCup.Website/wwwroot/js/custom-event-markup.js
+++ b/LongevityWorldCup.Website/wwwroot/js/custom-event-markup.js
@@ -1,4 +1,6 @@
 (function () {
+    let mentionResolver = null;
+
     function escapeHtml(value) {
         return String(value ?? "").replace(/[&<>"']/g, function (ch) {
             return {
@@ -29,21 +31,42 @@
         return /^https?:\/\/.+/i.test(String(value || "").trim());
     }
 
-    function renderMarkup(text) {
+    function humanizeSlug(value) {
+        return String(value || "")
+            .replace(/[_-]+/g, " ")
+            .trim()
+            .split(/\s+/)
+            .filter(Boolean)
+            .map(function (part) { return part.charAt(0).toUpperCase() + part.slice(1); })
+            .join(" ");
+    }
+
+    function resolveMentionText(slug, overrideResolver) {
+        var normalized = String(slug || "").trim();
+        if (!normalized) {
+            return "";
+        }
+
+        var resolver = typeof overrideResolver === "function" ? overrideResolver : mentionResolver;
+        var resolved = resolver ? resolver(normalized) : "";
+        return resolved ? String(resolved) : (humanizeSlug(normalized) || normalized);
+    }
+
+    function walk(text, handlers) {
         var s = String(text || "");
         var out = "";
         var i = 0;
         while (i < s.length) {
             var open = s.indexOf("[", i);
             if (open < 0) {
-                out += escapeHtml(s.slice(i));
+                out += handlers.text(s.slice(i));
                 break;
             }
 
-            out += escapeHtml(s.slice(i, open));
+            out += handlers.text(s.slice(i, open));
             var close = s.indexOf("](", open + 1);
             if (close < 0) {
-                out += escapeHtml(s.slice(open));
+                out += handlers.text(s.slice(open));
                 break;
             }
 
@@ -59,20 +82,22 @@
             }
 
             if (depth !== 0) {
-                out += escapeHtml(s.slice(open));
+                out += handlers.text(s.slice(open));
                 break;
             }
 
             var inner = s.slice(parenStart, j - 1);
             var key = label.trim().toLowerCase();
             if (key === "bold") {
-                out += '<span style="font-weight:800">' + renderMarkup(inner) + "</span>";
+                out += handlers.bold(inner);
             } else if (key === "strong") {
-                out += '<span style="font-weight:800;color:var(--secondary-color,#ff4f87)">' + renderMarkup(inner) + "</span>";
+                out += handlers.strong(inner);
+            } else if (key === "mention") {
+                out += handlers.mention(inner);
             } else if (isSafeHttpUrl(inner)) {
-                out += '<a href="' + escapeHtml(inner.trim()) + '" target="_top" rel="noopener">' + escapeHtml(label) + "</a>";
+                out += handlers.link(label, inner);
             } else {
-                out += escapeHtml(s.slice(open, j));
+                out += handlers.text(s.slice(open, j));
             }
 
             i = j;
@@ -81,14 +106,83 @@
         return out;
     }
 
-    function renderMarkupWithBreaks(text) {
-        return normalizeNewlines(text || "").split("\n").map(renderMarkup).join("<br>");
+    function renderMarkup(text, options) {
+        var opts = options || {};
+        return walk(text, {
+            text: function (value) { return escapeHtml(value); },
+            bold: function (inner) {
+                return '<span style="font-weight:800">' + renderMarkup(inner, opts) + "</span>";
+            },
+            strong: function (inner) {
+                return '<span style="font-weight:800;color:var(--secondary-color,#ff4f87)">' + renderMarkup(inner, opts) + "</span>";
+            },
+            mention: function (slug) {
+                var resolvedText = resolveMentionText(slug, opts.mentionResolver);
+                if (typeof opts.mentionRenderer === "function") {
+                    return String(opts.mentionRenderer(String(slug || "").trim(), resolvedText) || "");
+                }
+                return escapeHtml(resolvedText);
+            },
+            link: function (label, href) {
+                return '<a href="' + escapeHtml(href.trim()) + '" target="_top" rel="noopener">' + escapeHtml(label) + "</a>";
+            }
+        });
+    }
+
+    function renderMarkupWithBreaks(text, options) {
+        return normalizeNewlines(text || "").split("\n").map(function (line) {
+            return renderMarkup(line, options);
+        }).join("<br>");
+    }
+
+    function renderWebpageMarkup(text, options) {
+        var opts = options || {};
+        return renderMarkup(text, {
+            mentionResolver: opts.mentionResolver,
+            mentionRenderer: function (slug, displayText) {
+                var href = typeof opts.mentionHrefResolver === "function"
+                    ? opts.mentionHrefResolver(String(slug || "").trim())
+                    : "";
+
+                if (!href) {
+                    return escapeHtml(displayText);
+                }
+
+                return '<a href="' + escapeHtml(String(href)) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(displayText) + '</a>';
+            }
+        });
+    }
+
+    function renderWebpageMarkupWithBreaks(text, options) {
+        return normalizeNewlines(text || "").split("\n").map(function (line) {
+            return renderWebpageMarkup(line, options);
+        }).join("<br>");
+    }
+
+    function toPlainText(text, options) {
+        var opts = options || {};
+        var keepHyperlinkLabels = opts.keepHyperlinkLabels !== false;
+        return walk(text, {
+            text: function (value) { return value; },
+            bold: function (inner) { return toPlainText(inner, opts); },
+            strong: function (inner) { return toPlainText(inner, opts); },
+            mention: function (slug) { return resolveMentionText(slug, opts.mentionResolver); },
+            link: function (label) { return keepHyperlinkLabels ? label : ""; }
+        });
+    }
+
+    function setMentionResolver(resolver) {
+        mentionResolver = typeof resolver === "function" ? resolver : null;
     }
 
     window.CustomEventMarkup = {
         normalizeNewlines: normalizeNewlines,
         splitText: splitText,
         renderMarkup: renderMarkup,
-        renderMarkupWithBreaks: renderMarkupWithBreaks
+        renderMarkupWithBreaks: renderMarkupWithBreaks,
+        renderWebpageMarkup: renderWebpageMarkup,
+        renderWebpageMarkupWithBreaks: renderWebpageMarkupWithBreaks,
+        toPlainText: toPlainText,
+        setMentionResolver: setMentionResolver
     };
 })();

--- a/LongevityWorldCup.Website/wwwroot/js/custom-event-markup.js
+++ b/LongevityWorldCup.Website/wwwroot/js/custom-event-markup.js
@@ -159,6 +159,31 @@
         }).join("<br>");
     }
 
+    function renderImageMarkup(text, options) {
+        var opts = options || {};
+        return walk(text, {
+            text: function (value) { return escapeHtml(value); },
+            bold: function (inner) {
+                return '<span style="font-weight:800">' + renderImageMarkup(inner, opts) + "</span>";
+            },
+            strong: function (inner) {
+                return '<span style="font-weight:800;color:var(--secondary-color,#ff4f87)">' + renderImageMarkup(inner, opts) + "</span>";
+            },
+            mention: function (slug) {
+                return escapeHtml(resolveMentionText(slug, opts.mentionResolver));
+            },
+            link: function (label) {
+                return escapeHtml(label);
+            }
+        });
+    }
+
+    function renderImageMarkupWithBreaks(text, options) {
+        return normalizeNewlines(text || "").split("\n").map(function (line) {
+            return renderImageMarkup(line, options);
+        }).join("<br>");
+    }
+
     function toPlainText(text, options) {
         var opts = options || {};
         var keepHyperlinkLabels = opts.keepHyperlinkLabels !== false;
@@ -182,6 +207,8 @@
         renderMarkupWithBreaks: renderMarkupWithBreaks,
         renderWebpageMarkup: renderWebpageMarkup,
         renderWebpageMarkupWithBreaks: renderWebpageMarkupWithBreaks,
+        renderImageMarkup: renderImageMarkup,
+        renderImageMarkupWithBreaks: renderImageMarkupWithBreaks,
         toPlainText: toPlainText,
         setMentionResolver: setMentionResolver
     };

--- a/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
@@ -716,8 +716,8 @@
                 return "";
             }
         }
-        function renderCustomMarkup(text){return window.CustomEventMarkup.renderMarkup(text);}
-        function renderCustomMarkupWithBreaks(text){return window.CustomEventMarkup.renderMarkupWithBreaks(text);}
+        function renderCustomMarkup(text){return window.CustomEventMarkup.renderWebpageMarkup(text, eventBoardMarkupOptions);}
+        function renderCustomMarkupWithBreaks(text){return window.CustomEventMarkup.renderWebpageMarkupWithBreaks(text, eventBoardMarkupOptions);}
         function startOfLocalDay(d){return new Date(d.getFullYear(),d.getMonth(),d.getDate());}
         function relativeDayLabel(iso){
             const dt=new Date(iso); if(isNaN(dt)) return "";
@@ -793,6 +793,12 @@
             const map=lowerKeyMap(a);
             const k=map["name"]||map["athletename"]||map["fullname"]||map["displayname"];
             return k?String(a[k]).trim():"";
+        }
+        function resolveMentionName(slug, athletesIndex){
+            const key=slugifyLocal(normalizeLinkId(slug));
+            const athlete=athletesIndex.get(key);
+            if (athlete) return athleteName(athlete)||slug;
+            return String(slug||"").replace(/[_-]+/g," ").trim() || slug;
         }
         function athletePic(a){
             if(!a) return "";
@@ -979,6 +985,7 @@
         let allowBadgeClicks = true;
         let athletePageTargetSlug = null;
         let openLinksInNewTab = false;
+        let eventBoardMarkupOptions = {};
         
         function renderBadgeBubbleForLabel(label, athlete, leagueCategory=null, leagueValue=null, place=null){
             try{
@@ -1777,6 +1784,14 @@
 
             Promise.all([eventsReq,athletesReq]).then(([events,athletes])=>{
                 const athletesIndex=buildAthleteIndex(athletes);
+                eventBoardMarkupOptions = {
+                    mentionResolver: slug => resolveMentionName(slug, athletesIndex),
+                    mentionHrefResolver: slug => {
+                        const key = slugifyLocal(normalizeLinkId(slug));
+                        return athletesIndex.has(key) ? makeAthleteUrlFromSlug(slug) : "";
+                    }
+                };
+                window.CustomEventMarkup.setMentionResolver(slug => resolveMentionName(slug, athletesIndex));
                 let rows=toRows(Array.isArray(events)?events:[]);
 
                 const targetArg=normalizeIncomingAthleteId(athleteId);

--- a/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
@@ -791,7 +791,7 @@
         function athleteName(a){
             if(!a) return "";
             const map=lowerKeyMap(a);
-            const k=map["name"]||map["athletename"]||map["fullname"]||map["displayname"];
+            const k=map["displayname"]||map["name"]||map["athletename"]||map["fullname"];
             return k?String(a[k]).trim():"";
         }
         function resolveMentionName(slug, athletesIndex){


### PR DESCRIPTION
Now it is possible to mention people in custom events with `[mention](slug)`. And it will be displayed accordingly on each platform.

Webpage -> Display name as hyperlink to the athlete page
Slack -> Display name as hyperlink to the athlete page
X -> X handle if available, otherwise Display name
Threads -> Threads handle if available, otherwise Display name
Facebook -> Display name

<img width="1050" height="897" alt="image" src="https://github.com/user-attachments/assets/9a9c3c55-d555-43cf-a3d5-cc44c73c7842" />
