### PR TITLE
[codex] Polish media kit file list

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/misc-pages/media.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/media.html
@@ -95,12 +95,17 @@
         .media-file-name {
             min-width: 0;
             color: #243446;
-            overflow-wrap: anywhere;
+            overflow-wrap: break-word;
+            word-break: normal;
             line-height: 1.35;
         }
 
         .media-file-button {
             box-sizing: border-box;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.38rem;
             min-height: 34px;
             padding: 0.42rem 0.75rem;
             border: 1px solid rgba(0, 188, 212, 0.34);
@@ -109,6 +114,15 @@
             color: var(--primary-color);
             font-weight: 700;
             cursor: pointer;
+            white-space: nowrap;
+        }
+
+        .media-file-button::before {
+            content: "\f019";
+            font-family: "Font Awesome 6 Free";
+            font-weight: 900;
+            font-size: 0.9em;
+            line-height: 1;
         }
 
         .media-file-button:hover,
@@ -138,13 +152,31 @@
             }
 
             .media-file-row {
-                grid-template-columns: 1fr;
-                gap: 0.55rem;
-                align-items: stretch;
+                grid-template-columns: minmax(0, 1fr) 38px;
+                gap: 0.45rem;
+                align-items: center;
+            }
+
+            .media-file-name {
+                font-size: 0.88rem;
+                line-height: 1.32;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
             }
 
             .media-file-button {
-                width: 100%;
+                width: 38px;
+                min-width: 38px;
+                min-height: 40px;
+                padding: 0;
+                border-radius: 10px;
+                justify-self: end;
+                font-size: 0;
+            }
+
+            .media-file-button::before {
+                font-size: 1rem;
             }
         }
     </style>


### PR DESCRIPTION
## What changed
- Added a download icon to the generated Media Kit file actions for clearer visual affordance.
- Kept desktop row alignment stable while making the action button content feel more consistent.
- Made the mobile file list more compact with a right-aligned icon button and single-line truncated filenames.

This is visual-only: no business logic, data flow, backend code, APIs, routes, authentication, validation, download URLs, or database code was changed.

## Before / After screenshots

### Desktop before
![Desktop before](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/cddc05d978cf6f9977fb166fcb939430e2177052/pr578-before-desktop-media-kit-list.png)

### Desktop after
![Desktop after](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/49b2df9bcbc16357907311309f5a76f325edbbc7/pr578-after-desktop-media-kit-list.png)

### Mobile before
![Mobile before](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/ba431677e110b8fe38db6a31e7a69f088d02350c/pr578-before-mobile-media-kit-list.png)

### Mobile after
![Mobile after](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/8dd30dc8e52f110b9eef957e320ca4c00589eda9/pr578-after-mobile-media-kit-list.png)

## Diff summary
- `LongevityWorldCup.Website/wwwroot/misc-pages/media.html`: 37 insertions, 5 deletions

## Validation
- `dotnet build LongevityWorldCup.sln` passed with 0 warnings and 0 errors.
- `/media` returned HTTP 200 after restarting the local app.
- Screenshot raw URLs were verified as `200 image/png`.
- Screenshots were uploaded to a gist and are not committed to the repository.