### PR TITLE
[codex] Polish 404 page layout

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/error/404.html
+++ b/LongevityWorldCup.Website/wwwroot/error/404.html
@@ -8,22 +8,97 @@
         .join-game {
             display: none;
         }
+
+        .not-found-main {
+            max-width: 760px;
+            margin: 0 auto;
+            padding: 2.5rem 1rem 3.25rem;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+
+        .not-found-main [data-aos]:not(.aos-animate) {
+            opacity: 1;
+            transform: none;
+        }
+
+        .not-found-title {
+            margin: 0 0 1.35rem;
+            text-align: center;
+        }
+
+        .not-found-visual {
+            margin: 0 auto 1.45rem;
+            text-align: center;
+        }
+
+        .not-found-visual .illustration {
+            width: min(100%, 360px);
+            margin-bottom: 0;
+            box-sizing: border-box;
+        }
+
+        .not-found-copy {
+            max-width: 42ch;
+            margin: 0 auto 1.5rem;
+            color: #3f3f3f;
+            line-height: 1.45;
+            text-align: center;
+        }
+
+        .not-found-actions {
+            width: min(100%, 408px);
+            min-width: 0;
+            max-width: 408px;
+            display: flex;
+            flex-direction: column;
+            align-items: stretch;
+            margin: 0 auto;
+        }
+
+        .not-found-actions .option-button {
+            width: 100%;
+            min-width: 0;
+            max-width: none;
+            margin: 0;
+            box-sizing: border-box;
+        }
+
+        .not-found-actions .back-button {
+            margin-left: 0;
+        }
+
+        @media (max-width: 600px) {
+            .not-found-main {
+                padding: 2rem 1.35rem 2.75rem;
+            }
+
+            .not-found-title {
+                margin-bottom: 1rem;
+                font-size: 2rem;
+            }
+
+            .not-found-visual {
+                margin-bottom: 1.25rem;
+            }
+        }
     </style>
 </head>
 <body>
     <!--HEADER-->
-    <main>
+    <main class="not-found-main">
 
-        <h1 id="appReviewTitle" data-aos="fade" data-aos-duration="700" data-aos-delay="200">404 not found</h1>
-        <div style="text-align: center;" data-aos="fade" data-aos-duration="700" data-aos-delay="250">
+        <h1 id="appReviewTitle" class="not-found-title" data-aos="fade" data-aos-duration="700" data-aos-delay="200">404 not found</h1>
+        <div class="not-found-visual" data-aos="fade" data-aos-duration="700" data-aos-delay="250">
             <picture>
                 <img src="../error/herold.png" alt="Illustration for page not found" class="illustration" loading="lazy">
             </picture>
         </div>
-        <p data-aos="fade" data-aos-duration="700" data-aos-delay="300" style="text-align:center">
+        <p class="not-found-copy" data-aos="fade" data-aos-duration="700" data-aos-delay="300">
             This page didn’t qualify for the Longevity World Cup
         </p>
-        <div class="options-container" data-aos="fade" data-aos-duration="700" data-aos-delay="400">
+        <div class="options-container not-found-actions" data-aos="fade" data-aos-duration="700" data-aos-delay="400">
             <button class="option-button back-button" onclick="window.location.href = '/'">
                 <i class="fas fa-home"></i>&nbsp;Home
             </button>


### PR DESCRIPTION
## Summary
- Centered the 404 page content into a tighter, consistent vertical stack.
- Constrained the illustration size so the page message and Home action fit more comfortably in the first viewport.
- Aligned the Home action with the main content instead of letting it drift to the lower right.
- Kept the existing Home navigation behavior unchanged.

## Before screenshots
Screenshots are uploaded as GitHub-hosted images and are not committed to the repository.

Desktop:
![Before desktop 404](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/fe3451fe0410677ccf1bdde6997ec935047ccab1/pr572-before-desktop-404.png)

Mobile:
![Before mobile 404](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/36f2ec55018974ad2f185c6688b7d3fa5a51e3a1/pr572-before-mobile-404.png)

## After screenshots
Desktop:
![After desktop 404](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/f6927fec3a34542b7138eea2cc6b878f8aedf304/pr572-after-desktop-404.png)

Mobile:
![After mobile 404](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/fdc26d6ecaa64bfb212ca2a5697d1c49ba90d273/pr572-after-mobile-404.png)

## Validation
- `dotnet build LongevityWorldCup.sln /p:UseAppHost=false` succeeded with 0 errors. It reported one warning because the local website process was holding the generated `.exe` while serving `http://127.0.0.1:5298/`.
- `git diff --check` passed; Git only reported the existing LF-to-CRLF working-copy warning.
- Confirmed screenshot files remain outside the repo and are not tracked.