### PR TITLE
[codex] Polish Pheno age action layout

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/onboarding/pheno-age.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/pheno-age.html
@@ -23,6 +23,11 @@
             display: none;
         }
 
+        .phenoage-main [data-aos]:not(.aos-animate) {
+            opacity: 1;
+            transform: none;
+        }
+
         /* Visually Hidden Class for Accessibility */
         .visually-hidden {
             position: absolute !important;
@@ -525,6 +530,47 @@
             }
         }
 
+        .phenoage-result-actions {
+            width: min(100%, 400px);
+            min-width: 0;
+            max-width: 400px;
+            display: flex;
+            flex-direction: column;
+            align-items: stretch;
+            gap: 0.85rem;
+            margin: 1.25rem auto 0;
+        }
+
+            .phenoage-result-actions .option-button {
+                width: 100%;
+                min-width: 0;
+                max-width: none;
+                margin: 0;
+                box-sizing: border-box;
+            }
+
+            .phenoage-result-actions .back-button {
+                margin-left: 0 !important;
+                margin-right: 0 !important;
+            }
+
+            .phenoage-result-actions #continueButton:not(.show) {
+                position: absolute;
+                width: 1px;
+                height: 1px;
+                min-width: 0;
+                padding: 0;
+                margin: 0;
+                overflow: hidden;
+            }
+
+        @media (max-width: 600px) {
+            .phenoage-result-actions {
+                width: min(100%, 320px);
+                margin-top: 1rem;
+            }
+        }
+
         /* --- LWC 2-step wizard --- */
         .lwc-steps-shell {
             position: relative;
@@ -587,7 +633,7 @@
 </head>
 <body>
     <!--HEADER-->
-    <main>
+    <main class="phenoage-main">
         <div class="lwc-steps-shell" id="lwcStepsShell">
             <!--MAIN-PROGRESS-BAR-->
             <h1 id="mainPageTitleH2" data-aos="fade" data-aos-duration="700" data-aos-delay="250">
@@ -864,7 +910,7 @@
             </div>
         </div>
 
-        <div class="options-container" data-aos="fade" data-aos-duration="700" data-aos-delay="450">
+        <div class="options-container phenoage-result-actions" data-aos="fade" data-aos-duration="700" data-aos-delay="450">
             <button type="button" id="continueButton" class="option-button green" onclick="proceedToNextPage()">
                 Next&nbsp;<i class="fas fa-arrow-right"></i>
             </button>


### PR DESCRIPTION
## What changed
- Centered the Pheno Age result action area so the Back action aligns with the form column on desktop and mobile.
- Prevented the hidden `Next` action from reserving awkward layout space before it becomes visible.
- Scoped the first-paint AOS fallback to this page so the initial render does not appear blank or washed out while animation state settles.

This is visual-only: no business logic, data flow, backend code, APIs, routes, authentication, validation, or database code was changed.

## Before / After screenshots

### Desktop before
![Desktop before](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/bfdd37236fd92d406c1c5c427abd0ecb4b9f4c6a/pr576-before-desktop-pheno-age.png)

### Desktop after
![Desktop after](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/72946cde585801db83747508da3d80138e9bc892/pr576-after-desktop-pheno-age.png)

### Mobile before
![Mobile before](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/79952311a906db994e9dfe0e92440b92fced947e/pr576-before-mobile-pheno-age.png)

### Mobile after
![Mobile after](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/ba3bc89b3cc206d94ba1f89174099548cbd12a24/pr576-after-mobile-pheno-age.png)

## Diff summary
- `LongevityWorldCup.Website/wwwroot/onboarding/pheno-age.html`: 48 insertions, 2 deletions

## Validation
- `dotnet build LongevityWorldCup.sln` passed with 0 warnings and 0 errors.
- Screenshot raw URLs were verified as `200 image/png`.
- Screenshots were uploaded to a gist and are not committed to the repository.