### PR TITLE
[codex] Refine desktop Hall of Fame density

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/index.html
+++ b/LongevityWorldCup.Website/wwwroot/index.html
@@ -1200,6 +1200,37 @@
             color: var(--secondary-color);
         }
 
+        @media (min-width: 769px) {
+            .archive-section {
+                padding-top: 1.45rem;
+                padding-bottom: 1.35rem;
+            }
+
+            .archive-section h2 {
+                margin-bottom: 0.9rem;
+            }
+
+            .archive-table-wrapper {
+                margin: 1rem 0 0.9rem;
+            }
+
+            .archive-table thead th {
+                padding-top: 0.72rem;
+                padding-bottom: 0.72rem;
+            }
+
+            .archive-table td {
+                padding-top: 0.72rem;
+                padding-bottom: 0.72rem;
+            }
+
+            .archive-section > p {
+                margin-top: 0.9rem !important;
+                margin-bottom: 0 !important;
+                line-height: 1.35;
+            }
+        }
+
         /* Responsive Design */
         @media (max-width: 768px) {
             .archive-table-wrapper {


### PR DESCRIPTION
## What changed
- Tightened the desktop/tablet Hall of Fame section spacing so the single-row archive table no longer sits in an oversized card.
- Reduced desktop table/header/link vertical padding while preserving the mobile card layout.
- Kept this to CSS-only presentation changes in the homepage.

## Before / After screenshots
Screenshots are uploaded as GitHub-hosted images and are not committed to the repository.

Before desktop:
![Before desktop Hall of Fame](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/03b198801e19c1c5ac44c64387f3d7c094dca4e7/pr-next-before-desktop-hof.png)

After desktop:
![After desktop Hall of Fame](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/6706ac068b6360a15ddc2fae6eb56556a806da3e/pr-next-after-desktop-hof.png)

Mobile sanity check:
![Mobile sanity check Hall of Fame](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/40092f06fcf1f3294406ad6c27a5ead641978550/pr-next-mobile-hof-check.png)

## Validation
- `git diff --check` passed.
- `dotnet build LongevityWorldCup.sln` passed with 0 warnings and 0 errors.
- Restarted the local website and verified `http://127.0.0.1:5298/` returns HTTP 200.
- Confirmed `LongevityWorldCup.Documentation/pr-screenshots/` remains untracked.