### PR TITLE
[codex] Polish dashboard action layout

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/play/character-customization.html
+++ b/LongevityWorldCup.Website/wwwroot/play/character-customization.html
@@ -9,6 +9,79 @@
             display: none;
         }
 
+        .character-dashboard-main {
+            max-width: 760px;
+            margin: 0 auto;
+            padding: 2.5rem 1rem 3.25rem;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+
+        .character-dashboard-main [data-aos]:not(.aos-animate) {
+            opacity: 1;
+            transform: none;
+        }
+
+        .character-dashboard-title {
+            max-width: 100%;
+            margin: 0 0 1.25rem;
+            text-align: center;
+            overflow-wrap: anywhere;
+        }
+
+        .character-dashboard-visual {
+            margin: 0 auto 1.4rem;
+            text-align: center;
+        }
+
+        .character-dashboard-visual .illustration {
+            width: min(100%, 408px);
+            margin-bottom: 0;
+            box-sizing: border-box;
+        }
+
+        .character-dashboard-actions {
+            width: min(100%, 408px);
+            min-width: 0;
+            max-width: 408px;
+            display: flex;
+            flex-direction: column;
+            align-items: stretch;
+            gap: 0.85rem;
+            margin-top: 0.35rem;
+        }
+
+        .character-dashboard-actions .option-button {
+            width: 100%;
+            min-width: 0;
+            max-width: none;
+            margin: 0;
+            box-sizing: border-box;
+            gap: 0.35rem;
+            line-height: 1.25;
+            white-space: normal;
+        }
+
+        .character-dashboard-actions .back-button {
+            margin-left: 0;
+        }
+
+        @media (max-width: 600px) {
+            .character-dashboard-main {
+                padding: 2rem 1.35rem 2.75rem;
+            }
+
+            .character-dashboard-title {
+                margin-bottom: 1rem;
+                font-size: 2rem;
+            }
+
+            .character-dashboard-visual {
+                margin-bottom: 1.25rem;
+            }
+        }
+
         .autocomplete-wrapper {
             position: relative;
             z-index: 1000;
@@ -140,16 +213,16 @@
 </head>
 <body>
     <!--HEADER-->
-    <main>
-        <h1 id="character-title" data-aos="fade" data-aos-duration="700" data-aos-delay="250">Athlete selection</h1>
-        <div style="text-align: center;" data-aos="fade" data-aos-duration="700" data-aos-delay="300">
+    <main class="character-dashboard-main">
+        <h1 id="character-title" class="character-dashboard-title" data-aos="fade" data-aos-duration="700" data-aos-delay="250">Athlete selection</h1>
+        <div class="character-dashboard-visual" data-aos="fade" data-aos-duration="700" data-aos-delay="300">
             <picture>
                 <source srcset="../assets/content-images/headshot.webp" type="image/webp">
                 <source srcset="../assets/content-images/headshot.jpg" type="image/jpeg">
                 <img src="../assets/content-images/headshot.jpg" alt="Headshot" class="illustration" loading="lazy">
             </picture>
         </div>
-        <div class="options-container" data-aos="fade" data-aos-duration="700" data-aos-delay="350">
+        <div class="options-container character-dashboard-actions" data-aos="fade" data-aos-duration="700" data-aos-delay="350">
             <button class="option-button grey" onclick="window.location.href='/edit-profile'">
                 Edit profile&nbsp;<i class="fas fa-pen"></i>
             </button>


### PR DESCRIPTION
## What changed
- Centered the athlete dashboard action area into one consistent column.
- Brought the Back action into the same button stack instead of leaving it detached to the lower-right.
- Tightened mobile button sizing/wrapping so longer action labels and icons feel more consistent.

This is visual-only: no business logic, data flow, backend code, APIs, routes, authentication, validation, payment, or database code was changed.

## Before / After screenshots

### Desktop before
![Desktop before](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/7ba685669f6f51d4ad928089227e6e3d94cdcae2/pr577-before-desktop-dashboard-actions.png)

### Desktop after
![Desktop after](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/8899610673b7c9c44d61f111d012c2cc0df37a8d/pr577-after-desktop-dashboard-actions.png)

### Mobile before
![Mobile before](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/eaf01dc409cdc0fe58cfc6f692a771396533b127/pr577-before-mobile-dashboard-actions.png)

### Mobile after
![Mobile after](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/dd408982367be8e7a2ec96c77516c6c87d88ddd2/pr577-after-mobile-dashboard-actions.png)

## Diff summary
- `LongevityWorldCup.Website/wwwroot/play/character-customization.html`: 77 insertions, 4 deletions

## Validation
- `dotnet build LongevityWorldCup.sln` passed with 0 warnings and 0 errors.
- `/dashboard` returned HTTP 200 after restarting the local app.
- Screenshot raw URLs were verified as `200 image/png`.
- Screenshots were uploaded to a gist and are not committed to the repository.