### PR TITLE
[codex] Polish unsubscribe panel

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/unsubscribe.html
+++ b/LongevityWorldCup.Website/wwwroot/unsubscribe.html
@@ -7,33 +7,133 @@
         .join-game {
             display: none;
         }
+
+        .unsubscribe-panel {
+            max-width: 620px;
+            margin: 2.5rem auto;
+            padding: 1.75rem;
+            background: rgba(255, 255, 255, 0.72);
+            border-radius: 16px;
+            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+            text-align: center;
+        }
+
+        .unsubscribe-panel h1 {
+            margin-top: 0;
+            margin-bottom: 0.9rem;
+        }
+
+        .unsubscribe-panel h1[data-aos]:not(.aos-animate) {
+            opacity: 1;
+            transform: none;
+        }
+
+        .unsubscribe-copy {
+            max-width: 34rem;
+            margin: 0 auto;
+            color: #243446;
+            line-height: 1.45;
+        }
+
+        .unsubscribe-form {
+            display: grid;
+            gap: 0.65rem;
+            max-width: 420px;
+            margin: 1.35rem auto 0;
+            text-align: left;
+        }
+
+        .unsubscribe-form label {
+            font-weight: 700;
+            color: #243446;
+        }
+
+        .unsubscribe-form input {
+            width: 100%;
+            box-sizing: border-box;
+            min-height: 44px;
+            padding: 0.75rem 0.85rem;
+            border: 1px solid rgba(80, 97, 118, 0.28);
+            border-radius: 8px;
+            background: rgba(255, 255, 255, 0.92);
+            color: #243446;
+            font: inherit;
+        }
+
+        .unsubscribe-form input:focus {
+            border-color: var(--primary-color);
+            outline: 3px solid rgba(0, 188, 212, 0.18);
+            outline-offset: 1px;
+        }
+
+        .unsubscribe-button {
+            justify-self: start;
+            min-height: 42px;
+            margin-top: 0.25rem;
+            padding: 0.75rem 1.15rem;
+            border: none;
+            border-radius: 8px;
+            background: #0a7c0a;
+            color: #fff;
+            font-weight: 700;
+            cursor: pointer;
+            box-shadow: 0 8px 18px rgba(10, 124, 10, 0.16);
+        }
+
+        .unsubscribe-button:hover,
+        .unsubscribe-button:focus-visible {
+            background: #096f09;
+        }
+
+        .unsubscribe-message {
+            min-height: 1.35rem;
+            margin: 1rem 0 0;
+            font-weight: 700;
+            text-align: center;
+        }
+
+        @media (max-width: 600px) {
+            .unsubscribe-panel {
+                margin: 1.5rem 1rem;
+                padding: 1.35rem 1rem;
+                border-radius: 14px;
+            }
+
+            .unsubscribe-panel h1 {
+                font-size: 2rem;
+            }
+
+            .unsubscribe-button {
+                width: 100%;
+                justify-self: stretch;
+            }
+        }
     </style>
 </head>
 <body>
     <!--HEADER-->
     <main>
-        <section style="max-width:900px;margin:2rem auto;padding:1rem 1.25rem;">
+        <section class="unsubscribe-panel">
             <h1 data-aos="fade" data-aos-duration="700" data-aos-delay="250">Unsubscribe</h1>
-            <p>Remove your email from the Longevity World Cup yearly newsletter.</p>
+            <p class="unsubscribe-copy">Remove your email from the Longevity World Cup yearly newsletter.</p>
 
-            <form id="unsubscribe-form" novalidate style="max-width:520px;margin-top:1rem;">
-                <label for="email" style="display:block;margin-bottom:0.5rem;">Email address</label>
+            <form id="unsubscribe-form" class="unsubscribe-form" novalidate>
+                <label for="email">Email address</label>
                 <input id="email"
                        name="email"
                        type="email"
                        autocomplete="email"
                        placeholder="you@example.com"
-                       required
-                       style="width:100%;padding:0.75rem;border:1px solid #ccc;border-radius:6px;box-sizing:border-box;" />
+                       required />
 
                 <button id="unsubscribe-button"
                         type="submit"
-                        style="display:inline-block;margin-top:0.75rem;padding:0.75rem 1.25rem;border-radius:6px;background:#0a7c0a;color:#fff;text-decoration:none;border:none;cursor:pointer;">
+                        class="unsubscribe-button">
                     Unsubscribe
                 </button>
             </form>
 
-            <p id="message" aria-live="polite" style="margin-top:1rem;"></p>
+            <p id="message" class="unsubscribe-message" aria-live="polite"></p>
         </section>
     </main>
 


### PR DESCRIPTION
## What changed
- Moved the unsubscribe content into a centered panel that matches the rest of the public site style.
- Aligned the form fields and button more consistently on desktop.
- Improved mobile sizing so the input and CTA share a clean full-width rhythm.
- Kept all unsubscribe behavior and API calls unchanged.

## Visual verification
Screenshots are uploaded as GitHub-hosted images and are not committed to the repository.

Before desktop:
![Before desktop unsubscribe](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/763ddf09e5ae70157c921cd18cf1fd6e6406a7b4/pr567-before-desktop-unsubscribe.png)

After desktop:
![After desktop unsubscribe](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/fad34764d05211e0efcaa22dfa6c32d977783e5e/pr567-after-desktop-unsubscribe.png)

Before mobile:
![Before mobile unsubscribe](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/32a828c76dfe8cc0e7bb206ef8e09c28387a6d1d/pr567-before-mobile-unsubscribe.png)

After mobile:
![After mobile unsubscribe](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/47e22eb5bd7ea60473582363f8aacfd0fb6da16f/pr567-after-mobile-unsubscribe.png)

## Validation
- `dotnet build LongevityWorldCup.sln`
- `git diff --check`
- Confirmed screenshots under `.codex/` and `LongevityWorldCup.Documentation/pr-screenshots/` were not staged or committed.