### PR TITLE
Hide empty proof preview frame

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/play/proof-upload.html
+++ b/LongevityWorldCup.Website/wwwroot/play/proof-upload.html
@@ -16,6 +16,11 @@
             text-align: center;
         }
 
+            #proofImageContainer:empty,
+            #proofImageContainer:not(:has(img)) {
+                display: none !important;
+            }
+
             #proofImageContainer div {
                 position: relative;
                 display: inline-block;


### PR DESCRIPTION
## Summary
- Hide the proof preview fieldset until uploaded proof thumbnails actually exist.
- Remove the empty native-looking frame that appeared between the upload button and proof tracker.
- Keep the change CSS-only in `wwwroot/play/proof-upload.html`.

## Before / After Screenshots

### Desktop
Before:

![Before desktop](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/c4fe22c9063a1c101321e2ce55ab557a606fb0c7/pr589-before-desktop-proof-upload.png)

After:

![After desktop](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/5a886f4d3b92bb1ab7162e8700fd1cb8498f254c/pr589-after-desktop-proof-upload.png)

### Mobile 390px
Before:

![Before mobile](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/b48b1a008a403e87420f835f7d3f8301f2327cf4/pr589-before-mobile-proof-upload.png)

After:

![After mobile](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/4145e762eb42f8adcc14282a6ac698c1d34f016d/pr589-after-mobile-proof-upload.png)

### Narrow 320px
Before:

![Before narrow](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/db8c1ac66f425dad7efefff4aad127d74c420e95/pr589-before-narrow-proof-upload.png)

After:

![After narrow](https://gist.githubusercontent.com/nopara73/db2b375de3dd9a1caf763512b2c97d8b/raw/70afec84d48e33ddef7ad873afa24ae99c74c207/pr589-after-narrow-proof-upload.png)

## Validation
- `dotnet build LongevityWorldCup.sln`