### PR TITLE
Polish social preview cards

### DIFF
--- a/LongevityWorldCup.Website/Business/XDevPreviewService.cs
+++ b/LongevityWorldCup.Website/Business/XDevPreviewService.cs
@@ -558,18 +558,10 @@ public class XDevPreviewService
             sb.Append(WebUtility.HtmlEncode(card.Host));
         }
         sb.Append("</div>");
-        if (hasImage)
-        {
-            sb.Append("</a>");
-            sb.Append("<div class=\"link-preview-source\">From ");
-            sb.Append(WebUtility.HtmlEncode(displaySource));
-            sb.Append("</div>");
-            return;
-        }
 
         sb.Append("<div class=\"link-preview-meta\">");
         sb.Append("<div class=\"link-preview-domain\">");
-        sb.Append(WebUtility.HtmlEncode(string.IsNullOrWhiteSpace(card.SiteName) ? card.Host : card.SiteName));
+        sb.Append(WebUtility.HtmlEncode(string.IsNullOrWhiteSpace(card.SiteName) ? displaySource : card.SiteName));
         sb.Append("</div>");
         if (!string.IsNullOrWhiteSpace(card.Title))
         {

--- a/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
+++ b/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
@@ -1187,7 +1187,15 @@
                 return "";
             }
 
-            const data = ogPreviewCache.get(url) || buildOgPlaceholder(url);
+            const data = ogPreviewCache.get(url) || (ogPreviewPending.has(url)
+                ? {
+                    url,
+                    domain: getUrlDomain(url),
+                    title: "Loading link preview...",
+                    description: "",
+                    image: ""
+                }
+                : buildOgPlaceholder(url));
             const mediaHtml = data.image
                 ? `<img alt="link preview image" src="${escapeHtml(data.image)}" loading="lazy" referrerpolicy="no-referrer">`
                 : `


### PR DESCRIPTION
## Summary
- Keep X dev preview cards informative when a preview image exists by preserving metadata below the image.
- Show an explicit loading state in the custom event designer while OG metadata is still pending.

## Test plan
- dotnet build LongevityWorldCup.sln