### PR TITLE
Refine homepage newsletter mobile form

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/index.html
+++ b/LongevityWorldCup.Website/wwwroot/index.html
@@ -617,12 +617,13 @@
 
             #newsletter-form {
                 flex-direction: column;
-                width: min(100%, 18.75rem);
+                width: min(100%, 22rem);
                 margin: 0 auto;
                 gap: 0.85rem;
             }
 
-                .newsletter-section .shared-email-input {
+                #newsletter-form .shared-email-input {
+                    width: 100%;
                     margin: 0;
                 }
 


### PR DESCRIPTION
## Summary
- Widen the mobile homepage newsletter form to better match the card width.
- Remove the inherited mobile email-input bottom margin so the input and subscribe button use one consistent form gap.
- Keep the change CSS-only in `wwwroot/index.html`.

## Before / After Screenshots

### Desktop
Before:

![Before desktop](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/676fe634ed3c4424ff4fedea1c692541ee68dedb/pr585-before-desktop-home-newsletter.png)

After:

![After desktop](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/676fe634ed3c4424ff4fedea1c692541ee68dedb/pr585-after-desktop-home-newsletter.png)

### Mobile
Before:

![Before mobile](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/97c2a2dcf2c7d459431ca3cdc4b46f3803ad3a1f/pr585-before-mobile-home-newsletter.png)

After:

![After mobile](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/caad46fe92dcc52a75a5af8d35faeab08284d393/pr585-after-mobile-home-newsletter.png)

## Validation
- `dotnet build LongevityWorldCup.sln`