### PR TITLE
Fix image asset cache invalidation

### DIFF
--- a/LongevityWorldCup.Website/Business/AthleteDataService.cs
+++ b/LongevityWorldCup.Website/Business/AthleteDataService.cs
@@ -302,6 +302,7 @@ public class AthleteDataService : IDisposable
             // PROFILE PIC: look for "{key}.*" in that same folder
             var pic = Directory
                 .EnumerateFiles(folder, $"{folderName}.*", SearchOption.TopDirectoryOnly)
+                .Where(IsSupportedImageFile)
                 .OrderByDescending(File.GetLastWriteTimeUtc)
                 .FirstOrDefault();
             var profilePicUrl = pic is null
@@ -331,7 +332,7 @@ public class AthleteDataService : IDisposable
                 .EnumerateFiles(folder, "proof_*.*", SearchOption.TopDirectoryOnly)
                 .OrderBy(f => ExtractNumber(Path.GetFileNameWithoutExtension(f)));
             foreach (var p in proofFiles)
-                proofs.Add($"/athletes/{folderName}/{Path.GetFileName(p)}");
+                proofs.Add(BuildVersionedAthleteAssetUrl(folderName, Path.GetFileName(p), File.GetLastWriteTimeUtc(p).Ticks));
             athlete["Proofs"] = proofs;
 
             CanonicalizeIsoDatesInPlace(athlete);
@@ -343,6 +344,15 @@ public class AthleteDataService : IDisposable
 
     private static string BuildVersionedAthleteAssetUrl(string folderName, string fileName, long version)
         => $"/athletes/{folderName}/{fileName}?v={version}";
+
+    private static bool IsSupportedImageFile(string path)
+    {
+        var extension = Path.GetExtension(path);
+        return extension.Equals(".webp", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".png", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".jpg", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".jpeg", StringComparison.OrdinalIgnoreCase);
+    }
 
     private string? BuildOrGetProfileThumbUrl(string sourceImagePath, string folderName, string thumbSuffix, int sizePx, int quality)
     {

--- a/LongevityWorldCup.Website/Program.cs
+++ b/LongevityWorldCup.Website/Program.cs
@@ -237,8 +237,13 @@ namespace LongevityWorldCup.Website
             {
                 OnPrepareResponse = ctx =>
                 {
-                    ctx.Context.Response.Headers.CacheControl = "public,max-age=31536000";
-                    ctx.Context.Response.Headers.Expires = DateTime.UtcNow.AddYears(1).ToString("R");
+                    var hasVersion = ctx.Context.Request.Query.ContainsKey("v");
+                    ctx.Context.Response.Headers.CacheControl = hasVersion
+                        ? "public,max-age=31536000,immutable"
+                        : "public,max-age=300,must-revalidate";
+                    ctx.Context.Response.Headers.Expires = (hasVersion
+                        ? DateTime.UtcNow.AddYears(1)
+                        : DateTime.UtcNow.AddMinutes(5)).ToString("R");
                 }
             });
 


### PR DESCRIPTION
## Summary
- Cache immutable static assets only when they include a version query.
- Revalidate unversioned static assets quickly to avoid stale image/CSS/JS responses.
- Version athlete proof URLs and ignore non-image files when selecting profile pictures.

## Test plan
- dotnet build LongevityWorldCup.sln