### PR TITLE
[codex] Version image assets and preview metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,8 @@ This file documents project-specific rules that agents commonly get wrong. It is
 - Do not add raw script or stylesheet URLs such as `/js/foo.js` or `/css/foo.css` directly into injected HTML/partials unless there is a strong reason and you have verified cache behavior.
 - When a new static asset must be loaded from injected HTML/partials, add a placeholder and replace it through `AssetVersionProvider.AppendVersion(...)` in the middleware so clients receive a cache-busted URL.
 - Favicon and web manifest links in `wwwroot/partials/head.html` also use middleware placeholders; keep any new light or dark icon variants on that versioned path.
+- Shared header logo images also use middleware asset placeholders. Keep header/partial static assets on the placeholder path instead of hard-coded `/assets/...` URLs.
+- Athlete profile and proof asset URLs should be versioned when emitted from the data service. Unversioned `/athletes/...` and `/generated/...` requests are intentionally cached briefly only as a fallback.
 - When changing the API of an existing external JS file, review every injected HTML/partial caller in the repo and ensure the versioned URL path still goes through the middleware replacement flow.
 - If a helper is moved from inline script to a separate JS file, verify that the file is loaded in every page, modal, iframe, or embedded context that uses that helper.
 

--- a/LongevityWorldCup.Website/Business/AthleteDataService.cs
+++ b/LongevityWorldCup.Website/Business/AthleteDataService.cs
@@ -331,7 +331,7 @@ public class AthleteDataService : IDisposable
                 .EnumerateFiles(folder, "proof_*.*", SearchOption.TopDirectoryOnly)
                 .OrderBy(f => ExtractNumber(Path.GetFileNameWithoutExtension(f)));
             foreach (var p in proofFiles)
-                proofs.Add($"/athletes/{folderName}/{Path.GetFileName(p)}");
+                proofs.Add(BuildVersionedAthleteAssetUrl(folderName, Path.GetFileName(p), File.GetLastWriteTimeUtc(p).Ticks));
             athlete["Proofs"] = proofs;
 
             CanonicalizeIsoDatesInPlace(athlete);

--- a/LongevityWorldCup.Website/Middleware/HtmlInjectionMiddleware.cs
+++ b/LongevityWorldCup.Website/Middleware/HtmlInjectionMiddleware.cs
@@ -72,7 +72,7 @@ namespace LongevityWorldCup.Website.Middleware
                     // Replace placeholders with header and footer content
                     bodyContent = bodyContent
                         .Replace("<!--HEAD-->", head)
-                        .Replace("<!--HEADER-->", header)
+                        .Replace("<!--HEADER-->", ApplySharedAssetPlaceholders(header))
                         .Replace("<!--FOOTER-->", footer)
                         .Replace("<!--MAIN-PROGRESS-BAR-->", progressBar)
                         .Replace("<!--SUB-PROGRESS-BAR-->", subProgressBar)
@@ -112,7 +112,7 @@ namespace LongevityWorldCup.Website.Middleware
             var optionalHeadScripts = BuildOptionalHeadScripts(config);
             var modulesBootstrap = BuildModulesBootstrap(config);
 
-            return html
+            return ApplySharedAssetPlaceholders(html)
                 .Replace("{{OPTIONAL_HEAD_SCRIPTS}}", optionalHeadScripts)
                 .Replace("{{MODULES_BOOTSTRAP}}", modulesBootstrap)
                 .Replace("{{ASSET_FAVICON_ICO}}", _assetVersionProvider.AppendVersion("/assets/favicon.ico"))
@@ -132,6 +132,12 @@ namespace LongevityWorldCup.Website.Middleware
                 .Replace("{{ASSET_PRO_DISCOUNTS_JS}}", _assetVersionProvider.AppendVersion("/js/pro-discounts.js"))
                 .Replace("{{ASSET_PROOF_HELPERS_JS}}", _assetVersionProvider.AppendVersion("/js/proof-helpers.js"))
                 .Replace("{{ASSET_AGE_VISUALIZATION_JS}}", _assetVersionProvider.AppendVersion("/js/age-visualization.js"));
+        }
+
+        private string ApplySharedAssetPlaceholders(string html)
+        {
+            return html
+                .Replace("{{ASSET_FAVICON_128}}", _assetVersionProvider.AppendVersion("/assets/favicon-128x128.png"));
         }
 
         private string BuildOptionalHeadScripts(HeadAssetConfig config)

--- a/LongevityWorldCup.Website/Program.cs
+++ b/LongevityWorldCup.Website/Program.cs
@@ -237,8 +237,27 @@ namespace LongevityWorldCup.Website
             {
                 OnPrepareResponse = ctx =>
                 {
-                    ctx.Context.Response.Headers.CacheControl = "public,max-age=31536000";
-                    ctx.Context.Response.Headers.Expires = DateTime.UtcNow.AddYears(1).ToString("R");
+                    var request = ctx.Context.Request;
+                    var hasVersion = request.Query.ContainsKey("v");
+                    var path = request.Path.Value ?? "";
+                    var isGeneratedOrAthleteImage = path.StartsWith("/athletes/", StringComparison.OrdinalIgnoreCase)
+                        || path.StartsWith("/generated/", StringComparison.OrdinalIgnoreCase);
+
+                    if (hasVersion)
+                    {
+                        ctx.Context.Response.Headers.CacheControl = "public,max-age=31536000,immutable";
+                        ctx.Context.Response.Headers.Expires = DateTime.UtcNow.AddYears(1).ToString("R");
+                    }
+                    else if (isGeneratedOrAthleteImage)
+                    {
+                        ctx.Context.Response.Headers.CacheControl = "public,max-age=300,must-revalidate";
+                        ctx.Context.Response.Headers.Expires = DateTime.UtcNow.AddMinutes(5).ToString("R");
+                    }
+                    else
+                    {
+                        ctx.Context.Response.Headers.CacheControl = "public,max-age=86400";
+                        ctx.Context.Response.Headers.Expires = DateTime.UtcNow.AddDays(1).ToString("R");
+                    }
                 }
             });
 

--- a/LongevityWorldCup.Website/wwwroot/partials/head.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/head.html
@@ -8,6 +8,10 @@
 <meta property="og:title" content="{{SEO_OG_TITLE}}" />
 <meta property="og:description" content="{{SEO_OG_DESCRIPTION}}" />
 <meta property="og:image" content="{{SEO_OG_IMAGE}}" />
+<meta property="og:image:secure_url" content="{{SEO_OG_IMAGE}}" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="{{SEO_OG_TITLE}}" />
 <meta property="og:url" content="{{SEO_OG_URL}}" />
 <meta property="og:type" content="website" />
 <meta property="og:site_name" content="Longevity World Cup" />

--- a/LongevityWorldCup.Website/wwwroot/partials/header.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/header.html
@@ -550,7 +550,7 @@
 
 <header role="banner">
     <a href="/" class="header-link">
-        <img src="/assets/favicon-128x128.png"
+        <img src="{{ASSET_FAVICON_128}}"
              alt="Longevity World Cup logo, a phoenix symbolizing a new life"
              class="main-logo-image"
              width="128"
@@ -583,7 +583,7 @@
 </header>
 <div id="site-sticky-header" class="site-sticky-header" aria-hidden="true">
     <a href="/" class="site-sticky-header-link">
-        <img src="/assets/favicon-128x128.png"
+        <img src="{{ASSET_FAVICON_128}}"
              alt="Longevity World Cup logo, a phoenix symbolizing a new life"
              class="main-logo-image site-sticky-header-logo"
              loading="lazy">


### PR DESCRIPTION
## Summary

This splits the cache and preview metadata work out of the broader closed PR #528.

## What changed

- Version athlete proof URLs emitted by `AthleteDataService`.
- Keep immutable cache headers for `?v=` assets while making unversioned `/athletes/...` and `/generated/...` image requests revalidate quickly.
- Route shared header logo images through middleware asset-version placeholders.
- Add OG image dimensions, secure URL, and alt metadata for richer social previews.
- Update `AGENTS.md` with the asset-cache rules this codifies.

## Why

Athlete/proof images can change while their paths remain stable. Versioned URLs make intended image updates cache-safe, and the shorter fallback cache prevents stale unversioned image requests from lingering too long.

## Validation

- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj`

Build passed. Existing nullable warnings in `ApplicationController` still appear on this branch because they are already present on `master`.