### PR TITLE
Custom Event Designer as Social Post Manager

### DIFF
--- a/LongevityWorldCup.Documentation/CustomEvent.md
+++ b/LongevityWorldCup.Documentation/CustomEvent.md
@@ -11,8 +11,16 @@ Fill in:
 - `Title`
 - `Content`
 - target platforms
+- `Webpage` if the post should also appear on `/events`
 
 Then copy the generated server command and run it on the server.
+
+Behavior:
+
+- if `Webpage` is enabled, the post is stored in the DB and also appears on the public event feed
+- if `Webpage` is disabled, the post is still stored in the DB, but it stays hidden from the public website
+- hidden website posts can still be sent to Slack / X / Threads / Facebook
+- when `Webpage` is disabled, social post generation does not include a public event URL
 
 Example:
 

--- a/LongevityWorldCup.Website/Business/EventDataService.cs
+++ b/LongevityWorldCup.Website/Business/EventDataService.cs
@@ -5,7 +5,7 @@ using LongevityWorldCup.Website.Tools;
 
 namespace LongevityWorldCup.Website.Business;
 
-public record EventItem(string Id, EventType Type, string Text, DateTime OccurredAtUtc, double Relevance)
+public record EventItem(string Id, EventType Type, string Text, DateTime OccurredAtUtc, double Relevance, bool VisibleOnWebsite)
 {
     public JsonObject ToJson() => new()
     {
@@ -13,7 +13,8 @@ public record EventItem(string Id, EventType Type, string Text, DateTime Occurre
         ["Type"] = (int)Type,
         ["Text"] = Text,
         ["OccurredAt"] = OccurredAtUtc.ToString("o"),
-        ["Relevance"] = Relevance
+        ["Relevance"] = Relevance,
+        ["VisibleOnWebsite"] = VisibleOnWebsite
     };
 }
 
@@ -72,6 +73,7 @@ public sealed class EventDataService : IDisposable
                         Text           TEXT NOT NULL,
                         OccurredAt     TEXT NOT NULL,
                         Relevance      REAL  NOT NULL DEFAULT 5,
+                        VisibleOnWebsite INTEGER NOT NULL DEFAULT 1,
                         SlackProcessed INTEGER NOT NULL DEFAULT 0,
                         XProcessed     INTEGER NOT NULL DEFAULT 0,
                         ThreadsProcessed INTEGER NOT NULL DEFAULT 0,
@@ -145,6 +147,23 @@ public sealed class EventDataService : IDisposable
                 if (addedFacebookProcessed)
                 {
                     cmd.CommandText = "UPDATE Events SET FacebookProcessed = 1;";
+                    cmd.ExecuteNonQuery();
+                }
+
+                var addedVisibleOnWebsite = false;
+                cmd.CommandText = "ALTER TABLE Events ADD COLUMN VisibleOnWebsite INTEGER NOT NULL DEFAULT 1;";
+                try
+                {
+                    cmd.ExecuteNonQuery();
+                    addedVisibleOnWebsite = true;
+                }
+                catch
+                {
+                }
+
+                if (addedVisibleOnWebsite)
+                {
+                    cmd.CommandText = "UPDATE Events SET VisibleOnWebsite = 1;";
                     cmd.ExecuteNonQuery();
                 }
 
@@ -234,17 +253,17 @@ public sealed class EventDataService : IDisposable
             ProcessPendingImmediateCustomEventsForPlatform(
                 processedColumn: "XProcessed",
                 isConfigured: _xEvents.IsConfigured,
-                trySend: (id, rawText) => _xEvents.TrySendEventAsync(EventType.CustomEvent, rawText, id).GetAwaiter().GetResult());
+                trySend: (id, rawText, visibleOnWebsite) => _xEvents.TrySendEventAsync(EventType.CustomEvent, rawText, id, visibleOnWebsite).GetAwaiter().GetResult());
 
             ProcessPendingImmediateCustomEventsForPlatform(
                 processedColumn: "ThreadsProcessed",
                 isConfigured: _threadsEvents.IsConfigured,
-                trySend: (id, rawText) => _threadsEvents.TrySendEventAsync(EventType.CustomEvent, rawText, id).GetAwaiter().GetResult());
+                trySend: (id, rawText, visibleOnWebsite) => _threadsEvents.TrySendEventAsync(EventType.CustomEvent, rawText, id, visibleOnWebsite).GetAwaiter().GetResult());
 
             ProcessPendingImmediateCustomEventsForPlatform(
                 processedColumn: "FacebookProcessed",
                 isConfigured: _facebookEvents.IsConfigured,
-                trySend: (id, rawText) => _facebookEvents.TrySendEventAsync(EventType.CustomEvent, rawText, id).GetAwaiter().GetResult());
+                trySend: (id, rawText, visibleOnWebsite) => _facebookEvents.TrySendEventAsync(EventType.CustomEvent, rawText, id, visibleOnWebsite).GetAwaiter().GetResult());
         }
         finally
         {
@@ -252,7 +271,7 @@ public sealed class EventDataService : IDisposable
         }
     }
 
-    private void ProcessPendingImmediateCustomEventsForPlatform(string processedColumn, bool isConfigured, Func<string, string, bool> trySend)
+    private void ProcessPendingImmediateCustomEventsForPlatform(string processedColumn, bool isConfigured, Func<string, string, bool, bool> trySend)
     {
         if (!isConfigured)
         {
@@ -261,12 +280,12 @@ public sealed class EventDataService : IDisposable
         }
 
         var claimed = ClaimPendingCustomEvents(processedColumn);
-        foreach (var (id, rawText) in claimed)
+        foreach (var (id, rawText, visibleOnWebsite) in claimed)
         {
             var sent = false;
             try
             {
-                sent = trySend(id, rawText);
+                sent = trySend(id, rawText, visibleOnWebsite);
             }
             catch (Exception ex)
             {
@@ -278,7 +297,7 @@ public sealed class EventDataService : IDisposable
         }
     }
 
-    private List<(string Id, string Text)> ClaimPendingCustomEvents(string processedColumn)
+    private List<(string Id, string Text, bool VisibleOnWebsite)> ClaimPendingCustomEvents(string processedColumn)
     {
         return _db.Run(sqlite =>
         {
@@ -286,14 +305,14 @@ public sealed class EventDataService : IDisposable
             using var selectCmd = sqlite.CreateCommand();
             selectCmd.Transaction = tx;
             selectCmd.CommandText =
-                $"SELECT Id, Text FROM Events WHERE Type = @type AND {processedColumn} = 0 ORDER BY OccurredAt ASC;";
+                $"SELECT Id, Text, VisibleOnWebsite FROM Events WHERE Type = @type AND {processedColumn} = 0 ORDER BY OccurredAt ASC;";
             selectCmd.Parameters.AddWithValue("@type", (int)EventType.CustomEvent);
 
-            var claimed = new List<(string Id, string Text)>();
+            var claimed = new List<(string Id, string Text, bool VisibleOnWebsite)>();
             using var reader = selectCmd.ExecuteReader();
-            var pending = new List<(string Id, string Text)>();
+            var pending = new List<(string Id, string Text, bool VisibleOnWebsite)>();
             while (reader.Read())
-                pending.Add((reader.GetString(0), reader.GetString(1)));
+                pending.Add((reader.GetString(0), reader.GetString(1), reader.GetInt32(2) != 0));
 
             if (pending.Count > 0)
             {
@@ -302,11 +321,11 @@ public sealed class EventDataService : IDisposable
                 claimCmd.CommandText = $"UPDATE Events SET {processedColumn} = 2 WHERE Id = @id AND {processedColumn} = 0;";
                 var pId = claimCmd.Parameters.Add("@id", SqliteType.Text);
 
-                foreach (var (id, text) in pending)
+                foreach (var (id, text, visibleOnWebsite) in pending)
                 {
                     pId.Value = id;
                     if (claimCmd.ExecuteNonQuery() == 1)
-                        claimed.Add((id, text));
+                        claimed.Add((id, text, visibleOnWebsite));
                 }
             }
 
@@ -340,7 +359,7 @@ public sealed class EventDataService : IDisposable
 
     public const int XPriorityPrimaryMax = 8;
 
-    public IReadOnlyList<(string Id, EventType Type, string Text, DateTime OccurredAtUtc, double Relevance, int XPriority)> GetPendingXEvents(DateTime? fromUtc = null, DateTime? toUtc = null, int? limit = null)
+    public IReadOnlyList<(string Id, EventType Type, string Text, DateTime OccurredAtUtc, double Relevance, bool VisibleOnWebsite, int XPriority)> GetPendingXEvents(DateTime? fromUtc = null, DateTime? toUtc = null, int? limit = null)
     {
         var list = _db.Run(sqlite =>
         {
@@ -363,7 +382,7 @@ public sealed class EventDataService : IDisposable
                 parameters.Add(new SqliteParameter("@to", EnsureUtc(toUtc.Value).ToString("o")));
             }
 
-            var sql = "SELECT Id, Type, Text, OccurredAt, Relevance FROM Events WHERE " +
+            var sql = "SELECT Id, Type, Text, OccurredAt, Relevance, VisibleOnWebsite FROM Events WHERE " +
                 string.Join(" AND ", filters) +
                 " ORDER BY OccurredAt DESC";
             if (limit.HasValue)
@@ -376,21 +395,21 @@ public sealed class EventDataService : IDisposable
             cmd.CommandText = sql;
             foreach (var p in parameters) cmd.Parameters.Add(p);
 
-            var result = new List<(string Id, EventType Type, string Text, DateTime OccurredAtUtc, double Relevance)>();
+            var result = new List<(string Id, EventType Type, string Text, DateTime OccurredAtUtc, double Relevance, bool VisibleOnWebsite)>();
             using var r = cmd.ExecuteReader();
             while (r.Read())
             {
                 var typeInt = r.GetInt32(1);
                 var type = Enum.IsDefined(typeof(EventType), typeInt) ? (EventType)typeInt : EventType.General;
                 var occurred = DateTime.Parse(r.GetString(3), null, System.Globalization.DateTimeStyles.RoundtripKind);
-                result.Add((r.GetString(0), type, r.GetString(2), occurred, r.GetDouble(4)));
+                result.Add((r.GetString(0), type, r.GetString(2), occurred, r.GetDouble(4), r.GetInt32(5) != 0));
             }
             return result;
         });
-        var withPriority = list.Select(e => (e.Id, e.Type, e.Text, e.OccurredAtUtc, e.Relevance, GetXPriority(e.Type, e.Text))).ToList();
+        var withPriority = list.Select(e => (e.Id, e.Type, e.Text, e.OccurredAtUtc, e.Relevance, e.VisibleOnWebsite, GetXPriority(e.Type, e.Text))).ToList();
         withPriority.Sort((a, b) =>
         {
-            if (a.Item6 != b.Item6) return a.Item6.CompareTo(b.Item6);
+            if (a.Item7 != b.Item7) return a.Item7.CompareTo(b.Item7);
             return b.OccurredAtUtc.CompareTo(a.OccurredAtUtc);
         });
         return withPriority;
@@ -456,7 +475,7 @@ public sealed class EventDataService : IDisposable
         });
     }
 
-    public IReadOnlyList<(string Id, EventType Type, string Text, DateTime OccurredAtUtc, double Relevance, int XPriority)> GetPendingThreadsEvents(DateTime? fromUtc = null, DateTime? toUtc = null, int? limit = null)
+    public IReadOnlyList<(string Id, EventType Type, string Text, DateTime OccurredAtUtc, double Relevance, bool VisibleOnWebsite, int XPriority)> GetPendingThreadsEvents(DateTime? fromUtc = null, DateTime? toUtc = null, int? limit = null)
     {
         var list = _db.Run(sqlite =>
         {
@@ -479,7 +498,7 @@ public sealed class EventDataService : IDisposable
                 parameters.Add(new SqliteParameter("@to", EnsureUtc(toUtc.Value).ToString("o")));
             }
 
-            var sql = "SELECT Id, Type, Text, OccurredAt, Relevance FROM Events WHERE " +
+            var sql = "SELECT Id, Type, Text, OccurredAt, Relevance, VisibleOnWebsite FROM Events WHERE " +
                 string.Join(" AND ", filters) +
                 " ORDER BY OccurredAt DESC";
             if (limit.HasValue)
@@ -492,21 +511,21 @@ public sealed class EventDataService : IDisposable
             cmd.CommandText = sql;
             foreach (var p in parameters) cmd.Parameters.Add(p);
 
-            var result = new List<(string Id, EventType Type, string Text, DateTime OccurredAtUtc, double Relevance)>();
+            var result = new List<(string Id, EventType Type, string Text, DateTime OccurredAtUtc, double Relevance, bool VisibleOnWebsite)>();
             using var r = cmd.ExecuteReader();
             while (r.Read())
             {
                 var typeInt = r.GetInt32(1);
                 var type = Enum.IsDefined(typeof(EventType), typeInt) ? (EventType)typeInt : EventType.General;
                 var occurred = DateTime.Parse(r.GetString(3), null, System.Globalization.DateTimeStyles.RoundtripKind);
-                result.Add((r.GetString(0), type, r.GetString(2), occurred, r.GetDouble(4)));
+                result.Add((r.GetString(0), type, r.GetString(2), occurred, r.GetDouble(4), r.GetInt32(5) != 0));
             }
             return result;
         });
-        var withPriority = list.Select(e => (e.Id, e.Type, e.Text, e.OccurredAtUtc, e.Relevance, GetXPriority(e.Type, e.Text))).ToList();
+        var withPriority = list.Select(e => (e.Id, e.Type, e.Text, e.OccurredAtUtc, e.Relevance, e.VisibleOnWebsite, GetXPriority(e.Type, e.Text))).ToList();
         withPriority.Sort((a, b) =>
         {
-            if (a.Item6 != b.Item6) return a.Item6.CompareTo(b.Item6);
+            if (a.Item7 != b.Item7) return a.Item7.CompareTo(b.Item7);
             return b.OccurredAtUtc.CompareTo(a.OccurredAtUtc);
         });
         return withPriority;
@@ -533,7 +552,7 @@ public sealed class EventDataService : IDisposable
         });
     }
 
-    public IReadOnlyList<(string Id, EventType Type, string Text, DateTime OccurredAtUtc, double Relevance, int XPriority)> GetPendingFacebookEvents(DateTime? fromUtc = null, DateTime? toUtc = null, int? limit = null)
+    public IReadOnlyList<(string Id, EventType Type, string Text, DateTime OccurredAtUtc, double Relevance, bool VisibleOnWebsite, int XPriority)> GetPendingFacebookEvents(DateTime? fromUtc = null, DateTime? toUtc = null, int? limit = null)
     {
         var list = _db.Run(sqlite =>
         {
@@ -556,7 +575,7 @@ public sealed class EventDataService : IDisposable
                 parameters.Add(new SqliteParameter("@to", EnsureUtc(toUtc.Value).ToString("o")));
             }
 
-            var sql = "SELECT Id, Type, Text, OccurredAt, Relevance FROM Events WHERE " +
+            var sql = "SELECT Id, Type, Text, OccurredAt, Relevance, VisibleOnWebsite FROM Events WHERE " +
                 string.Join(" AND ", filters) +
                 " ORDER BY OccurredAt DESC";
             if (limit.HasValue)
@@ -569,21 +588,21 @@ public sealed class EventDataService : IDisposable
             cmd.CommandText = sql;
             foreach (var p in parameters) cmd.Parameters.Add(p);
 
-            var result = new List<(string Id, EventType Type, string Text, DateTime OccurredAtUtc, double Relevance)>();
+            var result = new List<(string Id, EventType Type, string Text, DateTime OccurredAtUtc, double Relevance, bool VisibleOnWebsite)>();
             using var r = cmd.ExecuteReader();
             while (r.Read())
             {
                 var typeInt = r.GetInt32(1);
                 var type = Enum.IsDefined(typeof(EventType), typeInt) ? (EventType)typeInt : EventType.General;
                 var occurred = DateTime.Parse(r.GetString(3), null, System.Globalization.DateTimeStyles.RoundtripKind);
-                result.Add((r.GetString(0), type, r.GetString(2), occurred, r.GetDouble(4)));
+                result.Add((r.GetString(0), type, r.GetString(2), occurred, r.GetDouble(4), r.GetInt32(5) != 0));
             }
             return result;
         });
-        var withPriority = list.Select(e => (e.Id, e.Type, e.Text, e.OccurredAtUtc, e.Relevance, GetXPriority(e.Type, e.Text))).ToList();
+        var withPriority = list.Select(e => (e.Id, e.Type, e.Text, e.OccurredAtUtc, e.Relevance, e.VisibleOnWebsite, GetXPriority(e.Type, e.Text))).ToList();
         withPriority.Sort((a, b) =>
         {
-            if (a.Item6 != b.Item6) return a.Item6.CompareTo(b.Item6);
+            if (a.Item7 != b.Item7) return a.Item7.CompareTo(b.Item7);
             return b.OccurredAtUtc.CompareTo(a.OccurredAtUtc);
         });
         return withPriority;
@@ -1120,7 +1139,7 @@ public sealed class EventDataService : IDisposable
         }
     }
 
-    public void CreateCustomEvent(string titleRaw, string contentRaw, DateTime? occurredAtUtc = null, double relevance = 15d)
+    public void CreateCustomEvent(string titleRaw, string contentRaw, DateTime? occurredAtUtc = null, double relevance = 15d, bool visibleOnWebsite = true)
     {
         if (string.IsNullOrWhiteSpace(titleRaw)) throw new ArgumentNullException(nameof(titleRaw));
         contentRaw ??= "";
@@ -1139,14 +1158,15 @@ public sealed class EventDataService : IDisposable
             insertCmd.Transaction = tx;
             insertCmd.CommandText =
                 """
-                INSERT INTO Events (Id, Type, Text, OccurredAt, Relevance, XProcessed, ThreadsProcessed, FacebookProcessed)
-                VALUES (@id, @type, @text, @occ, @rel, @xProcessed, @threadsProcessed, @facebookProcessed);
+                INSERT INTO Events (Id, Type, Text, OccurredAt, Relevance, VisibleOnWebsite, XProcessed, ThreadsProcessed, FacebookProcessed)
+                VALUES (@id, @type, @text, @occ, @rel, @visibleOnWebsite, @xProcessed, @threadsProcessed, @facebookProcessed);
                 """;
             insertCmd.Parameters.AddWithValue("@id", eventId);
             insertCmd.Parameters.AddWithValue("@type", (int)EventType.CustomEvent);
             insertCmd.Parameters.AddWithValue("@text", combinedRaw);
             insertCmd.Parameters.AddWithValue("@occ", occurredAt);
             insertCmd.Parameters.AddWithValue("@rel", relevance);
+            insertCmd.Parameters.AddWithValue("@visibleOnWebsite", visibleOnWebsite ? 1 : 0);
             insertCmd.Parameters.AddWithValue("@xProcessed", _xEvents.IsConfigured ? 0 : 1);
             insertCmd.Parameters.AddWithValue("@threadsProcessed", _threadsEvents.IsConfigured ? 0 : 1);
             insertCmd.Parameters.AddWithValue("@facebookProcessed", _facebookEvents.IsConfigured ? 0 : 1);
@@ -1168,6 +1188,7 @@ public sealed class EventDataService : IDisposable
         EventType? type = null,
         DateTime? fromUtc = null,
         DateTime? toUtc = null,
+        bool? visibleOnWebsite = null,
         int? limit = null,
         int offset = 0,
         bool newestFirst = true)
@@ -1193,8 +1214,14 @@ public sealed class EventDataService : IDisposable
             parameters.Add(new SqliteParameter("@to", EnsureUtc(toUtc.Value).ToString("o")));
         }
 
+        if (visibleOnWebsite.HasValue)
+        {
+            filters.Add("VisibleOnWebsite = @visibleOnWebsite");
+            parameters.Add(new SqliteParameter("@visibleOnWebsite", visibleOnWebsite.Value ? 1 : 0));
+        }
+
         var sql =
-            "SELECT Id, Type, Text, OccurredAt, Relevance FROM Events" +
+            "SELECT Id, Type, Text, OccurredAt, Relevance, VisibleOnWebsite FROM Events" +
             (filters.Count > 0 ? " WHERE " + string.Join(" AND ", filters) : "") +
             $" ORDER BY OccurredAt {(newestFirst ? "DESC" : "ASC")}, CASE " +
             $"WHEN Type = {(int)EventType.Joined} THEN 0 " +
@@ -1225,7 +1252,7 @@ public sealed class EventDataService : IDisposable
     public void ReloadIntoCache()
     {
         var arr = new JsonArray();
-        foreach (var e in GetEvents())
+        foreach (var e in GetEvents(visibleOnWebsite: true))
             arr.Add(e.ToJson());
         Events = arr;
     }
@@ -1237,9 +1264,10 @@ public sealed class EventDataService : IDisposable
         var text = r.GetString(2);
         var occurred = DateTime.Parse(r.GetString(3), null, System.Globalization.DateTimeStyles.RoundtripKind);
         var relevance = r.GetDouble(4);
+        var visibleOnWebsite = r.GetInt32(5) != 0;
 
         var type = Enum.IsDefined(typeof(EventType), typeInt) ? (EventType)typeInt : EventType.General;
-        return new EventItem(id, type, text, occurred, relevance);
+        return new EventItem(id, type, text, occurred, relevance, visibleOnWebsite);
     }
 
     private static DateTime EnsureUtc(DateTime dt) =>

--- a/LongevityWorldCup.Website/Business/FacebookEventService.cs
+++ b/LongevityWorldCup.Website/Business/FacebookEventService.cs
@@ -88,7 +88,7 @@ public class FacebookEventService
         return await TrySendEventAsync(type, rawText, eventId: null);
     }
 
-    public async Task<bool> TrySendEventAsync(EventType type, string rawText, string? eventId)
+    public async Task<bool> TrySendEventAsync(EventType type, string rawText, string? eventId, bool visibleOnWebsite = true)
     {
         if (type != EventType.CustomEvent || string.IsNullOrWhiteSpace(eventId))
         {
@@ -96,7 +96,7 @@ public class FacebookEventService
             return false;
         }
 
-        var plan = CustomEventSocialComposer.BuildPlan(eventId, rawText, 63206, ResolveMention);
+        var plan = CustomEventSocialComposer.BuildPlan(eventId, rawText, 63206, ResolveMention, includeEventUrl: visibleOnWebsite);
         if (plan.Mode == CustomEventPostMode.Text)
             return await TrySendAsync(plan.PostText);
 
@@ -150,12 +150,12 @@ public class FacebookEventService
         return false;
     }
 
-    public string? TryBuildMessage(EventType type, string rawText, string? eventId = null)
+    public string? TryBuildMessage(EventType type, string rawText, string? eventId = null, bool visibleOnWebsite = true)
     {
         if (type != EventType.CustomEvent || string.IsNullOrWhiteSpace(eventId))
             return null;
 
-        return CustomEventSocialComposer.BuildPlan(eventId, rawText, 63206, ResolveMention).PostText;
+        return CustomEventSocialComposer.BuildPlan(eventId, rawText, 63206, ResolveMention, includeEventUrl: visibleOnWebsite).PostText;
     }
 
     public string? TryBuildFillerMessage(FillerType fillerType, string payloadText)

--- a/LongevityWorldCup.Website/Business/ThreadsEventService.cs
+++ b/LongevityWorldCup.Website/Business/ThreadsEventService.cs
@@ -88,24 +88,24 @@ public class ThreadsEventService
         return await TrySendEventAsync(type, rawText, eventId: null);
     }
 
-    public async Task<bool> TrySendEventAsync(EventType type, string rawText, string? eventId)
+    public async Task<bool> TrySendEventAsync(EventType type, string rawText, string? eventId, bool visibleOnWebsite = true)
     {
         if (type == EventType.CustomEvent)
-            return await TrySendCustomEventAsync(rawText, eventId);
+            return await TrySendCustomEventAsync(rawText, eventId, visibleOnWebsite);
 
         var msg = BuildMessage(type, rawText);
         if (string.IsNullOrWhiteSpace(msg)) return false;
         return await TrySendAsync(msg);
     }
 
-    public string? TryBuildMessage(EventType type, string rawText, string? eventId = null)
+    public string? TryBuildMessage(EventType type, string rawText, string? eventId = null, bool visibleOnWebsite = true)
     {
         if (type == EventType.CustomEvent)
         {
             if (string.IsNullOrWhiteSpace(eventId))
                 return null;
 
-            return CustomEventSocialComposer.BuildPlan(eventId, rawText, 500, ResolveMention).PostText;
+            return CustomEventSocialComposer.BuildPlan(eventId, rawText, 500, ResolveMention, includeEventUrl: visibleOnWebsite).PostText;
         }
 
         var message = ThreadsMessageBuilder.ForEventText(
@@ -161,7 +161,7 @@ public class ThreadsEventService
             getBortzDiffForSlug: GetBortzDiff);
     }
 
-    private async Task<bool> TrySendCustomEventAsync(string rawText, string? eventId)
+    private async Task<bool> TrySendCustomEventAsync(string rawText, string? eventId, bool visibleOnWebsite)
     {
         if (string.IsNullOrWhiteSpace(eventId))
         {
@@ -169,7 +169,7 @@ public class ThreadsEventService
             return false;
         }
 
-        var plan = CustomEventSocialComposer.BuildPlan(eventId, rawText, 500, ResolveMention);
+        var plan = CustomEventSocialComposer.BuildPlan(eventId, rawText, 500, ResolveMention, includeEventUrl: visibleOnWebsite);
         if (plan.Mode == CustomEventPostMode.Text)
             return await TrySendAsync(plan.PostText);
 

--- a/LongevityWorldCup.Website/Business/XEventService.cs
+++ b/LongevityWorldCup.Website/Business/XEventService.cs
@@ -98,24 +98,24 @@ public class XEventService
         return await TrySendEventAsync(type, rawText, eventId: null);
     }
 
-    public async Task<bool> TrySendEventAsync(EventType type, string rawText, string? eventId)
+    public async Task<bool> TrySendEventAsync(EventType type, string rawText, string? eventId, bool visibleOnWebsite = true)
     {
         if (type == EventType.CustomEvent)
-            return await TrySendCustomEventAsync(rawText, eventId);
+            return await TrySendCustomEventAsync(rawText, eventId, visibleOnWebsite);
 
         var msg = BuildMessage(type, rawText);
         if (string.IsNullOrWhiteSpace(msg)) return false;
         return await TrySendAsync(msg);
     }
 
-    public string? TryBuildMessage(EventType type, string rawText, string? eventId = null)
+    public string? TryBuildMessage(EventType type, string rawText, string? eventId = null, bool visibleOnWebsite = true)
     {
         if (type == EventType.CustomEvent)
         {
             if (string.IsNullOrWhiteSpace(eventId))
                 return null;
 
-            return CustomEventSocialComposer.BuildPlan(eventId, rawText, 280, ResolveMention).PostText;
+            return CustomEventSocialComposer.BuildPlan(eventId, rawText, 280, ResolveMention, includeEventUrl: visibleOnWebsite).PostText;
         }
 
         var message = XMessageBuilder.ForEventText(
@@ -171,7 +171,7 @@ public class XEventService
             getBortzDiffForSlug: GetBortzDiff);
     }
 
-    private async Task<bool> TrySendCustomEventAsync(string rawText, string? eventId)
+    private async Task<bool> TrySendCustomEventAsync(string rawText, string? eventId, bool visibleOnWebsite)
     {
         if (string.IsNullOrWhiteSpace(eventId))
         {
@@ -179,7 +179,7 @@ public class XEventService
             return false;
         }
 
-        var plan = CustomEventSocialComposer.BuildPlan(eventId, rawText, 280, ResolveMention);
+        var plan = CustomEventSocialComposer.BuildPlan(eventId, rawText, 280, ResolveMention, includeEventUrl: visibleOnWebsite);
         if (plan.Mode == CustomEventPostMode.Text)
             return await TrySendAsync(plan.PostText);
 

--- a/LongevityWorldCup.Website/Jobs/FacebookDailyPostJob.cs
+++ b/LongevityWorldCup.Website/Jobs/FacebookDailyPostJob.cs
@@ -27,13 +27,13 @@ public class FacebookDailyPostJob : IJob
         _facebookEvents.SetAthletesForFacebook(_athletes.GetAthletesForX());
         var pending = _events.GetPendingFacebookEvents();
 
-        foreach (var (id, type, text, _, _, _) in pending)
+        foreach (var (id, type, text, _, _, visibleOnWebsite, _) in pending)
         {
-            var msg = _facebookEvents.TryBuildMessage(type, text, id);
+            var msg = _facebookEvents.TryBuildMessage(type, text, id, visibleOnWebsite);
             if (string.IsNullOrWhiteSpace(msg))
                 continue;
 
-            var sent = await _facebookEvents.TrySendEventAsync(type, text, id);
+            var sent = await _facebookEvents.TrySendEventAsync(type, text, id, visibleOnWebsite);
             if (!sent)
             {
                 _logger.LogWarning("FacebookDailyPostJob send failed for event {Id}; leaving unprocessed", id);

--- a/LongevityWorldCup.Website/Jobs/ThreadsDailyPostJob.cs
+++ b/LongevityWorldCup.Website/Jobs/ThreadsDailyPostJob.cs
@@ -32,7 +32,7 @@ public class ThreadsDailyPostJob : IJob
         var pending = _events.GetPendingThreadsEvents();
         var freshCutoff = DateTime.UtcNow.AddDays(-7);
 
-        foreach (var (id, type, text, occurredAtUtc, _, xPriority) in pending)
+        foreach (var (id, type, text, occurredAtUtc, _, visibleOnWebsite, xPriority) in pending)
         {
             if (type == EventType.BadgeAward)
             {
@@ -75,10 +75,10 @@ public class ThreadsDailyPostJob : IJob
                 continue;
             }
 
-            var msg = _threadsEvents.TryBuildMessage(type, text, id);
+            var msg = _threadsEvents.TryBuildMessage(type, text, id, visibleOnWebsite);
             if (string.IsNullOrWhiteSpace(msg)) continue;
 
-            var sent = await _threadsEvents.TrySendEventAsync(type, text, id);
+            var sent = await _threadsEvents.TrySendEventAsync(type, text, id, visibleOnWebsite);
             if (!sent)
             {
                 _logger.LogWarning("ThreadsDailyPostJob send failed for event {Id}; leaving unprocessed", id);

--- a/LongevityWorldCup.Website/Jobs/XDailyPostJob.cs
+++ b/LongevityWorldCup.Website/Jobs/XDailyPostJob.cs
@@ -32,7 +32,7 @@ public class XDailyPostJob : IJob
         var pending = _events.GetPendingXEvents();
         var freshCutoff = DateTime.UtcNow.AddDays(-7);
 
-        foreach (var (id, type, text, occurredAtUtc, _, xPriority) in pending)
+        foreach (var (id, type, text, occurredAtUtc, _, visibleOnWebsite, xPriority) in pending)
         {
             if (type == EventType.BadgeAward)
             {
@@ -75,10 +75,10 @@ public class XDailyPostJob : IJob
                 continue;
             }
 
-            var msg = _xEvents.TryBuildMessage(type, text, id);
+            var msg = _xEvents.TryBuildMessage(type, text, id, visibleOnWebsite);
             if (string.IsNullOrWhiteSpace(msg)) continue;
 
-            var sent = await _xEvents.TrySendEventAsync(type, text, id);
+            var sent = await _xEvents.TrySendEventAsync(type, text, id, visibleOnWebsite);
             if (!sent)
             {
                 _logger.LogWarning("XDailyPostJob send failed for event {Id}; leaving unprocessed", id);

--- a/LongevityWorldCup.Website/Scripts/custom_event.sh
+++ b/LongevityWorldCup.Website/Scripts/custom_event.sh
@@ -204,7 +204,7 @@ if not isinstance(content, str):
     sys.exit(1)
 
 flags = []
-for key in ("sendToSlack", "sendToX", "sendToThreads", "sendToFacebook"):
+for key in ("sendToWebpage", "sendToSlack", "sendToX", "sendToThreads", "sendToFacebook"):
     flags.append("1" if bool(data.get(key)) else "0")
 
 if not any(flag == "1" for flag in flags):
@@ -217,17 +217,18 @@ for value in (title, content, *flags):
 PY
   )
 
-  if [[ "${#payload_fields[@]}" -lt 6 ]]; then
-    echo "Invalid payload fields" >&2
-    exit 1
-  fi
+if [[ "${#payload_fields[@]}" -lt 7 ]]; then
+  echo "Invalid payload fields" >&2
+  exit 1
+fi
 
-  title_raw="${payload_fields[0]}"
-  content_raw="${payload_fields[1]}"
-  send_slack="${payload_fields[2]}"
-  send_x="${payload_fields[3]}"
-  send_threads="${payload_fields[4]}"
-  send_facebook="${payload_fields[5]}"
+title_raw="${payload_fields[0]}"
+content_raw="${payload_fields[1]}"
+send_webpage="${payload_fields[2]}"
+send_slack="${payload_fields[3]}"
+send_x="${payload_fields[4]}"
+send_threads="${payload_fields[5]}"
+send_facebook="${payload_fields[6]}"
 }
 
 render() {
@@ -258,6 +259,7 @@ render() {
 
 selected_platforms() {
   local items=()
+  [[ "$send_webpage" == "1" ]] && items+=("Webpage")
   [[ "$send_slack" == "1" ]] && items+=("Slack")
   [[ "$send_x" == "1" ]] && items+=("X")
   [[ "$send_threads" == "1" ]] && items+=("Threads")
@@ -306,6 +308,7 @@ slack_processed="$([[ "$send_slack" == "1" ]] && echo 0 || echo 1)"
 x_processed="$([[ "$send_x" == "1" ]] && echo 0 || echo 1)"
 threads_processed="$([[ "$send_threads" == "1" ]] && echo 0 || echo 1)"
 facebook_processed="$([[ "$send_facebook" == "1" ]] && echo 0 || echo 1)"
+visible_on_website="$([[ "$send_webpage" == "1" ]] && echo 1 || echo 0)"
 
 precheck_writeability
 
@@ -318,7 +321,7 @@ err=""
 attempt=0
 delay_ms="$sqlite_retry_initial_ms"
 while :; do
-  out="$(as_svc sqlite3 -cmd ".timeout $sqlite_timeout_ms" "$db_path" "BEGIN IMMEDIATE; INSERT INTO Events (Id, Type, Text, OccurredAt, Relevance, SlackProcessed, XProcessed, ThreadsProcessed, FacebookProcessed) VALUES ('$id', 6, '$txt', strftime('%Y-%m-%dT%H:%M:%fZ','now'), 15, $slack_processed, $x_processed, $threads_processed, $facebook_processed); COMMIT;" 2>&1)"
+  out="$(as_svc sqlite3 -cmd ".timeout $sqlite_timeout_ms" "$db_path" "BEGIN IMMEDIATE; INSERT INTO Events (Id, Type, Text, OccurredAt, Relevance, VisibleOnWebsite, SlackProcessed, XProcessed, ThreadsProcessed, FacebookProcessed) VALUES ('$id', 6, '$txt', strftime('%Y-%m-%dT%H:%M:%fZ','now'), 15, $visible_on_website, $slack_processed, $x_processed, $threads_processed, $facebook_processed); COMMIT;" 2>&1)"
   rc=$?
   if [[ $rc -eq 0 ]]; then
     echo "Inserted $id into $db_path"

--- a/LongevityWorldCup.Website/Tools/CustomEventSocialComposer.cs
+++ b/LongevityWorldCup.Website/Tools/CustomEventSocialComposer.cs
@@ -26,19 +26,19 @@ public static class CustomEventSocialComposer
 
     public static CustomEventSocialPlan BuildPlan(string eventId, string rawText, int maxTextLength)
     {
-        return BuildPlan(eventId, rawText, maxTextLength, mentionResolver: null);
+        return BuildPlan(eventId, rawText, maxTextLength, mentionResolver: null, includeEventUrl: true);
     }
 
-    public static CustomEventSocialPlan BuildPlan(string eventId, string rawText, int maxTextLength, Func<string, string>? mentionResolver)
+    public static CustomEventSocialPlan BuildPlan(string eventId, string rawText, int maxTextLength, Func<string, string>? mentionResolver, bool includeEventUrl = true)
     {
         var (titleRaw, contentRaw) = CustomEventMarkup.SplitTitleAndContent(rawText);
         var titleText = CollapseWhitespace(CustomEventMarkup.ToPlainText(titleRaw, keepHyperlinkLabels: true, mentionResolver)).Trim();
         var bodyText = CustomEventMarkup.ToPlainText(contentRaw, keepHyperlinkLabels: true, mentionResolver).Trim();
-        var eventUrl = BuildEventUrl(eventId);
+        var eventUrl = includeEventUrl ? BuildEventUrl(eventId) : string.Empty;
         var hasHyperlinks = CustomEventMarkup.ContainsHyperlink(rawText);
 
         var textPostWithoutEventUrl = BuildTextPost(titleText, bodyText, eventUrl: null);
-        if (!hasHyperlinks)
+        if (!hasHyperlinks || string.IsNullOrWhiteSpace(eventUrl))
         {
             if (!string.IsNullOrWhiteSpace(textPostWithoutEventUrl) && textPostWithoutEventUrl.Length <= maxTextLength)
                 return new CustomEventSocialPlan(CustomEventPostMode.Text, titleText, bodyText, eventUrl, textPostWithoutEventUrl);

--- a/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
+++ b/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
@@ -212,6 +212,12 @@
             flex-wrap: wrap;
         }
 
+        .validation-hint {
+            font-size: 12px;
+            color: #ffb7c9;
+            line-height: 1.4;
+        }
+
         button {
             border: 0;
             border-radius: 10px;
@@ -701,6 +707,7 @@
                     <button id="copyCommandBtn" type="button">Copy Command</button>
                     <div id="copyState" style="font-size:12px;color:var(--muted);"></div>
                 </div>
+                <div id="commandValidationHint" class="validation-hint" hidden>Title is required before the command can be generated or copied.</div>
             </div>
         </div>
 
@@ -745,6 +752,7 @@
         const webpagePreviewBlock = document.getElementById("webpagePreviewBlock");
         const webpagePreviewSurface = document.getElementById("webpagePreviewSurface");
         const commandOutput = document.getElementById("commandOutput");
+        const commandValidationHint = document.getElementById("commandValidationHint");
         const copyCommandBtn = document.getElementById("copyCommandBtn");
         const copyState = document.getElementById("copyState");
         const insertBoldBtn = document.getElementById("insertBoldBtn");
@@ -1560,6 +1568,7 @@
             const titleRaw = titleInput.value.trim();
             const contentRaw = contentInput.value.trim();
             const combinedRaw = contentRaw ? `${titleRaw}\n\n${contentRaw}` : titleRaw;
+            const hasTitle = !!titleRaw;
             const payload = {
                 title: titleRaw,
                 content: contentRaw,
@@ -1574,6 +1583,8 @@
 
             webpagePreviewBlock.style.display = sendWebpage.checked ? "" : "none";
             webpagePreviewSurface.hidden = !sendWebpage.checked;
+            commandValidationHint.hidden = hasTitle;
+            copyCommandBtn.disabled = !hasTitle;
 
             document.getElementById("eventTitlePreview").innerHTML = renderWebpageMarkup(normalizeNewlines(titleRaw).replace(/\n+/g, " ").trim());
             document.getElementById("eventContentPreview").innerHTML = contentRaw ? renderWebpageMarkupWithBreaks(contentRaw) : "";
@@ -1595,9 +1606,13 @@
                 )
             ).join("");
 
-            const payloadJsonText = JSON.stringify(payload);
-            const payloadToken = base64UrlEncodeUtf8(payloadJsonText);
-            commandOutput.value = buildServerCommand(payloadToken);
+            if (hasTitle) {
+                const payloadJsonText = JSON.stringify(payload);
+                const payloadToken = base64UrlEncodeUtf8(payloadJsonText);
+                commandOutput.value = buildServerCommand(payloadToken);
+            } else {
+                commandOutput.value = "";
+            }
         }
 
         async function copyText(value, message) {
@@ -1706,7 +1721,12 @@
         insertStrongBtn.addEventListener("click", insertStrong);
         insertLinkBtn.addEventListener("click", insertLink);
         insertMentionBtn.addEventListener("click", insertMention);
-        copyCommandBtn.addEventListener("click", async () => copyText(commandOutput.value, "Command copied."));
+        copyCommandBtn.addEventListener("click", async () => {
+            if (!commandOutput.value) {
+                return;
+            }
+            await copyText(commandOutput.value, "Command copied.");
+        });
         window.addEventListener("resize", update);
 
         fetch("/api/data/athletes", { headers: { accept: "application/json" } })

--- a/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
+++ b/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Custom Event Designer</title>
+    <title>Social Post Manager</title>
     <style>
         @font-face {
             font-family: "Poppins";
@@ -635,7 +635,7 @@
 <body>
     <div class="page">
         <div class="panel">
-            <h1>Custom Event Designer</h1>
+            <h1>Social Post Manager</h1>
 
             <div class="format-toolbar">
                 <button id="insertBoldBtn" class="tool-btn" type="button">Bold</button>
@@ -663,6 +663,7 @@
             <div>
                 <div style="margin-bottom:6px;font-size:13px;">Send to</div>
                 <div class="checks">
+                    <label class="check"><input id="sendWebpage" type="checkbox" checked /><span>Webpage</span></label>
                     <label class="check"><input id="sendSlack" type="checkbox" checked /><span>Slack</span></label>
                     <label class="check"><input id="sendX" type="checkbox" checked /><span>X</span></label>
                     <label class="check"><input id="sendThreads" type="checkbox" /><span>Threads</span></label>
@@ -685,11 +686,11 @@
                 These previews are not pixel-perfect. They are only approximate guidance for webpage and social output.
             </div>
 
-            <div class="panel preview-block">
+            <div id="webpagePreviewBlock" class="panel preview-block">
                 <div class="preview-title">
                     <h2>Webpage Preview</h2>
                 </div>
-                <div class="webpage-surface">
+                <div id="webpagePreviewSurface" class="webpage-surface">
                     <div class="webpage-event">
                         <div class="webpage-event-row">
                             <div id="eventTitlePreview" class="webpage-event-title formatted"></div>
@@ -712,10 +713,13 @@
         const SEND_TO_STORAGE_KEY = "customEventDesigner.sendTo";
         const titleInput = document.getElementById("titleInput");
         const contentInput = document.getElementById("contentInput");
+        const sendWebpage = document.getElementById("sendWebpage");
         const sendSlack = document.getElementById("sendSlack");
         const sendX = document.getElementById("sendX");
         const sendThreads = document.getElementById("sendThreads");
         const sendFacebook = document.getElementById("sendFacebook");
+        const webpagePreviewBlock = document.getElementById("webpagePreviewBlock");
+        const webpagePreviewSurface = document.getElementById("webpagePreviewSurface");
         const commandOutput = document.getElementById("commandOutput");
         const copyCommandBtn = document.getElementById("copyCommandBtn");
         const copyState = document.getElementById("copyState");
@@ -1194,20 +1198,20 @@
             return finalTitle ? `${finalTitle}\n\n${eventUrl}` : eventUrl;
         }
 
-        function buildPlan(titleRaw, contentRaw, maxLength, platformKey) {
+        function buildPlan(titleRaw, contentRaw, maxLength, platformKey, includeEventUrl) {
             const rawText = contentRaw ? `${titleRaw}\n\n${contentRaw}` : titleRaw;
             const mentionResolver = slug => resolveMentionSlug(slug, platformKey);
             const titleText = collapseWhitespace(plainTextWithLabels(titleRaw, mentionResolver));
             const bodyText = plainTextWithLabels(contentRaw, mentionResolver);
-            const eventUrl = buildPreviewEventUrl(titleRaw, contentRaw);
+            const eventUrl = includeEventUrl ? buildPreviewEventUrl(titleRaw, contentRaw) : "";
             const hasHyperlinks = containsHyperlink(rawText);
             const textWithoutUrl = buildTextPost(titleText, bodyText, null);
 
-            if (!hasHyperlinks && textWithoutUrl && textWithoutUrl.length <= maxLength) {
+            if ((!hasHyperlinks || !eventUrl) && textWithoutUrl && textWithoutUrl.length <= maxLength) {
                 return { mode: "text", postText: textWithoutUrl };
             }
 
-            if (hasHyperlinks) {
+            if (hasHyperlinks && eventUrl) {
                 const textWithUrl = buildTextPost(titleText, bodyText, eventUrl);
                 if (textWithUrl && textWithUrl.length <= maxLength) {
                     return { mode: "text", postText: textWithUrl };
@@ -1237,6 +1241,7 @@
                 if (!raw) return;
 
                 const data = JSON.parse(raw);
+                if (typeof data.sendWebpage === "boolean") sendWebpage.checked = data.sendWebpage;
                 if (typeof data.sendSlack === "boolean") sendSlack.checked = data.sendSlack;
                 if (typeof data.sendX === "boolean") sendX.checked = data.sendX;
                 if (typeof data.sendThreads === "boolean") sendThreads.checked = data.sendThreads;
@@ -1248,6 +1253,7 @@
         function saveSendToSettings() {
             try {
                 localStorage.setItem(SEND_TO_STORAGE_KEY, JSON.stringify({
+                    sendWebpage: sendWebpage.checked,
                     sendSlack: sendSlack.checked,
                     sendX: sendX.checked,
                     sendThreads: sendThreads.checked,
@@ -1309,7 +1315,7 @@
             insertSnippet("[mention](", "athlete_slug", ")", (prefix) => prefix.length, (prefix, innerText) => prefix.length + innerText.length);
         }
 
-        function getSelectedPlatformPlans(titleRaw, contentRaw) {
+        function getSelectedPlatformPlans(titleRaw, contentRaw, includeEventUrl) {
             return PLATFORM_CONFIGS
                 .filter(platform => platform.checkbox.checked)
                 .map(platform => {
@@ -1320,7 +1326,7 @@
                             titleRaw: titleRaw,
                             contentRaw: contentRaw
                         }
-                        : buildPlan(titleRaw, contentRaw, platform.limit, platform.key);
+                        : buildPlan(titleRaw, contentRaw, platform.limit, platform.key, includeEventUrl);
                     return { key: platform.key, label: platform.label, limit: platform.limit, ...plan };
                 });
         }
@@ -1464,20 +1470,24 @@
             const payload = {
                 title: titleRaw,
                 content: contentRaw,
+                sendToWebpage: sendWebpage.checked,
                 sendToSlack: sendSlack.checked,
                 sendToX: sendX.checked,
                 sendToThreads: sendThreads.checked,
                 sendToFacebook: sendFacebook.checked
             };
 
+            webpagePreviewBlock.style.display = sendWebpage.checked ? "" : "none";
+            webpagePreviewSurface.hidden = !sendWebpage.checked;
+
             document.getElementById("eventTitlePreview").innerHTML = renderWebpageMarkup(normalizeNewlines(titleRaw).replace(/\n+/g, " ").trim());
             document.getElementById("eventContentPreview").innerHTML = contentRaw ? renderWebpageMarkupWithBreaks(contentRaw) : "";
 
-            const selectedPlans = getSelectedPlatformPlans(titleRaw, contentRaw);
+            const selectedPlans = getSelectedPlatformPlans(titleRaw, contentRaw, sendWebpage.checked);
 
             const titleText = collapseWhitespace(plainTextWithLabels(titleRaw, slug => resolveMentionSlug(slug, "x")));
             const bodyText = plainTextWithLabels(contentRaw, slug => resolveMentionSlug(slug, "x"));
-            const eventUrl = containsHyperlink(combinedRaw) ? buildPreviewEventUrl(titleRaw, contentRaw) : null;
+            const eventUrl = sendWebpage.checked && containsHyperlink(combinedRaw) ? buildPreviewEventUrl(titleRaw, contentRaw) : null;
 
             socialPreviewList.innerHTML = selectedPlans.map(plan =>
                 renderPlatformPreviewCard(
@@ -1560,7 +1570,7 @@
             closeMentionSuggestions();
         });
 
-        [titleInput, contentInput, sendSlack, sendX, sendThreads, sendFacebook].forEach(el => {
+        [titleInput, contentInput, sendWebpage, sendSlack, sendX, sendThreads, sendFacebook].forEach(el => {
             el.addEventListener("input", event => {
                 if (event.target === titleInput || event.target === contentInput) {
                     updateMentionSuggestions(event.target);

--- a/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
+++ b/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
@@ -297,9 +297,11 @@
 
         .formatted strong { font-weight: 700; }
         .formatted .strong { color: #ff4081; font-weight: 700; }
-        .formatted a { color: #7a49b7; text-decoration: underline; }
+        .formatted a { color: #0645ad; text-decoration: underline; }
         .x-text a { color: #1d9bf0; text-decoration: none; }
         .x-text a:hover { text-decoration: underline; }
+        .slack-text a { color: #1264a3; text-decoration: none; }
+        .slack-text a:hover { text-decoration: underline; }
 
         .webpage-surface {
             width: fit-content;
@@ -400,13 +402,41 @@
             width: 40px;
             height: 40px;
             border-radius: 999px;
-            background: #1d9bf0;
             color: white;
             display: grid;
             place-items: center;
-            font-size: 13px;
-            font-weight: 700;
-            flex: 0 0 40px;
+            position: relative;
+            overflow: hidden;
+            box-shadow: inset 0 0 0 1px rgba(255,255,255,0.08);
+        }
+
+        .platform-avatar {
+            width: 100%;
+            height: 100%;
+            display: grid;
+            place-items: center;
+        }
+
+        .platform-avatar-x {
+            background: #000000;
+        }
+
+        .platform-avatar-threads {
+            background: #101010;
+        }
+
+        .platform-avatar-facebook {
+            background: #1877f2;
+        }
+
+        .platform-avatar-slack {
+            background: #4a154b;
+        }
+
+        .platform-avatar svg {
+            width: 60%;
+            height: 60%;
+            display: block;
         }
 
         .x-main {
@@ -509,6 +539,92 @@
             letter-spacing: 0.02em;
             white-space: pre-wrap;
             word-break: break-word;
+        }
+
+        .slack-shell {
+            width: min(720px, calc(100vw - 180px));
+            border-radius: 14px;
+            border: 1px solid rgba(255,255,255,0.06);
+            background: #1b1d21;
+            color: #f8f8f8;
+            padding: 16px 18px;
+            box-shadow: 0 14px 32px rgba(0,0,0,0.22);
+        }
+
+        .slack-message {
+            display: grid;
+            grid-template-columns: auto 1fr;
+            gap: 10px;
+            align-items: start;
+        }
+
+        .slack-avatar {
+            width: 34px;
+            height: 34px;
+            border-radius: 8px;
+            color: #fff;
+            flex: 0 0 34px;
+            overflow: hidden;
+            box-shadow: inset 0 0 0 1px rgba(255,255,255,0.06);
+        }
+
+        .slack-body {
+            min-width: 0;
+            display: grid;
+            gap: 4px;
+            padding-top: 1px;
+        }
+
+        .slack-author-row {
+            display: flex;
+            align-items: center;
+            gap: 7px;
+            min-width: 0;
+            flex-wrap: wrap;
+            line-height: 1.1;
+        }
+
+        .slack-author {
+            font-size: 15px;
+            font-weight: 700;
+            color: #ffffff;
+        }
+
+        .slack-app-badge {
+            display: inline-flex;
+            align-items: center;
+            height: 18px;
+            padding: 0 5px;
+            border-radius: 4px;
+            background: rgba(255,255,255,0.1);
+            color: rgba(255,255,255,0.72);
+            font-size: 10px;
+            font-weight: 700;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+        }
+
+        .slack-timestamp {
+            font-size: 12px;
+            font-weight: 500;
+            color: #a8adb4;
+        }
+
+        .slack-text {
+            font-size: 15px;
+            line-height: 1.4;
+            color: #d1d2d3;
+            overflow-wrap: anywhere;
+            word-break: break-word;
+        }
+
+        .slack-text strong {
+            font-weight: 700;
+            color: #ffffff;
+        }
+
+        .slack-text em {
+            font-style: italic;
         }
 
         @media (max-width: 1080px) {
@@ -616,15 +732,47 @@
         let activeMentionIndex = 0;
 
         const PLATFORM_CONFIGS = [
+            { key: "slack", label: "Slack", checkbox: sendSlack, fixedMode: "slack" },
             { key: "x", label: "X", checkbox: sendX, limit: LIMITS.x },
             { key: "threads", label: "Threads", checkbox: sendThreads, limit: LIMITS.threads },
             { key: "facebook", label: "Facebook", checkbox: sendFacebook, limit: 63206 }
         ];
         const PLATFORM_PREVIEW_META = {
+            slack: { name: "Longevity World Cup", handle: "#highlights", avatar: "LW", label: "Slack" },
             x: { name: "Longevity World Cup", handle: "@longevitywc", avatar: "LW", label: "X" },
             threads: { name: "Longevity World Cup", handle: "@longevityworldcup", avatar: "LW", label: "Threads" },
             facebook: { name: "Longevity World Cup", handle: "Facebook Page", avatar: "LW", label: "Facebook" }
         };
+
+        function renderPlatformAvatar(platformKey, sizeClass = "x-avatar") {
+            const logos = {
+                x: `
+                    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                        <path fill="#ffffff" d="M18.9 2H22l-6.77 7.74L23.2 22h-6.26l-4.9-7.42L5.55 22H2.44l7.24-8.27L1.8 2h6.42l4.43 6.74L18.9 2Z"/>
+                    </svg>`,
+                threads: `
+                    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                        <path fill="#ffffff" d="M12.186 24h-.007c-3.581-.024-6.334-1.205-8.184-3.509C2.35 18.44 1.5 15.586 1.472 12.01v-.017c.03-3.579.879-6.43 2.525-8.482C5.845 1.205 8.6.024 12.18 0h.014c2.746.02 5.043.725 6.826 2.098 1.677 1.29 2.858 3.13 3.509 5.467l-2.04.569c-1.104-3.96-3.898-5.984-8.304-6.015-2.91.022-5.11.936-6.54 2.717C4.307 6.504 3.616 8.914 3.589 12c.027 3.086.718 5.496 2.057 7.164 1.43 1.783 3.631 2.698 6.54 2.717 2.623-.02 4.358-.631 5.8-2.045 1.647-1.613 1.618-3.593 1.09-4.798-.31-.71-.873-1.3-1.634-1.75-.192 1.352-.622 2.446-1.284 3.272-.886 1.102-2.14 1.704-3.73 1.79-1.202.065-2.361-.218-3.259-.801-1.063-.689-1.685-1.74-1.752-2.964-.065-1.19.408-2.285 1.33-3.082.88-.76 2.119-1.207 3.583-1.291a13.853 13.853 0 0 1 3.02.142c-.126-.742-.375-1.332-.75-1.757-.513-.586-1.308-.883-2.359-.89h-.029c-.844 0-1.992.232-2.721 1.32L7.734 7.847c.98-1.454 2.568-2.256 4.478-2.256h.044c3.194.02 5.097 1.975 5.287 5.388.108.046.216.094.321.142 1.49.7 2.58 1.761 3.154 3.07.797 1.82.871 4.79-1.548 7.158-1.85 1.81-4.094 2.628-7.277 2.65Zm1.003-11.69c-.242 0-.487.007-.739.021-1.836.103-2.98.946-2.916 2.143.067 1.256 1.452 1.839 2.784 1.767 1.224-.065 2.818-.543 3.086-3.71a10.5 10.5 0 0 0-2.215-.221z"/>
+                    </svg>`,
+                facebook: `
+                    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                        <path fill="#ffffff" d="M13.65 21v-8.2h2.76l.41-3.2h-3.17V7.56c0-.92.26-1.55 1.58-1.55H17V3.15c-.3-.04-1.3-.13-2.47-.13-2.45 0-4.13 1.49-4.13 4.24V9.6H7.63v3.2h2.77V21h3.25Z"/>
+                    </svg>`,
+                slack: `
+                    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                        <path fill="#36C5F0" d="M9.77 2a2.24 2.24 0 1 0 0 4.48h2.24V4.24A2.24 2.24 0 0 0 9.77 2Zm0 5.99H4.24a2.24 2.24 0 0 0 0 4.48h5.53a2.24 2.24 0 0 0 0-4.48Z"/>
+                        <path fill="#2EB67D" d="M22 9.77a2.24 2.24 0 1 0-4.48 0v2.24h2.24A2.24 2.24 0 0 0 22 9.77Zm-5.99 0V4.24a2.24 2.24 0 0 0-4.48 0v5.53a2.24 2.24 0 0 0 4.48 0Z"/>
+                        <path fill="#ECB22E" d="M14.23 22a2.24 2.24 0 1 0 0-4.48h-2.24v2.24A2.24 2.24 0 0 0 14.23 22Zm0-5.99h5.53a2.24 2.24 0 0 0 0-4.48h-5.53a2.24 2.24 0 1 0 0 4.48Z"/>
+                        <path fill="#E01E5A" d="M2 14.23a2.24 2.24 0 1 0 4.48 0v-2.24H4.24A2.24 2.24 0 0 0 2 14.23Zm5.99 0v5.53a2.24 2.24 0 0 0 4.48 0v-5.53a2.24 2.24 0 1 0-4.48 0Z"/>
+                    </svg>`
+            };
+            return `
+                <div class="${escapeHtml(sizeClass)}">
+                    <div class="platform-avatar platform-avatar-${escapeHtml(platformKey)}">
+                        ${logos[platformKey] || ""}
+                    </div>
+                </div>`;
+        }
 
         function escapeHtml(value) {
             return (value ?? "")
@@ -727,6 +875,42 @@
             }
 
             return matches.sort((a, b) => b.handle.length - a.handle.length);
+        }
+
+        function applySlackMarkupToHtml(value) {
+            let html = escapeHtml(String(value || ""));
+
+            html = html.replace(/\[strong\]\(([^()]*)\)/gi, (_match, inner) => `<strong><em>${inner}</em></strong>`);
+            html = html.replace(/\[bold\]\(([^()]*)\)/gi, (_match, inner) => `<strong>${inner}</strong>`);
+            html = html.replace(/\[mention\]\(([^()]*)\)/gi, (_match, slug) => {
+                const normalized = String(slug || "").trim();
+                if (!normalized) {
+                    return "";
+                }
+
+                const href = escapeHtml(buildAthleteProfileUrl(normalized));
+                const label = escapeHtml(resolveMentionDisplayName(normalized));
+                return `<a href="${href}" target="_blank" rel="noopener noreferrer">${label}</a>`;
+            });
+            html = html.replace(/\[([^\[\]]+)\]\((https?:[^)\s]+)\)/gi, (_match, label, href) => {
+                return `<a href="${escapeHtml(href)}" target="_blank" rel="noopener noreferrer">${escapeHtml(label)}</a>`;
+            });
+
+            return html;
+        }
+
+        function renderSlackPreviewMessage(titleRaw, contentRaw) {
+            const titleHtml = applySlackMarkupToHtml(titleRaw);
+            if (!contentRaw || !contentRaw.trim()) {
+                return titleHtml;
+            }
+
+            const contentHtml = applySlackMarkupToHtml(contentRaw)
+                .replace(/\r\n/g, "\n")
+                .replace(/\r/g, "\n")
+                .replace(/\n/g, "<br>");
+
+            return `${titleHtml}<br><br>${contentHtml}`;
         }
 
         function formatPlainPostTextToHtml(value, clickableMentions) {
@@ -1130,7 +1314,12 @@
                 .filter(platform => platform.checkbox.checked)
                 .map(platform => {
                     const plan = platform.fixedMode
-                        ? { mode: platform.fixedMode, postText: buildTextPost(collapseWhitespace(plainTextWithLabels(titleRaw, slug => resolveMentionSlug(slug, platform.key))), plainTextWithLabels(contentRaw, slug => resolveMentionSlug(slug, platform.key)), null) }
+                        ? {
+                            mode: platform.fixedMode,
+                            postText: buildTextPost(collapseWhitespace(plainTextWithLabels(titleRaw, slug => resolveMentionSlug(slug, platform.key))), plainTextWithLabels(contentRaw, slug => resolveMentionSlug(slug, platform.key)), null),
+                            titleRaw: titleRaw,
+                            contentRaw: contentRaw
+                        }
                         : buildPlan(titleRaw, contentRaw, platform.limit, platform.key);
                     return { key: platform.key, label: platform.label, limit: platform.limit, ...plan };
                 });
@@ -1176,7 +1365,7 @@
                     </div>
                     <div class="preview-surface fit-content" style="border:0;background:transparent;padding:0;">
                         <div class="x-post">
-                            <div class="x-avatar">${escapeHtml(meta.avatar)}</div>
+                            ${renderPlatformAvatar(platformKey)}
                             <div class="x-main">
                                 <div class="x-head">
                                     <span class="x-name">${escapeHtml(meta.name)}</span>
@@ -1188,6 +1377,31 @@
                             </div>
                         </div>
                     </div>    
+                </div>`;
+        }
+
+        function renderSlackPreviewCard(titleRaw, contentRaw) {
+            const meta = PLATFORM_PREVIEW_META.slack;
+            return `
+                <div class="panel preview-block">
+                    <div class="preview-title" style="margin-bottom:8px;">
+                        <h2>${escapeHtml(meta.label)} Preview</h2>
+                    </div>
+                    <div class="preview-surface fit-content" style="border:0;background:transparent;padding:0;">
+                        <div class="slack-shell">
+                            <div class="slack-message">
+                                ${renderPlatformAvatar("slack", "slack-avatar")}
+                                <div class="slack-body">
+                                    <div class="slack-author-row">
+                                        <span class="slack-author">${escapeHtml(meta.name)}</span>
+                                        <span class="slack-app-badge">APP</span>
+                                        <span class="slack-timestamp">now</span>
+                                    </div>
+                                    <div class="slack-text">${renderSlackPreviewMessage(titleRaw, contentRaw)}</div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 </div>`;
         }
 
@@ -1205,7 +1419,7 @@
                     </div>
                     <div class="preview-surface fit-content" style="border:0;background:transparent;padding:0;">
                         <div class="x-post">
-                            <div class="x-avatar">${escapeHtml(meta.avatar)}</div>
+                            ${renderPlatformAvatar(platformKey)}
                             <div class="x-main">
                                 <div class="x-head">
                                     <span class="x-name">${escapeHtml(meta.name)}</span>
@@ -1230,6 +1444,10 @@
         }
 
         function renderPlatformPreviewCard(plan, contentRaw, fallbackTextPost, fallbackImagePost, clickableMentions) {
+            if (plan.mode === "slack") {
+                return renderSlackPreviewCard(plan.titleRaw || "", plan.contentRaw || "");
+            }
+
             if (plan.mode === "image") {
                 return renderImagePreviewCard(plan.key, plan.postText || fallbackImagePost, contentRaw, clickableMentions);
             }

--- a/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
+++ b/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
@@ -267,7 +267,30 @@
             display: flex;
             align-items: center;
             gap: 10px;
-            flex-wrap: wrap;
+            justify-content: space-between;
+            width: 100%;
+        }
+
+        .preview-title h2 {
+            min-width: 0;
+        }
+
+        .preview-copy-btn {
+            padding: 6px 10px;
+            border-radius: 9px;
+            background: rgba(255,255,255,0.08);
+            color: rgba(255,255,255,0.88);
+            font-size: 11px;
+            line-height: 1.2;
+        }
+
+        .preview-copy-btn:hover {
+            background: rgba(255,255,255,0.14);
+        }
+
+        .preview-copy-btn.is-copied {
+            background: rgba(103, 211, 147, 0.22);
+            color: #dff7e7;
         }
 
         .preview-platforms {
@@ -689,6 +712,7 @@
             <div id="webpagePreviewBlock" class="panel preview-block">
                 <div class="preview-title">
                     <h2>Webpage Preview</h2>
+                    <button type="button" class="preview-copy-btn" data-copy-source="webpage">Copy Text</button>
                 </div>
                 <div id="webpagePreviewSurface" class="webpage-surface">
                     <div class="webpage-event">
@@ -734,6 +758,7 @@
         let athleteMentionItems = [];
         let activeMentionContext = null;
         let activeMentionIndex = 0;
+        let previewCopyPayloads = new Map();
 
         const PLATFORM_CONFIGS = [
             { key: "slack", label: "Slack", checkbox: sendSlack, fixedMode: "slack" },
@@ -804,6 +829,9 @@
         }
         function buildAthleteProfileUrl(slug) {
             return `/athlete/${encodeURIComponent(normalizeAthleteSlugForUrl(slug))}`;
+        }
+        function buildAthleteProfileAbsoluteUrl(slug) {
+            return `https://longevityworldcup.com${buildAthleteProfileUrl(slug)}`;
         }
         function hasKnownMentionSlug(slug) {
             const key = String(slug || "").trim().toLowerCase();
@@ -901,6 +929,39 @@
             });
 
             return html;
+        }
+
+        function applySlackMarkupToText(value) {
+            let text = String(value || "");
+
+            text = text.replace(/\[strong\]\(([^()]*)\)/gi, (_match, inner) => `*_${inner}_*`);
+            text = text.replace(/\[bold\]\(([^()]*)\)/gi, (_match, inner) => `*${inner}*`);
+            text = text.replace(/\[mention\]\(([^()]*)\)/gi, (_match, slug) => {
+                const normalized = String(slug || "").trim();
+                if (!normalized) {
+                    return "";
+                }
+
+                return `<${buildAthleteProfileAbsoluteUrl(normalized)}|${resolveMentionDisplayName(normalized)}>`;
+            });
+            text = text.replace(/\[([^\[\]]+)\]\((https?:[^)\s]+)\)/gi, (_match, label, href) => `<${href}|${label}>`);
+
+            return text;
+        }
+
+        function buildSlackRawMessage(titleRaw, contentRaw) {
+            const titleText = applySlackMarkupToText(titleRaw);
+            if (!contentRaw || !contentRaw.trim()) {
+                return titleText;
+            }
+
+            return `${titleText}\n\n${applySlackMarkupToText(contentRaw)}`;
+        }
+
+        function registerPreviewCopyText(value) {
+            const key = `preview-${previewCopyPayloads.size + 1}`;
+            previewCopyPayloads.set(key, String(value || ""));
+            return key;
         }
 
         function renderSlackPreviewMessage(titleRaw, contentRaw) {
@@ -1186,6 +1247,10 @@
             return parts.join("\n\n").trim();
         }
 
+        function buildWebpageRawMessage(titleRaw, contentRaw) {
+            return contentRaw ? `${titleRaw}\n\n${contentRaw}` : titleRaw;
+        }
+
         function buildImageCaption(titleText, eventUrl, maxLength) {
             const normalizedTitle = collapseWhitespace(titleText);
             if (!eventUrl) return normalizedTitle;
@@ -1222,6 +1287,28 @@
                 mode: "image",
                 postText: buildImageCaption(titleText, hasHyperlinks ? eventUrl : "", maxLength)
             };
+        }
+
+        function buildPlatformRawText(platformKey, plan, titleRaw, contentRaw, includeEventUrl) {
+            if (platformKey === "webpage") {
+                return buildWebpageRawMessage(titleRaw, contentRaw);
+            }
+
+            if (platformKey === "slack") {
+                return buildSlackRawMessage(titleRaw, contentRaw);
+            }
+
+            if (plan && typeof plan.postText === "string") {
+                return plan.postText;
+            }
+
+            if (platformKey === "x" || platformKey === "threads" || platformKey === "facebook") {
+                const fallbackLimit = platformKey === "x" ? LIMITS.x : (platformKey === "threads" ? LIMITS.threads : 63206);
+                const fallbackPlan = buildPlan(titleRaw, contentRaw, fallbackLimit, platformKey, includeEventUrl);
+                return fallbackPlan.postText || "";
+            }
+
+            return "";
         }
 
         function base64UrlEncodeUtf8(value) {
@@ -1362,12 +1449,14 @@
             return settings;
         }
 
-        function renderTextPreviewCard(platformKey, postText, clickableMentions) {
+        function renderTextPreviewCard(platformKey, postText, clickableMentions, rawCopyText) {
             const meta = PLATFORM_PREVIEW_META[platformKey] || PLATFORM_PREVIEW_META.x;
+            const copyKey = registerPreviewCopyText(rawCopyText);
             return `
                 <div class="panel preview-block">
                     <div class="preview-title" style="margin-bottom:8px;">
                         <h2>${escapeHtml(meta.label)} Preview</h2>
+                        <button type="button" class="preview-copy-btn" data-copy-key="${escapeHtml(copyKey)}">Copy Text</button>
                     </div>
                     <div class="preview-surface fit-content" style="border:0;background:transparent;padding:0;">
                         <div class="x-post">
@@ -1388,10 +1477,12 @@
 
         function renderSlackPreviewCard(titleRaw, contentRaw) {
             const meta = PLATFORM_PREVIEW_META.slack;
+            const copyKey = registerPreviewCopyText(buildSlackRawMessage(titleRaw, contentRaw));
             return `
                 <div class="panel preview-block">
                     <div class="preview-title" style="margin-bottom:8px;">
                         <h2>${escapeHtml(meta.label)} Preview</h2>
+                        <button type="button" class="preview-copy-btn" data-copy-key="${escapeHtml(copyKey)}">Copy Text</button>
                     </div>
                     <div class="preview-surface fit-content" style="border:0;background:transparent;padding:0;">
                         <div class="slack-shell">
@@ -1411,17 +1502,19 @@
                 </div>`;
         }
 
-        function renderImagePreviewCard(platformKey, postText, contentRaw, clickableMentions) {
+        function renderImagePreviewCard(platformKey, postText, contentRaw, clickableMentions, rawCopyText) {
             const meta = PLATFORM_PREVIEW_META[platformKey] || PLATFORM_PREVIEW_META.x;
             const layout = getImagePreviewLayout(contentRaw, platformKey);
             const frameWidth = 560;
             const scale = frameWidth / 1200;
             const frameHeight = 675 * scale;
+            const copyKey = registerPreviewCopyText(rawCopyText);
 
             return `
                 <div class="panel preview-block">
                     <div class="preview-title" style="margin-bottom:8px;">
                         <h2>${escapeHtml(meta.label)} Preview</h2>
+                        <button type="button" class="preview-copy-btn" data-copy-key="${escapeHtml(copyKey)}">Copy Text</button>
                     </div>
                     <div class="preview-surface fit-content" style="border:0;background:transparent;padding:0;">
                         <div class="x-post">
@@ -1449,16 +1542,16 @@
                 </div>`;
         }
 
-        function renderPlatformPreviewCard(plan, contentRaw, fallbackTextPost, fallbackImagePost, clickableMentions) {
+        function renderPlatformPreviewCard(plan, contentRaw, fallbackTextPost, fallbackImagePost, clickableMentions, rawCopyText) {
             if (plan.mode === "slack") {
                 return renderSlackPreviewCard(plan.titleRaw || "", plan.contentRaw || "");
             }
 
             if (plan.mode === "image") {
-                return renderImagePreviewCard(plan.key, plan.postText || fallbackImagePost, contentRaw, clickableMentions);
+                return renderImagePreviewCard(plan.key, plan.postText || fallbackImagePost, contentRaw, clickableMentions, rawCopyText);
             }
 
-            return renderTextPreviewCard(plan.key, plan.postText || fallbackTextPost, clickableMentions);
+            return renderTextPreviewCard(plan.key, plan.postText || fallbackTextPost, clickableMentions, rawCopyText);
         }
 
         function update() {
@@ -1476,6 +1569,8 @@
                 sendToThreads: sendThreads.checked,
                 sendToFacebook: sendFacebook.checked
             };
+            previewCopyPayloads = new Map();
+            previewCopyPayloads.set("webpage", buildPlatformRawText("webpage", null, titleRaw, contentRaw, sendWebpage.checked));
 
             webpagePreviewBlock.style.display = sendWebpage.checked ? "" : "none";
             webpagePreviewSurface.hidden = !sendWebpage.checked;
@@ -1495,7 +1590,8 @@
                     contentRaw,
                     buildTextPost(titleText, bodyText, eventUrl),
                     buildImageCaption(titleText, eventUrl ?? "", plan.limit ?? LIMITS.x),
-                    collectClickableMentions(combinedRaw, plan.key)
+                    collectClickableMentions(combinedRaw, plan.key),
+                    buildPlatformRawText(plan.key, plan, titleRaw, contentRaw, sendWebpage.checked)
                 )
             ).join("");
 
@@ -1510,6 +1606,18 @@
             setTimeout(() => {
                 if (copyState.textContent === message) copyState.textContent = "";
             }, 2000);
+        }
+
+        async function copyPreviewText(button, value) {
+            await navigator.clipboard.writeText(value);
+            const original = button.dataset.copyLabel || button.textContent || "Copy Text";
+            button.dataset.copyLabel = original;
+            button.textContent = "Copied";
+            button.classList.add("is-copied");
+            setTimeout(() => {
+                button.textContent = original;
+                button.classList.remove("is-copied");
+            }, 1400);
         }
 
         [titleInput, contentInput].forEach(el => {
@@ -1568,6 +1676,20 @@
                 return;
             }
             closeMentionSuggestions();
+        });
+
+        document.addEventListener("click", event => {
+            const button = event.target instanceof Element ? event.target.closest("[data-copy-key], [data-copy-source]") : null;
+            if (!button) {
+                return;
+            }
+
+            const copyKey = button.getAttribute("data-copy-key") || button.getAttribute("data-copy-source");
+            if (!copyKey || !previewCopyPayloads.has(copyKey)) {
+                return;
+            }
+
+            copyPreviewText(button, previewCopyPayloads.get(copyKey) || "");
         });
 
         [titleInput, contentInput, sendWebpage, sendSlack, sendX, sendThreads, sendFacebook].forEach(el => {


### PR DESCRIPTION
This PR upgrades the custom event tool into a multi-platform social post manager.
It is now possible to store a custom event without showing it on the website, while still sending it to the selected social platforms.

<img width="1239" height="1189" alt="localhost_5297_internal_custom-event-designer html (2)" src="https://github.com/user-attachments/assets/a9ee3195-0d06-4724-8473-5289a369dc84" />
