### PR TITLE
[codex] Improve proof preview readability

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/js/misc.js
+++ b/LongevityWorldCup.Website/wwwroot/js/misc.js
@@ -335,8 +335,12 @@ window.optimizeImageClient = async function (dataUri) {
     }
     const blob = new Blob([bytes], { type: contentType });
 
-    // Create ImageBitmap for resizing
-    const img = await createImageBitmap(blob);
+    let img;
+    try {
+        img = await createImageBitmap(blob);
+    } catch (e) {
+        return { dataUrl: dataUri, contentType, extension: contentType.split('/')[1] };
+    }
 
     // Determine new size
     const maxSize = 2048;
@@ -373,6 +377,8 @@ window.optimizeImageClient = async function (dataUri) {
     }
     const webpBase64 = btoa(binary);
     const webpDataUrl = 'data:image/webp;base64,' + webpBase64;
+
+    if (typeof img.close === 'function') img.close();
 
     return {
         dataUrl: webpDataUrl,

--- a/LongevityWorldCup.Website/wwwroot/js/proof-helpers.js
+++ b/LongevityWorldCup.Website/wwwroot/js/proof-helpers.js
@@ -102,16 +102,22 @@ window.getProofChecklistLabelsFromSession = function () {
 window.setupProofUploadHTML = function (nextButton, uploadProofButton, proofPicInput, proofImageContainer, proofPics, biomarkerChecklistContainer, biomarkers) {
     nextButton.disabled = true;
 
-    // ——— Load PDF.js if not already loaded ———
-    if (!window.pdfjsLib) {
+    function ensurePdfJsLoaded() {
+        if (window.pdfjsLib) return Promise.resolve(window.pdfjsLib);
+        if (window.__pdfJsLoadingPromise) return window.__pdfJsLoadingPromise;
+
         const pdfScript = document.createElement('script');
-        pdfScript.src = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.8.162/pdf.min.js';
-        pdfScript.onload = () => {
-            // point to the worker
-            pdfjsLib.GlobalWorkerOptions.workerSrc =
-                'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.8.162/pdf.worker.min.js';
-        };
-        document.head.appendChild(pdfScript);
+        window.__pdfJsLoadingPromise = new Promise((resolve, reject) => {
+            pdfScript.src = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.8.162/pdf.min.js';
+            pdfScript.onload = () => {
+                pdfjsLib.GlobalWorkerOptions.workerSrc =
+                    'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.8.162/pdf.worker.min.js';
+                resolve(window.pdfjsLib);
+            };
+            pdfScript.onerror = reject;
+            document.head.appendChild(pdfScript);
+        });
+        return window.__pdfJsLoadingPromise;
     }
 
     // Attach event listener to the Upload Proof button
@@ -145,8 +151,8 @@ window.setupProofUploadHTML = function (nextButton, uploadProofButton, proofPicI
 
                     // process one by one to preserve order
                     for (const file of Array.from(files)) {
-                        const raw = await readDataURL(file);
                         if (file.type === 'application/pdf') {
+                            await ensurePdfJsLoaded();
                             // read file as arrayBuffer
                             const arrayBuffer = await file.arrayBuffer();
                             // load PDF
@@ -154,8 +160,12 @@ window.setupProofUploadHTML = function (nextButton, uploadProofButton, proofPicI
                             const pdfDoc = await loadingTask.promise;
                             // render each page
                             for (let pageNum = 1; pageNum <= pdfDoc.numPages; pageNum++) {
+                                if (proofPics.length >= 9) {
+                                    customAlert('Only the first 9 proof images were added.');
+                                    break;
+                                }
                                 const page = await pdfDoc.getPage(pageNum);
-                                const viewport = page.getViewport({ scale: 1 });
+                                const viewport = page.getViewport({ scale: 2 });
                                 const canvas = document.createElement('canvas');
                                 canvas.width = viewport.width;
                                 canvas.height = viewport.height;
@@ -170,6 +180,12 @@ window.setupProofUploadHTML = function (nextButton, uploadProofButton, proofPicI
                             continue;
                         }
 
+                        if (proofPics.length >= 9) {
+                            customAlert('You can upload a maximum of 9 images.');
+                            break;
+                        }
+
+                        const raw = await readDataURL(file);
                         const { dataUrl } = await window.optimizeImageClient(raw);
                         if (dataUrl) {
                             proofPics.push(dataUrl);
@@ -210,7 +226,7 @@ function updateProofImageContainer(container, nextButton, proofPics, uploadProof
             let img = document.createElement('img');
             img.src = proofPics[i];
             img.alt = 'Proof image ' + (i + 1);
-            img.style = 'max-width: 100%; border: 2px solid var(--dark-text-color); border-radius: 8px;';
+            img.style = 'display: block; width: 100%; height: auto; max-width: 100%; border: 2px solid var(--dark-text-color); border-radius: 8px; background: #fff;';
 
             let removeButton = document.createElement('button');
             removeButton.textContent = 'Remove';

--- a/LongevityWorldCup.Website/wwwroot/onboarding/convergence.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/convergence.html
@@ -93,14 +93,17 @@
 
         #proofImageContainer div {
             position: relative;
-            display: inline-block;
+            display: block;
             margin: 0.5rem;
         }
 
         #proofImageContainer img {
-            max-width: 200px;
+            width: 100%;
+            max-width: 100%;
+            height: auto;
             border: 2px solid var(--dark-text-color);
             border-radius: 8px;
+            background: #fff;
         }
 
         #proofImageContainer button {

--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -849,10 +849,10 @@
     /* =========================
        11) Proofs & enlarged overlay
        ========================= */
-    .proofs-gallery{ display:flex; flex-direction:column; align-items:center; flex-wrap:wrap; gap:1rem; justify-content:center; padding:0; }
-    .proof-item{ width:100%; height:auto; border-radius:10px; overflow:hidden; cursor:pointer; transition:transform .3s ease; }
-    .proof-item:hover{ transform: scale(1.05); }
-    .proof-item img{ width:100%; height:100%; object-fit:cover; }
+    .proofs-gallery{ display:flex; flex-direction:column; align-items:center; gap:1rem; justify-content:center; padding:0; }
+    .proof-item{ width:100%; max-width:960px; height:auto; border-radius:8px; overflow:hidden; cursor:pointer; transition:transform .3s ease; background:#fff; border:1px solid rgba(0,0,0,.12); }
+    .proof-item:hover{ transform: scale(1.01); }
+    .proof-item img{ display:block; width:100%; height:auto; max-height:none; object-fit:contain; background:#fff; }
 
     .enlarged-portrait{
         position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,.85);
@@ -1028,7 +1028,7 @@
 
         /* Mobile modal improvements */
         .modal-content{
-            width:95%; padding:15px; margin:0; max-height:100vh; height:100vh;
+            width:100%; padding:15px; margin:0; max-height:100dvh; height:100dvh;
             border-radius:0 !important; /* Remove rounded corners on mobile immediately */
             padding-top:max(15px, env(safe-area-inset-top));
             padding-bottom:max(15px, env(safe-area-inset-bottom));
@@ -1039,6 +1039,8 @@
             border-radius:0 !important; /* Also remove rounded corners in guess-mode on mobile */
         }
         #athlete-profile .portrait-wrapper{ width:50%; }
+        .proof-item{ max-width:100%; border-radius:6px; }
+        .proofs-gallery{ gap:.75rem; }
         .modal-scroll-progress{ height:2px; }
         
         /* Ensure minimum touch target sizes */
@@ -4878,13 +4880,18 @@
         const proofsGallery = document.getElementById('proofsGallery');
         proofsGallery.innerHTML = '';
 
-        fullAthleteData.Proofs.forEach(proofUrl => {
+        (fullAthleteData.Proofs || []).forEach((proofUrl, index) => {
             const proofItem = document.createElement('div');
             proofItem.classList.add('proof-item');
-            proofItem.innerHTML = `<img src="${proofUrl}" alt="Proof Image" loading="lazy">`;
+            const img = document.createElement('img');
+            img.src = proofUrl;
+            img.alt = `Proof image ${index + 1}`;
+            img.loading = 'lazy';
+            img.decoding = 'async';
+            proofItem.appendChild(img);
             proofsGallery.appendChild(proofItem);
 
-            proofItem.querySelector('img').addEventListener('click', function () {
+            img.addEventListener('click', function () {
                 openEnlargedView(this);
             });
         });

--- a/LongevityWorldCup.Website/wwwroot/play/proof-upload.html
+++ b/LongevityWorldCup.Website/wwwroot/play/proof-upload.html
@@ -11,21 +11,24 @@
 
         #proofImageContainer {
             width: 90%;
-            max-width: 600px;
+            max-width: 960px;
             margin: 1rem auto 0;
             text-align: center;
         }
 
             #proofImageContainer div {
                 position: relative;
-                display: inline-block;
+                display: block;
                 margin: 0.5rem;
             }
 
             #proofImageContainer img {
-                max-width: 200px;
+                width: 100%;
+                max-width: 100%;
+                height: auto;
                 border: 2px solid var(--dark-text-color);
                 border-radius: 8px;
+                background: #fff;
             }
 
             #proofImageContainer button {


### PR DESCRIPTION
## Summary

This splits proof readability and small mobile/design polish out of the broader closed PR #528.

## What changed

- Load PDF.js through a reusable promise so PDF proof uploads wait for the library before rendering.
- Render uploaded PDF pages at a higher scale for clearer proof images.
- Keep the proof upload limit enforced across multi-page PDFs.
- Show proof previews as full-width readable documents instead of cropped thumbnails.
- Build proof gallery images with DOM APIs and safer alt text.
- Make mobile athlete modals use `100dvh` and tighten proof spacing on small screens.
- Return the original image from client optimization when `createImageBitmap` cannot decode a selected file.

## Why

Proofs are lab-document evidence, so cropping them like decorative thumbnails can hide important text. PDF uploads also needed a small loading guard to avoid fragile timing when the script was not ready yet.

## Validation

- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj`

Build passed cleanly on this branch.