### PR TITLE
[codex] Polish unsubscribe form action

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/unsubscribe.html
+++ b/LongevityWorldCup.Website/wwwroot/unsubscribe.html
@@ -67,7 +67,8 @@
         }
 
         .unsubscribe-button {
-            justify-self: start;
+            width: 100%;
+            justify-self: stretch;
             min-height: 42px;
             margin-top: 0.25rem;
             padding: 0.75rem 1.15rem;
@@ -104,8 +105,7 @@
             }
 
             .unsubscribe-button {
-                width: 100%;
-                justify-self: stretch;
+                min-height: 44px;
             }
         }
     </style>


### PR DESCRIPTION
## What changed
- Made the unsubscribe submit action match the email field width on desktop.
- Kept the mobile full-width action treatment while preserving a comfortable touch target.
- Improved visual alignment inside the form without changing the form behavior.

This is visual-only: no business logic, data flow, backend code, APIs, routes, authentication, validation, unsubscribe behavior, or database code was changed.

## Before / After screenshots

### Desktop before
![Desktop before](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/54448f445a4e3a893d913cf87e78f9a39eab3fd2/pr580-before-desktop-unsubscribe-form.png)

### Desktop after
![Desktop after](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/4e511b96d02b362edfe796ea1650e4786ea01672/pr580-after-desktop-unsubscribe-form.png)

### Mobile before
![Mobile before](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/b0afb16848d83db287fd0a78b19a1581b9161e40/pr580-before-mobile-unsubscribe-form.png)

### Mobile after
![Mobile after](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/c1596a00660db3ea71a7df781f0ea08437701764/pr580-after-mobile-unsubscribe-form.png)

## Diff summary
- `LongevityWorldCup.Website/wwwroot/unsubscribe.html`: 3 insertions, 3 deletions

## Validation
- `dotnet build LongevityWorldCup.sln` passed with 0 warnings and 0 errors.
- `/unsubscribe` returned HTTP 200 after restarting the local app.
- Screenshot raw URLs were verified as `200 image/png`.
- Screenshots were uploaded to a gist and are not committed to the repository.