### PR TITLE
[codex] Fix injected page asset and header bugs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ This file documents project-specific rules that agents commonly get wrong. It is
 - When a new static asset must be loaded from injected HTML/partials, add a placeholder and replace it through `AssetVersionProvider.AppendVersion(...)` in the middleware so clients receive a cache-busted URL.
 - Favicon and web manifest links in `wwwroot/partials/head.html` also use middleware placeholders; keep any new light or dark icon variants on that versioned path.
 - Shared header logo images also use middleware asset placeholders. Keep header/partial static assets on the placeholder path instead of hard-coded `/assets/...` URLs.
+- Bioage onboarding pages load `wwwroot/css/bioageform.css` through the `{{ASSET_BIOAGEFORM_CSS}}` middleware placeholder; do not hard-code `/css/bioageform.css` in those injected pages.
 - Athlete profile and proof asset URLs should be versioned when emitted from the data service. Unversioned `/athletes/...` and `/generated/...` requests are intentionally cached briefly only as a fallback.
 - When changing the API of an existing external JS file, review every injected HTML/partial caller in the repo and ensure the versioned URL path still goes through the middleware replacement flow.
 - If a helper is moved from inline script to a separate JS file, verify that the file is loaded in every page, modal, iframe, or embedded context that uses that helper.

--- a/LongevityWorldCup.Website/Middleware/HtmlInjectionMiddleware.cs
+++ b/LongevityWorldCup.Website/Middleware/HtmlInjectionMiddleware.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using LongevityWorldCup.Website.Business;
 using LongevityWorldCup.Website.Tools;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace LongevityWorldCup.Website.Middleware
 {
@@ -80,13 +81,14 @@ namespace LongevityWorldCup.Website.Middleware
                         .Replace("<!--GUESS-MY-AGE-->", guessMyAge)
                         .Replace("<!--EVENT-BOARD-CONTENT-->", eventBoardContent)
                         .Replace("<!--AGE-VISUALIZATION-->", ageVisualization)
+                        .Replace("{{ASSET_BIOAGEFORM_CSS}}", _assetVersionProvider.AppendVersion("/css/bioageform.css"))
                         .Replace("{{ASSET_CUSTOM_EVENT_MARKUP_JS}}", _assetVersionProvider.AppendVersion("/js/custom-event-markup.js"));
                     bodyContent = ReplacePageTitle(bodyContent, seo.PageTitle);
 
                     // Optionally remove the play button on certain pages
                     if (path?.Contains("join-game", StringComparison.OrdinalIgnoreCase) is true)
                     {
-                        bodyContent = bodyContent.Replace("<button class=\"join-game\">", "<!-- Removed Join Game Button -->");
+                        bodyContent = RemoveJoinGameButtons(bodyContent);
                     }
 
                     // Write the modified content to the response
@@ -432,6 +434,15 @@ $@"<script type=""module"">
 
             end += titleClose.Length;
             return html.Remove(start, end - start).Insert(start, replacement);
+        }
+
+        private static string RemoveJoinGameButtons(string html)
+        {
+            return Regex.Replace(
+                html,
+                @"\s*<button\b(?=[^>]*\bclass\s*=\s*[""'][^""']*\bjoin-game\b)[\s\S]*?</button>",
+                "",
+                RegexOptions.IgnoreCase);
         }
 
         private static string EncodeMeta(string value)

--- a/LongevityWorldCup.Website/wwwroot/onboarding/bortz-age.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/bortz-age.html
@@ -3,8 +3,8 @@
 <head>
     <title>Longevity World Cup - Bortz Age</title>
     <!--HEAD-->
-    <link rel="preload" href="/css/bioageform.css" as="style">
-    <link rel="stylesheet" href="/css/bioageform.css">
+    <link rel="preload" href="{{ASSET_BIOAGEFORM_CSS}}" as="style">
+    <link rel="stylesheet" href="{{ASSET_BIOAGEFORM_CSS}}">
     <style>
         /* Match join-game biological age intro styling; align width with .bioageform */
         .lab-reassurance {

--- a/LongevityWorldCup.Website/wwwroot/onboarding/convergence.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/convergence.html
@@ -4,7 +4,7 @@
     <title>Longevity World Cup - Convergence</title>
     <!--HEAD-->
     <link rel="stylesheet" href="https://unpkg.com/cropperjs@1.5.13/dist/cropper.min.css">
-    <link rel="stylesheet" href="/css/bioageform.css">
+    <link rel="stylesheet" href="{{ASSET_BIOAGEFORM_CSS}}">
     <style>
         /* Hide the join-game button in the header */
         .join-game {

--- a/LongevityWorldCup.Website/wwwroot/onboarding/pheno-age.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/pheno-age.html
@@ -3,8 +3,8 @@
 <head>
     <title>Longevity World Cup - Pheno Age</title>
     <!--HEAD-->
-    <link rel="preload" href="/css/bioageform.css" as="style">
-    <link rel="stylesheet" href="/css/bioageform.css">
+    <link rel="preload" href="{{ASSET_BIOAGEFORM_CSS}}" as="style">
+    <link rel="stylesheet" href="{{ASSET_BIOAGEFORM_CSS}}">
     <style>
         /* Match join-game biological age intro styling; align width with .bioageform */
         .lab-reassurance {


### PR DESCRIPTION
## Summary

Fixes two small injected-page issues:

- Removes the header play buttons on the join-game page using the actual rendered `join-game` button class instead of an exact markup fragment that no longer matched.
- Routes the bioage onboarding stylesheet through the middleware asset-versioning flow via `{{ASSET_BIOAGEFORM_CSS}}`.
- Updates `AGENTS.md` with the concrete bioage stylesheet placeholder rule.

## Root Cause

The join-game header removal used an exact string replacement that did not match the current header button markup. The bioage onboarding pages also had direct `/css/bioageform.css` links, bypassing the project’s middleware cache-busting convention for injected HTML.

## Validation

- `dotnet build LongevityWorldCup.sln --artifacts-path tmp\verify-artifacts`
- `dotnet test LongevityWorldCup.sln --artifacts-path tmp\verify-test-artifacts`
- `git diff --check`
- Direct regex check against `wwwroot/partials/header.html` confirmed `join-game` buttons are removed.