### PR TITLE
[codex] Preserve leaderboard state when viewing all athletes

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/index.html
+++ b/LongevityWorldCup.Website/wwwroot/index.html
@@ -1295,7 +1295,7 @@
 
         <!--LEADERBOARD-CONTENT-->
         <div style="text-align: center; margin-top: 20px;">
-            <button id="viewAllAthletesBtn" onclick="window.location.href='/leaderboard'" class="rankings-btn" aria-label="View all athletes on the leaderboard">
+            <button id="viewAllAthletesBtn" onclick="window.location.href = window.getFullLeaderboardUrlWithCurrentState ? window.getFullLeaderboardUrlWithCurrentState() : '/leaderboard'" class="rankings-btn" aria-label="View all athletes on the leaderboard">
                 View all athletes
             </button>
         </div>

--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -3195,7 +3195,7 @@
         const searchInput = document.getElementById('athleteSearch');
         const searchQuery = searchInput ? searchInput.value.trim() : '';
         if (searchQuery) {
-            url.searchParams.set('search', searchQuery);
+            url.searchParams.set('search', encodeURIComponent(searchQuery));
         }
 
         const selectedDivisions = Array.from(document.querySelectorAll('input[name="division"]:checked'))

--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -251,14 +251,6 @@
     .sidebar-toggle:hover{ background:var(--primary-color); transform:scale(1.05); }
     .sidebar-toggle i{ color:var(--primary-color); font-size:1.5rem; transition:color .3s ease; }
     .sidebar-toggle:hover i{ color:var(--card-bg); }
-    .sidebar-toggle.has-active-state{
-        border-color:#e53935; box-shadow:0 0 0 4px rgba(229,57,53,.14);
-    }
-    .sidebar-toggle.has-active-state i{ color:#e53935; }
-    .sidebar-toggle.has-active-state:hover,
-    .sidebar-toggle.has-active-state.active{ background:#e53935; border-color:#e53935; }
-    .sidebar-toggle.has-active-state:hover i,
-    .sidebar-toggle.has-active-state.active i{ color:var(--card-bg); }
     .sidebar-toggle.has-active-state::after{
         content:''; position:absolute; top:-4px; right:-4px; width:12px; height:12px; border-radius:50%;
         background:#e53935; border:2px solid var(--card-bg); box-shadow:0 1px 4px rgba(0,0,0,.2);
@@ -285,11 +277,14 @@
         margin:0; padding:1rem 0; text-align:center; font-size:1.2rem; color:var(--primary-color);
         display:flex; align-items:center; justify-content:left; border-bottom:2px solid var(--primary-color);
     }
-    .sidebar .sidebar-title .sidebar-icon{ display:inline-block; font-size:2rem; }
+    .sidebar .sidebar-title .sidebar-icon{ display:inline-block; font-size:2rem; position:relative; }
+    .sidebar.has-active-state .sidebar-title .sidebar-icon::after{
+        content:''; position:absolute; top:0; right:-4px; width:12px; height:12px; border-radius:50%;
+        background:#e53935; border:2px solid var(--card-bg); box-shadow:0 1px 4px rgba(0,0,0,.2);
+    }
     .sidebar .sidebar-title .sidebar-title-text{ display:none; margin-left:.5rem; font-size:2rem; }
     .sidebar:hover .sidebar-title .sidebar-title-text,
     .sidebar.expanded .sidebar-title .sidebar-title-text{ display:inline-block; }
-    .sidebar.has-active-state .sidebar-title .sidebar-icon i{ color:#e53935; }
 
     .sidebar:hover ~ .content, .sidebar.expanded ~ .content{ margin-left:200px; }
 
@@ -300,6 +295,7 @@
     .filter-section label{ display:flex; align-items:center; cursor:pointer; color:#555; transition:color .2s; }
     .filter-section input[type="checkbox"]{ margin-right:.5rem; accent-color:var(--primary-color); }
     .filter-section label:hover{ color:var(--primary-color); }
+    .filter-section label.active{ font-weight:bold; color:var(--secondary-color); }
     .filter-section input[type="checkbox"]:checked + label{ font-weight:bold; color:var(--secondary-color); }
 
     /* =========================
@@ -1071,8 +1067,25 @@
                     <span class="sidebar-title-text">Leagues</span>
                 </h2>
                 <div class="collapsed-title" data-aos="fade" data-aos-duration="700" data-aos-delay="200">ULTIMATE LEAGUE</div>
+                <div class="filter-section" id="aging-clock-filter-section">
+                    <h3>Aging Clocks</h3>
+                    <ul>
+                        <li>
+                            <label data-aging-clock-view="bortz">
+                                <input type="checkbox" name="agingClockView" value="bortz">
+                                🩸 Bortz Age (<span class="filter-count">0</span>)
+                            </label>
+                        </li>
+                        <li>
+                            <label data-aging-clock-view="pheno">
+                                <input type="checkbox" name="agingClockView" value="pheno">
+                                🩸 Pheno Age (<span class="filter-count">0</span>)
+                            </label>
+                        </li>
+                    </ul>
+                </div>
                 <div class="filter-section" id="league-track-filter-section">
-                    <h3>Track</h3>
+                    <h3>Tracks</h3>
                     <ul></ul> <!-- This will be populated dynamically -->
                 </div>
                 <div class="filter-section" id="division-filter-section" data-aos="fade" data-aos-duration="700" data-aos-delay="200">
@@ -1659,7 +1672,7 @@
                 // Array to store athletes with their lowest PhenoAge and age reduction
                 var viewAllAthletesBtn = document.getElementById('viewAllAthletesBtn');
                 if (viewAllAthletesBtn) {
-                    document.getElementById('viewAllAthletesBtn').textContent = `VIEW ALL ATHLETES (${athletes.length})`;
+                    updateViewAllAthletesButton(athletes.length);
                 }
                 athleteResults = athletes.map(athlete => {
                     // Calculate the chronological age from the athlete's DateOfBirth
@@ -1988,6 +2001,7 @@
                 generateGenerationFilters(athleteResults);
                 generateExclusiveFilters(athleteResults);
                 generateLeagueTrackFilters(athleteResults);
+                updateFilterCounts(athleteResults);
 
                 // Sort the athletes by age reduction in ascending order
                 athleteResults.sort(window.compareAthleteRank);
@@ -3015,11 +3029,38 @@
         return !!hasCheckedFilters || currentLeaderboardView !== 'ultimate' || hasSearch;
     }
 
+    function hasActiveLeaderboardFilterState() {
+        const hasCheckedFilters = document.querySelector('input[name="division"]:checked, input[name="generation"]:checked, input[name="exclusiveLeague"]:checked, input[name="leagueTrack"]:checked');
+        const viewRadio = document.querySelector('input[name="leaderboardView"]:checked');
+        const currentLeaderboardView = viewRadio ? viewRadio.value : 'ultimate';
+        return !!hasCheckedFilters || currentLeaderboardView !== 'ultimate';
+    }
+
+    function syncAgingClockFilters(currentLeaderboardView) {
+        document.querySelectorAll('input[name="agingClockView"]').forEach(input => {
+            const isActive = input.value === currentLeaderboardView;
+            input.checked = isActive;
+            input.closest('label')?.classList.toggle('active', isActive);
+        });
+    }
+
+    function updateViewAllAthletesButton(count) {
+        const button = document.getElementById('viewAllAthletesBtn');
+        if (!button) return;
+
+        const hasResults = Number.isFinite(count) && count > 0;
+        const totalCount = Array.isArray(athleteResults) && athleteResults.length > 0 ? athleteResults.length : count;
+        const label = hasActiveLeaderboardState() && hasResults ? 'VIEW THIS LEADERBOARD' : 'VIEW ALL ATHLETES';
+        const displayCount = hasResults ? count : totalCount;
+        button.dataset.useDefaultLeaderboardUrl = hasResults ? 'false' : 'true';
+        button.textContent = Number.isFinite(displayCount) ? `${label} (${displayCount})` : label;
+    }
+
     function updateLeaderboardStateIndicator() {
         const sidebarToggle = document.querySelector('.sidebar-toggle');
         const sidebar = document.querySelector('.sidebar');
 
-        const hasActiveState = hasActiveLeaderboardState();
+        const hasActiveState = hasActiveLeaderboardFilterState();
         if (sidebarToggle) {
             sidebarToggle.classList.toggle('has-active-state', hasActiveState);
         }
@@ -3029,6 +3070,11 @@
     }
 
     window.getFullLeaderboardUrlWithCurrentState = function () {
+        const button = document.getElementById('viewAllAthletesBtn');
+        if (button?.dataset.useDefaultLeaderboardUrl === 'true') {
+            return '/leaderboard';
+        }
+
         const url = new URL('/leaderboard', window.location.origin);
         const searchInput = document.getElementById('athleteSearch');
         const searchQuery = searchInput ? searchInput.value.trim() : '';
@@ -3085,6 +3131,7 @@
         // Get leaderboard view (ultimate | bortz | pheno)
         const viewRadio = document.querySelector('input[name="leaderboardView"]:checked');
         const currentLeaderboardView = viewRadio ? viewRadio.value : 'ultimate';
+        syncAgingClockFilters(currentLeaderboardView);
 
         const hasBortz = (a) => a.bortzAgeReduction != null && Number.isFinite(a.bortzAgeReduction);
 
@@ -3181,6 +3228,7 @@
         const unslicedFilteredAthletes = filteredAthletes;
 
         filteredAthletes = filteredAthletes.slice(0, maxAthletesGlobal);
+        updateViewAllAthletesButton(unslicedFilteredAthletes.length);
 
         // Determine if filters are used (league track counts only when exactly one selected)
         const filtersUsed = selectedDivisions.length > 0 || selectedGenerations.length > 0 || selectedExclusiveLeagues.length > 0 ||
@@ -3480,6 +3528,23 @@
     }
 
     function updateFilterCounts(filteredAthletes) {
+        // Update aging clock counts
+        const hasBortzForClockCount = (a) => a.bortzAgeReduction != null && Number.isFinite(a.bortzAgeReduction);
+        const hasPhenoForClockCount = (a) => a.ageReduction != null && Number.isFinite(a.ageReduction);
+        const agingClockCounts = {
+            bortz: filteredAthletes.filter(hasBortzForClockCount).length,
+            pheno: filteredAthletes.filter(hasPhenoForClockCount).length
+        };
+
+        document.querySelectorAll('.filter-section label[data-aging-clock-view]').forEach(label => {
+            const clock = label.getAttribute('data-aging-clock-view');
+            const count = agingClockCounts[clock] || 0;
+            const countSpan = label.querySelector('.filter-count');
+            if (countSpan) {
+                countSpan.textContent = count;
+            }
+        });
+
         // Update division counts
         const divisionCounts = {};
         filteredAthletes.forEach(athlete => {
@@ -3601,6 +3666,17 @@
     document.querySelectorAll('input[name="leaderboardView"]').forEach(radio => {
         radio.addEventListener('change', function () { performFilter(); });
     });
+    document.querySelectorAll('input[name="agingClockView"]').forEach(input => {
+        input.addEventListener('change', function (event) {
+            event.stopPropagation();
+            const targetView = this.checked ? this.value : 'ultimate';
+            const viewRadio = document.getElementById(`view-${targetView}`);
+            if (viewRadio) {
+                viewRadio.checked = true;
+            }
+            performFilter();
+        });
+    });
     // Clicking the active Bortz or Pheno badge again deselects it (none = Ultimate view)
     document.querySelectorAll('.leaderboard-view-switcher .view-badge').forEach(label => {
         label.addEventListener('click', function (e) {
@@ -3714,8 +3790,8 @@
         const professionalCount = athletes.filter(a => isPro(a)).length;
 
         const tracks = [
-            { value: 'Amateur', label: 'Amateur', count: amateurCount },
-            { value: 'Professional', label: 'Pro', count: professionalCount }
+            { value: 'Professional', label: 'Pro', count: professionalCount },
+            { value: 'Amateur', label: 'Amateur', count: amateurCount }
         ];
 
         tracks.forEach(({ value, label, count }) => {

--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -252,9 +252,8 @@
     .sidebar-toggle i{ color:var(--primary-color); font-size:1.5rem; transition:color .3s ease; }
     .sidebar-toggle:hover i{ color:var(--card-bg); }
     .sidebar-toggle.has-active-state::after{
-        content:attr(data-active-count); position:absolute; top:-7px; right:-7px; min-width:18px; height:18px; padding:0 4px; border-radius:999px;
-        background:var(--secondary-color); border:2px solid var(--card-bg); box-shadow:0 1px 4px rgba(0,0,0,.2);
-        color:var(--card-bg); font-size:.68rem; font-weight:700; line-height:14px; text-align:center;
+        content:''; position:absolute; top:-4px; right:-4px; width:12px; height:12px; border-radius:50%;
+        background:#e53935; border:2px solid var(--card-bg); box-shadow:0 1px 4px rgba(0,0,0,.2);
     }
 
     .sidebar-close{
@@ -281,7 +280,7 @@
     .sidebar .sidebar-title .sidebar-icon{ display:inline-block; font-size:2rem; position:relative; }
     .sidebar.has-active-state .sidebar-title .sidebar-icon::after{
         content:''; position:absolute; top:0; right:-4px; width:12px; height:12px; border-radius:50%;
-        background:var(--secondary-color); border:2px solid var(--card-bg); box-shadow:0 1px 4px rgba(0,0,0,.2);
+        background:#e53935; border:2px solid var(--card-bg); box-shadow:0 1px 4px rgba(0,0,0,.2);
     }
     .sidebar .sidebar-title .sidebar-title-text{ display:none; margin-left:.5rem; font-size:2rem; }
     .sidebar:hover .sidebar-title .sidebar-title-text,
@@ -3031,25 +3030,10 @@
     }
 
     function hasActiveLeaderboardFilterState() {
-        return getActiveLeaderboardFilterGroupCount() > 0;
-    }
-
-    function getActiveLeaderboardFilterGroupCount() {
-        const hasSelectedDivisions = document.querySelectorAll('input[name="division"]:checked').length > 0;
-        const hasSelectedGenerations = document.querySelectorAll('input[name="generation"]:checked').length > 0;
-        const hasSelectedExclusiveLeagues = document.querySelectorAll('input[name="exclusiveLeague"]:checked').length > 0;
-        const hasSelectedTrack = document.querySelectorAll('input[name="leagueTrack"]:checked').length === 1;
+        const hasCheckedFilters = document.querySelector('input[name="division"]:checked, input[name="generation"]:checked, input[name="exclusiveLeague"]:checked, input[name="leagueTrack"]:checked');
         const viewRadio = document.querySelector('input[name="leaderboardView"]:checked');
         const currentLeaderboardView = viewRadio ? viewRadio.value : 'ultimate';
-        const hasSelectedAgingClock = currentLeaderboardView !== 'ultimate';
-
-        return [
-            hasSelectedAgingClock,
-            hasSelectedTrack,
-            hasSelectedDivisions,
-            hasSelectedGenerations,
-            hasSelectedExclusiveLeagues
-        ].filter(Boolean).length;
+        return !!hasCheckedFilters || currentLeaderboardView !== 'ultimate';
     }
 
     function syncAgingClockFilters(currentLeaderboardView) {
@@ -3076,15 +3060,9 @@
         const sidebarToggle = document.querySelector('.sidebar-toggle');
         const sidebar = document.querySelector('.sidebar');
 
-        const activeGroupCount = getActiveLeaderboardFilterGroupCount();
-        const hasActiveState = activeGroupCount > 0;
+        const hasActiveState = hasActiveLeaderboardFilterState();
         if (sidebarToggle) {
             sidebarToggle.classList.toggle('has-active-state', hasActiveState);
-            if (hasActiveState) {
-                sidebarToggle.dataset.activeCount = String(activeGroupCount);
-            } else {
-                delete sidebarToggle.dataset.activeCount;
-            }
         }
         if (sidebar) {
             sidebar.classList.toggle('has-active-state', hasActiveState);

--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -27,6 +27,23 @@
 
     /* Common transition for table rows and podium items */
     .leaderboard table tbody tr, .podium-item{ transition:opacity .3s ease, transform .3s ease; }
+    .leaderboard table tbody tr.fade-in{ animation:filterRowFade .22s ease-out both; }
+    .podium-item.fade-in{ animation:filterPodiumFade .22s ease-out both; }
+
+    @keyframes filterRowFade{
+        from{ opacity:.82; }
+        to{ opacity:1; }
+    }
+
+    @keyframes filterPodiumFade{
+        from{ opacity:.82; transform:translateY(1px); }
+        to{ opacity:1; transform:translateY(0); }
+    }
+
+    @media (prefers-reduced-motion: reduce){
+        .leaderboard table tbody tr.fade-in,
+        .podium-item.fade-in{ animation:none; }
+    }
 
     /* =========================
        3) Global layout / shell
@@ -3280,6 +3297,7 @@
             const item = document.querySelector(`.podium-item[data-athlete-name="${athleteName}"]`);
             if (item) {
                 item.style.display = '';
+                window.showWithDelay(item);
                 anyPodiumVisible = true;
             }
         });

--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -23,6 +23,23 @@
     .highlight{ background-color: rgba(255,255,0,.5); color:#000; }
     .fade-out{ opacity:0; transition:opacity .4s ease; }
     .no-results{ color:var(--primary-color); font-weight:bold; text-align:center; padding:1rem; font-size:1.2rem; }
+    .leaderboard table tbody tr.no-results{ cursor:default; }
+    .leaderboard table tbody tr.no-results:hover{ transform:none; box-shadow:none; }
+    .leaderboard table tbody tr.no-results td{ cursor:default; }
+    .no-results-empty-state{ display:flex; flex-direction:column; align-items:center; gap:.65rem; padding:1.25rem 1rem; }
+    .no-results-empty-state p{ margin:0; }
+    .show-all-athletes-btn{
+        border:1px solid var(--primary-color); border-radius:4px; background:transparent; color:var(--primary-color);
+        font:inherit; font-size:.9rem; font-weight:700; padding:.35rem .7rem; cursor:pointer; transform:none !important;
+        appearance:none; -webkit-appearance:none; box-shadow:none;
+        transition:border-color .2s ease, color .2s ease;
+    }
+    .show-all-athletes-btn:hover,
+    .show-all-athletes-btn:active,
+    .show-all-athletes-btn:focus{
+        background:transparent; color:var(--secondary-color); border-color:var(--secondary-color);
+        outline:none; box-shadow:none; transform:none !important; font:inherit; font-size:.9rem; font-weight:700;
+    }
     #comingSoon{ font-size:.5rem; font-weight:normal; }
 
     /* Common transition for table rows and podium items */
@@ -302,6 +319,19 @@
     .sidebar .sidebar-title .sidebar-title-text{ display:none; margin-left:.5rem; font-size:2rem; }
     .sidebar:hover .sidebar-title .sidebar-title-text,
     .sidebar.expanded .sidebar-title .sidebar-title-text{ display:inline-block; }
+    .clear-sidebar-filters{
+        display:none; align-items:center; gap:.25rem; margin:.6rem 0 1rem; padding:0; color:#777;
+        font-size:.85rem; font-weight:700; cursor:pointer; line-height:1.2;
+    }
+    .clear-sidebar-filters .clear-sidebar-filters-icon{
+        display:inline-block; width:.85rem; color:inherit; font-size:.85rem; line-height:1; text-align:center; vertical-align:-.05em;
+    }
+    .clear-sidebar-filters:hover,
+    .clear-sidebar-filters:focus,
+    .clear-sidebar-filters:active{ color:#777; outline:none; }
+    .clear-sidebar-filters[hidden]{ display:none !important; }
+    .sidebar.has-active-state:hover .clear-sidebar-filters,
+    .sidebar.has-active-state.expanded .clear-sidebar-filters{ display:inline-flex; }
 
     .sidebar:hover ~ .content, .sidebar.expanded ~ .content{ margin-left:200px; }
 
@@ -1086,6 +1116,10 @@
                     <span class="sidebar-icon"><i class="fa fa-trophy"></i></span>
                     <span class="sidebar-title-text">Leagues</span>
                 </h2>
+                <span class="clear-sidebar-filters" id="clearSidebarFiltersBtn" role="button" tabindex="0" hidden>
+                    <i class="fa fa-times clear-sidebar-filters-icon" aria-hidden="true"></i>
+                    <span>Clear filters</span>
+                </span>
                 <div class="collapsed-title" data-aos="fade" data-aos-duration="700" data-aos-delay="200">ULTIMATE LEAGUE</div>
                 <div class="filter-section" id="aging-clock-filter-section">
                     <h3>Aging Clocks</h3>
@@ -3121,6 +3155,34 @@
         if (sidebar) {
             sidebar.classList.toggle('has-active-state', hasActiveState);
         }
+        const clearFiltersButton = document.getElementById('clearSidebarFiltersBtn');
+        if (clearFiltersButton) {
+            clearFiltersButton.hidden = !hasActiveState;
+        }
+    }
+
+    function clearSidebarFilters() {
+        document.querySelectorAll('input[name="division"], input[name="generation"], input[name="exclusiveLeague"], input[name="leagueTrack"]').forEach(input => {
+            input.checked = false;
+        });
+
+        const ultimateView = document.getElementById('view-ultimate');
+        if (ultimateView) {
+            ultimateView.checked = true;
+        }
+
+        performFilter();
+    }
+
+    function showAllAthletes() {
+        const searchInput = document.getElementById('athleteSearch');
+        if (searchInput) {
+            searchInput.value = '';
+        }
+
+        document.querySelector('.clear-icon')?.classList.remove('visible');
+        window.removeAllHighlights();
+        clearSidebarFilters();
     }
 
     window.getFullLeaderboardUrlWithCurrentState = function () {
@@ -3646,20 +3708,17 @@
         const anyVisible = Array.from(tableRows).some(row => row.style.display !== 'none');
 
         if (!anyVisible) {
-            if (query.trim() !== '') {
-                const tableBody = document.querySelector('.leaderboard table tbody');
-                const noResults = document.createElement('tr');
-                noResults.classList.add('no-results');
-                noResults.innerHTML = `<td colspan="6">No results found for "<strong>${window.escapeHTML(query)}</strong>".</td>`;
-                tableBody.appendChild(noResults);
-            }
-            else {
-                const tableBody = document.querySelector('.leaderboard table tbody');
-                const noResults = document.createElement('tr');
-                noResults.classList.add('no-results');
-                noResults.innerHTML = `<td colspan="6">It looks like no athletes have joined this league yet.</td>`;
-                tableBody.appendChild(noResults);
-            }
+            const tableBody = document.querySelector('.leaderboard table tbody');
+            const noResults = document.createElement('tr');
+            noResults.classList.add('no-results');
+            noResults.innerHTML = `
+                <td colspan="6">
+                    <div class="no-results-empty-state">
+                        <p>No athletes match this leaderboard.</p>
+                        <button type="button" class="show-all-athletes-btn">Show all athletes</button>
+                    </div>
+                </td>`;
+            tableBody.appendChild(noResults);
         }
     }
 
@@ -3705,6 +3764,26 @@
             event.preventDefault();
             clearSearch();
         }
+    });
+
+    const clearSidebarFiltersButton = document.getElementById('clearSidebarFiltersBtn');
+    clearSidebarFiltersButton?.addEventListener('click', function (event) {
+        event.preventDefault();
+        event.stopPropagation();
+        clearSidebarFilters();
+    });
+    clearSidebarFiltersButton?.addEventListener('keydown', function (event) {
+        if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
+            event.preventDefault();
+            event.stopPropagation();
+            clearSidebarFilters();
+        }
+    });
+    document.addEventListener('click', function (event) {
+        if (!event.target.closest('.show-all-athletes-btn')) return;
+
+        event.preventDefault();
+        showAllAthletes();
     });
 
     document.querySelectorAll('input[name="leaderboardView"]').forEach(radio => {

--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -244,13 +244,25 @@
     .sidebar.partially-expanded{ width:80px; }
     .sidebar-toggle{
         background:var(--card-bg); border:2px solid var(--primary-color); border-radius:50%; width:40px; height:40px;
-        display:flex; align-items:center; justify-content:center; cursor:pointer; transition:background-color .3s ease, transform .3s ease; margin-right:1rem;
+        display:flex; align-items:center; justify-content:center; cursor:pointer; transition:background-color .3s ease, border-color .3s ease, box-shadow .3s ease, transform .3s ease; margin-right:1rem; position:relative;
     }
     .sidebar-toggle.active{ background:var(--primary-color); transform:scale(1); }
     .sidebar-toggle.active i{ color:var(--card-bg); }
     .sidebar-toggle:hover{ background:var(--primary-color); transform:scale(1.05); }
     .sidebar-toggle i{ color:var(--primary-color); font-size:1.5rem; transition:color .3s ease; }
     .sidebar-toggle:hover i{ color:var(--card-bg); }
+    .sidebar-toggle.has-active-state{
+        border-color:#e53935; box-shadow:0 0 0 4px rgba(229,57,53,.14);
+    }
+    .sidebar-toggle.has-active-state i{ color:#e53935; }
+    .sidebar-toggle.has-active-state:hover,
+    .sidebar-toggle.has-active-state.active{ background:#e53935; border-color:#e53935; }
+    .sidebar-toggle.has-active-state:hover i,
+    .sidebar-toggle.has-active-state.active i{ color:var(--card-bg); }
+    .sidebar-toggle.has-active-state::after{
+        content:''; position:absolute; top:-4px; right:-4px; width:12px; height:12px; border-radius:50%;
+        background:#e53935; border:2px solid var(--card-bg); box-shadow:0 1px 4px rgba(0,0,0,.2);
+    }
 
     .sidebar-close{
         display:none; background:none; border:none; font-size:1.5rem; color:var(--primary-color); cursor:pointer;
@@ -277,6 +289,7 @@
     .sidebar .sidebar-title .sidebar-title-text{ display:none; margin-left:.5rem; font-size:2rem; }
     .sidebar:hover .sidebar-title .sidebar-title-text,
     .sidebar.expanded .sidebar-title .sidebar-title-text{ display:inline-block; }
+    .sidebar.has-active-state .sidebar-title .sidebar-icon i{ color:#e53935; }
 
     .sidebar:hover ~ .content, .sidebar.expanded ~ .content{ margin-left:200px; }
 
@@ -3002,6 +3015,19 @@
         return !!hasCheckedFilters || currentLeaderboardView !== 'ultimate' || hasSearch;
     }
 
+    function updateLeaderboardStateIndicator() {
+        const sidebarToggle = document.querySelector('.sidebar-toggle');
+        const sidebar = document.querySelector('.sidebar');
+
+        const hasActiveState = hasActiveLeaderboardState();
+        if (sidebarToggle) {
+            sidebarToggle.classList.toggle('has-active-state', hasActiveState);
+        }
+        if (sidebar) {
+            sidebar.classList.toggle('has-active-state', hasActiveState);
+        }
+    }
+
     window.getFullLeaderboardUrlWithCurrentState = function () {
         const url = new URL('/leaderboard', window.location.origin);
         const searchInput = document.getElementById('athleteSearch');
@@ -3303,6 +3329,8 @@
         if (typeof AOS !== 'undefined') {
             AOS.refresh();
         }
+
+        updateLeaderboardStateIndicator();
 
         const url = new URL(window.location.href);
         url.hash = ""; // <- this line removes #ABCD or any other fragment

--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -270,7 +270,7 @@
     .sidebar-toggle:hover i{ color:var(--card-bg); }
     .sidebar-toggle.has-active-state::after{
         content:''; position:absolute; top:-4px; right:-4px; width:12px; height:12px; border-radius:50%;
-        background:#e53935; border:2px solid var(--card-bg); box-shadow:0 1px 4px rgba(0,0,0,.2);
+        background:var(--secondary-color); border:2px solid var(--card-bg); box-shadow:0 1px 4px rgba(0,0,0,.2);
     }
 
     .sidebar-close{
@@ -297,7 +297,7 @@
     .sidebar .sidebar-title .sidebar-icon{ display:inline-block; font-size:2rem; position:relative; }
     .sidebar.has-active-state .sidebar-title .sidebar-icon::after{
         content:''; position:absolute; top:0; right:-4px; width:12px; height:12px; border-radius:50%;
-        background:#e53935; border:2px solid var(--card-bg); box-shadow:0 1px 4px rgba(0,0,0,.2);
+        background:var(--secondary-color); border:2px solid var(--card-bg); box-shadow:0 1px 4px rgba(0,0,0,.2);
     }
     .sidebar .sidebar-title .sidebar-title-text{ display:none; margin-left:.5rem; font-size:2rem; }
     .sidebar:hover .sidebar-title .sidebar-title-text,
@@ -311,7 +311,8 @@
     .filter-section ul{ list-style:none; padding:0; }
     .filter-section li{ margin-bottom:.5rem; }
     .filter-section label{ display:flex; align-items:center; cursor:pointer; color:#555; transition:color .2s; }
-    .filter-section label.is-zero-count:not(.active){ opacity:.55; }
+    .filter-section label.is-zero-count:not(.active){ opacity:.55; cursor:default; }
+    .filter-section label.is-zero-count:not(.active) input[type="checkbox"]{ pointer-events:none; }
     .filter-section input[type="checkbox"]{ margin-right:.5rem; accent-color:var(--primary-color); }
     .filter-section label:hover{ color:var(--primary-color); }
     .filter-section label.active{ font-weight:bold; color:var(--secondary-color); }
@@ -3090,7 +3091,11 @@
             countSpan.textContent = count;
         }
 
+        const input = label.querySelector('input[type="checkbox"]');
         label.classList.toggle('is-zero-count', count === 0);
+        if (input) {
+            input.disabled = count === 0 && !input.checked;
+        }
     }
 
     function updateViewAllAthletesButton(count) {

--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -3002,6 +3002,42 @@
         return !!hasCheckedFilters || currentLeaderboardView !== 'ultimate' || hasSearch;
     }
 
+    window.getFullLeaderboardUrlWithCurrentState = function () {
+        const url = new URL('/leaderboard', window.location.origin);
+        const searchInput = document.getElementById('athleteSearch');
+        const searchQuery = searchInput ? searchInput.value.trim() : '';
+        if (searchQuery) {
+            url.searchParams.set('search', searchQuery);
+        }
+
+        const selectedDivisions = Array.from(document.querySelectorAll('input[name="division"]:checked'))
+            .map(checkbox => checkbox.value.toLowerCase());
+        const selectedGenerations = Array.from(document.querySelectorAll('input[name="generation"]:checked'))
+            .map(checkbox => checkbox.value.toLowerCase());
+        const selectedExclusiveLeagues = Array.from(document.querySelectorAll('input[name="exclusiveLeague"]:checked'))
+            .map(checkbox => checkbox.value.toLowerCase());
+        const selectedLeagueTracks = Array.from(document.querySelectorAll('input[name="leagueTrack"]:checked'))
+            .map(checkbox => checkbox.value.toLowerCase());
+
+        const filters = [
+            ...selectedDivisions,
+            ...selectedGenerations,
+            ...selectedExclusiveLeagues,
+            ...(selectedLeagueTracks.length === 1 ? selectedLeagueTracks : [])
+        ];
+        if (filters.length > 0) {
+            url.searchParams.set('filters', filters.join(','));
+        }
+
+        const viewRadio = document.querySelector('input[name="leaderboardView"]:checked');
+        const currentLeaderboardView = viewRadio ? viewRadio.value.toLowerCase() : 'ultimate';
+        if (currentLeaderboardView === 'bortz' || currentLeaderboardView === 'pheno') {
+            url.searchParams.set('view', currentLeaderboardView);
+        }
+
+        return `${url.pathname}${url.search}${url.hash}`;
+    };
+
     function performFilter() {
         // Get selected divisions
         const selectedDivisions = Array.from(document.querySelectorAll('input[name="division"]:checked'))

--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -252,8 +252,9 @@
     .sidebar-toggle i{ color:var(--primary-color); font-size:1.5rem; transition:color .3s ease; }
     .sidebar-toggle:hover i{ color:var(--card-bg); }
     .sidebar-toggle.has-active-state::after{
-        content:''; position:absolute; top:-4px; right:-4px; width:12px; height:12px; border-radius:50%;
-        background:#e53935; border:2px solid var(--card-bg); box-shadow:0 1px 4px rgba(0,0,0,.2);
+        content:attr(data-active-count); position:absolute; top:-7px; right:-7px; min-width:18px; height:18px; padding:0 4px; border-radius:999px;
+        background:var(--secondary-color); border:2px solid var(--card-bg); box-shadow:0 1px 4px rgba(0,0,0,.2);
+        color:var(--card-bg); font-size:.68rem; font-weight:700; line-height:14px; text-align:center;
     }
 
     .sidebar-close{
@@ -280,7 +281,7 @@
     .sidebar .sidebar-title .sidebar-icon{ display:inline-block; font-size:2rem; position:relative; }
     .sidebar.has-active-state .sidebar-title .sidebar-icon::after{
         content:''; position:absolute; top:0; right:-4px; width:12px; height:12px; border-radius:50%;
-        background:#e53935; border:2px solid var(--card-bg); box-shadow:0 1px 4px rgba(0,0,0,.2);
+        background:var(--secondary-color); border:2px solid var(--card-bg); box-shadow:0 1px 4px rgba(0,0,0,.2);
     }
     .sidebar .sidebar-title .sidebar-title-text{ display:none; margin-left:.5rem; font-size:2rem; }
     .sidebar:hover .sidebar-title .sidebar-title-text,
@@ -3030,10 +3031,25 @@
     }
 
     function hasActiveLeaderboardFilterState() {
-        const hasCheckedFilters = document.querySelector('input[name="division"]:checked, input[name="generation"]:checked, input[name="exclusiveLeague"]:checked, input[name="leagueTrack"]:checked');
+        return getActiveLeaderboardFilterGroupCount() > 0;
+    }
+
+    function getActiveLeaderboardFilterGroupCount() {
+        const hasSelectedDivisions = document.querySelectorAll('input[name="division"]:checked').length > 0;
+        const hasSelectedGenerations = document.querySelectorAll('input[name="generation"]:checked').length > 0;
+        const hasSelectedExclusiveLeagues = document.querySelectorAll('input[name="exclusiveLeague"]:checked').length > 0;
+        const hasSelectedTrack = document.querySelectorAll('input[name="leagueTrack"]:checked').length === 1;
         const viewRadio = document.querySelector('input[name="leaderboardView"]:checked');
         const currentLeaderboardView = viewRadio ? viewRadio.value : 'ultimate';
-        return !!hasCheckedFilters || currentLeaderboardView !== 'ultimate';
+        const hasSelectedAgingClock = currentLeaderboardView !== 'ultimate';
+
+        return [
+            hasSelectedAgingClock,
+            hasSelectedTrack,
+            hasSelectedDivisions,
+            hasSelectedGenerations,
+            hasSelectedExclusiveLeagues
+        ].filter(Boolean).length;
     }
 
     function syncAgingClockFilters(currentLeaderboardView) {
@@ -3060,9 +3076,15 @@
         const sidebarToggle = document.querySelector('.sidebar-toggle');
         const sidebar = document.querySelector('.sidebar');
 
-        const hasActiveState = hasActiveLeaderboardFilterState();
+        const activeGroupCount = getActiveLeaderboardFilterGroupCount();
+        const hasActiveState = activeGroupCount > 0;
         if (sidebarToggle) {
             sidebarToggle.classList.toggle('has-active-state', hasActiveState);
+            if (hasActiveState) {
+                sidebarToggle.dataset.activeCount = String(activeGroupCount);
+            } else {
+                delete sidebarToggle.dataset.activeCount;
+            }
         }
         if (sidebar) {
             sidebar.classList.toggle('has-active-state', hasActiveState);

--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -306,10 +306,12 @@
     .sidebar:hover ~ .content, .sidebar.expanded ~ .content{ margin-left:200px; }
 
     .filter-section{ margin-bottom:1.5rem; }
-    .filter-section h3{ margin-bottom:.5rem; color:var(--secondary-color); font-size:1.2rem; }
+    .filter-section h3{ margin-bottom:.5rem; color:var(--primary-color); font-size:1.2rem; transition:color .2s ease; }
+    .filter-section.has-active-filter h3{ color:var(--secondary-color); }
     .filter-section ul{ list-style:none; padding:0; }
     .filter-section li{ margin-bottom:.5rem; }
     .filter-section label{ display:flex; align-items:center; cursor:pointer; color:#555; transition:color .2s; }
+    .filter-section label.is-zero-count:not(.active){ opacity:.55; }
     .filter-section input[type="checkbox"]{ margin-right:.5rem; accent-color:var(--primary-color); }
     .filter-section label:hover{ color:var(--primary-color); }
     .filter-section label.active{ font-weight:bold; color:var(--secondary-color); }
@@ -3061,6 +3063,36 @@
         });
     }
 
+    function updateActiveFilterSections() {
+        document.querySelectorAll('.filter-section input[type="checkbox"]').forEach(input => {
+            input.closest('label')?.classList.toggle('active', input.checked);
+        });
+
+        const sectionFilters = {
+            'aging-clock-filter-section': document.querySelectorAll('input[name="agingClockView"]:checked').length > 0,
+            'league-track-filter-section': document.querySelectorAll('input[name="leagueTrack"]:checked').length === 1,
+            'division-filter-section': document.querySelectorAll('input[name="division"]:checked').length > 0,
+            'generation-filter-section': document.querySelectorAll('input[name="generation"]:checked').length > 0,
+            'exclusive-filter-section': document.querySelectorAll('input[name="exclusiveLeague"]:checked').length > 0
+        };
+
+        Object.entries(sectionFilters).forEach(([sectionId, hasActiveFilter]) => {
+            const section = document.getElementById(sectionId);
+            if (!section) return;
+
+            section.classList.toggle('has-active-filter', hasActiveFilter);
+        });
+    }
+
+    function updateFilterCountLabel(label, count) {
+        const countSpan = label.querySelector('.filter-count');
+        if (countSpan) {
+            countSpan.textContent = count;
+        }
+
+        label.classList.toggle('is-zero-count', count === 0);
+    }
+
     function updateViewAllAthletesButton(count) {
         const button = document.getElementById('viewAllAthletesBtn');
         if (!button) return;
@@ -3149,6 +3181,7 @@
         const viewRadio = document.querySelector('input[name="leaderboardView"]:checked');
         const currentLeaderboardView = viewRadio ? viewRadio.value : 'ultimate';
         syncAgingClockFilters(currentLeaderboardView);
+        updateActiveFilterSections();
 
         const hasBortz = (a) => a.bortzAgeReduction != null && Number.isFinite(a.bortzAgeReduction);
 
@@ -3557,10 +3590,7 @@
         document.querySelectorAll('.filter-section label[data-aging-clock-view]').forEach(label => {
             const clock = label.getAttribute('data-aging-clock-view');
             const count = agingClockCounts[clock] || 0;
-            const countSpan = label.querySelector('.filter-count');
-            if (countSpan) {
-                countSpan.textContent = count;
-            }
+            updateFilterCountLabel(label, count);
         });
 
         // Update division counts
@@ -3573,10 +3603,7 @@
         document.querySelectorAll('.filter-section label[data-division]').forEach(label => {
             const division = label.getAttribute('data-division');
             const count = divisionCounts[division] || 0;
-            const countSpan = label.querySelector('.filter-count');
-            if (countSpan) {
-                countSpan.textContent = count;
-            }
+            updateFilterCountLabel(label, count);
         });
 
         // Update generation counts
@@ -3589,10 +3616,7 @@
         document.querySelectorAll('.filter-section label[data-generation]').forEach(label => {
             const generation = label.getAttribute('data-generation');
             const count = generationCounts[generation] || 0;
-            const countSpan = label.querySelector('.filter-count');
-            if (countSpan) {
-                countSpan.textContent = count;
-            }
+            updateFilterCountLabel(label, count);
         });
 
         // Update league track counts (Amateur / Professional by tier)
@@ -3602,10 +3626,7 @@
         document.querySelectorAll('.filter-section label[data-league-track]').forEach(label => {
             const track = label.getAttribute('data-league-track');
             const count = (track === 'Amateur') ? amateurCount : (track === 'Professional') ? professionalCount : 0;
-            const countSpan = label.querySelector('.filter-count');
-            if (countSpan) {
-                countSpan.textContent = count;
-            }
+            updateFilterCountLabel(label, count);
         });
     }
 


### PR DESCRIPTION
## Summary
- Preserve homepage leaderboard search, filters, and view mode when opening the full leaderboard.
- Add a small frontend helper that builds a `/leaderboard` URL from the current controls.
- Add an Aging Clocks sidebar section for Bortz Age and Pheno Age, synced with the top clock chips.
- Rename Track to Tracks and order Pro before Amateur in the track filters.
- Show subtle teal notification dots on the filter toggle and sidebar trophy when sidebar-visible leaderboard state is active, without recoloring the icons.
- Update the homepage CTA to say `VIEW THIS LEADERBOARD (N)` when the current state has matches, and fall back to `VIEW ALL ATHLETES (total)` plus plain `/leaderboard` when there are no matches.
- Keep existing leaderboard ranking behavior unchanged.

## Validation
- `dotnet build LongevityWorldCup.sln` before the visual follow-ups.
- Browser smoke test on `http://localhost:5099/`: default button navigation opens `/leaderboard`.
- Browser smoke test: Amateur filter opens `/leaderboard?filters=amateur`.
- Browser smoke test: combined Women's + Gen X + Pheno + search opens `/leaderboard?search=max&filters=women%27s%2Cgen+x&view=pheno` and applies the selected filters/view on the full leaderboard.
- Browser smoke test: Aging Clocks counts initialize and update, and Bortz/Pheno sidebar choices sync with top chips.
- Browser smoke test: zero-result search shows `VIEW ALL ATHLETES (194)` and navigates to plain `/leaderboard`.

Closes #210