### PR TITLE
[codex] Polish review title layout

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/onboarding/application-review.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/application-review.html
@@ -88,15 +88,17 @@
             }
 
             .application-review-title {
-                flex-direction: column;
-                align-items: center;
-                gap: 0.25rem;
+                display: block;
                 margin-bottom: 1rem;
                 font-size: 2rem;
+                line-height: 1.08;
             }
 
             .application-review-title i {
-                font-size: 0.9em;
+                display: inline-block;
+                margin-left: 0.32rem;
+                font-size: 0.78em;
+                vertical-align: 0.04em;
             }
 
             .application-review-copy {


### PR DESCRIPTION
## What changed
- Tightened the Application Review title layout on mobile.
- Kept the rocket icon attached to the heading instead of placing it on a separate third line.
- Left the desktop presentation effectively unchanged.

This is visual-only: no business logic, data flow, backend code, APIs, routes, authentication, validation, payment checks, or database code was changed.

## Before / After screenshots

### Desktop before
![Desktop before](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/8825fa1b4abfcd939c3a8d35a84a07735f736d1d/pr579-before-desktop-review-title.png)

### Desktop after
![Desktop after](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/96dcbcbb183d55f9ed8b7e94caf46de218d9d074/pr579-after-desktop-review-title.png)

### Mobile before
![Mobile before](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/ef4bcdb58804c69553dfe0b6183435678bc2eed8/pr579-before-mobile-review-title.png)

### Mobile after
![Mobile after](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/ba2ea780f0814f99f772e5d0274b9af6232aa593/pr579-after-mobile-review-title.png)

## Diff summary
- `LongevityWorldCup.Website/wwwroot/onboarding/application-review.html`: 6 insertions, 4 deletions

## Validation
- `dotnet build LongevityWorldCup.sln` passed with 0 warnings and 0 errors.
- `/review` returned HTTP 200 after restarting the local app.
- Screenshot raw URLs were verified as `200 image/png`.
- Screenshots were uploaded to a gist and are not committed to the repository.