### PR TITLE
Polish image previews and proof rendering

### DIFF
--- a/LongevityWorldCup.Website/Business/AthleteDataService.cs
+++ b/LongevityWorldCup.Website/Business/AthleteDataService.cs
@@ -302,6 +302,7 @@ public class AthleteDataService : IDisposable
             // PROFILE PIC: look for "{key}.*" in that same folder
             var pic = Directory
                 .EnumerateFiles(folder, $"{folderName}.*", SearchOption.TopDirectoryOnly)
+                .Where(IsSupportedImageFile)
                 .OrderByDescending(File.GetLastWriteTimeUtc)
                 .FirstOrDefault();
             var profilePicUrl = pic is null
@@ -331,7 +332,7 @@ public class AthleteDataService : IDisposable
                 .EnumerateFiles(folder, "proof_*.*", SearchOption.TopDirectoryOnly)
                 .OrderBy(f => ExtractNumber(Path.GetFileNameWithoutExtension(f)));
             foreach (var p in proofFiles)
-                proofs.Add($"/athletes/{folderName}/{Path.GetFileName(p)}");
+                proofs.Add(BuildVersionedAthleteAssetUrl(folderName, Path.GetFileName(p), File.GetLastWriteTimeUtc(p).Ticks));
             athlete["Proofs"] = proofs;
 
             CanonicalizeIsoDatesInPlace(athlete);
@@ -343,6 +344,15 @@ public class AthleteDataService : IDisposable
 
     private static string BuildVersionedAthleteAssetUrl(string folderName, string fileName, long version)
         => $"/athletes/{folderName}/{fileName}?v={version}";
+
+    private static bool IsSupportedImageFile(string path)
+    {
+        var extension = Path.GetExtension(path);
+        return extension.Equals(".webp", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".png", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".jpg", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".jpeg", StringComparison.OrdinalIgnoreCase);
+    }
 
     private string? BuildOrGetProfileThumbUrl(string sourceImagePath, string folderName, string thumbSuffix, int sizePx, int quality)
     {

--- a/LongevityWorldCup.Website/Business/XDevPreviewService.cs
+++ b/LongevityWorldCup.Website/Business/XDevPreviewService.cs
@@ -558,18 +558,10 @@ public class XDevPreviewService
             sb.Append(WebUtility.HtmlEncode(card.Host));
         }
         sb.Append("</div>");
-        if (hasImage)
-        {
-            sb.Append("</a>");
-            sb.Append("<div class=\"link-preview-source\">From ");
-            sb.Append(WebUtility.HtmlEncode(displaySource));
-            sb.Append("</div>");
-            return;
-        }
 
         sb.Append("<div class=\"link-preview-meta\">");
         sb.Append("<div class=\"link-preview-domain\">");
-        sb.Append(WebUtility.HtmlEncode(string.IsNullOrWhiteSpace(card.SiteName) ? card.Host : card.SiteName));
+        sb.Append(WebUtility.HtmlEncode(string.IsNullOrWhiteSpace(card.SiteName) ? displaySource : card.SiteName));
         sb.Append("</div>");
         if (!string.IsNullOrWhiteSpace(card.Title))
         {

--- a/LongevityWorldCup.Website/Program.cs
+++ b/LongevityWorldCup.Website/Program.cs
@@ -237,8 +237,13 @@ namespace LongevityWorldCup.Website
             {
                 OnPrepareResponse = ctx =>
                 {
-                    ctx.Context.Response.Headers.CacheControl = "public,max-age=31536000";
-                    ctx.Context.Response.Headers.Expires = DateTime.UtcNow.AddYears(1).ToString("R");
+                    var hasVersion = ctx.Context.Request.Query.ContainsKey("v");
+                    ctx.Context.Response.Headers.CacheControl = hasVersion
+                        ? "public,max-age=31536000,immutable"
+                        : "public,max-age=300,must-revalidate";
+                    ctx.Context.Response.Headers.Expires = (hasVersion
+                        ? DateTime.UtcNow.AddYears(1)
+                        : DateTime.UtcNow.AddMinutes(5)).ToString("R");
                 }
             });
 

--- a/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
+++ b/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
@@ -1187,7 +1187,15 @@
                 return "";
             }
 
-            const data = ogPreviewCache.get(url) || buildOgPlaceholder(url);
+            const data = ogPreviewCache.get(url) || (ogPreviewPending.has(url)
+                ? {
+                    url,
+                    domain: getUrlDomain(url),
+                    title: "Loading link preview...",
+                    description: "",
+                    image: ""
+                }
+                : buildOgPlaceholder(url));
             const mediaHtml = data.image
                 ? `<img alt="link preview image" src="${escapeHtml(data.image)}" loading="lazy" referrerpolicy="no-referrer">`
                 : `

--- a/LongevityWorldCup.Website/wwwroot/js/proof-helpers.js
+++ b/LongevityWorldCup.Website/wwwroot/js/proof-helpers.js
@@ -102,16 +102,28 @@ window.getProofChecklistLabelsFromSession = function () {
 window.setupProofUploadHTML = function (nextButton, uploadProofButton, proofPicInput, proofImageContainer, proofPics, biomarkerChecklistContainer, biomarkers) {
     nextButton.disabled = true;
 
-    // ——— Load PDF.js if not already loaded ———
-    if (!window.pdfjsLib) {
-        const pdfScript = document.createElement('script');
-        pdfScript.src = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.8.162/pdf.min.js';
-        pdfScript.onload = () => {
-            // point to the worker
-            pdfjsLib.GlobalWorkerOptions.workerSrc =
-                'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.8.162/pdf.worker.min.js';
-        };
-        document.head.appendChild(pdfScript);
+    if (!window.pdfjsLib && !window.__proofPdfJsReady) {
+        window.__proofPdfJsReady = new Promise((resolve, reject) => {
+            const existing = document.querySelector('script[data-proof-pdfjs="true"]');
+            if (existing) {
+                existing.addEventListener('load', resolve, { once: true });
+                existing.addEventListener('error', reject, { once: true });
+                return;
+            }
+
+            const pdfScript = document.createElement('script');
+            pdfScript.src = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.8.162/pdf.min.js';
+            pdfScript.dataset.proofPdfjs = 'true';
+            pdfScript.onload = () => {
+                pdfjsLib.GlobalWorkerOptions.workerSrc =
+                    'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.8.162/pdf.worker.min.js';
+                resolve();
+            };
+            pdfScript.onerror = reject;
+            document.head.appendChild(pdfScript);
+        });
+    } else if (window.pdfjsLib) {
+        window.__proofPdfJsReady = Promise.resolve();
     }
 
     // Attach event listener to the Upload Proof button
@@ -147,13 +159,15 @@ window.setupProofUploadHTML = function (nextButton, uploadProofButton, proofPicI
                     for (const file of Array.from(files)) {
                         const raw = await readDataURL(file);
                         if (file.type === 'application/pdf') {
-                            // read file as arrayBuffer
+                            await window.__proofPdfJsReady;
                             const arrayBuffer = await file.arrayBuffer();
-                            // load PDF
                             const loadingTask = pdfjsLib.getDocument({ data: arrayBuffer });
                             const pdfDoc = await loadingTask.promise;
-                            // render each page
                             for (let pageNum = 1; pageNum <= pdfDoc.numPages; pageNum++) {
+                                if (proofPics.length >= 9) {
+                                    customAlert('Only the first 9 proof images were added.');
+                                    break;
+                                }
                                 const page = await pdfDoc.getPage(pageNum);
                                 const viewport = page.getViewport({ scale: 1 });
                                 const canvas = document.createElement('canvas');
@@ -180,6 +194,9 @@ window.setupProofUploadHTML = function (nextButton, uploadProofButton, proofPicI
                 }
                 // Reset the file input's value to allow re-uploading the same file if needed
                 proofPicInput.value = "";
+            } catch (error) {
+                customAlert('We could not read one of those proof files. Please try an image or a smaller PDF.');
+                throw error;
             } finally {
                 hideLoading();
             }
@@ -200,21 +217,20 @@ window.setupProofUploadHTML = function (nextButton, uploadProofButton, proofPicI
 
 function updateProofImageContainer(container, nextButton, proofPics, uploadProofButton) {
     container.innerHTML = '';
-    // Use the global `proofPics` variable directly
     if (proofPics.length > 0) {
         container.innerHTML = '<p><strong>Proof uploaded successfully.</strong></p>';
         for (let i = 0; i < proofPics.length; i++) {
             let imgContainer = document.createElement('div');
-            imgContainer.style = 'position: relative; display: inline-block; margin: 0.5rem;';
+            imgContainer.style = 'position: relative; display: block; margin: 0.75rem auto; max-width: min(100%, 760px);';
 
             let img = document.createElement('img');
             img.src = proofPics[i];
             img.alt = 'Proof image ' + (i + 1);
-            img.style = 'max-width: 100%; border: 2px solid var(--dark-text-color); border-radius: 8px;';
+            img.style = 'display: block; width: auto; max-width: 100%; max-height: 70vh; margin: 0 auto; object-fit: contain; background: #fff; border: 2px solid var(--dark-text-color); border-radius: 8px;';
 
             let removeButton = document.createElement('button');
             removeButton.textContent = 'Remove';
-            removeButton.style = 'position: absolute; top: 5px; right: 5px; background-color: rgba(255, 0, 0, 0.7); color: var(--light-text-color); border: none; border-radius: 3px; cursor: pointer;';
+            removeButton.style = 'position: absolute; top: 8px; right: 8px; background-color: rgba(120, 0, 0, 0.82); color: var(--light-text-color); border: none; border-radius: 999px; cursor: pointer; padding: 0.35rem 0.65rem;';
             removeButton.addEventListener('click', function () {
                 proofPics.splice(i, 1);
                 updateProofImageContainer(container, nextButton, proofPics, uploadProofButton);

--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -422,6 +422,13 @@
         transition: transform .3s ease;
     }
     .portrait:hover{ transform: scale(var(--portrait-hover-scale)); }
+    .portrait.portrait-fallback,
+    #modalProfilePic.portrait-fallback,
+    .podium-item .podium-portrait.portrait-fallback{
+        object-fit:contain;
+        background:#fff;
+        padding:.35rem;
+    }
 
     /* PODIUM portrait (bounded even if not wrapped) */
     .podium-item .podium-portrait{
@@ -849,10 +856,11 @@
     /* =========================
        11) Proofs & enlarged overlay
        ========================= */
-    .proofs-gallery{ display:flex; flex-direction:column; align-items:center; flex-wrap:wrap; gap:1rem; justify-content:center; padding:0; }
-    .proof-item{ width:100%; height:auto; border-radius:10px; overflow:hidden; cursor:pointer; transition:transform .3s ease; }
+    .proofs-gallery{ display:flex; flex-direction:column; align-items:stretch; gap:1rem; justify-content:center; padding:0; width:100%; }
+    .proof-item{ width:100%; height:auto; border-radius:10px; overflow:hidden; cursor:pointer; transition:transform .3s ease; background:#fff; box-shadow:0 1px 8px rgba(0,0,0,.08); }
     .proof-item:hover{ transform: scale(1.05); }
-    .proof-item img{ width:100%; height:100%; object-fit:cover; }
+    .proof-item img{ display:block; width:auto; max-width:100%; height:auto; max-height:72vh; object-fit:contain; margin:0 auto; background:#fff; }
+    .proofs-empty{ margin:.5rem 0 0; color:#666; text-align:center; font-size:.95rem; }
 
     .enlarged-portrait{
         position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,.85);
@@ -1028,7 +1036,7 @@
 
         /* Mobile modal improvements */
         .modal-content{
-            width:95%; padding:15px; margin:0; max-height:100vh; height:100vh;
+            width:100%; padding:15px; margin:0; max-height:100vh; height:100vh; box-sizing:border-box;
             border-radius:0 !important; /* Remove rounded corners on mobile immediately */
             padding-top:max(15px, env(safe-area-inset-top));
             padding-bottom:max(15px, env(safe-area-inset-bottom));
@@ -1039,6 +1047,7 @@
             border-radius:0 !important; /* Also remove rounded corners in guess-mode on mobile */
         }
         #athlete-profile .portrait-wrapper{ width:50%; }
+        .proof-item img{ max-height:80vh; }
         .modal-scroll-progress{ height:2px; }
         
         /* Ensure minimum touch target sizes */
@@ -1431,10 +1440,24 @@
     let athleteResults = [];
     let athletesOrderedByPace;
     let athletesOrderedByBortzPace;
+    const defaultProfilePic = '/assets/HdLogo_thumb_sm.png';
 
     const currentSeasonStartDate = new Date(new Date().getFullYear(), 0, 1);
 
     markAthleteSkippedIfInURL();
+
+    function getAthletePortraitUrl(athlete) {
+        return (athlete && (athlete.profilePicThumb || athlete.profilePic || athlete.ProfilePicLeaderboardThumb || athlete.ProfilePicThumb || athlete.ProfilePic)) || defaultProfilePic;
+    }
+
+    function wirePortraitFallback(img) {
+        if (!img) return;
+        img.onerror = function () {
+            this.onerror = null;
+            this.src = defaultProfilePic;
+            this.classList.add('portrait-fallback');
+        };
+    }
 
     function markAthleteSkippedForGuessMyAge(athleteSlug) {
         if (!athleteSlug) {
@@ -2195,12 +2218,14 @@
                                         const podiumItem = document.createElement('div');
                                         podiumItem.classList.add('podium-item', rankClass);
 
+                                        const podiumPortraitUrl = getAthletePortraitUrl(athlete);
+
                                         // Populate the inner HTML of podiumItem
                                         podiumItem.innerHTML = `
                                             <div class="podium-rank" title="${athlete.rank === 1 ? '1st Place' : athlete.rank === 2 ? '2nd Place' : '3rd Place'}">
                                                 ${rankEmoji}
                                             </div>
-                                            <img src="${athlete.profilePicThumb || athlete.profilePic}" alt="${athlete.displayName} portrait" class="podium-portrait" loading="lazy">
+                                            <img src="${podiumPortraitUrl}" alt="${athlete.displayName} portrait" class="podium-portrait" loading="lazy">
                                             <div class="name-row">
                                                 <span class="athlete-name" style="cursor: pointer;" title="View stats of ${athlete.displayName}">${athlete.displayName}</span>
                                             </div>
@@ -2219,6 +2244,7 @@
 
                                         // Append the podiumItem to the podium container
                                         podium.appendChild(podiumItem);
+                                        wirePortraitFallback(podiumItem.querySelector('img.podium-portrait'));
 
                                         // After appending the podium item
                                         podiumItem.setAttribute('data-division', athlete.division.toLowerCase());
@@ -2322,8 +2348,9 @@
                     row.querySelector('.rank').textContent = athlete.rank;
                     const athleteCell = row.querySelector('.athlete-td');
                     const portraitImg = athleteCell.querySelector('img.portrait');
-                    portraitImg.src = athlete.profilePicThumb || athlete.profilePic;
+                    portraitImg.src = getAthletePortraitUrl(athlete);
                     portraitImg.alt = `${athlete.displayName} portrait`;
+                    wirePortraitFallback(portraitImg);
                     if (athlete.isNew) {
                         portraitImg.classList.add('is-new');
                         applyNewUI(portraitImg);
@@ -4348,9 +4375,11 @@
         }
         
         const profilePic = document.getElementById('modalProfilePic');
-        profilePic.src = fullAthleteData.ProfilePic;
+        profilePic.src = getAthletePortraitUrl(fullAthleteData);
         profilePic.alt = `${modalDisplayName} Profile Picture`;
         profilePic.loading = 'lazy';
+        profilePic.classList.remove('portrait-fallback');
+        wirePortraitFallback(profilePic);
 
         const athleteProfileEl = document.getElementById('athlete-profile');
         if (athleteProfileEl) {
@@ -4876,15 +4905,31 @@
 
     function populateProofsGallery(fullAthleteData) {
         const proofsGallery = document.getElementById('proofsGallery');
+        if (!proofsGallery) return;
         proofsGallery.innerHTML = '';
 
-        fullAthleteData.Proofs.forEach(proofUrl => {
+        const proofs = Array.isArray(fullAthleteData && fullAthleteData.Proofs)
+            ? fullAthleteData.Proofs.filter(Boolean)
+            : [];
+        if (proofs.length === 0) {
+            const empty = document.createElement('p');
+            empty.className = 'proofs-empty';
+            empty.textContent = 'No public proofs available yet.';
+            proofsGallery.appendChild(empty);
+            return;
+        }
+
+        proofs.forEach((proofUrl, index) => {
             const proofItem = document.createElement('div');
             proofItem.classList.add('proof-item');
-            proofItem.innerHTML = `<img src="${proofUrl}" alt="Proof Image" loading="lazy">`;
+            const img = document.createElement('img');
+            img.src = proofUrl;
+            img.alt = `Proof image ${index + 1}`;
+            img.loading = 'lazy';
+            proofItem.appendChild(img);
             proofsGallery.appendChild(proofItem);
 
-            proofItem.querySelector('img').addEventListener('click', function () {
+            img.addEventListener('click', function () {
                 openEnlargedView(this);
             });
         });


### PR DESCRIPTION
## Summary
- Tighten cache behavior so versioned assets stay immutable while mutable assets revalidate quickly.
- Add safer profile/proof image handling, including versioned proof URLs and portrait fallbacks.
- Improve proof readability, PDF upload edge cases, and preview-card loading/metadata behavior.

## Test plan
- dotnet build LongevityWorldCup.sln
- node --check LongevityWorldCup.Website/wwwroot/js/proof-helpers.js
- git diff --check