### PR TITLE
Reduce redundant events page header

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/event-board/event-board.html
+++ b/LongevityWorldCup.Website/wwwroot/event-board/event-board.html
@@ -3,10 +3,19 @@
 <head>
     <title>Longevity World Cup - Event Board</title>
     <!--HEAD-->
+    <style>
+        .event-board-page .events-board thead {
+            display: none;
+        }
+
+        .event-board-page .events-board table {
+            padding-bottom: 0;
+        }
+    </style>
 </head>
 <body>
 <!--HEADER-->
-<main>
+<main class="event-board-page">
     <h1 id="eventBoardTitle">Highlights</h1>
     <!--EVENT-BOARD-CONTENT-->
     <div class="options-container" data-aos="fade" data-aos-duration="700" data-aos-delay="700">


### PR DESCRIPTION
## Summary
- Hide the repeated board header on the standalone Events page so the page title is the single visible `Highlights` label.
- Keep the shared event-board partial untouched; the styling is scoped to `event-board.html` only.
- Remove extra bottom padding from the standalone board table so the content card feels tighter.

## Before / After Screenshots

### Desktop
Before:

![Before desktop](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/4029b97cc29cf03512c5b9c2981b84f8a0bb1ba2/pr588-before-desktop-events-page.png)

After:

![After desktop](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/1d7255ed9d710a97e62d9eaf2b013943899dafb3/pr588-after-desktop-events-page.png)

### Mobile 390px
Before:

![Before mobile](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/5c8ea2bd3421fad3d41af32e77198044db9aae96/pr588-before-mobile-events-page.png)

After:

![After mobile](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/c764ddb006057a10f25e4ea2308693b8687258fc/pr588-after-mobile-events-page.png)

### Narrow 320px
Before:

![Before narrow](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/79363fcca877b33373ffe4a11181d68719904e92/pr588-before-narrow-events-page.png)

After:

![After narrow](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/62b88e0d6399d4115053a279df052b29e5c53ba5/pr588-after-narrow-events-page.png)

## Validation
- `dotnet build LongevityWorldCup.sln`