### PR TITLE
Fix narrow leaderboard header clipping

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -1545,6 +1545,19 @@
                 padding-right: 0.55rem;
             }
 
+            .leaderboard table th:nth-child(4) {
+                text-align: center;
+                padding-right: 0.25rem;
+            }
+
+            .leaderboard table th:nth-child(4) a {
+                display: inline-block;
+                max-width: 4.8rem;
+                line-height: 1.12;
+                text-align: center;
+                white-space: normal;
+            }
+
             .leaderboard table td.rank-td {
                 padding-left: 0.7rem;
                 padding-right: 0.45rem;


### PR DESCRIPTION
## Summary
- Prevent the mobile leaderboard `Age reduction` header from clipping on 320px-wide screens.
- Center and wrap only the narrow breakpoint header link while keeping age-reduction values right-aligned.
- Keep the change CSS-only in `wwwroot/partials/leaderboard-content.html`.

## Before / After Screenshots

### Mobile 390px
Before:

![Before mobile](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/558f62fa05ccb829b7c50567f6ac22d9220e7dc0/pr587-before-mobile-leaderboard-header.png)

After:

![After mobile](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/558f62fa05ccb829b7c50567f6ac22d9220e7dc0/pr587-after-mobile-leaderboard-header.png)

### Narrow 320px
Before:

![Before narrow](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/cf9aaf699b9e44ae9e251998327c02f57a2c511d/pr587-before-narrow-leaderboard-header.png)

After:

![After narrow](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/e4a2fd06646365f8610c4e50bb9e5ece4a5efbc2/pr587-after-narrow-leaderboard-header.png)

## Validation
- `dotnet build LongevityWorldCup.sln`