### PR TITLE
[codex] Polish convergence action layout

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/onboarding/convergence.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/convergence.html
@@ -124,11 +124,47 @@
             width: 100%;
         }
 
+        .convergence-main [data-aos]:not(.aos-animate) {
+            opacity: 1;
+            transform: none;
+        }
+
+        .convergence-actions {
+            width: min(100%, 400px);
+            min-width: 0;
+            max-width: 400px;
+            display: flex;
+            flex-direction: column;
+            align-items: stretch;
+            gap: 0.85rem;
+            margin: 1.4rem auto 0;
+        }
+
+        .convergence-actions .option-button {
+            width: 100%;
+            min-width: 0;
+            max-width: none;
+            margin: 0;
+            box-sizing: border-box;
+        }
+
+        .convergence-actions .back-button {
+            margin-left: 0 !important;
+            margin-right: 0 !important;
+        }
+
+        @media (max-width: 600px) {
+            .convergence-actions {
+                width: min(100%, 320px);
+                margin-top: 1.25rem;
+            }
+        }
+
     </style>
 </head>
 <body>
     <!--HEADER-->
-    <main>
+    <main class="convergence-main">
         <!--MAIN-PROGRESS-BAR-->
         <h1 data-aos="fade" data-aos-duration="700" data-aos-delay="400">1. Enter the arena</h1>
         <form id="descriptionForm" class="bioageform" data-aos="fade" data-aos-duration="700" data-aos-delay="450">
@@ -256,7 +292,7 @@
                 <div id="whyCharCounter" class="char-counter">0/250</div>
             </div>
 
-            <div class="options-container">
+            <div class="options-container convergence-actions">
                 <button type="button" class="option-button green" id="nextButton" aria-label="Proceed to the next stage">Next</button>
                 <button type="button" class="option-button back-button" id="backButton">
                     <i class="fas fa-arrow-left"></i>&nbsp;Back


### PR DESCRIPTION
## Summary
- Aligned the first-step Convergence form actions into one centered responsive stack.
- Made the Back action match the Next button width instead of drifting left inside the card.
- Added a scoped first-paint guard so the convergence content does not render washed out while AOS settles.
- Kept the existing form ids, validation, stage flow, click handlers, API calls, storage, routes, and submission behavior unchanged.

## Before screenshots
Screenshots are uploaded as GitHub-hosted images and are not committed to the repository.

Desktop:
![Before desktop convergence](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/ddd4c6ffbd8dda194bdbcbc743dc06a050debb16/pr574-before-desktop-convergence.png)

Mobile:
![Before mobile convergence](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/3dd5e8786aae4979f4eef8604edf433d1afffbd0/pr574-before-mobile-convergence.png)

## After screenshots
Desktop:
![After desktop convergence](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/0872f7a14178938a440cc4e0c3f95000d6b986ba/pr574-after-desktop-convergence.png)

Mobile:
![After mobile convergence](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/13ba51223c4bae22ba459239209fbd3732a5c4f4/pr574-after-mobile-convergence.png)

## Validation
- `dotnet build LongevityWorldCup.sln` passed with 0 warnings and 0 errors.
- `git diff --check` passed; Git only reported the existing LF-to-CRLF working-copy warning.
- Confirmed screenshot files remain outside the repo and are not tracked.