### PR TITLE
[codex] Polish social post preview mobile layout

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
+++ b/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
@@ -766,6 +766,11 @@
 
         @media (max-width: 1080px) {
             .page { grid-template-columns: 1fr; }
+            .preview-stack { align-items: stretch; }
+            .preview-warning,
+            .preview-block,
+            .preview-surface,
+            .webpage-surface { width: 100%; max-width: 100%; }
         }
     </style>
 </head>


### PR DESCRIPTION
## What changed
- When the social post manager stacks to one column, the preview stack now stretches to the available width.
- The warning banner, preview block, preview surface, and webpage preview surface now align with the form panel on mobile/tablet widths.
- Kept the change visual-only in `LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html`; no business logic, data flow, backend code, APIs, routes, authentication, validation, or database code changed.

## Visual issues fixed
- On mobile, the warning banner was unnecessarily narrow and wrapped awkwardly.
- The webpage preview panel was visually inset compared with the form panel above it.
- The stacked preview column now has a consistent left/right edge rhythm.

## Before / after screenshots

### Desktop
Before:
![Before desktop social post manager](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/54aafb35fe4e40c1bd0b445bb40caf38b9c65f3a/pr584-before-desktop-social-post-preview-mobile.png)

After:
![After desktop social post manager](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/54aafb35fe4e40c1bd0b445bb40caf38b9c65f3a/pr584-after-desktop-social-post-preview-mobile.png)

### Mobile
Before:
![Before mobile social post manager](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/206e4816ce845a77eea6d9241fc03a4cf6f2e8a6/pr584-before-mobile-social-post-preview-mobile.png)

After:
![After mobile social post manager](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/390a9abcae0f3b4aa97bf6f7f49c0ecd7ed9e43d/pr584-after-mobile-social-post-preview-mobile.png)

## Git diff summary
- `LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html`: 5 insertions.

## Validation
- `dotnet build LongevityWorldCup.sln` passed with 0 warnings and 0 errors.
- `http://127.0.0.1:5298/internal/custom-event-designer.html` returned HTTP 200 after restart.
- Screenshot raw URLs were verified as `200 image/png`.
- Screenshot files were not committed to this repository.