### PR TITLE
[codex] Refine desktop footer spacing

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/partials/footer.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/footer.html
@@ -43,7 +43,7 @@
         padding: 0 1.5rem;
         display: grid;
         grid-template-columns: repeat(2, minmax(8.5rem, max-content));
-        column-gap: clamp(2.5rem, 8vw, 6rem);
+        column-gap: clamp(4rem, 16vw, 13rem);
         justify-content: center;
         align-items: start;
         margin-bottom: 0;


### PR DESCRIPTION
## What changed
- Increased the desktop footer column gap so the two link groups do not feel squeezed together in the center of the full-width footer.
- Left the existing mobile footer spacing unchanged.
- Kept this to a one-line CSS-only presentation change in the footer partial.

## Before / After screenshots
Screenshots are uploaded as GitHub-hosted images and are not committed to the repository.

Before desktop:
![Before desktop footer](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/a00dcf5c6d6a9962f819da8923fbc030b3bfaf64/pr563-before-desktop-footer.png)

After desktop:
![After desktop footer](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/3b8148e068019559e7ce715f51d8f47134acc28b/pr563-after-desktop-footer.png)

Mobile sanity check:
![Mobile footer sanity check](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/842a170d7cdfc43720a7ff6bb8384cad39b52267/pr563-mobile-footer-check.png)

## Validation
- `git diff --check` passed.
- `dotnet build LongevityWorldCup.sln` passed with 0 warnings and 0 errors.
- Restarted the local website and verified `http://127.0.0.1:5298/` returns HTTP 200.
- Confirmed no PR screenshot files are tracked.