### PR TITLE
[codex] Polish join card narrow layout

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/onboarding/join-game.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/join-game.html
@@ -116,7 +116,7 @@
       .track-card h2 {
         margin: 0 0 0.35rem;
         line-height: 1.2;
-        white-space: nowrap;
+        white-space: normal;
       }
 
       .track-card h2 .track-name {
@@ -382,6 +382,25 @@
       /* Keep title clear of the prize-money ribbon */
       .track-card.pro h2 {
         padding-right: 4rem;
+      }
+
+      @media (max-width: 360px) {
+        .track-card.pro h2 {
+          padding-right: 2.5rem;
+        }
+
+        .track-card-meta {
+          grid-template-columns: 1fr;
+          gap: 0.2rem;
+        }
+
+        .track-card-meta dt {
+          margin-top: 0.45rem;
+        }
+
+        .track-card-meta dt:first-child {
+          margin-top: 0;
+        }
       }
 
       /* Only the direct child is the ribbon band; .btc-symbol stays inline on it */


### PR DESCRIPTION
## What changed
- Allowed join-card headings to wrap instead of forcing a single line.
- Added a very narrow viewport layout for join-card metadata so labels and values stack cleanly at 360px and below.
- Kept the change visual-only in `LongevityWorldCup.Website/wwwroot/onboarding/join-game.html`; no business logic, data flow, backend code, APIs, routes, authentication, validation, or database code changed.

## Visual issues fixed
- The Professional card title could run past its usable content width on very narrow phones.
- The Professional card metadata links, especially `Ultimate League` and `Pheno Age + Bortz Age`, clipped against the right edge at 320px.
- The responsive metadata spacing now stays aligned and readable without changing the normal desktop/tablet layout.

## Before / after screenshots

### Mobile 390px
Before:
![Before mobile join card layout](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/6cc41441e820db20431057627c4aaf36e63653f9/pr581-before-mobile-join-card-title-layout.png)

After:
![After mobile join card layout](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/6cc41441e820db20431057627c4aaf36e63653f9/pr581-after-mobile-join-card-title-layout.png)

### Narrow phone 320px, Professional card
Before:
![Before narrow Professional card layout](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/b83963ebc9a1a1a4f439f064d8c91cf9f740cb12/pr581-before-narrow-professional-title.png)

After:
![After narrow Professional card layout](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/cc07f784117a0ac8afcda6254c12202d99a59bcd/pr581-after-narrow-professional-title.png)

## Git diff summary
- `LongevityWorldCup.Website/wwwroot/onboarding/join-game.html`: 20 insertions, 1 deletion.

## Validation
- `dotnet build LongevityWorldCup.sln` passed with 0 warnings and 0 errors.
- `http://127.0.0.1:5298/join` returned HTTP 200 after restart.
- Screenshot raw URLs were verified as `200 image/png`.
- Screenshot files were not committed to this repository.