### PR TITLE
[codex] Polish application review panel

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/onboarding/application-review.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/application-review.html
@@ -8,42 +8,144 @@
         .join-game {
             display: none;
         }
+
+        .application-review-panel {
+            max-width: 720px;
+            margin: 2.25rem auto;
+            padding: 1.75rem;
+            background: rgba(255, 255, 255, 0.68);
+            border-radius: 16px;
+            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+            text-align: center;
+        }
+
+        .application-review-panel [data-aos]:not(.aos-animate) {
+            opacity: 1;
+            transform: none;
+        }
+
+        .application-review-title {
+            display: flex;
+            justify-content: center;
+            align-items: baseline;
+            gap: 0.55rem;
+            margin-top: 0;
+            margin-bottom: 1.25rem;
+        }
+
+        .application-review-title i {
+            font-size: 0.85em;
+        }
+
+        .application-review-visual {
+            margin: 0 auto 1.35rem;
+        }
+
+        .application-review-visual .illustration {
+            width: min(100%, 408px);
+            margin-bottom: 0;
+            box-sizing: border-box;
+        }
+
+        .application-review-copy {
+            max-width: 62ch;
+            margin: 0.8rem auto 0;
+            color: #4f5b68;
+            line-height: 1.45;
+            text-align: center;
+        }
+
+        .application-review-copy.primary {
+            font-size: 1.02rem;
+            color: #3f4a56;
+        }
+
+        .application-review-highlight {
+            color: #4CAF50;
+            font-weight: 700;
+            text-decoration: underline;
+        }
+
+        .application-review-actions {
+            margin-top: 1.45rem;
+        }
+
+        .application-review-actions .option-button {
+            width: auto;
+            min-width: 10rem;
+            max-width: none;
+            margin-bottom: 0;
+            margin-left: auto;
+            margin-right: auto;
+            padding-inline: 1.35rem;
+        }
+
+        @media (max-width: 600px) {
+            .application-review-panel {
+                margin: 1.5rem 1rem;
+                padding: 1.35rem 1rem;
+                border-radius: 14px;
+            }
+
+            .application-review-title {
+                flex-direction: column;
+                align-items: center;
+                gap: 0.25rem;
+                margin-bottom: 1rem;
+                font-size: 2rem;
+            }
+
+            .application-review-title i {
+                font-size: 0.9em;
+            }
+
+            .application-review-copy {
+                font-size: 0.95rem;
+            }
+
+            .application-review-actions .option-button {
+                width: 100%;
+                min-width: 0;
+            }
+        }
     </style>
 </head>
 <body>
     <!--HEADER-->
     <main>
-        <h1 id="appReviewTitle" data-aos="fade" data-aos-duration="700" data-aos-delay="200">
-            <span id="appReviewText">Application review</span> <i class="fas fa-rocket"></i>
-        </h1>
-        <!-- Create distinct URLs or manually defined versions for each scenario -->
-        <div style="text-align: center;" data-aos="fade" data-aos-duration="700" data-aos-delay="250">
-            <picture>
-                <source srcset="../assets/content-images/bean-waiting.webp" type="image/webp">
-                <source srcset="../assets/content-images/bean-waiting.png" type="image/png">
-                <img src="../assets/content-images/bean-waiting.png" alt="Waiting" class="illustration" loading="lazy">
-            </picture>
-        </div>
-        <p data-aos="fade" data-aos-duration="700" data-aos-delay="300" style="text-align:center">
-            We're reviewing <span id="whatAreWeReviewing">your application</span>, which may take a day or two. Afterwards we'll contact you at <span id="contactEmailPlaceholder" style="color: #4CAF50; font-weight: bold; text-decoration: underline;">
-                [insert contact email address here]
-            </span>
-        </p>
-        <p data-aos="fade" data-aos-duration="700" data-aos-delay="350" style="text-align:center">
-            <span class="smaller-text">
+        <section class="application-review-panel">
+            <h1 id="appReviewTitle" class="application-review-title" data-aos="fade" data-aos-duration="700" data-aos-delay="200">
+                <span id="appReviewText">Application review</span> <i class="fas fa-rocket"></i>
+            </h1>
+            <!-- Create distinct URLs or manually defined versions for each scenario -->
+            <div class="application-review-visual" data-aos="fade" data-aos-duration="700" data-aos-delay="250">
+                <picture>
+                    <source srcset="../assets/content-images/bean-waiting.webp" type="image/webp">
+                    <source srcset="../assets/content-images/bean-waiting.png" type="image/png">
+                    <img src="../assets/content-images/bean-waiting.png" alt="Waiting" class="illustration" loading="lazy">
+                </picture>
+            </div>
+            <p class="application-review-copy primary" data-aos="fade" data-aos-duration="700" data-aos-delay="300">
+                We're reviewing <span id="whatAreWeReviewing">your application</span>, which may take a day or two. Afterwards we'll contact you at <span id="contactEmailPlaceholder" class="application-review-highlight">
+                    [insert contact email address here]
+                </span>
+            </p>
+            <p class="application-review-copy" data-aos="fade" data-aos-duration="700" data-aos-delay="350">
+                <span class="smaller-text">
                 Questions, concerns, or signs of aging? Let us know at <a href="mailto:longevityworldcup@gmail.com">longevityworldcup@gmail.com</a>
             </span>
-        </p>
-        <p data-aos="fade" data-aos-duration="700" data-aos-delay="400" style="text-align:center">
-            <span class="smaller-text">
-                Want to hang out with other longevity athletes? Join the <span style="color: #4CAF50; font-weight: bold;">#longevity-world-cup</span> room on the <a href="https://join.slack.com/t/tumblebit/shared_invite/zt-2wzmjg6tg-PRup8nbL7GxViJzofNoBFQ">TumbleBit Slack</a>!
+            </p>
+            <p class="application-review-copy" data-aos="fade" data-aos-duration="700" data-aos-delay="400">
+                <span class="smaller-text">
+                Want to hang out with other longevity athletes? Join the <span class="application-review-highlight">#longevity-world-cup</span> room on the <a href="https://join.slack.com/t/tumblebit/shared_invite/zt-2wzmjg6tg-PRup8nbL7GxViJzofNoBFQ">TumbleBit Slack</a>!
             </span>
-        </p>
-        <div class="options-container" data-aos="fade" data-aos-duration="700" data-aos-delay="400">
-            <button class="option-button back-button" onclick="window.location.href='/'">
-                <i class="fas fa-home"></i>&nbsp;Home
-            </button>
-        </div>
+            </p>
+            <div class="options-container application-review-actions" data-aos="fade" data-aos-duration="700" data-aos-delay="400">
+                <button class="option-button back-button" onclick="window.location.href='/'">
+                    <i class="fas fa-home"></i>&nbsp;Home
+                </button>
+            </div>
+        </section>
     </main>
     <!--FOOTER-->
 


### PR DESCRIPTION
## Summary
- Centered the application review content in a consistent panel so the page reads as one intentional state instead of separate floating elements.
- Tightened title, image, copy, and Home action spacing for desktop and mobile.
- Improved text contrast and line length while preserving existing page behavior and submission/payment review logic.

## Before screenshots
Screenshots are uploaded as GitHub-hosted images and are not committed to the repository.

Desktop:
![Before desktop application review](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/7e107f91fec80322c037b84aa9223f1f398816c4/pr568-before-desktop-application-review.png)

Mobile:
![Before mobile application review](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/47ab409650f61e9da6985ce363088ebd0563d665/pr568-before-mobile-application-review.png)

## After screenshots
Desktop:
![After desktop application review](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/b9407f34ef263442a95031f9081a279512696875/pr568-after-desktop-application-review.png)

Mobile:
![After mobile application review](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/f61b379f3739be4a5d5751aef5000d8afdd1b840/pr568-after-mobile-application-review.png)

## Validation
- `dotnet build LongevityWorldCup.sln` passed with 0 warnings and 0 errors.
- `git diff --check` passed; Git only reported the existing LF-to-CRLF working-copy warning.