### PR TITLE
[codex] Polish play menu framing

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/play/menu.html
+++ b/LongevityWorldCup.Website/wwwroot/play/menu.html
@@ -9,13 +9,27 @@
             display: none;
         }
 
+        .play-menu-hero {
+            text-align: center;
+            padding: clamp(1.4rem, 3vh, 2.25rem) 1rem 0;
+        }
+
+        .play-menu-hero[data-aos]:not(.aos-animate),
+        .play-menu-actions[data-aos]:not(.aos-animate) {
+            opacity: 1;
+            transform: none;
+        }
+
         .img-crop {
-            height: clamp(240px, 60vh, 720px);
+            width: min(92vw, 408px);
+            height: clamp(360px, 60vh, 720px);
             overflow: hidden;
-            display: inline-block; /* keeps same width as before */
+            display: block;
+            margin: 0 auto;
         }
 
             .img-crop .illustration {
+                box-sizing: border-box;
                 width: 100%; /* same width behavior */
                 height: auto;
                 display: block;
@@ -23,13 +37,32 @@
                 top: 50%;
                 transform: translateY(-50%); /* equal crop top/bottom */
             }
+
+        .play-menu-actions {
+            margin-top: 1.5rem;
+        }
+
+        @media (max-width: 600px) {
+            .play-menu-hero {
+                padding: 1.1rem 1rem 0;
+            }
+
+            .img-crop {
+                width: min(91vw, 380px);
+                height: clamp(420px, 68vh, 650px);
+            }
+
+            .play-menu-actions {
+                margin-top: 1.35rem;
+            }
+        }
     </style>
 </head>
 <body>
     <!--HEADER-->
     <main>
         <h1 class="visually-hidden">Game menu</h1>
-        <div style="text-align: center;" data-aos="fade" data-aos-duration="700" data-aos-delay="300">
+        <div class="play-menu-hero" data-aos="fade" data-aos-duration="700" data-aos-delay="300">
             <div class="img-crop">
                 <img src="../assets/content-images/JustTrackIt.jpg"
                      alt="Illustration encouraging athletes to track their progress"
@@ -40,7 +73,7 @@
             </div>
         </div>
 
-        <div class="options-container" data-aos="fade" data-aos-duration="700" data-aos-delay="400">
+        <div class="options-container play-menu-actions" data-aos="fade" data-aos-duration="700" data-aos-delay="400">
             <button id="newGameBtn" class="option-button grey" onclick="window.location.href='/join'">
                 I'm a new athlete
             </button>


### PR DESCRIPTION
## What changed
- Added consistent breathing room between the compact header and the play menu illustration.
- Constrained the illustration crop width so it stays centered and avoids mobile edge clipping.
- Kept the menu controls grouped with a consistent gap below the illustration.
- Ensured the menu content remains visible before AOS animation classes settle.

## Visual verification
Screenshots are uploaded as GitHub-hosted images and are not committed to the repository.

Before desktop:
![Before desktop play menu](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/584ce48b1e863ef468f0e6505b4ed98533a6739d/pr566-before-desktop-play-menu.png)

After desktop:
![After desktop play menu](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/f728c445a44eb36fcc1aeada0177a2a85e79a928/pr566-after-desktop-play-menu.png)

Before mobile:
![Before mobile play menu](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/7aeb86445049d66c3178891697e84d4e0847a553/pr566-before-mobile-play-menu.png)

After mobile:
![After mobile play menu](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/c1883e6f6e6604a1122da5c8ee229560a48528a3/pr566-after-mobile-play-menu.png)

## Validation
- `dotnet build LongevityWorldCup.sln`
- `git diff --check`
- Confirmed screenshots under `.codex/` and `LongevityWorldCup.Documentation/pr-screenshots/` were not staged or committed.