### PR TITLE
[codex] Polish leaderboard toolbar alignment

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -1386,7 +1386,8 @@
         }
         .leaderboard-toolbar{
             flex-direction:column; align-items:stretch; gap:.75rem; margin-top:1.25rem;
-            max-width:calc(100vw - 4rem);
+            width:100%;
+            max-width:none;
             margin-left:auto;
             margin-right:auto;
         }


### PR DESCRIPTION
## What changed
- Let the mobile leaderboard toolbar span the same content width as the leaderboard table.
- Removed the extra mobile-only max-width inset that made the view chips and search row feel narrower than the table below.
- Kept the change visual-only in `LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html`; no ranking, sorting, business logic, data flow, backend code, APIs, routes, authentication, validation, or database code changed.

## Visual issues fixed
- On mobile, the Bortz/Pheno chips and search/filter row were inset more deeply than the leaderboard card.
- The controls now align with the table edges, creating a cleaner first viewport rhythm.
- Desktop remains visually unchanged.

## Before / after screenshots

### Desktop
Before:
![Before desktop leaderboard toolbar](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/e7ad0d1eeb8344221aa76748288802c9031115ea/pr583-before-desktop-leaderboard-toolbar-alignment.png)

After:
![After desktop leaderboard toolbar](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/e7ad0d1eeb8344221aa76748288802c9031115ea/pr583-after-desktop-leaderboard-toolbar-alignment.png)

### Mobile
Before:
![Before mobile leaderboard toolbar](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/181cccac7bb8f92de45ae747e159ec03d6c93759/pr583-before-mobile-leaderboard-toolbar-alignment.png)

After:
![After mobile leaderboard toolbar](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/f40d68d42fcc5f7c09174ad664df81e00cfab6a2/pr583-after-mobile-leaderboard-toolbar-alignment.png)

## Git diff summary
- `LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html`: 2 insertions, 1 deletion.

## Validation
- `dotnet build LongevityWorldCup.sln` passed with 0 warnings and 0 errors.
- `http://127.0.0.1:5298/leaderboard` returned HTTP 200 after restart.
- Screenshot raw URLs were verified as `200 image/png`.
- Screenshot files were not committed to this repository.