### PR TITLE
CustomEvent - better posting logic for hyperlinks

### DIFF
--- a/LongevityWorldCup.Website/Tools/CustomEventMarkup.cs
+++ b/LongevityWorldCup.Website/Tools/CustomEventMarkup.cs
@@ -36,6 +36,16 @@ public static class CustomEventMarkup
         return ContainsHyperlinkCore(text, 0, text.Length);
     }
 
+    public static string? GetSingleHyperlink(string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return null;
+
+        var links = new List<string>(capacity: 2);
+        CollectHyperlinks(text, 0, text.Length, links);
+        return links.Count == 1 ? links[0] : null;
+    }
+
     public static IReadOnlyList<CustomEventSegment> ParseSegments(string? text, bool keepHyperlinkLabels, Func<string, string>? mentionResolver = null)
     {
         var output = new List<CustomEventSegment>();
@@ -98,6 +108,52 @@ public static class CustomEventMarkup
         }
 
         return false;
+    }
+
+    private static void CollectHyperlinks(string text, int start, int length, List<string> links)
+    {
+        var end = start + length;
+        var i = start;
+        while (i < end)
+        {
+            var open = text.IndexOf('[', i);
+            if (open < 0 || open >= end)
+                return;
+
+            var close = text.IndexOf("](", open + 1, StringComparison.Ordinal);
+            if (close < 0 || close >= end)
+                return;
+
+            var label = text[(open + 1)..close];
+            var parenStart = close + 2;
+            var j = parenStart;
+            var depth = 1;
+            while (j < end && depth > 0)
+            {
+                var ch = text[j];
+                if (ch == '(') depth++;
+                else if (ch == ')') depth--;
+                j++;
+            }
+
+            if (depth != 0)
+                return;
+
+            var inner = text.Substring(parenStart, j - parenStart - 1);
+            var key = label.Trim().ToLowerInvariant();
+            if (key == "bold" || key == "strong")
+            {
+                CollectHyperlinks(inner, 0, inner.Length, links);
+            }
+            else if (IsSafeHttpUrl(inner))
+            {
+                links.Add(inner.Trim());
+                if (links.Count > 1)
+                    return;
+            }
+
+            i = j;
+        }
     }
 
     private static void ParseInto(List<CustomEventSegment> output, string text, int start, int length, CustomEventTextStyle inheritedStyle, bool keepHyperlinkLabels, Func<string, string>? mentionResolver)

--- a/LongevityWorldCup.Website/Tools/CustomEventSocialComposer.cs
+++ b/LongevityWorldCup.Website/Tools/CustomEventSocialComposer.cs
@@ -34,7 +34,8 @@ public static class CustomEventSocialComposer
         var (titleRaw, contentRaw) = CustomEventMarkup.SplitTitleAndContent(rawText);
         var titleText = CollapseWhitespace(CustomEventMarkup.ToPlainText(titleRaw, keepHyperlinkLabels: true, mentionResolver)).Trim();
         var bodyText = CustomEventMarkup.ToPlainText(contentRaw, keepHyperlinkLabels: true, mentionResolver).Trim();
-        var eventUrl = includeEventUrl ? BuildEventUrl(eventId) : string.Empty;
+        var singleHyperlink = CustomEventMarkup.GetSingleHyperlink(rawText);
+        var eventUrl = singleHyperlink ?? (includeEventUrl ? BuildEventUrl(eventId) : string.Empty);
         var hasHyperlinks = CustomEventMarkup.ContainsHyperlink(rawText);
 
         var textPostWithoutEventUrl = BuildTextPost(titleText, bodyText, eventUrl: null);
@@ -43,11 +44,11 @@ public static class CustomEventSocialComposer
             if (!string.IsNullOrWhiteSpace(textPostWithoutEventUrl) && textPostWithoutEventUrl.Length <= maxTextLength)
                 return new CustomEventSocialPlan(CustomEventPostMode.Text, titleText, bodyText, eventUrl, textPostWithoutEventUrl);
         }
-        else
+
+        var textPostWithEventUrl = BuildTextPost(titleText, bodyText, eventUrl);
+        if (!string.IsNullOrWhiteSpace(textPostWithEventUrl) && textPostWithEventUrl.Length <= maxTextLength)
         {
-            var textPostWithEventUrl = BuildTextPost(titleText, bodyText, eventUrl);
-            if (!string.IsNullOrWhiteSpace(textPostWithEventUrl) && textPostWithEventUrl.Length <= maxTextLength)
-                return new CustomEventSocialPlan(CustomEventPostMode.Text, titleText, bodyText, eventUrl, textPostWithEventUrl);
+            return new CustomEventSocialPlan(CustomEventPostMode.Text, titleText, bodyText, eventUrl, textPostWithEventUrl);
         }
 
         var imageCaption = BuildImageCaption(titleText, hasHyperlinks ? eventUrl : string.Empty, maxTextLength);

--- a/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
+++ b/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
@@ -1028,6 +1028,62 @@
             return matches.sort((a, b) => b.handle.length - a.handle.length);
         }
 
+        function findPreviewLinks(text) {
+            const value = String(text || "");
+            const matches = [];
+            const seen = new Set();
+
+            for (const match of value.matchAll(/https?:\/\/[^\s<>|]+/gi)) {
+                const raw = String(match[0] || "");
+                const start = match.index ?? -1;
+                if (!raw || start < 0) {
+                    continue;
+                }
+
+                const key = `${start}:${raw}`;
+                if (seen.has(key)) {
+                    continue;
+                }
+
+                seen.add(key);
+                matches.push({
+                    raw,
+                    normalized: raw,
+                    start,
+                    end: start + raw.length
+                });
+            }
+
+            for (const match of value.matchAll(/(^|[\s(>])((?:[a-z0-9-]+\.)+[a-z]{2,}(?:\/[^\s<]*)?)/gim)) {
+                const raw = String(match[2] || "");
+                const offset = String(match[1] || "").length;
+                const start = (match.index ?? -1) + offset;
+                if (!raw || start < 0) {
+                    continue;
+                }
+
+                const overlapsExplicit = matches.some(item => start >= item.start && start < item.end);
+                if (overlapsExplicit) {
+                    continue;
+                }
+
+                const key = `${start}:${raw}`;
+                if (seen.has(key)) {
+                    continue;
+                }
+
+                seen.add(key);
+                matches.push({
+                    raw,
+                    normalized: /^https?:\/\//i.test(raw) ? raw : `https://${raw}`,
+                    start,
+                    end: start + raw.length
+                });
+            }
+
+            return matches.sort((a, b) => a.start - b.start);
+        }
+
         function getOgPreviewUrl(platformKey, plan) {
             if (platformKey === "facebook" || platformKey === "webpage") {
                 return "";
@@ -1040,27 +1096,35 @@
             const text = platformKey === "slack"
                 ? buildSlackRawMessage(plan.titleRaw || "", plan.contentRaw || "")
                 : String(plan.postText || "");
-            const urlMatches = text.match(/https?:\/\/[^\s]+/gi);
-            return urlMatches && urlMatches.length ? urlMatches[urlMatches.length - 1] : "";
+            const links = findPreviewLinks(text);
+            if (!links.length) {
+                return "";
+            }
+
+            if (platformKey === "slack") {
+                const httpsLinks = links.filter(link => /^https:\/\//i.test(String(link.raw || "")));
+                return httpsLinks.length ? httpsLinks[httpsLinks.length - 1].normalized : "";
+            }
+
+            return links[links.length - 1].normalized;
         }
 
         function getXPreviewVisibleText(postText) {
             const text = String(postText || "");
-            const urlMatches = [...text.matchAll(/https?:\/\/[^\s]+/gi)];
-            if (!urlMatches.length) {
+            const links = findPreviewLinks(text);
+            if (!links.length) {
                 return text;
             }
 
-            const last = urlMatches[urlMatches.length - 1];
-            const start = last.index ?? -1;
-            if (start < 0) {
+            const last = links[links.length - 1];
+            const tail = text.slice(last.end);
+            if (tail.trim().length > 0) {
                 return text;
             }
-
-            const end = start + last[0].length;
+            const start = last.start;
+            const end = last.end;
             const before = text.slice(0, start).replace(/\s+$/g, "");
-            const after = text.slice(end).replace(/^\s+/g, "");
-            return [before, after].filter(Boolean).join("\n");
+            return before;
         }
 
         function getUrlDomain(url) {
@@ -1162,6 +1226,8 @@
             html = html.replace(/\[([^\[\]]+)\]\((https?:[^)\s]+)\)/gi, (_match, label, href) => {
                 return `<a href="${escapeHtml(href)}" target="_blank" rel="noopener noreferrer">${escapeHtml(label)}</a>`;
             });
+            html = html.replace(/(?<!["'=])(https?:\/\/[^\s<>|]+)/gi, '<a href="$1" target="_blank" rel="noopener noreferrer">$1</a>');
+            html = html.replace(/(^|[\s(>])((?:[a-z0-9-]+\.)+[a-z]{2,}(?:\/[^\s<]*)?)/gim, '$1<a href="https://$2" target="_blank" rel="noopener noreferrer">$2</a>');
 
             return html;
         }
@@ -1401,7 +1467,11 @@
             }
 
             if (value.startsWith("@")) {
-                return value;
+                if (platformKey === "x" || platformKey === "threads") {
+                    return value;
+                }
+
+                return "";
             }
 
             try {
@@ -1687,7 +1757,7 @@
             const meta = PLATFORM_PREVIEW_META[platformKey] || PLATFORM_PREVIEW_META.x;
             const copyKey = registerPreviewCopyText(rawCopyText);
             const ogCardHtml = renderOgCard(ogPreviewUrl);
-            const visibleText = platformKey === "x" && ogPreviewUrl
+            const visibleText = platformKey === "x"
                 ? getXPreviewVisibleText(postText)
                 : postText;
             return `

--- a/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
+++ b/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
@@ -1011,8 +1011,27 @@
             const text = platformKey === "slack"
                 ? buildSlackRawMessage(plan.titleRaw || "", plan.contentRaw || "")
                 : String(plan.postText || "");
-            const urlMatch = text.match(/https?:\/\/[^\s]+/i);
-            return urlMatch ? urlMatch[0] : "";
+            const urlMatches = text.match(/https?:\/\/[^\s]+/gi);
+            return urlMatches && urlMatches.length ? urlMatches[urlMatches.length - 1] : "";
+        }
+
+        function getXPreviewVisibleText(postText) {
+            const text = String(postText || "");
+            const urlMatches = [...text.matchAll(/https?:\/\/[^\s]+/gi)];
+            if (!urlMatches.length) {
+                return text;
+            }
+
+            const last = urlMatches[urlMatches.length - 1];
+            const start = last.index ?? -1;
+            if (start < 0) {
+                return text;
+            }
+
+            const end = start + last[0].length;
+            const before = text.slice(0, start).replace(/\s+$/g, "");
+            const after = text.slice(end).replace(/^\s+/g, "");
+            return [before, after].filter(Boolean).join("\n");
         }
 
         function getUrlDomain(url) {
@@ -1635,6 +1654,9 @@
             const meta = PLATFORM_PREVIEW_META[platformKey] || PLATFORM_PREVIEW_META.x;
             const copyKey = registerPreviewCopyText(rawCopyText);
             const ogCardHtml = renderOgCard(ogPreviewUrl);
+            const visibleText = platformKey === "x" && ogPreviewUrl
+                ? getXPreviewVisibleText(postText)
+                : postText;
             return `
                 <div class="panel preview-block">
                     <div class="preview-title" style="margin-bottom:8px;">
@@ -1650,7 +1672,7 @@
                                     <span class="x-handle">${escapeHtml(meta.handle)}</span>
                                     <span class="x-meta">now</span>
                                 </div>
-                                <div class="x-text">${formatPlainPostTextToHtml(postText, clickableMentions)}</div>
+                                <div class="x-text">${formatPlainPostTextToHtml(visibleText, clickableMentions)}</div>
                                 ${ogCardHtml}
                                 <div class="x-actions"><span>Reply</span><span>Repost</span><span>Like</span><span>View</span></div>
                             </div>

--- a/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
+++ b/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
@@ -824,6 +824,7 @@
         }
 
         function containsHyperlink(value) { return window.CustomEventMarkup.containsHyperlink(value); }
+        function getSingleHyperlink(value) { return window.CustomEventMarkup.getSingleHyperlink(value); }
 
         function normalizeNewlines(value) { return window.CustomEventMarkup.normalizeNewlines(value); }
         function renderCustomMarkup(text) {
@@ -1276,7 +1277,8 @@
             const mentionResolver = slug => resolveMentionSlug(slug, platformKey);
             const titleText = collapseWhitespace(plainTextWithLabels(titleRaw, mentionResolver));
             const bodyText = plainTextWithLabels(contentRaw, mentionResolver);
-            const eventUrl = includeEventUrl ? buildPreviewEventUrl(titleRaw, contentRaw) : "";
+            const singleHyperlink = getSingleHyperlink(rawText);
+            const eventUrl = singleHyperlink || (includeEventUrl ? buildPreviewEventUrl(titleRaw, contentRaw) : "");
             const hasHyperlinks = containsHyperlink(rawText);
             const textWithoutUrl = buildTextPost(titleText, bodyText, null);
 
@@ -1284,11 +1286,9 @@
                 return { mode: "text", postText: textWithoutUrl };
             }
 
-            if (hasHyperlinks && eventUrl) {
-                const textWithUrl = buildTextPost(titleText, bodyText, eventUrl);
-                if (textWithUrl && textWithUrl.length <= maxLength) {
-                    return { mode: "text", postText: textWithUrl };
-                }
+            const textWithUrl = buildTextPost(titleText, bodyText, eventUrl);
+            if (textWithUrl && textWithUrl.length <= maxLength) {
+                return { mode: "text", postText: textWithUrl };
             }
 
             return {
@@ -1593,7 +1593,10 @@
 
             const titleText = collapseWhitespace(plainTextWithLabels(titleRaw, slug => resolveMentionSlug(slug, "x")));
             const bodyText = plainTextWithLabels(contentRaw, slug => resolveMentionSlug(slug, "x"));
-            const eventUrl = sendWebpage.checked && containsHyperlink(combinedRaw) ? buildPreviewEventUrl(titleRaw, contentRaw) : null;
+            const singleHyperlink = getSingleHyperlink(combinedRaw);
+            const eventUrl = singleHyperlink || (sendWebpage.checked && containsHyperlink(combinedRaw)
+                ? buildPreviewEventUrl(titleRaw, contentRaw)
+                : null);
 
             socialPreviewList.innerHTML = selectedPlans.map(plan =>
                 renderPlatformPreviewCard(

--- a/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
+++ b/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
@@ -509,7 +509,7 @@
 
         .og-card {
             margin-top: 10px;
-            border-radius: 16px;
+            border-radius: 14px;
             overflow: hidden;
             border: 1px solid rgba(255,255,255,0.10);
             background: rgba(255,255,255,0.04);
@@ -517,7 +517,7 @@
         }
 
         .og-card-media {
-            height: 180px;
+            height: 140px;
             background: linear-gradient(135deg, rgba(255,255,255,0.08), rgba(255,255,255,0.02));
             display: flex;
             align-items: end;
@@ -536,21 +536,50 @@
             width: 100%;
             height: 100%;
             display: grid;
-            place-items: center;
+            align-content: center;
+            justify-items: center;
+            gap: 8px;
             color: rgba(255,255,255,0.55);
             font-size: 12px;
             letter-spacing: 0.04em;
             text-transform: uppercase;
+            background:
+                repeating-linear-gradient(
+                    135deg,
+                    rgba(255,255,255,0.05),
+                    rgba(255,255,255,0.05) 12px,
+                    rgba(255,255,255,0.02) 12px,
+                    rgba(255,255,255,0.02) 24px
+                );
+        }
+
+        .og-card-media-fallback-badge {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 5px 10px;
+            border-radius: 999px;
+            background: rgba(255, 176, 0, 0.18);
+            border: 1px solid rgba(255, 176, 0, 0.35);
+            color: #ffd37a;
+            font-size: 11px;
+            font-weight: 700;
+            letter-spacing: 0.03em;
+            text-transform: none;
+        }
+
+        .og-card-media-fallback-domain {
+            opacity: 0.9;
         }
 
         .og-card-body {
-            padding: 12px 14px;
+            padding: 10px 12px;
             display: grid;
-            gap: 6px;
+            gap: 5px;
         }
 
         .og-card-domain {
-            font-size: 12px;
+            font-size: 11px;
             color: #71767b;
             white-space: nowrap;
             overflow: hidden;
@@ -558,7 +587,7 @@
         }
 
         .og-card-title {
-            font-size: 14px;
+            font-size: 13px;
             font-weight: 700;
             line-height: 1.3;
             color: #e7e9ea;
@@ -569,17 +598,17 @@
         }
 
         .og-card-desc {
-            font-size: 13px;
+            font-size: 12px;
             line-height: 1.35;
             color: #9aa0a6;
             display: -webkit-box;
-            -webkit-line-clamp: 3;
+            -webkit-line-clamp: 2;
             -webkit-box-orient: vertical;
             overflow: hidden;
         }
 
         .og-card-url {
-            font-size: 12px;
+            font-size: 11px;
             color: #71767b;
             white-space: nowrap;
             overflow: hidden;
@@ -1097,7 +1126,11 @@
             const data = ogPreviewCache.get(url) || buildOgPlaceholder(url);
             const mediaHtml = data.image
                 ? `<img alt="link preview image" src="${escapeHtml(data.image)}" loading="lazy" referrerpolicy="no-referrer">`
-                : `<div class="og-card-media-fallback">${escapeHtml(data.domain || getUrlDomain(url))}</div>`;
+                : `
+                    <div class="og-card-media-fallback">
+                        <div class="og-card-media-fallback-badge">Placeholder preview</div>
+                        <div class="og-card-media-fallback-domain">${escapeHtml(data.domain || getUrlDomain(url))}</div>
+                    </div>`;
 
             return `
                 <div class="og-card">

--- a/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
+++ b/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
@@ -507,6 +507,85 @@
             font-size: 12px;
         }
 
+        .og-card {
+            margin-top: 10px;
+            border-radius: 16px;
+            overflow: hidden;
+            border: 1px solid rgba(255,255,255,0.10);
+            background: rgba(255,255,255,0.04);
+            width: min(560px, calc(100vw - 180px));
+        }
+
+        .og-card-media {
+            height: 180px;
+            background: linear-gradient(135deg, rgba(255,255,255,0.08), rgba(255,255,255,0.02));
+            display: flex;
+            align-items: end;
+            justify-content: flex-start;
+            overflow: hidden;
+        }
+
+        .og-card-media img {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+            display: block;
+        }
+
+        .og-card-media-fallback {
+            width: 100%;
+            height: 100%;
+            display: grid;
+            place-items: center;
+            color: rgba(255,255,255,0.55);
+            font-size: 12px;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+        }
+
+        .og-card-body {
+            padding: 12px 14px;
+            display: grid;
+            gap: 6px;
+        }
+
+        .og-card-domain {
+            font-size: 12px;
+            color: #71767b;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .og-card-title {
+            font-size: 14px;
+            font-weight: 700;
+            line-height: 1.3;
+            color: #e7e9ea;
+            display: -webkit-box;
+            -webkit-line-clamp: 2;
+            -webkit-box-orient: vertical;
+            overflow: hidden;
+        }
+
+        .og-card-desc {
+            font-size: 13px;
+            line-height: 1.35;
+            color: #9aa0a6;
+            display: -webkit-box;
+            -webkit-line-clamp: 3;
+            -webkit-box-orient: vertical;
+            overflow: hidden;
+        }
+
+        .og-card-url {
+            font-size: 12px;
+            color: #71767b;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
         .x-media {
             border-radius: 16px;
             overflow: hidden;
@@ -767,6 +846,8 @@
         let activeMentionContext = null;
         let activeMentionIndex = 0;
         let previewCopyPayloads = new Map();
+        let ogPreviewCache = new Map();
+        let ogPreviewPending = new Set();
 
         const PLATFORM_CONFIGS = [
             { key: "slack", label: "Slack", checkbox: sendSlack, fixedMode: "slack" },
@@ -916,6 +997,99 @@
             }
 
             return matches.sort((a, b) => b.handle.length - a.handle.length);
+        }
+
+        function getOgPreviewUrl(platformKey, plan) {
+            if (platformKey === "facebook" || platformKey === "webpage") {
+                return "";
+            }
+
+            if (!plan || (plan.mode !== "text" && plan.mode !== "slack")) {
+                return "";
+            }
+
+            const text = platformKey === "slack"
+                ? buildSlackRawMessage(plan.titleRaw || "", plan.contentRaw || "")
+                : String(plan.postText || "");
+            const urlMatch = text.match(/https?:\/\/[^\s]+/i);
+            return urlMatch ? urlMatch[0] : "";
+        }
+
+        function getUrlDomain(url) {
+            try {
+                return new URL(url).hostname.replace(/^www\./i, "");
+            } catch {
+                return url;
+            }
+        }
+
+        function buildOgPlaceholder(url) {
+            return {
+                url,
+                domain: getUrlDomain(url),
+                title: "Link preview unavailable",
+                description: "Metadata could not be loaded. This is a placeholder preview.",
+                image: ""
+            };
+        }
+
+        async function fetchOgPreview(url) {
+            const endpoint = `https://api.microlink.io/?url=${encodeURIComponent(url)}&audio=false&video=false&screenshot=false`;
+            const response = await fetch(endpoint, { headers: { accept: "application/json" } });
+            if (!response.ok) {
+                throw new Error(`OG fetch failed: ${response.status}`);
+            }
+
+            const json = await response.json();
+            const data = json?.data || {};
+            return {
+                url,
+                domain: data.publisher || data.author || getUrlDomain(url),
+                title: data.title || getUrlDomain(url),
+                description: data.description || "",
+                image: data.image?.url || data.logo?.url || ""
+            };
+        }
+
+        function ensureOgPreview(url) {
+            if (!url || ogPreviewCache.has(url) || ogPreviewPending.has(url)) {
+                return;
+            }
+
+            ogPreviewPending.add(url);
+            fetchOgPreview(url)
+                .then(data => {
+                    ogPreviewCache.set(url, data && data.title ? data : buildOgPlaceholder(url));
+                })
+                .catch(() => {
+                    ogPreviewCache.set(url, buildOgPlaceholder(url));
+                })
+                .finally(() => {
+                    ogPreviewPending.delete(url);
+                    update();
+                });
+        }
+
+        function renderOgCard(url) {
+            if (!url) {
+                return "";
+            }
+
+            const data = ogPreviewCache.get(url) || buildOgPlaceholder(url);
+            const mediaHtml = data.image
+                ? `<img alt="link preview image" src="${escapeHtml(data.image)}" loading="lazy" referrerpolicy="no-referrer">`
+                : `<div class="og-card-media-fallback">${escapeHtml(data.domain || getUrlDomain(url))}</div>`;
+
+            return `
+                <div class="og-card">
+                    <div class="og-card-media">${mediaHtml}</div>
+                    <div class="og-card-body">
+                        <div class="og-card-domain">${escapeHtml(data.domain || getUrlDomain(url))}</div>
+                        <div class="og-card-title">${escapeHtml(data.title || getUrlDomain(url))}</div>
+                        ${data.description ? `<div class="og-card-desc">${escapeHtml(data.description)}</div>` : ""}
+                        <div class="og-card-url">${escapeHtml(url)}</div>
+                    </div>
+                </div>`;
         }
 
         function applySlackMarkupToHtml(value) {
@@ -1457,9 +1631,10 @@
             return settings;
         }
 
-        function renderTextPreviewCard(platformKey, postText, clickableMentions, rawCopyText) {
+        function renderTextPreviewCard(platformKey, postText, clickableMentions, rawCopyText, ogPreviewUrl) {
             const meta = PLATFORM_PREVIEW_META[platformKey] || PLATFORM_PREVIEW_META.x;
             const copyKey = registerPreviewCopyText(rawCopyText);
+            const ogCardHtml = renderOgCard(ogPreviewUrl);
             return `
                 <div class="panel preview-block">
                     <div class="preview-title" style="margin-bottom:8px;">
@@ -1476,6 +1651,7 @@
                                     <span class="x-meta">now</span>
                                 </div>
                                 <div class="x-text">${formatPlainPostTextToHtml(postText, clickableMentions)}</div>
+                                ${ogCardHtml}
                                 <div class="x-actions"><span>Reply</span><span>Repost</span><span>Like</span><span>View</span></div>
                             </div>
                         </div>
@@ -1483,9 +1659,10 @@
                 </div>`;
         }
 
-        function renderSlackPreviewCard(titleRaw, contentRaw) {
+        function renderSlackPreviewCard(titleRaw, contentRaw, ogPreviewUrl) {
             const meta = PLATFORM_PREVIEW_META.slack;
             const copyKey = registerPreviewCopyText(buildSlackRawMessage(titleRaw, contentRaw));
+            const ogCardHtml = renderOgCard(ogPreviewUrl);
             return `
                 <div class="panel preview-block">
                     <div class="preview-title" style="margin-bottom:8px;">
@@ -1503,6 +1680,7 @@
                                         <span class="slack-timestamp">now</span>
                                     </div>
                                     <div class="slack-text">${renderSlackPreviewMessage(titleRaw, contentRaw)}</div>
+                                    ${ogCardHtml}
                                 </div>
                             </div>
                         </div>
@@ -1550,16 +1728,16 @@
                 </div>`;
         }
 
-        function renderPlatformPreviewCard(plan, contentRaw, fallbackTextPost, fallbackImagePost, clickableMentions, rawCopyText) {
+        function renderPlatformPreviewCard(plan, contentRaw, fallbackTextPost, fallbackImagePost, clickableMentions, rawCopyText, ogPreviewUrl) {
             if (plan.mode === "slack") {
-                return renderSlackPreviewCard(plan.titleRaw || "", plan.contentRaw || "");
+                return renderSlackPreviewCard(plan.titleRaw || "", plan.contentRaw || "", ogPreviewUrl);
             }
 
             if (plan.mode === "image") {
                 return renderImagePreviewCard(plan.key, plan.postText || fallbackImagePost, contentRaw, clickableMentions, rawCopyText);
             }
 
-            return renderTextPreviewCard(plan.key, plan.postText || fallbackTextPost, clickableMentions, rawCopyText);
+            return renderTextPreviewCard(plan.key, plan.postText || fallbackTextPost, clickableMentions, rawCopyText, ogPreviewUrl);
         }
 
         function update() {
@@ -1590,6 +1768,12 @@
             document.getElementById("eventContentPreview").innerHTML = contentRaw ? renderWebpageMarkupWithBreaks(contentRaw) : "";
 
             const selectedPlans = getSelectedPlatformPlans(titleRaw, contentRaw, sendWebpage.checked);
+            selectedPlans.forEach(plan => {
+                const ogPreviewUrl = getOgPreviewUrl(plan.key, plan);
+                if (ogPreviewUrl) {
+                    ensureOgPreview(ogPreviewUrl);
+                }
+            });
 
             const titleText = collapseWhitespace(plainTextWithLabels(titleRaw, slug => resolveMentionSlug(slug, "x")));
             const bodyText = plainTextWithLabels(contentRaw, slug => resolveMentionSlug(slug, "x"));
@@ -1605,7 +1789,8 @@
                     buildTextPost(titleText, bodyText, eventUrl),
                     buildImageCaption(titleText, eventUrl ?? "", plan.limit ?? LIMITS.x),
                     collectClickableMentions(combinedRaw, plan.key),
-                    buildPlatformRawText(plan.key, plan, titleRaw, contentRaw, sendWebpage.checked)
+                    buildPlatformRawText(plan.key, plan, titleRaw, contentRaw, sendWebpage.checked),
+                    getOgPreviewUrl(plan.key, plan)
                 )
             ).join("");
 

--- a/LongevityWorldCup.Website/wwwroot/js/custom-event-markup.js
+++ b/LongevityWorldCup.Website/wwwroot/js/custom-event-markup.js
@@ -35,6 +35,12 @@
         return containsHyperlinkCore(String(text || ""));
     }
 
+    function getSingleHyperlink(text) {
+        var links = [];
+        collectHyperlinks(String(text || ""), links);
+        return links.length === 1 ? links[0] : "";
+    }
+
     function containsHyperlinkCore(text) {
         var s = String(text || "");
         var i = 0;
@@ -78,6 +84,50 @@
         }
 
         return false;
+    }
+
+    function collectHyperlinks(text, links) {
+        var s = String(text || "");
+        var i = 0;
+        while (i < s.length) {
+            var open = s.indexOf("[", i);
+            if (open < 0) {
+                return;
+            }
+
+            var close = s.indexOf("](", open + 1);
+            if (close < 0) {
+                return;
+            }
+
+            var label = s.slice(open + 1, close);
+            var parenStart = close + 2;
+            var depth = 1;
+            var j = parenStart;
+            while (j < s.length && depth > 0) {
+                var ch = s[j];
+                if (ch === "(") depth++;
+                else if (ch === ")") depth--;
+                j++;
+            }
+
+            if (depth !== 0) {
+                return;
+            }
+
+            var inner = s.slice(parenStart, j - 1);
+            var key = label.trim().toLowerCase();
+            if (key === "bold" || key === "strong") {
+                collectHyperlinks(inner, links);
+            } else if (isSafeHttpUrl(inner)) {
+                links.push(inner.trim());
+                if (links.length > 1) {
+                    return;
+                }
+            }
+
+            i = j;
+        }
     }
 
     function humanizeSlug(value) {
@@ -253,6 +303,7 @@
         normalizeNewlines: normalizeNewlines,
         splitText: splitText,
         containsHyperlink: containsHyperlink,
+        getSingleHyperlink: getSingleHyperlink,
         renderMarkup: renderMarkup,
         renderMarkupWithBreaks: renderMarkupWithBreaks,
         renderWebpageMarkup: renderWebpageMarkup,


### PR DESCRIPTION
Previously when there was a hyperlink in the content, for X, Threads, Facebook we inserted the LWC page event link, where the hyperlink was working.

Now if there is only 1 hyperlink, rather put the URL of it in the post instead of the LWC page event link. 

Before:
<img width="674" height="280" alt="image" src="https://github.com/user-attachments/assets/0d3062c6-d82b-49f3-ac74-b3befd03ba4f" />

After:
<img width="684" height="548" alt="image" src="https://github.com/user-attachments/assets/050c1a5d-abb6-4e0c-befd-468912de5a24" />
