### PR TITLE
Add Logger

### DIFF
--- a/LongevityWorldCup.Website/Business/DailyFileLoggerProvider.cs
+++ b/LongevityWorldCup.Website/Business/DailyFileLoggerProvider.cs
@@ -1,0 +1,159 @@
+using System.Collections.Concurrent;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using LongevityWorldCup.Website.Tools;
+
+namespace LongevityWorldCup.Website.Business;
+
+public sealed class DailyFileLoggerProvider : ILoggerProvider
+{
+    private readonly string _logDirectory;
+    private readonly int _retentionDays;
+    private readonly object _writeLock = new();
+    private readonly ConcurrentDictionary<string, DailyFileLogger> _loggers = new(StringComparer.Ordinal);
+    private int _disposed;
+    private DateOnly _currentUtcDay;
+    private string _currentLogPath;
+
+    public DailyFileLoggerProvider(string? logDirectory = null, int retentionDays = 10)
+    {
+        _retentionDays = Math.Max(1, retentionDays);
+        _logDirectory = string.IsNullOrWhiteSpace(logDirectory)
+            ? Path.Combine(EnvironmentHelpers.GetDataDir(), "Logs")
+            : logDirectory;
+
+        Directory.CreateDirectory(_logDirectory);
+        _currentUtcDay = DateOnly.FromDateTime(DateTime.UtcNow);
+        _currentLogPath = BuildLogPath(_currentUtcDay);
+        CleanupOldLogs(_currentUtcDay);
+    }
+
+    public ILogger CreateLogger(string categoryName)
+    {
+        return _loggers.GetOrAdd(categoryName, name => new DailyFileLogger(this, name));
+    }
+
+    public void Dispose()
+    {
+        Interlocked.Exchange(ref _disposed, 1);
+    }
+
+    private void WriteEntry(string categoryName, LogLevel logLevel, EventId eventId, string message, Exception? exception)
+    {
+        if (Volatile.Read(ref _disposed) == 1)
+            return;
+
+        try
+        {
+            lock (_writeLock)
+            {
+                var nowUtc = DateTime.UtcNow;
+                var utcDay = DateOnly.FromDateTime(nowUtc);
+                if (utcDay != _currentUtcDay)
+                {
+                    _currentUtcDay = utcDay;
+                    _currentLogPath = BuildLogPath(utcDay);
+                    CleanupOldLogs(utcDay);
+                }
+
+                var entry = FormatEntry(nowUtc, categoryName, logLevel, eventId, message, exception);
+                File.AppendAllText(_currentLogPath, entry);
+            }
+        }
+        catch
+        {
+        }
+    }
+
+    private string BuildLogPath(DateOnly utcDay)
+    {
+        return Path.Combine(_logDirectory, $"{utcDay:yyyy-MM-dd}.log");
+    }
+
+    private void CleanupOldLogs(DateOnly currentUtcDay)
+    {
+        var cutoffDay = currentUtcDay.AddDays(-(_retentionDays - 1));
+
+        foreach (var path in Directory.EnumerateFiles(_logDirectory, "*.log", SearchOption.TopDirectoryOnly))
+        {
+            try
+            {
+                var fileName = Path.GetFileNameWithoutExtension(path);
+                if (DateOnly.TryParseExact(fileName, "yyyy-MM-dd", out var fileDay) && fileDay < cutoffDay)
+                    File.Delete(path);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    private static string FormatEntry(DateTime utcNow, string categoryName, LogLevel logLevel, EventId eventId, string message, Exception? exception)
+    {
+        var sb = new StringBuilder();
+        sb.Append(utcNow.ToString("yyyy-MM-dd HH:mm:ss.fff"));
+        sb.Append("Z [");
+        sb.Append(logLevel);
+        sb.Append("] ");
+        sb.Append(categoryName);
+
+        if (eventId.Id != 0 || !string.IsNullOrWhiteSpace(eventId.Name))
+        {
+            sb.Append(" (EventId=");
+            sb.Append(eventId.Id);
+            if (!string.IsNullOrWhiteSpace(eventId.Name))
+            {
+                sb.Append(", Name=");
+                sb.Append(eventId.Name);
+            }
+            sb.Append(')');
+        }
+
+        if (!string.IsNullOrWhiteSpace(message))
+        {
+            sb.Append(" - ");
+            sb.Append(message.Replace("\r\n", "\n", StringComparison.Ordinal).Replace('\r', '\n'));
+        }
+
+        sb.AppendLine();
+
+        if (exception is not null)
+        {
+            sb.AppendLine(exception.ToString());
+            sb.AppendLine();
+        }
+
+        return sb.ToString();
+    }
+
+    private sealed class DailyFileLogger : ILogger
+    {
+        private readonly DailyFileLoggerProvider _provider;
+        private readonly string _categoryName;
+
+        public DailyFileLogger(DailyFileLoggerProvider provider, string categoryName)
+        {
+            _provider = provider;
+            _categoryName = categoryName;
+        }
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return logLevel != LogLevel.None;
+        }
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            if (!IsEnabled(logLevel))
+                return;
+
+            var message = formatter(state, exception);
+            if (string.IsNullOrWhiteSpace(message) && exception is null)
+                return;
+
+            _provider.WriteEntry(_categoryName, logLevel, eventId, message, exception);
+        }
+    }
+}

--- a/LongevityWorldCup.Website/Business/EventDataService.cs
+++ b/LongevityWorldCup.Website/Business/EventDataService.cs
@@ -282,16 +282,29 @@ public sealed class EventDataService : IDisposable
         var claimed = ClaimPendingCustomEvents(processedColumn);
         foreach (var (id, rawText, visibleOnWebsite) in claimed)
         {
+            _log.LogInformation(
+                "Immediate custom event dispatch started for platform column {ProcessedColumn}, event {EventId}, visibleOnWebsite {VisibleOnWebsite}, textLength {TextLength}",
+                processedColumn,
+                id,
+                visibleOnWebsite,
+                rawText?.Length ?? 0);
+
             var sent = false;
             try
             {
-                sent = trySend(id, rawText, visibleOnWebsite);
+                sent = trySend(id, rawText ?? "", visibleOnWebsite);
             }
             catch (Exception ex)
             {
                 _log.LogError(ex, "Immediate custom event send failed for platform column {ProcessedColumn} and event {EventId}.", processedColumn, id);
                 sent = false;
             }
+
+            _log.LogInformation(
+                "Immediate custom event dispatch finished for platform column {ProcessedColumn}, event {EventId}, succeeded {Succeeded}",
+                processedColumn,
+                id,
+                sent);
 
             FinalizeClaimedCustomEvent(processedColumn, id, sent);
         }

--- a/LongevityWorldCup.Website/Business/FacebookApiClient.cs
+++ b/LongevityWorldCup.Website/Business/FacebookApiClient.cs
@@ -138,6 +138,13 @@ public class FacebookApiClient
         const int maxAttempts = 2;
         for (var attempt = 1; attempt <= maxAttempts; attempt++)
         {
+            _log.LogInformation(
+                "Facebook photo publish attempt {Attempt}/{MaxAttempts} for imageUrl {ImageUrl} with textLength {TextLength}",
+                attempt,
+                maxAttempts,
+                imageUrl,
+                text.Length);
+
             var endpoint = $"{GraphApiBaseUrl}/{Uri.EscapeDataString(pageId)}/photos";
             using var req = new HttpRequestMessage(HttpMethod.Post, endpoint);
             req.Content = new FormUrlEncodedContent(new[]

--- a/LongevityWorldCup.Website/Business/FacebookEventService.cs
+++ b/LongevityWorldCup.Website/Business/FacebookEventService.cs
@@ -97,6 +97,15 @@ public class FacebookEventService
         }
 
         var plan = CustomEventSocialComposer.BuildPlan(eventId, rawText, 63206, ResolveMention, includeEventUrl: visibleOnWebsite);
+        _log.LogInformation(
+            "Facebook custom event plan for event {EventId}: mode {Mode}, visibleOnWebsite {VisibleOnWebsite}, postLength {PostLength}, titleLength {TitleLength}, bodyLength {BodyLength}",
+            eventId,
+            plan.Mode,
+            visibleOnWebsite,
+            plan.PostText.Length,
+            plan.TitleText.Length,
+            plan.BodyText.Length);
+
         if (plan.Mode == CustomEventPostMode.Text)
             return await TrySendAsync(plan.PostText);
 
@@ -112,6 +121,12 @@ public class FacebookEventService
             _log.LogWarning("Facebook custom event image render returned no asset for event {EventId}.", eventId);
             return false;
         }
+
+        _log.LogInformation(
+            "Facebook custom event {EventId} sending image post with imageUrl {ImageUrl} and postLength {PostLength}",
+            eventId,
+            imageAsset.Value.PublicUrl,
+            plan.PostText.Length);
 
         const int maxAttempts = 2;
         const int retryDelayMs = 750;

--- a/LongevityWorldCup.Website/Business/ThreadsApiClient.cs
+++ b/LongevityWorldCup.Website/Business/ThreadsApiClient.cs
@@ -130,6 +130,12 @@ public class ThreadsApiClient
             var creation = await CreateImageContainerAsync(text, imageUrl, token);
             if (creation.Success && !string.IsNullOrWhiteSpace(creation.Id))
             {
+                _log.LogInformation(
+                    "Threads image container created successfully with creationId {CreationId}, textLength {TextLength}, imageUrl {ImageUrl}",
+                    creation.Id,
+                    text.Length,
+                    imageUrl);
+
                 var publish = await PublishContainerAsync(creation.Id, token);
                 if (publish.Success && !string.IsNullOrWhiteSpace(publish.Id))
                     return publish.Id;
@@ -250,7 +256,7 @@ public class ThreadsApiClient
 
         if (!res.IsSuccessStatusCode)
         {
-            _log.LogError("Threads publish failed: {StatusCode} {Body}", res.StatusCode, json);
+            _log.LogError("Threads publish failed for creationId {CreationId}: {StatusCode} {Body}", creationId, res.StatusCode, json);
             return (false, null, ShouldRefreshToken(res.StatusCode, json));
         }
 

--- a/LongevityWorldCup.Website/Business/ThreadsEventService.cs
+++ b/LongevityWorldCup.Website/Business/ThreadsEventService.cs
@@ -170,6 +170,15 @@ public class ThreadsEventService
         }
 
         var plan = CustomEventSocialComposer.BuildPlan(eventId, rawText, 500, ResolveMention, includeEventUrl: visibleOnWebsite);
+        _log.LogInformation(
+            "Threads custom event plan for event {EventId}: mode {Mode}, visibleOnWebsite {VisibleOnWebsite}, captionLength {CaptionLength}, titleLength {TitleLength}, bodyLength {BodyLength}",
+            eventId,
+            plan.Mode,
+            visibleOnWebsite,
+            plan.PostText.Length,
+            plan.TitleText.Length,
+            plan.BodyText.Length);
+
         if (plan.Mode == CustomEventPostMode.Text)
             return await TrySendAsync(plan.PostText);
 
@@ -185,6 +194,12 @@ public class ThreadsEventService
             _log.LogWarning("Threads custom event image render returned no asset for event {EventId}.", eventId);
             return false;
         }
+
+        _log.LogInformation(
+            "Threads custom event {EventId} sending image post with imageUrl {ImageUrl} and captionLength {CaptionLength}",
+            eventId,
+            imageAsset.Value.PublicUrl,
+            plan.PostText.Length);
 
         const int maxAttempts = 2;
         const int retryDelayMs = 750;

--- a/LongevityWorldCup.Website/Business/XApiClient.cs
+++ b/LongevityWorldCup.Website/Business/XApiClient.cs
@@ -53,6 +53,8 @@ public class XApiClient
         streamContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(contentType);
         form.Add(streamContent, "media", "media");
 
+        _log.LogInformation("X media upload started with contentType {ContentType}", contentType);
+
         using var req = new HttpRequestMessage(HttpMethod.Post, MediaUploadEndpoint);
         req.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
         req.Content = form;
@@ -71,9 +73,17 @@ public class XApiClient
             using var doc = JsonDocument.Parse(json);
             var root = doc.RootElement;
             if (root.TryGetProperty("media_id_string", out var idEl))
-                return idEl.GetString();
+            {
+                var mediaId = idEl.GetString();
+                _log.LogInformation("X media upload succeeded with mediaId {MediaId}", mediaId);
+                return mediaId;
+            }
             if (root.TryGetProperty("media_id", out var idElNum))
-                return idElNum.GetRawText();
+            {
+                var mediaId = idElNum.GetRawText();
+                _log.LogInformation("X media upload succeeded with mediaId {MediaId}", mediaId);
+                return mediaId;
+            }
         }
         catch (Exception ex)
         {

--- a/LongevityWorldCup.Website/Business/XEventService.cs
+++ b/LongevityWorldCup.Website/Business/XEventService.cs
@@ -180,6 +180,15 @@ public class XEventService
         }
 
         var plan = CustomEventSocialComposer.BuildPlan(eventId, rawText, 280, ResolveMention, includeEventUrl: visibleOnWebsite);
+        _log.LogInformation(
+            "X custom event plan for event {EventId}: mode {Mode}, visibleOnWebsite {VisibleOnWebsite}, postLength {PostLength}, titleLength {TitleLength}, bodyLength {BodyLength}",
+            eventId,
+            plan.Mode,
+            visibleOnWebsite,
+            plan.PostText.Length,
+            plan.TitleText.Length,
+            plan.BodyText.Length);
+
         if (plan.Mode == CustomEventPostMode.Text)
             return await TrySendAsync(plan.PostText);
 
@@ -202,6 +211,12 @@ public class XEventService
             _log.LogWarning("X custom event media upload returned no media id for event {EventId}.", eventId);
             return false;
         }
+
+        _log.LogInformation(
+            "X custom event {EventId} sending image post with mediaId {MediaId} and postLength {PostLength}",
+            eventId,
+            mediaId,
+            plan.PostText.Length);
 
         return await TrySendAsync(plan.PostText, new[] { mediaId });
     }

--- a/LongevityWorldCup.Website/Jobs/FacebookDailyPostJob.cs
+++ b/LongevityWorldCup.Website/Jobs/FacebookDailyPostJob.cs
@@ -27,11 +27,19 @@ public class FacebookDailyPostJob : IJob
         _facebookEvents.SetAthletesForFacebook(_athletes.GetAthletesForX());
         var pending = _events.GetPendingFacebookEvents();
 
-        foreach (var (id, type, text, _, _, visibleOnWebsite, _) in pending)
+        foreach (var (id, type, text, occurredAtUtc, _, visibleOnWebsite, _) in pending)
         {
             var msg = _facebookEvents.TryBuildMessage(type, text, id, visibleOnWebsite);
             if (string.IsNullOrWhiteSpace(msg))
                 continue;
+
+            _logger.LogInformation(
+                "FacebookDailyPostJob selected event {Id} type {Type} occurredAt {OccurredAtUtc} visibleOnWebsite {VisibleOnWebsite} messageLength {MessageLength}",
+                id,
+                type,
+                occurredAtUtc,
+                visibleOnWebsite,
+                msg.Length);
 
             var sent = await _facebookEvents.TrySendEventAsync(type, text, id, visibleOnWebsite);
             if (!sent)

--- a/LongevityWorldCup.Website/Jobs/ThreadsDailyPostJob.cs
+++ b/LongevityWorldCup.Website/Jobs/ThreadsDailyPostJob.cs
@@ -78,6 +78,14 @@ public class ThreadsDailyPostJob : IJob
             var msg = _threadsEvents.TryBuildMessage(type, text, id, visibleOnWebsite);
             if (string.IsNullOrWhiteSpace(msg)) continue;
 
+            _logger.LogInformation(
+                "ThreadsDailyPostJob selected event {Id} type {Type} occurredAt {OccurredAtUtc} visibleOnWebsite {VisibleOnWebsite} messageLength {MessageLength}",
+                id,
+                type,
+                occurredAtUtc,
+                visibleOnWebsite,
+                msg.Length);
+
             var sent = await _threadsEvents.TrySendEventAsync(type, text, id, visibleOnWebsite);
             if (!sent)
             {
@@ -123,6 +131,13 @@ public class ThreadsDailyPostJob : IJob
                 _logger.LogInformation("ThreadsDailyPostJob skipped unchanged filler {FillerType} {PayloadText}", fillerType, payloadText);
                 continue;
             }
+
+            _logger.LogInformation(
+                "ThreadsDailyPostJob selected filler {FillerType} subject {SubjectSlug} messageLength {MessageLength} infoToken {InfoToken}",
+                fillerType,
+                subjectSlug,
+                fillerMsg.Length,
+                infoToken);
 
             var fillerSent = await _threadsEvents.TrySendAsync(fillerMsg);
             if (!fillerSent)

--- a/LongevityWorldCup.Website/Jobs/XDailyPostJob.cs
+++ b/LongevityWorldCup.Website/Jobs/XDailyPostJob.cs
@@ -78,6 +78,14 @@ public class XDailyPostJob : IJob
             var msg = _xEvents.TryBuildMessage(type, text, id, visibleOnWebsite);
             if (string.IsNullOrWhiteSpace(msg)) continue;
 
+            _logger.LogInformation(
+                "XDailyPostJob selected event {Id} type {Type} occurredAt {OccurredAtUtc} visibleOnWebsite {VisibleOnWebsite} messageLength {MessageLength}",
+                id,
+                type,
+                occurredAtUtc,
+                visibleOnWebsite,
+                msg.Length);
+
             var sent = await _xEvents.TrySendEventAsync(type, text, id, visibleOnWebsite);
             if (!sent)
             {
@@ -123,6 +131,13 @@ public class XDailyPostJob : IJob
                 _logger.LogInformation("XDailyPostJob skipped unchanged filler {FillerType} {PayloadText}", fillerType, payloadText);
                 continue;
             }
+
+            _logger.LogInformation(
+                "XDailyPostJob selected filler {FillerType} subject {SubjectSlug} messageLength {MessageLength} infoToken {InfoToken}",
+                fillerType,
+                subjectSlug,
+                fillerMsg.Length,
+                infoToken);
 
             var fillerSent = await _xEvents.TrySendAsync(fillerMsg);
             if (!fillerSent)

--- a/LongevityWorldCup.Website/Program.cs
+++ b/LongevityWorldCup.Website/Program.cs
@@ -69,6 +69,7 @@ namespace LongevityWorldCup.Website
 
             var appConfig = Config.LoadAsync().GetAwaiter().GetResult();
             builder.Services.AddSingleton(appConfig);
+            builder.Logging.AddProvider(new DailyFileLoggerProvider());
             builder.Logging.AddProvider(new SlackErrorLoggerProvider(appConfig.SlackErrorWebhookUrl));
             builder.Services.AddHttpClient<SlackWebhookClient>();
             builder.Services.AddSingleton<SlackEventService>();


### PR DESCRIPTION
This PR adds daily file logging for the website app and improves diagnostics around social posting. Logs are now written to one file per UTC day, and log files older than 10 days are deleted automatically. 

It also adds targeted extra logging in the X, Threads, and Facebook posting flows. The new logs help show which event or filler was selected, whether a custom event was sent as text or image, and which media or publish identifiers were used during sending.