### PR TITLE
[codex] Polish Bortz age action layout

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/onboarding/bortz-age.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/bortz-age.html
@@ -23,6 +23,11 @@
             display: none;
         }
 
+        .bioage-main [data-aos]:not(.aos-animate) {
+            opacity: 1;
+            transform: none;
+        }
+
         /* Visually Hidden Class for Accessibility */
         .visually-hidden {
             position: absolute !important;
@@ -535,6 +540,47 @@
             }
         }
 
+        .bioage-result-actions {
+            width: min(100%, 400px);
+            min-width: 0;
+            max-width: 400px;
+            display: flex;
+            flex-direction: column;
+            align-items: stretch;
+            gap: 0.85rem;
+            margin: 1.25rem auto 0;
+        }
+
+            .bioage-result-actions .option-button {
+                width: 100%;
+                min-width: 0;
+                max-width: none;
+                margin: 0;
+                box-sizing: border-box;
+            }
+
+            .bioage-result-actions .back-button {
+                margin-left: 0 !important;
+                margin-right: 0 !important;
+            }
+
+            .bioage-result-actions #continueButton:not(.show) {
+                position: absolute;
+                width: 1px;
+                height: 1px;
+                min-width: 0;
+                padding: 0;
+                margin: 0;
+                overflow: hidden;
+            }
+
+        @media (max-width: 600px) {
+            .bioage-result-actions {
+                width: min(100%, 320px);
+                margin-top: 1rem;
+            }
+        }
+
         /* --- LWC 2-step wizard --- */
         .lwc-steps-shell {
             position: relative;
@@ -597,7 +643,7 @@
 </head>
 <body>
     <!--HEADER-->
-    <main>
+    <main class="bioage-main">
         <div class="lwc-steps-shell" id="lwcStepsShell">
             <!--MAIN-PROGRESS-BAR-->
             <h1 id="mainPageTitleH2" data-aos="fade" data-aos-duration="700" data-aos-delay="250">
@@ -1043,7 +1089,7 @@
             </div>
         </div>
 
-        <div class="options-container" data-aos="fade" data-aos-duration="700" data-aos-delay="450">
+        <div class="options-container bioage-result-actions" data-aos="fade" data-aos-duration="700" data-aos-delay="450">
             <button type="button" id="continueButton" class="option-button green" onclick="proceedToNextPage()">
                 Next&nbsp;<i class="fas fa-arrow-right"></i>
             </button>


### PR DESCRIPTION
## What changed
- Centered the Bortz age result action area to match the form column on desktop and mobile.
- Prevented the hidden `Next` action from reserving layout space before it becomes visible.
- Scoped the first-paint AOS fallback to this page so the initial render does not appear washed out while the animation state settles.

This is visual-only: no business logic, data flow, backend code, APIs, routes, authentication, validation, or database code was changed.

## Before / After screenshots

### Desktop before
![Desktop before](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/b5037964524c6a7c6627d24ebf831d94719933ee/pr575-before-desktop-bortz-age.png)

### Desktop after
![Desktop after](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/21d766f2eac919eaf1549ff3937f91f7c9ae51e1/pr575-after-desktop-bortz-age.png)

### Mobile before
![Mobile before](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/ade41e1f999639c7c456b22214f2a0ff603c49b0/pr575-before-mobile-bortz-age.png)

### Mobile after
![Mobile after](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/7c59070f73bd740314b4be162345d7e884fe001b/pr575-after-mobile-bortz-age.png)

## Diff summary
- `LongevityWorldCup.Website/wwwroot/onboarding/bortz-age.html`: 48 insertions, 2 deletions

## Validation
- `dotnet build LongevityWorldCup.sln` passed with 0 warnings and 0 errors.
- Screenshot raw URLs were verified as `200 image/png`.
- Screenshots were uploaded to a gist and are not committed to the repository.