### PR TITLE
[codex] Polish media kit download list

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/misc-pages/media.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/media.html
@@ -8,33 +8,172 @@
         .join-game {
             display: none;
         }
+
+        .media-kit-panel {
+            max-width: 820px;
+            margin: 2.25rem auto;
+            padding: 1.75rem;
+            background: rgba(255, 255, 255, 0.74);
+            border-radius: 16px;
+            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+        }
+
+        .media-kit-title {
+            margin-top: 0;
+            margin-bottom: 0.8rem;
+            text-align: center;
+        }
+
+        .media-kit-title[data-aos]:not(.aos-animate) {
+            opacity: 1;
+            transform: none;
+        }
+
+        .media-kit-intro {
+            margin: 0;
+            color: #2b3748;
+            text-align: center;
+        }
+
+        .media-kit-actions {
+            margin: 1.25rem 0 1.5rem;
+            text-align: center;
+        }
+
+        .media-kit-primary-download {
+            box-sizing: border-box;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 44px;
+            padding: 0.78rem 1.25rem;
+            border-radius: 8px;
+            background: #0a7c0a;
+            color: #fff;
+            font-weight: 700;
+            text-decoration: none;
+            box-shadow: 0 8px 18px rgba(10, 124, 10, 0.16);
+        }
+
+        .media-kit-primary-download:hover,
+        .media-kit-primary-download:focus-visible {
+            background: #096f09;
+            color: #fff;
+        }
+
+        .media-kit-preview {
+            margin-top: 0;
+        }
+
+        .media-kit-loading,
+        .media-kit-fallback {
+            margin-top: 0.75rem;
+            color: #506176;
+            text-align: center;
+        }
+
+        .media-kit-file-list {
+            display: grid;
+            gap: 0.5rem;
+            list-style: none;
+            padding: 0;
+            margin: 0;
+        }
+
+        .media-file-row {
+            box-sizing: border-box;
+            display: grid;
+            grid-template-columns: minmax(0, 1fr) auto;
+            gap: 0.75rem;
+            align-items: center;
+            padding: 0.65rem 0.75rem;
+            border: 1px solid rgba(0, 0, 0, 0.06);
+            border-radius: 10px;
+            background: rgba(248, 250, 252, 0.8);
+        }
+
+        .media-file-name {
+            min-width: 0;
+            color: #243446;
+            overflow-wrap: anywhere;
+            line-height: 1.35;
+        }
+
+        .media-file-button {
+            box-sizing: border-box;
+            min-height: 34px;
+            padding: 0.42rem 0.75rem;
+            border: 1px solid rgba(0, 188, 212, 0.34);
+            border-radius: 7px;
+            background: rgba(255, 255, 255, 0.9);
+            color: var(--primary-color);
+            font-weight: 700;
+            cursor: pointer;
+        }
+
+        .media-file-button:hover,
+        .media-file-button:focus-visible {
+            border-color: var(--primary-color);
+            background: rgba(0, 188, 212, 0.08);
+        }
+
+        .media-kit-contact {
+            margin: 1.5rem 0 0;
+            text-align: center;
+        }
+
+        @media (max-width: 600px) {
+            .media-kit-panel {
+                margin: 1.5rem 1rem;
+                padding: 1.35rem 1rem;
+                border-radius: 14px;
+            }
+
+            .media-kit-title {
+                font-size: 2rem;
+            }
+
+            .media-kit-primary-download {
+                width: 100%;
+            }
+
+            .media-file-row {
+                grid-template-columns: 1fr;
+                gap: 0.55rem;
+                align-items: stretch;
+            }
+
+            .media-file-button {
+                width: 100%;
+            }
+        }
     </style>
 </head>
 <body>
     <!--HEADER-->
     <main>
-        <section style="max-width:900px;margin:2rem auto;padding:1rem 1.25rem;">
-            <h1 data-aos="fade" data-aos-duration="700" data-aos-delay="250">Media kit</h1>
-            <p>Press-ready assets for Longevity World Cup.</p>
+        <section class="media-kit-panel">
+            <h1 class="media-kit-title" data-aos="fade" data-aos-duration="700" data-aos-delay="250">Media kit</h1>
+            <p class="media-kit-intro">Press-ready assets for Longevity World Cup.</p>
 
-            <p style="margin:1rem 0;">
+            <p class="media-kit-actions">
                 <a href="https://cdn.jsdelivr.net/gh/nopara73/LongevityWorldCup@master/LongevityWorldCup.Documentation/MediaKit.zip"
                    target="_blank" rel="noopener noreferrer"
-                   style="display:inline-block;padding:0.75rem 1.25rem;border-radius:6px;background:#0a7c0a;color:#fff;text-decoration:none;">
+                   class="media-kit-primary-download">
                     Download full media kit (ZIP)
                 </a>
             </p>
 
             <!-- Live file list extracted from ZIP (auto-load) -->
-            <div id="zipPreview" style="margin-top:1.5rem;">
-                <div id="loading" style="margin-top:0.75rem;">Loading…</div>
-                <ul id="fileList" style="list-style:none;padding:0;margin-top:0.75rem;"></ul>
-                <div id="fallback" style="display:none;margin-top:0.75rem;">
+            <div id="zipPreview" class="media-kit-preview">
+                <div id="loading" class="media-kit-loading">Loading…</div>
+                <ul id="fileList" class="media-kit-file-list"></ul>
+                <div id="fallback" class="media-kit-fallback" style="display:none;">
                     Failed to preview. Use the ZIP link above.
                 </div>
             </div>
 
-            <p style="margin-top:1.5rem;">
+            <p class="media-kit-contact">
                 Press contact:
                 <a href="mailto:longevityworldcup@gmail.com">longevityworldcup@gmail.com</a>
             </p>
@@ -76,19 +215,15 @@
 
                 for (const path of files) {
                     const li = document.createElement('li');
-                    li.style.margin = '0.35rem 0';
+                    li.className = 'media-file-row';
 
                     const name = document.createElement('span');
                     name.textContent = path;
-                    name.style.marginRight = '0.5rem';
+                    name.className = 'media-file-name';
 
                     const btn = document.createElement('button');
                     btn.textContent = 'Download';
-                    btn.style.padding = '0.3rem 0.6rem';
-                    btn.style.marginLeft = '0.25rem';
-                    btn.style.border = '1px solid #ccc';
-                    btn.style.borderRadius = '4px';
-                    btn.style.cursor = 'pointer';
+                    btn.className = 'media-file-button';
                     btn.addEventListener('click', async () => {
                         const file = zip.file(path);
                         const blob = await file.async('blob');


### PR DESCRIPTION
## What changed
- Restyled the Media kit page into a consistent panel that matches the site shell.
- Restored the page title visibility on first render.
- Aligned per-file download buttons into consistent rows on desktop.
- Improved mobile wrapping so long media-kit filenames no longer run into the download controls.

## Visual verification
Screenshots are uploaded as GitHub-hosted images and are not committed to the repository.

Before desktop:
![Before desktop media kit](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/3d0733f8dc0b5fe97de64034a971795bc14d7bb8/pr565-before-desktop-media.png)

After desktop:
![After desktop media kit](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/6523927d00d9601a50cf3f0ebd6e604fba9e4614/pr565-after-desktop-media.png)

Before mobile:
![Before mobile media kit](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/a8ae2b08239e525989a64188727d708168b688c5/pr565-before-mobile-media.png)

After mobile:
![After mobile media kit](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/beb56a630baf72849063ff828e035837bfc957ba/pr565-after-mobile-media.png)

## Validation
- `dotnet build LongevityWorldCup.sln`
- `git diff --check`
- Confirmed screenshots under `.codex/` and `LongevityWorldCup.Documentation/pr-screenshots/` were not staged or committed.