### PR TITLE
[codex] Polish highlights row reveal contrast

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
@@ -1,7 +1,7 @@
 <style>
     :root{
-        --row-fade-duration:.35s;
-        --row-stagger-step:40ms;
+        --row-fade-duration:.24s;
+        --row-stagger-step:24ms;
         --row-stagger-group-size:8;
         --row-delay:0ms;
         --donation-gift:#10b981;
@@ -29,12 +29,12 @@
     }
 
     @keyframes fadeInBoard{
-        from{opacity:0;transform:translateY(10px)}
+        from{opacity:.9;transform:translateY(4px)}
         to{opacity:1;transform:translateY(0)}
     }
 
-    .fade-in-board{animation:fadeInBoard .6s ease-in-out both}
-    .row-appear{opacity:0;transform:translateY(8px)}
+    .fade-in-board{animation:fadeInBoard .42s ease-in-out both}
+    .row-appear{opacity:.82;transform:translateY(4px)}
     .row-appear.is-visible{
         opacity:1;
         transform:translateY(0);


### PR DESCRIPTION
## What changed
- Tuned the Highlights page row reveal animation so the first visible rows start readable instead of appearing blank or washed out during the initial reveal.
- Kept the change to CSS timing/opacity only in `LongevityWorldCup.Website/wwwroot/partials/event-board-content.html`.

## Visual verification
Screenshots are uploaded as GitHub-hosted images and are not committed to the repository.

Before desktop first paint:
![Before desktop first paint](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/a0af095daffb65c7e79a28db0acf55b501110fdc/pr564-before-events-first-paint.png)

After desktop first paint:
![After desktop first paint](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/bc91c64df84380835fa6429129ca48aa83b5988f/pr564-after-events-first-paint.png)

Before mobile first paint:
![Before mobile first paint](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/68ba670a3faf90fa2689bf770bc6e1f0666ec4df/pr564-before-mobile-events-first-paint.png)

After mobile first paint:
![After mobile first paint](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/439c0911a53328bda85c76341057ee8fcfefb2f9/pr564-after-mobile-events-first-paint.png)

## Validation
- `dotnet build LongevityWorldCup.sln`
- `git diff --check`
- Confirmed no files under `.codex/` or `LongevityWorldCup.Documentation/pr-screenshots/` were staged or committed.