### PR TITLE
[codex] Polish first-impression UI

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/index.html
+++ b/LongevityWorldCup.Website/wwwroot/index.html
@@ -111,21 +111,19 @@
 
         .game-description {
             text-align: center;
-            margin: 0.5rem 0 2rem;
-            line-height: 1.7;
-            color: #4a5568;
-            font-size: 1.05rem;
+            margin: 0.25rem auto 2rem;
+            line-height: 1.65;
+            color: #334155;
+            font-size: clamp(1.02rem, 1.3vw, 1.08rem);
             font-weight: 400;
             letter-spacing: 0.005em;
-            max-width: 42em;
-            margin-left: auto;
-            margin-right: auto;
+            max-width: 43em;
             padding: 0 1rem;
         }
 
         .game-description strong {
             font-weight: 600;
-            color: #2d3748;
+            color: #1f2937;
         }
 
         /* Common container for sections */
@@ -137,6 +135,16 @@
             max-width: 1250px; /* Adjusted to better match the leaderboard width */
             box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
             text-align: center;
+        }
+
+        .section-container[data-aos]:not(.aos-animate) {
+            opacity: 1 !important;
+            transform: none !important;
+        }
+
+        .section-container [data-aos]:not(.aos-animate) {
+            opacity: 1 !important;
+            transform: none !important;
         }
 
             /* Heading style */
@@ -193,8 +201,8 @@
 
         /* Styling for the VIEW FULL RANKINGS button */
         .rankings-btn {
-            padding: 1rem 2rem;
-            font-size: 1.2rem;
+            padding: 0.9rem 1.8rem;
+            font-size: 1.08rem;
             background: linear-gradient(135deg, var(--primary-color, #3498db), #4fa3e8); /* Subtle gradient */
             color: var(--light-text-color);
             border: none;
@@ -203,6 +211,11 @@
             transition: background 0.3s ease, transform 0.2s ease, box-shadow 0.3s ease;
             font-weight: bold;
             box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1); /* Subtle shadow */
+        }
+
+        .full-rankings-action {
+            text-align: center;
+            margin: 1.5rem auto 0;
         }
 
             /* Hover effect for the VIEW FULL RANKINGS button */
@@ -217,6 +230,8 @@
             display: flex;
             justify-content: center;
             align-items: center;
+            gap: 0.75rem;
+            flex-wrap: wrap;
         }
 
         /* Styles for the copy button */
@@ -278,8 +293,10 @@
             top: 0;
             left: 0;
             width: 0%; /* Updated dynamically */
-            height: 100%;
-            background: linear-gradient(90deg, rgba(255, 165, 0, 0.3), rgba(255, 223, 186, 0.1)); /* Light orange gradient */
+            height: 0.45rem;
+            background: linear-gradient(90deg, rgba(247, 147, 26, 0.85), rgba(255, 193, 7, 0.55));
+            border-radius: 15px 0 999px 0;
+            box-shadow: 0 2px 8px rgba(247, 147, 26, 0.18);
             z-index: 1;
             transition: width 0.5s ease-in-out; /* Smooth animation for width changes */
         }
@@ -307,17 +324,38 @@
             background: var(--card-bg);
             color: var(--dark-text-color);
             border-radius: 15px;
-            padding: 2rem;
+            padding: 1.85rem 2rem 1.95rem;
             margin: 2rem auto;
+            max-width: 980px;
             text-align: center;
         }
 
-            .newsletter-section h3,
+            .newsletter-section h2 {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                gap: 0.55rem;
+                margin: 0 0 1.15rem;
+                font-size: clamp(1.45rem, 2.4vw, 2rem);
+                color: #2d3748;
+            }
+
+            .newsletter-section h2 i {
+                font-size: 0.9em;
+            }
+
             .newsletter-section p {
                 color: #4a5568;
                 line-height: 1.7;
                 font-weight: 400;
                 letter-spacing: 0.005em;
+            }
+
+            .newsletter-section p {
+                max-width: 56rem;
+                margin-left: auto;
+                margin-right: auto;
+                margin-bottom: 1.35rem;
             }
 
             .newsletter-section strong {
@@ -333,6 +371,7 @@
                 padding: 0.6rem 1rem;
                 border-radius: 25px;
                 box-sizing: border-box;
+                height: 42px;
             }
 
                 .shared-email-input:focus {
@@ -340,8 +379,8 @@
                 }
 
             .newsletter-section .shared-email-input {
-                width: 250px;
-                margin-right: 1rem;
+                width: clamp(280px, 34vw, 420px);
+                margin-right: 0;
             }
 
             .shared-email-button {
@@ -360,6 +399,8 @@
                 align-items: center;
                 justify-content: center;
                 gap: 0.45rem;
+                min-width: 9rem;
+                height: 42px;
             }
 
                 .shared-email-button:hover {
@@ -445,6 +486,21 @@
                 padding: 1.5rem;
             }
 
+            .newsletter-section {
+                padding: 1.45rem 1.35rem 1.5rem;
+            }
+
+                .newsletter-section h2 {
+                    gap: 0.45rem;
+                    margin-bottom: 1rem;
+                    font-size: clamp(1.35rem, 6vw, 1.6rem);
+                    line-height: 1.25;
+                }
+
+                .newsletter-section p {
+                    margin-bottom: 1.25rem;
+                }
+
             .btc-status {
                 font-size: 1.2rem;
                 margin: 0;
@@ -479,7 +535,7 @@
 
         .lwc-highlights-countdown-wrapper {
             max-width: 1250px;
-            margin: 2rem auto;
+            margin: 2rem auto 2.25rem;
             display: flex;
             gap: 1.75rem;
             align-items: stretch;
@@ -507,7 +563,7 @@
             padding: 0; /* spacing handled inside */
             margin-bottom: 0;
             background-color: var(--card-bg);
-            border-radius: 20px;
+            border-radius: 18px;
             box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
             overflow: hidden;
         }
@@ -769,7 +825,9 @@
         @media (max-width: 991px) {
             .lwc-highlights-countdown-wrapper {
                 flex-direction: column;
-                margin-top: 1.5rem;
+                gap: 1.35rem;
+                margin-top: 1.35rem;
+                margin-bottom: 2rem;
             }
 
                 .lwc-highlights-countdown-wrapper > #events-root-index,
@@ -784,6 +842,28 @@
         }
 
         @media (max-width: 576px) {
+            .game-description {
+                margin-bottom: 1.75rem;
+                padding: 0 1.35rem;
+                line-height: 1.6;
+            }
+
+            .lwc-highlights-countdown-wrapper {
+                margin-top: 1.25rem;
+                gap: 1.2rem;
+            }
+
+            #events-root-index .events-board,
+            .events-board--timer {
+                border-radius: 14px;
+            }
+
+            #events-root-index .events-board thead th,
+            .lwc-countdown-header-row {
+                padding-left: 14px;
+                padding-right: 14px;
+            }
+
             .lwc-countdown-body {
                 padding: 18px 14px 20px;
             }
@@ -818,6 +898,16 @@
             .lwc-merch-mobile-slide .lwc-merch-item-price {
                 font-size: 0.68rem;
             }
+
+            .full-rankings-action {
+                margin-top: 1.25rem;
+            }
+
+            .rankings-btn {
+                width: min(100%, 19rem);
+                padding: 0.85rem 1.4rem;
+                font-size: 1rem;
+            }
         }
 
         @media (max-width: 400px) {
@@ -842,16 +932,19 @@
         /* ===== Historical Archive Section ===== */
         .archive-section {
             text-align: center;
+            padding-top: 1.75rem;
+            padding-bottom: 1.55rem;
         }
 
         .archive-section h2 {
-            margin-bottom: 1.5rem;
+            margin-top: 0;
+            margin-bottom: 1.15rem;
         }
 
         /* Table Wrapper */
         .archive-table-wrapper {
             overflow-x: auto;
-            margin: 2rem 0;
+            margin: 1.35rem 0 1.1rem;
             max-width: 100%;
             -webkit-overflow-scrolling: touch;
             scrollbar-width: thin;
@@ -893,7 +986,7 @@
             text-transform: uppercase;
             font-size: .85rem;
             letter-spacing: 0.08em;
-            padding: 1rem 1.5rem;
+            padding: 0.85rem 1.35rem;
             text-align: center;
             border-bottom: 1px solid rgba(0,0,0,.03);
         }
@@ -943,7 +1036,7 @@
 
         /* Table Cells */
         .archive-table td {
-            padding: 1rem 1.5rem;
+            padding: 0.85rem 1.35rem;
             text-align: center;
             font-size: 0.975rem;
             color: #4a5568;
@@ -979,7 +1072,7 @@
             font-weight: 600;
             font-size: 0.9rem;
             display: block;
-            margin-top: 0.25rem;
+            margin-top: 0.18rem;
             margin-left: 0;
             white-space: nowrap;
         }
@@ -1293,7 +1386,7 @@
 
 
         <!--LEADERBOARD-CONTENT-->
-        <div style="text-align: center; margin-top: 20px;">
+        <div class="full-rankings-action">
             <button id="viewAllAthletesBtn" onclick="window.location.href = window.getFullLeaderboardUrlWithCurrentState ? window.getFullLeaderboardUrlWithCurrentState() : '/leaderboard'" class="rankings-btn" aria-label="View all athletes on the leaderboard">
                 View all athletes
             </button>

--- a/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
@@ -560,27 +560,42 @@
     }
 
     @media (max-width:600px){
-        .events-board thead th{font-size:.85rem;padding:10px 12px}
-        .view-all{font-size:.75rem}
-        .events-board tbody td{padding:0 12px;height:auto;line-height:1.25}
+        .events-board thead th{font-size:.82rem;padding:11px 12px;color:#087f8f}
+        .view-all{font-size:.75rem;color:#087f8f;opacity:1}
+        .events-board tbody td{padding:0 12px;height:auto;line-height:1.28}
         .events-board table tbody tr{height:auto}
         .col-avatar{width:28px}
         .avatar,.avatar-fallback{width:22px;height:22px;border-width:2px}
         .event-message{font-size:.95rem}
-        .col-date{font-size:.72rem;opacity:.6;padding-left:6px}
+        .col-date{font-size:.72rem;opacity:1;color:#64748b;padding-left:6px}
         .events-board table tbody tr:hover{transform:none;box-shadow:0 4px 10px rgba(0,0,0,.08)}
         .events-board td.event-message{align-items:center;align-content:center}
 
         /* Homepage/mobile highlights: prevent table-width blowout from single-line rows. */
+        .events-board:not(.athlete-scroll){
+            --badge-size:21px;
+            --badge-icon-size:.7rem;
+            --badge-inline-gap:.1rem;
+            --badge-gap:.16rem;
+        }
+        .events-board:not(.athlete-scroll) .event-message{
+            font-size:.9rem;
+        }
         .events-board:not(.athlete-scroll) td.event-message .event-message-cell{
             white-space:normal;
             overflow-x:hidden;
             flex-wrap:wrap;
-            row-gap:.15rem;
+            align-items:baseline;
+            column-gap:.2rem;
+            row-gap:.18rem;
+            line-height:1.3;
+            min-height:48px;
+            padding-top:.32rem;
+            padding-bottom:.32rem;
         }
         .events-board:not(.athlete-scroll) td.col-avatar{
-            width:34px;
-            padding-right:8px;
+            width:32px;
+            padding-right:7px;
         }
         .events-board:not(.athlete-scroll) td.col-date{
             width:58px;
@@ -596,6 +611,9 @@
         .events-board:not(.athlete-scroll) td.event-message .event-message-cell .badge-chip,
         .events-board:not(.athlete-scroll) td.event-message .event-message-cell .more-link{
             white-space:nowrap;
+        }
+        .events-board:not(.athlete-scroll) .event-inline-text{
+            line-height:1.3;
         }
 
         /* Mobile athlete profile: avoid per-row horizontal scrolling/overlap in highlights. */
@@ -619,6 +637,16 @@
 
     @media (max-width:360px){
         .col-date{display:none}
+    }
+
+    @media (max-width:420px){
+        .events-board:not(.athlete-scroll) td.col-date{
+            display:none;
+        }
+
+        .events-board:not(.athlete-scroll) table{
+            table-layout:auto;
+        }
     }
 </style>
 

--- a/LongevityWorldCup.Website/wwwroot/partials/footer.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/footer.html
@@ -3,7 +3,7 @@
     .footer {
         background: var(--background-color);
         color: var(--light-text-color);
-        padding: 2rem 0;
+        padding: 1.75rem 0 1.6rem;
         margin-top: 4rem;
         position: relative;
         width: 100%;
@@ -21,7 +21,7 @@
         width: 100%;
         will-change: transform;
         font-weight: 400;
-        font-size: 0.975rem;
+        font-size: 0.95rem;
         letter-spacing: 0.005em;
     }
 
@@ -41,36 +41,45 @@
         max-width: 1200px;
         margin: 0 auto;
         padding: 0 1.5rem;
-        display: flex;
+        display: grid;
+        grid-template-columns: repeat(2, minmax(8.5rem, max-content));
+        column-gap: clamp(2.5rem, 8vw, 6rem);
         justify-content: center;
-        align-items: flex-start;
-        flex-direction: row;
+        align-items: start;
         margin-bottom: 0;
     }
 
     .footer-column {
         display: flex;
         flex-direction: column;
-        margin-bottom: 1rem;
-        width: auto;
-        margin: 0 3rem;
+        gap: 0.05rem;
+        margin: 0;
         align-items: flex-start;
     }
 
     @media (max-width: 768px) {
+        .footer {
+            padding: 1.65rem 0 1.35rem;
+        }
+
         .footer-container {
-            margin-bottom: 60px; /* Leave room for play button */
+            margin-bottom: 0;
+            padding: 0 2.5rem;
+            column-gap: clamp(2rem, 9vw, 3.25rem);
+        }
+
+        .footer-link {
+            padding: 0.42rem 0;
         }
     }
 
     @media (max-width: 375px) {
         .footer-container {
-            flex-direction: column;
-            margin-bottom: 0; /* It's a column now, so play button have space */
+            padding: 0 1.5rem;
+            column-gap: 1.75rem;
         }
 
         .footer-column {
-            width: 100%;
             margin: 0;
         }
     }

--- a/LongevityWorldCup.Website/wwwroot/partials/header.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/header.html
@@ -51,11 +51,11 @@
 
     .tagline {
         display: block;
-        margin-top: 0.8rem;
-        font-size: 1.1rem;
+        margin-top: 0.65rem;
+        font-size: clamp(1rem, 1.5vw, 1.1rem);
         font-weight: 400;
-        color: #cccccc; /* Soft gray for subtle contrast */
-        letter-spacing: 1px;
+        color: #e2e8f0;
+        letter-spacing: 0.04em;
     }
 
     body {
@@ -69,7 +69,7 @@
 
     main {
         max-width: 1200px;
-        margin: 3rem auto;
+        margin: 2.5rem auto 3rem;
         padding: 0 1rem;
     }
 
@@ -78,7 +78,7 @@
         background: var(--background-color);
         color: var(--light-text-color);
         text-align: center;
-        padding: 2rem 0;
+        padding: clamp(1.35rem, 2.6vw, 1.75rem) 0 clamp(1.6rem, 3vw, 2rem);
         position: relative;
         overflow: hidden;
         display: flex;
@@ -91,14 +91,27 @@
         filter: invert(100%);
     }
 
+    .header-link {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
+
+    .header-link > .main-logo-image {
+        width: clamp(92px, 10vw, 112px);
+        height: auto;
+        margin-bottom: 0.9rem;
+    }
+
     .bannertext {
         text-align: center; /* Optional */
-        font-size: 2.7rem;
+        font-size: clamp(2.15rem, 5vw, 2.7rem);
+        line-height: 1.08;
         font-weight: 700;
         text-transform: capitalize;
-        letter-spacing: 2px;
+        letter-spacing: 0.05em;
         position: relative;
-        text-shadow: 4px 4px 8px rgba(0, 0, 0, 0.3);
+        text-shadow: 3px 3px 8px rgba(0, 0, 0, 0.35);
         padding: 0 1rem;
     }
 
@@ -129,9 +142,10 @@
     }
 
     .join-game {
-        margin-top: 2rem;
-        padding: 1rem 2rem;
-        font-size: 1.5rem;
+        margin-top: 1.5rem;
+        padding: 0.9rem 1.9rem;
+        font-size: clamp(1.25rem, 2vw, 1.5rem);
+        line-height: 1;
         background: var(--main-action-color);
         color: var(--light-text-color);
         border: none;
@@ -142,15 +156,19 @@
         animation: glow 1s ease-in-out 3;
         position: relative;
         z-index: 1;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.35rem;
     }
 
     .join-game-middle {
         display: inline-block;
-        line-height: 1; /* Reset line height */
-        vertical-align: middle; /* Align vertically in relation to other text */
-        font-size: 1rem; /* Adjust font size to fit within the button */
+        line-height: 1;
+        vertical-align: middle;
+        font-size: 0.68em;
         position: relative;
-        top: -2px; /* Fine-tune vertical alignment */
+        top: -1px;
     }
 
     .join-game::before {
@@ -177,43 +195,45 @@
 
     .join-game:hover {
         background: var(--main-action-selected-color);
-        transform: scale(1.1) rotate(1deg); /* Slight enlarge and tilt effect */
-        box-shadow: 0 8px 16px rgba(0, 0, 0, 0.3), 0 0 20px rgba(72, 187, 120, 0.6); /* Enhanced shadow and glow */
+        transform: scale(1.04) rotate(1deg); /* Slight enlarge and tilt effect */
+        box-shadow: 0 8px 16px rgba(0, 0, 0, 0.26), 0 0 16px rgba(72, 187, 120, 0.45); /* Enhanced shadow and glow */
         transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
     }
 
     .scrolled-button {
         position: fixed;
-        bottom: 20px;
-        right: 20px;
-        transform: scale(0.9); /* Slightly reduce size */
+        top: 7px;
+        bottom: auto;
+        right: 24px;
+        transform: none;
         z-index: 1000;
-        padding: 0.8rem 1.5rem;
+        margin-top: 0;
+        padding: 0.45rem 0.95rem;
+        font-size: 1rem;
         background: var(--main-action-color);
         transition: transform 0.5s ease, background 0.3s ease, box-shadow 0.3s ease;
     }
 
         .scrolled-button:hover {
             background: var(--main-action-selected-color);
-            transform: scale(1.1) rotate(1deg); /* Slight enlarge and tilt effect */
-            box-shadow: 0 8px 16px rgba(0, 0, 0, 0.3), 0 0 20px rgba(72, 187, 120, 0.6); /* Enhanced shadow and glow */
+            transform: scale(1.04);
+            box-shadow: 0 8px 16px rgba(0, 0, 0, 0.26), 0 0 16px rgba(72, 187, 120, 0.45); /* Enhanced shadow and glow */
             transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
         }
 
     @keyframes glow {
         0%, 100% {
-            box-shadow: 0 0 5px #B3E5FC, 0 0 10px #B3E5FC, 0 0 15px #CFD8DC, 0 0 20px #CFD8DC;
+            box-shadow: 0 0 4px rgba(179, 229, 252, 0.65), 0 0 10px rgba(179, 229, 252, 0.45), 0 0 16px rgba(207, 216, 220, 0.36);
         }
 
         50% {
-            box-shadow: 0 0 20px #CFD8DC, 0 0 30px #B3E5FC, 0 0 40px #B3E5FC, 0 0 50px #CFD8DC;
+            box-shadow: 0 0 10px rgba(207, 216, 220, 0.5), 0 0 18px rgba(179, 229, 252, 0.5), 0 0 26px rgba(179, 229, 252, 0.36);
         }
     }
 
     .header-link {
         text-decoration: none;
         color: inherit; /* Inherit the color from the parent element */
-        display: block; /* Makes the entire anchor area clickable */
     }
 
         .header-link h1 {
@@ -540,6 +560,50 @@
     @media (prefers-reduced-motion: reduce) {
         .site-sticky-header {
             transition: none;
+        }
+    }
+
+    @media (max-width: 768px) {
+        main {
+            margin-top: 2rem;
+        }
+
+        header {
+            padding: 1.45rem 0 1.85rem;
+        }
+
+        .header-link > .main-logo-image {
+            width: clamp(88px, 25vw, 108px);
+            margin-bottom: 0.85rem;
+        }
+
+        .bannertext {
+            font-size: clamp(2.2rem, 10vw, 2.55rem);
+            letter-spacing: 0.035em;
+        }
+
+        .join-game {
+            margin-top: 1.35rem;
+            padding: 0.9rem 1.7rem;
+            max-width: calc(100vw - 3rem);
+        }
+
+        .scrolled-button {
+            display: none !important;
+        }
+    }
+
+    @media (max-width: 380px) {
+        .bannertext {
+            font-size: 2.1rem;
+        }
+
+        .tagline {
+            font-size: 0.96rem;
+        }
+
+        .join-game {
+            padding-inline: 1.45rem;
         }
     }
     /* Always reserve space so scrollIntoView/anchor links are not covered by the sticky bar (works on load and when sticky is visible) */

--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -1345,6 +1345,39 @@
     /* =========================
        13) Mobile
        ========================= */
+    @media (min-width: 769px) and (max-width: 800px){
+        .content{
+            padding-left:max(1rem, env(safe-area-inset-left));
+            padding-right:max(1rem, env(safe-area-inset-right));
+        }
+        .leaderboard-toolbar{
+            flex-direction:column;
+            align-items:stretch;
+            gap:.75rem;
+            margin-top:1.25rem;
+        }
+        .leaderboard-view-switcher{
+            margin-left:0;
+            order:1;
+        }
+        .search-container{ flex:0 1 calc(100% - 48px); min-width:0; width:calc(100% - 48px); max-width:none; margin-top:0; }
+        .search-wrapper{ display:flex; align-items:center; gap:.5rem; flex:1; min-width:0; width:100%; order:2; }
+        .sidebar-toggle{ align-self:center; height:40px; flex-shrink:0; margin-right:0; }
+        .leaderboard table{ width:100%; table-layout:auto; }
+        .leaderboard table .sponsor-th,
+        .leaderboard table .sponsor-td,
+        .leaderboard table .media-contact-th,
+        .leaderboard table .media-contact-td{
+            display:none;
+        }
+        .leaderboard table th:nth-child(4),
+        .leaderboard table td:nth-child(4){ padding-right:0.5rem; }
+        .leaderboard table td .badge-section{ display:none; }
+        .leaderboard table th{ font-size:.62rem; }
+        .leaderboard table td{ font-size:.84rem; }
+        .leaderboard .portrait{ width:44px; height:44px; }
+    }
+
     @media (max-width: 768px){
         .content{
             padding-left:max(1rem, env(safe-area-inset-left));


### PR DESCRIPTION
## What changed

This PR applies first-impression UI polish across the public homepage surfaces: hero/header, mobile highlights, compact leaderboard/table responsiveness, donation and newsletter cards, and footer spacing.

## Why

The screen had several visual rough edges in the initial viewport and lower homepage sections: oversized glow treatments, awkward mobile wrapping, loose card spacing, clipped tablet controls, and outdated mobile footer spacing. These changes are presentation-only and keep business logic, APIs, routes, validation, auth, and data flow untouched.

## Validation

- Captured before/after screenshots during each polish pass.
- Ran `dotnet build LongevityWorldCup.sln` successfully.
