### PR TITLE
Align character selection field width

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/play/character-selection.html
+++ b/LongevityWorldCup.Website/wwwroot/play/character-selection.html
@@ -54,7 +54,7 @@
             padding: 0;
             font-size: 1.2rem;
             width: min(100%, 408px);
-            max-width: 400px;
+            max-width: 408px;
             display: flex;
             justify-content: center;
             align-items: center; /* Vertically center the text */


### PR DESCRIPTION
## Summary
- Align the athlete selection search field with the 408px image/action stack width.
- Keep the change CSS-only in `wwwroot/play/character-selection.html`.
- Preserve mobile behavior while cleaning up the desktop first impression.

## Before / After Screenshots

### Desktop
Before:

![Before desktop](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/16c3f0b2a8498697bed1201bc60dd1c5b0073482/pr586-before-desktop-character-selection.png)

After:

![After desktop](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/7ad9194ecdb61f357e2377a64afd630ad972b826/pr586-after-desktop-character-selection.png)

### Mobile
Before:

![Before mobile](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/72a5b2fb00379b7979e5cfe83ab543d5d1d995f4/pr586-before-mobile-character-selection.png)

After:

![After mobile](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/72a5b2fb00379b7979e5cfe83ab543d5d1d995f4/pr586-after-mobile-character-selection.png)

## Validation
- `dotnet build LongevityWorldCup.sln`