### PR TITLE
[codex] Polish proof upload composition

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/play/proof-upload.html
+++ b/LongevityWorldCup.Website/wwwroot/play/proof-upload.html
@@ -9,12 +9,88 @@
             display: none;
         }
 
+        .proof-upload-main {
+            max-width: 760px;
+            margin: 0 auto;
+            padding: 2.5rem 1rem 3.25rem;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+
+        .proof-upload-main [data-aos]:not(.aos-animate) {
+            opacity: 1;
+            transform: none;
+        }
+
+        .proof-upload-title {
+            margin: 0 0 1.25rem;
+            text-align: center;
+        }
+
+        .proof-upload-visual {
+            margin: 0 auto 1.45rem;
+            text-align: center;
+        }
+
+        .proof-upload-visual .illustration {
+            width: min(100%, 408px);
+            margin-bottom: 0;
+            box-sizing: border-box;
+        }
+
+        .proof-upload-copy {
+            max-width: 58ch;
+            margin: 0 auto 0.75rem;
+            color: #3f3f3f;
+            line-height: 1.45;
+            text-align: center;
+        }
+
+        .proof-upload-copy.smaller-text {
+            max-width: 52ch;
+            margin-bottom: 1.5rem;
+            color: #4d4d4d;
+        }
+
+        .proof-upload-primary-action,
+        .proof-upload-final-actions {
+            width: min(100%, 408px);
+            min-width: 0;
+            max-width: 408px;
+            display: flex;
+            flex-direction: column;
+            align-items: stretch;
+            gap: 0.85rem;
+            margin: 0 auto;
+        }
+
+        .proof-upload-primary-action .option-button,
+        .proof-upload-final-actions .option-button {
+            width: 100%;
+            min-width: 0;
+            max-width: none;
+            margin: 0;
+            box-sizing: border-box;
+        }
+
+        .proof-upload-final-actions .back-button {
+            margin-left: 0;
+        }
+
         #proofImageContainer {
             width: 90%;
             max-width: 600px;
-            margin: 1rem auto 0;
+            margin: 1.25rem auto 0;
+            padding: 0;
+            border: 0;
+            min-inline-size: 0;
             text-align: center;
         }
+
+            #proofImageContainer:empty {
+                display: none;
+            }
 
             #proofImageContainer div {
                 position: relative;
@@ -38,34 +114,61 @@
                 border-radius: 3px;
                 cursor: pointer;
             }
+
+        #biomarker-checklist {
+            width: min(100%, 408px);
+            max-width: 408px;
+            margin: 1.25rem auto 1.35rem;
+            box-sizing: border-box;
+            color: #222;
+        }
+
+        @media (max-width: 600px) {
+            .proof-upload-main {
+                padding: 2rem 1.35rem 2.75rem;
+            }
+
+            .proof-upload-title {
+                margin-bottom: 1rem;
+                font-size: 2rem;
+            }
+
+            .proof-upload-visual {
+                margin-bottom: 1.25rem;
+            }
+
+            .proof-upload-copy {
+                max-width: 100%;
+            }
+        }
     </style>
 </head>
 <body>
     <!--HEADER-->
-    <main>
-        <h1 id="character-title" data-aos="fade" data-aos-duration="700" data-aos-delay="250">Athlete selection</h1>
-        <div style="text-align: center;" data-aos="fade" data-aos-duration="700" data-aos-delay="300">
+    <main class="proof-upload-main">
+        <h1 id="character-title" class="proof-upload-title" data-aos="fade" data-aos-duration="700" data-aos-delay="250">Athlete selection</h1>
+        <div class="proof-upload-visual" data-aos="fade" data-aos-duration="700" data-aos-delay="300">
             <picture>
                 <source srcset="../assets/content-images/proof.webp" type="image/webp">
                 <source srcset="../assets/content-images/proof.jpg" type="image/jpeg">
                 <img src="../assets/content-images/proof.jpg" alt="Illustration of uploading lab proof documents" class="illustration" loading="lazy">
             </picture>
         </div>
-        <p id="mainProofInstructions" data-aos="fade" data-aos-duration="700" data-aos-delay="350" style="text-align:center"></p>
-        <p id="subProofInstructions" class="smaller-text" data-aos="fade" data-aos-duration="700" data-aos-delay="400" style="text-align:center"></p>
+        <p id="mainProofInstructions" class="proof-upload-copy" data-aos="fade" data-aos-duration="700" data-aos-delay="350"></p>
+        <p id="subProofInstructions" class="proof-upload-copy smaller-text" data-aos="fade" data-aos-duration="700" data-aos-delay="400"></p>
 
-        <div class="options-container" data-aos="fade" data-aos-duration="700" data-aos-delay="450">
+        <div class="options-container proof-upload-primary-action" data-aos="fade" data-aos-duration="700" data-aos-delay="450">
             <input type="file" id="proofPicInput" accept="image/*,application/pdf" style="display: none;" multiple>
             <button type="button" id="uploadProofButton" class="option-button grey green">
                 Upload proofs
             </button>
         </div>
 
-        <fieldset id="proofImageContainer" style="text-align: center; margin-top: 1rem;"></fieldset>
+        <fieldset id="proofImageContainer"></fieldset>
 
-        <div id="biomarker-checklist" style="width: 90%; max-width: 600px; margin: 1rem auto 0; "></div>
+        <div id="biomarker-checklist"></div>
 
-        <div class="options-container" data-aos="fade" data-aos-duration="700" data-aos-delay="450">
+        <div class="options-container proof-upload-final-actions" data-aos="fade" data-aos-duration="700" data-aos-delay="450">
             <button id="submitButton" type="submit" class="option-button green"></button>
             <button class="option-button back-button" onclick="window.goBackOrHome()">
                 <i class="fas fa-arrow-left"></i>&nbsp;Back


### PR DESCRIPTION
## Summary
- Centered the proof upload screen into one clearer vertical flow.
- Aligned the illustration, instruction text, upload button, proof tracker, submit button, and Back button to consistent widths.
- Removed the empty proof preview fieldset frame so the initial state no longer shows a stray horizontal line.
- Kept upload inputs, button ids, event handlers, submission logic, API calls, routes, storage, and validation unchanged.

## Before screenshots
Screenshots are uploaded as GitHub-hosted images and are not committed to the repository.

Desktop:
![Before desktop proof upload](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/d33be650a7ee75d81308b73c7538e97affe0461d/pr570-before-desktop-proof-upload.png)

Mobile:
![Before mobile proof upload](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/c9e2122a6d6ec18b531d8b569e3ecb08444dfec2/pr570-before-mobile-proof-upload.png)

## After screenshots
Desktop:
![After desktop proof upload](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/7aa600f988d8f1194c588689db84fb92fb8f534c/pr570-after-desktop-proof-upload.png)

Mobile:
![After mobile proof upload](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/ea4b5f2ac16ee31ddfd0d95ff7b9381cd470c654/pr570-after-mobile-proof-upload.png)

## Validation
- `dotnet build LongevityWorldCup.sln` completed successfully.
- `git diff --check` passed; Git only reported the existing LF-to-CRLF working-copy warning.
- Confirmed screenshot files remain outside the repo and are not tracked.