### PR TITLE
[codex] Mobile roughness

### DIFF
--- a/LongevityWorldCup.Website/Middleware/HtmlInjectionMiddleware.cs
+++ b/LongevityWorldCup.Website/Middleware/HtmlInjectionMiddleware.cs
@@ -113,7 +113,7 @@ namespace LongevityWorldCup.Website.Middleware
             var optionalHeadScripts = BuildOptionalHeadScripts(config);
             var modulesBootstrap = BuildModulesBootstrap(config);
 
-            return ApplySharedAssetPlaceholders(html)
+            return ApplySharedCssPlaceholders(ApplySharedAssetPlaceholders(html))
                 .Replace("{{OPTIONAL_HEAD_SCRIPTS}}", optionalHeadScripts)
                 .Replace("{{MODULES_BOOTSTRAP}}", modulesBootstrap)
                 .Replace("{{ASSET_FAVICON_ICO}}", _assetVersionProvider.AppendVersion("/assets/favicon.ico"))
@@ -139,6 +139,12 @@ namespace LongevityWorldCup.Website.Middleware
         {
             return html
                 .Replace("{{ASSET_FAVICON_128}}", _assetVersionProvider.AppendVersion("/assets/favicon-128x128.png"));
+        }
+
+        private string ApplySharedCssPlaceholders(string html)
+        {
+            return html
+                .Replace("{{ASSET_MOBILE_ROUGHNESS_CSS}}", _assetVersionProvider.AppendVersion("/css/mobile-roughness.css"));
         }
 
         private string BuildOptionalHeadScripts(HeadAssetConfig config)

--- a/LongevityWorldCup.Website/wwwroot/css/bioageform.css
+++ b/LongevityWorldCup.Website/wwwroot/css/bioageform.css
@@ -1,6 +1,7 @@
 /* Add these styles inside your <style> tag */
 .bioageform {
-    max-width: 600px;
+    width: min(100%, 600px);
+    max-width: calc(100vw - 2rem);
     margin: 2rem auto;
     padding: 1rem;
     background-color: #f9f9f9;
@@ -9,6 +10,8 @@
     flex-direction: column;
     align-items: center; /* Centers the button horizontally */
     position: relative; /* Position relative to make dropdown align correctly */
+    min-width: 0;
+    box-sizing: border-box;
 }
 
     .bioageform label {
@@ -21,6 +24,7 @@
     .bioageform input,
     .bioageform select {
         width: 100%;
+        min-width: 0;
         min-height: 44px;
         padding: 0.65rem 0.75rem;
         margin-top: 0.5rem;
@@ -55,7 +59,10 @@
 /* Responsive adjustments */
 @media (max-width: 600px) {
     .bioageform {
-        padding: 1rem;
+        width: 100%;
+        max-width: calc(100vw - 1.5rem);
+        margin: 1.35rem auto;
+        padding: 0.9rem;
     }
 }
 
@@ -66,8 +73,11 @@
     padding: 1.2rem 1.15rem;
     margin-top: 2rem;
     border-radius: 12px;
-    width: 90%; /* Allow fieldset to fill available space */
+    width: 100%;
+    max-width: 100%;
     box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.85), 0 1px 2px rgba(15, 23, 42, 0.04);
+    min-width: 0;
+    box-sizing: border-box;
 }
 
 .bioageform fieldset:first-of-type {
@@ -88,6 +98,7 @@
     line-height: 1.2;
     box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06);
     white-space: normal;
+    overflow-wrap: anywhere;
 }
 
 .bioageform legend .category-icon {
@@ -101,6 +112,7 @@
 
 .bioageform textarea {
     width: 100%;
+    min-width: 0;
     min-height: 7rem;
     padding: 0.65rem 0.75rem;
     margin-top: 0.5rem;
@@ -111,4 +123,25 @@
     line-height: 1.45;
     resize: vertical; /* Allow users to resize vertically */
     transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+@media (max-width: 420px) {
+    .bioageform {
+        max-width: calc(100vw - 1rem);
+        padding: 0.75rem;
+    }
+
+    .bioageform fieldset {
+        padding: 1rem 0.85rem;
+        margin-top: 1.35rem;
+    }
+
+    .bioageform legend {
+        max-width: 100%;
+        font-size: 0.95rem;
+    }
+
+    .bioageform label {
+        line-height: 1.25;
+    }
 }

--- a/LongevityWorldCup.Website/wwwroot/css/mobile-roughness.css
+++ b/LongevityWorldCup.Website/wwwroot/css/mobile-roughness.css
@@ -1,0 +1,232 @@
+*, *::before, *::after {
+    box-sizing: border-box;
+}
+
+html {
+    max-width: 100%;
+    overflow-x: clip;
+    -webkit-text-size-adjust: 100%;
+    text-size-adjust: 100%;
+    scroll-padding-top: calc(56px + env(safe-area-inset-top, 0px));
+}
+
+body {
+    min-width: 0;
+    max-width: 100%;
+    overflow-x: clip;
+}
+
+main,
+section,
+article,
+aside,
+header,
+footer,
+.content,
+.main-container,
+.options-container {
+    min-width: 0;
+}
+
+img,
+svg,
+canvas,
+video,
+iframe {
+    max-width: 100%;
+}
+
+img,
+video {
+    height: auto;
+}
+
+button,
+[role="button"],
+a,
+input,
+select,
+textarea {
+    touch-action: manipulation;
+}
+
+input,
+select,
+textarea,
+button {
+    max-width: 100%;
+    font: inherit;
+}
+
+input,
+select,
+textarea {
+    font-size: 1rem;
+}
+
+a,
+button,
+[role="button"],
+label {
+    -webkit-tap-highlight-color: rgba(0, 188, 212, 0.18);
+}
+
+a:focus-visible,
+button:focus-visible,
+[role="button"]:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+    outline: 3px solid rgba(0, 188, 212, 0.72);
+    outline-offset: 3px;
+}
+
+[hidden],
+template {
+    display: none !important;
+}
+
+.option-button,
+.join-game,
+.footer-link,
+.sidebar-toggle,
+.sidebar-close,
+.clear-icon,
+.close,
+.personal-link-icon,
+dialog button,
+input[type="button"],
+input[type="submit"],
+input[type="reset"] {
+    min-height: 44px;
+}
+
+.personal-link-icon {
+    min-width: 44px;
+}
+
+.option-button,
+.join-game {
+    white-space: normal;
+    overflow-wrap: anywhere;
+}
+
+.visually-hidden {
+    overflow: hidden !important;
+}
+
+@supports (height: 100dvh) {
+    .modal,
+    dialog[open] {
+        max-height: 100dvh;
+    }
+}
+
+@media (hover: none), (pointer: coarse) {
+    a:hover,
+    button:hover,
+    [role="button"]:hover,
+    .option-button:hover,
+    .join-game:hover,
+    .footer-link:hover,
+    .leaderboard table tbody tr:hover,
+    .track-card:hover {
+        transform: none !important;
+    }
+
+    .badge-class:hover,
+    .modal-badge-item:hover .modal-badge-name {
+        transform: none !important;
+    }
+}
+
+@media (max-width: 768px) {
+    body {
+        min-height: 100svh;
+    }
+
+    main {
+        width: 100%;
+        padding-left: max(1rem, env(safe-area-inset-left, 0px));
+        padding-right: max(1rem, env(safe-area-inset-right, 0px));
+    }
+
+    h1,
+    h2,
+    h3,
+    .bannertext {
+        overflow-wrap: anywhere;
+        text-wrap: balance;
+    }
+
+    table {
+        max-width: 100%;
+    }
+
+    .dialog,
+    .modal {
+        width: 100%;
+        max-width: 100vw;
+    }
+
+    .dialog-content,
+    dialog {
+        max-width: calc(100vw - 1.5rem);
+        max-height: calc(100dvh - 1.5rem);
+    }
+
+    .autocomplete-items,
+    .suggestions,
+    [role="listbox"] {
+        max-height: min(44vh, 18rem);
+        overscroll-behavior: contain;
+    }
+
+    .leaderboard-view-switcher .view-badge,
+    .join-game.scrolled-button {
+        min-height: 44px;
+    }
+}
+
+@media (max-width: 900px) {
+    a.badge-class,
+    .badge-class.badge-clickable,
+    .badge-class[data-clickable="true"] {
+        min-width: 44px;
+        min-height: 44px;
+    }
+}
+
+@media (max-width: 420px) {
+    main {
+        padding-left: max(0.875rem, env(safe-area-inset-left, 0px));
+        padding-right: max(0.875rem, env(safe-area-inset-right, 0px));
+    }
+
+    .option-button {
+        padding-left: 1rem;
+        padding-right: 1rem;
+    }
+}
+
+@media (max-width: 900px) and (max-height: 480px) and (orientation: landscape) {
+    main {
+        margin-top: 1rem;
+    }
+
+    .dialog-content,
+    dialog {
+        max-height: calc(100dvh - 1rem);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.001ms !important;
+        animation-iteration-count: 1 !important;
+        scroll-behavior: auto !important;
+        transition-duration: 0.001ms !important;
+    }
+}

--- a/LongevityWorldCup.Website/wwwroot/misc-pages/media.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/media.html
@@ -115,7 +115,7 @@
             align-items: center;
             justify-content: center;
             gap: 0.38rem;
-            min-height: 34px;
+            min-height: 44px;
             padding: 0.42rem 0.75rem;
             border: 1px solid rgba(0, 188, 212, 0.34);
             border-radius: 7px;

--- a/LongevityWorldCup.Website/wwwroot/onboarding/bortz-age.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/bortz-age.html
@@ -10,7 +10,7 @@
         .lab-reassurance {
             margin: 1.5rem auto 0;
             width: min(100%, 600px);
-            max-width: 600px;
+            max-width: calc(100vw - 2rem);
             padding: 1rem 1.25rem;
             box-sizing: border-box;
             border-radius: 8px;
@@ -24,7 +24,7 @@
         .lab-access-panel {
             margin: 1rem auto 0;
             width: min(100%, 600px);
-            max-width: 600px;
+            max-width: calc(100vw - 2rem);
             padding: 1.1rem 1.15rem 1rem;
             box-sizing: border-box;
             border-radius: 8px;
@@ -67,7 +67,7 @@
             align-items: center;
             justify-content: center;
             gap: 0.35rem;
-            min-height: 40px;
+            min-height: 44px;
             margin: 0.75rem auto 0;
             padding: 0.45rem 0.85rem;
             box-sizing: border-box;
@@ -184,13 +184,14 @@
                 box-sizing: border-box;
             }
 
-        @media (max-width: 360px) {
+        @media (max-width: 420px) {
             .biomarker-card-content .input-group {
                 flex-wrap: wrap;
             }
 
                 .biomarker-card-content .input-group select {
                     flex: 1 1 8rem;
+                    width: 100%;
                 }
         }
 

--- a/LongevityWorldCup.Website/wwwroot/onboarding/convergence.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/convergence.html
@@ -246,8 +246,9 @@
             position: absolute;
             top: 0.75rem !important;
             right: 0.75rem !important;
-            min-height: 32px;
-            padding: 0.35rem 0.65rem !important;
+            min-height: 44px;
+            min-width: 44px;
+            padding: 0.45rem 0.75rem !important;
             background-color: #b91c1c !important;
             color: var(--light-text-color);
             border: none;
@@ -496,7 +497,7 @@
 
                 <!-- Name Field -->
                 <label for="name">Name</label>
-                <input type="text" id="name" name="name" required aria-required="true" placeholder="Real name or cyber alias — your call">
+                <input type="text" id="name" name="name" required aria-required="true" autocomplete="name" placeholder="Real name or cyber alias — your call">
                 <span id="nameError" class="error-message"></span>
 
                 <!-- Division Field -->
@@ -563,7 +564,7 @@
 
                 <!-- Link to Personal Page (Optional) -->
                 <label for="personalLink">Link (optional)</label>
-                <input type="url" id="personalLink" name="personalLink" placeholder="https://yourwebsite.com">
+                <input type="url" id="personalLink" name="personalLink" inputmode="url" autocomplete="url" placeholder="https://yourwebsite.com">
                 <p class="convergence-helper-text">
                     Provide a link to your personal page, social media profile, or any other online presence you wish to advertise.
                 </p>
@@ -584,7 +585,7 @@
                 <div id="congratsText" class="convergence-application-copy" style="display:none">
                     <strong>Congratulations!</strong> All that's left to do is to provide an email where we can reach you about your application.
                 </div>
-                <input type="email" id="accountEmail" name="accountEmail" required aria-required="true" placeholder="pizza_lover@hungry.com">
+                <input type="email" id="accountEmail" name="accountEmail" required aria-required="true" autocomplete="email" placeholder="pizza_lover@hungry.com">
             </fieldset>
 
             <!-- WHY Field (Initially Hidden) -->

--- a/LongevityWorldCup.Website/wwwroot/onboarding/join-game.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/join-game.html
@@ -220,6 +220,14 @@
         color: #1e293b;
       }
 
+      .track-card-meta dd a {
+        display: inline-flex;
+        align-items: center;
+        min-height: 44px;
+        margin: -0.75rem 0;
+        padding: 0 0.05rem;
+      }
+
       /* "limited time" as a smaller, muted aside */
       .entry-aside {
         font-size: 0.82em;

--- a/LongevityWorldCup.Website/wwwroot/onboarding/pheno-age.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/pheno-age.html
@@ -10,7 +10,7 @@
         .lab-reassurance {
             margin: 1.5rem auto 0;
             width: min(100%, 600px);
-            max-width: 600px;
+            max-width: calc(100vw - 2rem);
             padding: 1rem 1.25rem;
             box-sizing: border-box;
             border-radius: 8px;
@@ -111,13 +111,14 @@
                 box-sizing: border-box;
             }
 
-        @media (max-width: 360px) {
+        @media (max-width: 420px) {
             .biomarker-card-content .input-group {
                 flex-wrap: wrap;
             }
 
                 .biomarker-card-content .input-group select {
                     flex: 1 1 8rem;
+                    width: 100%;
                 }
         }
 

--- a/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
@@ -205,8 +205,9 @@
     .view-all{
         display:inline-flex;
         align-items:center;
-        min-height:2rem;
-        padding:0 .25rem;
+        justify-content:center;
+        min-height:44px;
+        padding:0 .55rem;
         box-sizing:border-box;
         color:var(--events-header-action);
         font-weight:700;
@@ -269,6 +270,15 @@
         transform:none;
         transition-property:box-shadow,background-color;
     }
+    @media (max-width:900px){
+        .events-board table tbody tr:hover,
+        .events-board table tbody tr.group-hover,
+        .events-board table tbody tr.custom-event-row:hover,
+        .events-board table tbody tr.custom-event-row:has(+ tr.custom-event-details:hover),
+        .events-board table tbody tr.custom-event-details:hover{
+            transform:none;
+        }
+    }
 
     .events-board tbody td{
         height:auto;
@@ -302,7 +312,8 @@
     .avatar-fallback{display:inline-flex;align-items:center;justify-content:center;color:#5a6b7b;font-weight:800;font-size:.7rem;text-transform:uppercase;line-height:24px}
     .avatar-link{
         display:inline-flex;align-items:center;justify-content:center;cursor:pointer;
-        min-width:2rem;min-height:2rem;box-sizing:border-box;border-radius:999px;
+        min-width:44px;min-height:44px;box-sizing:border-box;border-radius:999px;
+        margin:-6px;
     }
     .avatar,
     .avatar-fallback{transition:transform .15s ease,box-shadow .15s ease;will-change:transform}
@@ -312,7 +323,8 @@
     .avatar-link:focus .avatar-fallback{transform:scale(1.15);box-shadow:0 2px 6px rgba(0,0,0,.16)}
     .avatar-disabled{
         display:inline-flex;align-items:center;justify-content:center;cursor:default;
-        min-width:2rem;min-height:2rem;box-sizing:border-box;border-radius:999px;
+        min-width:44px;min-height:44px;box-sizing:border-box;border-radius:999px;
+        margin:-6px;
     }
     .avatar-disabled .avatar,.avatar-disabled .avatar-fallback{transition:none;transform:none;box-shadow:0 1px 3px rgba(0,0,0,.12)}
     .avatar-disabled:hover .avatar,.avatar-disabled:focus .avatar,
@@ -361,7 +373,26 @@
     .name-and-rank{display:inline-flex;align-items:baseline;gap:.15rem}
     .event-message .rank-badge{display:inline-flex;align-items:baseline;gap:.15rem;white-space:nowrap}
     .event-message .rank-icon{margin-left:.2rem}
-    .event-message a.placement-link{text-decoration:none}
+    .event-message a.event-athlete-link:not(.avatar-link){
+        display:inline-flex;
+        align-items:center;
+        min-height:44px;
+        min-width:44px;
+        justify-content:center;
+        margin:-11px 0;
+        padding:0 .05rem;
+        line-height:1.1;
+    }
+    .event-message a.placement-link{
+        display:inline-flex;
+        align-items:center;
+        justify-content:center;
+        min-height:44px;
+        min-width:44px;
+        margin:-12px -.3rem;
+        padding:0 .25rem;
+        text-decoration:none;
+    }
     .event-message a.placement-link:hover,
     .event-message a.placement-link:focus{text-decoration:none}
     .event-message a.more-link{
@@ -526,9 +557,9 @@
         align-items:center;
         justify-content:center;
 
-        width:2rem;
-        height:2rem;
-        margin:-.45rem 0 -.45rem .2rem;
+        width:44px;
+        height:44px;
+        margin:-.82rem 0 -.82rem .2rem;
         padding:0;
 
         color:var(--events-text);

--- a/LongevityWorldCup.Website/wwwroot/partials/head.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/head.html
@@ -50,6 +50,7 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js" defer></script>
 
 <link rel="stylesheet" href="{{ASSET_BADGES_CSS}}">
+<link rel="stylesheet" href="{{ASSET_MOBILE_ROUGHNESS_CSS}}">
 
 <script>
     window.modulesReady = Promise.resolve();

--- a/LongevityWorldCup.Website/wwwroot/partials/header.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/header.html
@@ -210,7 +210,7 @@
         transform: none;
         z-index: 1000;
         margin-top: 0;
-        min-height: 2.25rem;
+        min-height: 44px;
         padding: 0.55rem 1rem;
         box-sizing: border-box;
         font-size: 1rem;
@@ -344,8 +344,9 @@
         border: none;
         box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1); /* Subtle shadow */
         transition: background 0.3s ease, box-shadow 0.3s ease, transform 0.2s ease;
-        width: 100px; /* Match "Next" button width */
-        height: 40px; /* Match "Next" button height */
+        min-width: 100px; /* Match "Next" button width */
+        min-height: 44px;
+        height: auto;
         font-size: 1rem; /* Adjust font size for consistency */
         padding: 0.5rem 1.5rem;
         border-radius: 30px; /* Keep consistent rounding */
@@ -368,8 +369,10 @@
         font-weight: bold;
         background: none;
         border: none;
-        width: 40px; /* Set width */
-        height: 40px; /* Set height */
+        min-width: 44px;
+        min-height: 44px;
+        width: 44px;
+        height: 44px;
         display: flex;
         align-items: center;
         justify-content: center;
@@ -412,9 +415,11 @@
     #custom-alert {
         border: none;
         border-radius: 15px;
-        padding: 20px;
+        padding: max(20px, env(safe-area-inset-top)) max(20px, env(safe-area-inset-right)) max(20px, env(safe-area-inset-bottom)) max(20px, env(safe-area-inset-left));
         max-width: 400px;
         width: 90%;
+        max-height: calc(100dvh - 1.5rem);
+        overflow: auto;
         background: var(--card-bg);
         color: var(--dark-text-color);
         text-align: center;
@@ -439,6 +444,7 @@
             display: block;
             margin: 0 auto;
             padding: 0.7rem 1.5rem;
+            min-height: 44px;
             font-size: 1rem;
             background: var(--main-action-color);
             color: var(--light-text-color);
@@ -518,8 +524,9 @@
     #loading-dialog {
         border: none;
         border-radius: 15px;
-        padding: 2rem;
+        padding: max(2rem, env(safe-area-inset-top)) max(2rem, env(safe-area-inset-right)) max(2rem, env(safe-area-inset-bottom)) max(2rem, env(safe-area-inset-left));
         max-width: 200px;
+        max-height: calc(100dvh - 1.5rem);
         background: var(--card-bg);
         box-shadow: 0 4px 6px rgba(0,0,0,0.1);
         text-align: center;
@@ -620,13 +627,13 @@
         }
 
         .header-link > .main-logo-image {
-            width: clamp(88px, 25vw, 108px);
+            width: 96px;
             margin-bottom: 0.85rem;
         }
 
         .bannertext {
-            font-size: clamp(2.2rem, 10vw, 2.55rem);
-            letter-spacing: 0.035em;
+            font-size: 2.35rem;
+            letter-spacing: 0;
             max-width: calc(100vw - 1.5rem);
             padding-inline: 0.5rem;
         }
@@ -644,8 +651,8 @@
 
     @media (max-width: 600px) {
         .bannertext {
-            font-size: clamp(1.85rem, 6vw, 2.05rem);
-            letter-spacing: 0.025em;
+            font-size: 2rem;
+            letter-spacing: 0;
             max-width: calc(100vw - 1.25rem);
         }
 
@@ -665,12 +672,12 @@
         }
 
         .header-link > .main-logo-image {
-            width: clamp(78px, 23vw, 94px);
+            width: 86px;
             margin-bottom: 0.7rem;
         }
 
         .bannertext {
-            font-size: clamp(1.85rem, 8vw, 2.05rem);
+            font-size: 1.9rem;
             line-height: 1.05;
             max-width: calc(100vw - 1.25rem);
         }
@@ -694,12 +701,12 @@
         }
 
         .header-link > .main-logo-image {
-            width: clamp(62px, 11vw, 76px);
+            width: 68px;
             margin-bottom: 0.5rem;
         }
 
         .bannertext {
-            font-size: clamp(1.9rem, 6vw, 2.35rem);
+            font-size: 2rem;
             line-height: 1.02;
         }
 

--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -1588,6 +1588,55 @@
         .leaderboard .portrait{ width:44px; height:44px; }
     }
 
+    @media (min-width: 769px) and (max-width: 900px){
+        .content{
+            padding-left:max(1rem, env(safe-area-inset-left));
+            padding-right:max(1rem, env(safe-area-inset-right));
+            box-sizing:border-box;
+            width:100%;
+            max-width:100%;
+        }
+        .leaderboard{ overflow:visible; }
+        .leaderboard table{
+            width:100%;
+            max-width:100%;
+            table-layout:auto;
+        }
+        .leaderboard table tbody tr:hover{
+            transform:none;
+        }
+        .leaderboard table .sponsor-th,
+        .leaderboard table .sponsor-td,
+        .leaderboard table .media-contact-th,
+        .leaderboard table .media-contact-td{
+            display:none;
+        }
+        .leaderboard table td .badge-section{ display:none; }
+        .leaderboard table th{
+            font-size:.66rem;
+            line-height:1.05;
+            letter-spacing:.05em;
+            padding:.82rem .55rem;
+        }
+        .leaderboard table td{
+            font-size:.82rem;
+            padding-left:.55rem;
+            padding-right:.55rem;
+        }
+        .leaderboard table th:nth-child(4),
+        .leaderboard table td.age-reduction-td{
+            width:7rem;
+            min-width:7rem;
+            text-align:right;
+            padding-left:.4rem;
+            padding-right:.8rem;
+        }
+        .leaderboard table td.rank-td{
+            padding-left:.8rem;
+            padding-right:.5rem;
+        }
+    }
+
     @media (max-width: 768px){
         .content{
             padding-left:max(1rem, env(safe-area-inset-left));
@@ -1643,12 +1692,13 @@
             padding:1rem 1rem 1.75rem; padding-bottom:calc(env(safe-area-inset-bottom) + 1.75rem);
             position:fixed; top:0; left:0; height:100%; align-items:stretch; border-radius:0 18px 18px 0;
             background:var(--card-bg); z-index:1002; box-shadow:0 18px 42px rgba(0,0,0,.26); overflow-y:auto; transform:translateX(-105%);
-            transition:transform .3s ease-in-out; box-sizing:border-box; overscroll-behavior:contain;
+            visibility:hidden; pointer-events:none;
+            transition:transform .3s ease-in-out, visibility 0s linear .3s; box-sizing:border-box; overscroll-behavior:contain;
         }
         .sidebar.expanded{
             display:block; width:min(82vw, 320px); max-width:calc(100vw - 2rem);
             padding:1rem 1rem 1.75rem; padding-bottom:calc(env(safe-area-inset-bottom) + 1.75rem);
-            transform:translateX(0);
+            transform:translateX(0); visibility:visible; pointer-events:auto; transition-delay:0s;
         }
         .sidebar .filter-section{ display:block; }
         .sidebar .collapsed-title{ display:none; }
@@ -1900,17 +1950,17 @@
             }
         }
 
-        @media (max-width: 300px) {
+        @media (max-width: 420px) {
             .leaderboard table thead {
                 display: none;
             }
 
             .leaderboard table tbody tr:not(.tier-separator) {
                 display: grid;
-                grid-template-columns: 2.2rem minmax(0, 1fr);
+                grid-template-columns: 2.25rem minmax(0, 1fr);
                 align-items: center;
-                row-gap: 0.08rem;
-                padding: 0.58rem 0.7rem;
+                row-gap: 0.12rem;
+                padding: 0.68rem 0.85rem;
             }
 
             .leaderboard table tbody tr:not(.tier-separator):hover {
@@ -1949,13 +1999,13 @@
                 grid-row: 2;
                 width: auto !important;
                 min-width: 0 !important;
-                padding: 0 0 0 calc(32px + 0.45rem) !important;
+                padding: 0 0 0 calc(34px + 0.45rem) !important;
                 text-align: left !important;
             }
 
             .leaderboard .portrait {
-                width: 32px;
-                height: 32px;
+                width: 34px;
+                height: 34px;
             }
 
             .leaderboard .athlete-name {
@@ -1986,7 +2036,7 @@
 
         /* Mobile modal improvements */
         .modal-content{
-            width:100%; padding:15px; margin:0; max-height:100vh; height:100vh; box-sizing:border-box;
+            width:100%; padding:15px; margin:0; max-height:100dvh; height:100dvh; box-sizing:border-box;
             border-radius:0 !important; /* Remove rounded corners on mobile immediately */
             padding-top:max(15px, env(safe-area-inset-top));
             padding-bottom:max(15px, env(safe-area-inset-bottom));
@@ -2064,8 +2114,8 @@
             display:inline-flex; align-items:center; justify-content:center;
         }
         #detailsModal #closeAthleteDetailsModal{
-            top:18px;
-            left:18px;
+            top:max(18px, env(safe-area-inset-top));
+            left:max(18px, env(safe-area-inset-left));
         }
         
         /* Sticky header adjustments for mobile */
@@ -6373,7 +6423,9 @@
 
     function syncSidebarDrawerBackdrop() {
         const isMobileDrawer = window.matchMedia('(max-width: 768px)').matches;
-        document.body.classList.toggle('sidebar-drawer-open', isMobileDrawer && sidebar.classList.contains('expanded'));
+        const isOpenMobileDrawer = isMobileDrawer && sidebar.classList.contains('expanded');
+        document.body.classList.toggle('sidebar-drawer-open', isOpenMobileDrawer);
+        sidebar.setAttribute('aria-hidden', isMobileDrawer && !isOpenMobileDrawer ? 'true' : 'false');
     }
 
     function getSidebarFocusableControls() {
@@ -6418,6 +6470,7 @@
         if (!sidebar.classList.contains('expanded')) {
             sidebar.classList.add('expanded');
         }
+        sidebar.setAttribute('aria-hidden', 'false');
         if (!sidebarToggle.classList.contains('active')) {
             sidebarToggle.classList.add('active')
         }
@@ -6452,6 +6505,7 @@
 
     function closeSidebar(options = {}) {
         sidebar.classList.remove('expanded');
+        sidebar.setAttribute('aria-hidden', 'true');
         sidebarToggle.classList.remove('active');
         sidebar.classList.remove('partially-expanded');
         if (!sidebar.classList.contains('button-collapsed')) {
@@ -6482,6 +6536,7 @@
         }, 50);
     }
 
+    syncSidebarDrawerBackdrop();
     window.addEventListener('resize', syncSidebarDrawerBackdrop);
 
     // Sidebar swipe gesture

--- a/LongevityWorldCup.Website/wwwroot/play/edit-profile.html
+++ b/LongevityWorldCup.Website/wwwroot/play/edit-profile.html
@@ -152,6 +152,8 @@
             padding: 1.25rem;
             width: min(calc(100vw - 2rem), 430px);
             max-width: 430px;
+            max-height: calc(100dvh - 1.5rem);
+            overflow: auto;
             border: 1px solid rgba(15, 23, 42, 0.12);
             border-radius: 8px;
             box-shadow: 0 24px 60px rgba(15, 23, 42, 0.28);
@@ -199,7 +201,7 @@
             top: 0;
             left: 0;
             width: 100vw;
-            height: 100vh;
+            height: 100dvh;
             background: rgba(15, 23, 42, 0.58);
             backdrop-filter: blur(4px);
             -webkit-backdrop-filter: blur(4px);
@@ -296,6 +298,7 @@
 
             #changeProfileCropperModal {
                 width: calc(100vw - 1.5rem);
+                max-height: calc(100dvh - 1rem);
                 padding: 1rem;
             }
 
@@ -346,6 +349,7 @@
                 <input type="text"
                        id="personalLinkInput"
                        name="personalLink"
+                       inputmode="url"
                        autocomplete="off"
                        placeholder="Enter personal link…">
                 <button id="restorePersonalLinkBtn" class="option-button icon-only" style="display:none" title="Restore personal link">

--- a/LongevityWorldCup.Website/wwwroot/play/proof-upload.html
+++ b/LongevityWorldCup.Website/wwwroot/play/proof-upload.html
@@ -198,8 +198,9 @@
                 position: absolute;
                 top: 0.75rem !important;
                 right: 0.75rem !important;
-                min-height: 32px;
-                padding: 0.35rem 0.65rem !important;
+                min-height: 44px;
+                min-width: 44px;
+                padding: 0.45rem 0.75rem !important;
                 background-color: #b91c1c !important;
                 color: var(--light-text-color);
                 border: none;

--- a/LongevityWorldCup.Website/wwwroot/privacy-policy.html
+++ b/LongevityWorldCup.Website/wwwroot/privacy-policy.html
@@ -22,6 +22,8 @@
 
         body {
             margin: 0;
+            max-width: 100%;
+            overflow-x: clip;
             font-family: Roboto, Arial, sans-serif;
             background:
                 radial-gradient(circle at top right, rgba(114, 193, 107, 0.14), transparent 30%),
@@ -32,22 +34,23 @@
 
         .wrap {
             width: min(820px, calc(100% - 32px));
-            margin: clamp(24px, 5vw, 48px) auto 64px;
+            margin: 32px auto 64px;
         }
 
         .card {
             background: rgba(23, 27, 34, 0.92);
             border: 1px solid var(--line);
             border-radius: 18px;
-            padding: clamp(24px, 5vw, 40px);
+            padding: 32px;
             box-shadow: 0 20px 70px rgba(0, 0, 0, 0.35);
         }
 
         h1 {
             margin: 0 0 8px;
             font-family: Orbitron, Roboto, Arial, sans-serif;
-            font-size: clamp(28px, 5vw, 42px);
+            font-size: 2.4rem;
             line-height: 1.15;
+            overflow-wrap: anywhere;
         }
 
         h2 {
@@ -112,6 +115,10 @@
             .card {
                 border-radius: 16px;
                 padding: 22px 20px 28px;
+            }
+
+            h1 {
+                font-size: 2rem;
             }
 
             .meta {

--- a/LongevityWorldCup.Website/wwwroot/unsubscribe.html
+++ b/LongevityWorldCup.Website/wwwroot/unsubscribe.html
@@ -10,8 +10,8 @@
 
         .unsubscribe-panel {
             max-width: 620px;
-            margin: clamp(1.75rem, 5vw, 3rem) auto;
-            padding: clamp(1.5rem, 4vw, 2.25rem);
+            margin: 2.25rem auto;
+            padding: 2rem;
             background: rgba(255, 255, 255, 0.84);
             border: 1px solid rgba(255, 255, 255, 0.68);
             border-radius: 16px;
@@ -22,7 +22,9 @@
         .unsubscribe-panel h1 {
             margin-top: 0;
             margin-bottom: 0.8rem;
-            font-size: clamp(2rem, 4vw, 2.65rem);
+            font-size: 2.5rem;
+            line-height: 1.12;
+            overflow-wrap: anywhere;
         }
 
         .unsubscribe-panel h1[data-aos]:not(.aos-animate) {


### PR DESCRIPTION
## Summary

Completes the mobile roughness pass for public and play surfaces:

- Adds a versioned shared `mobile-roughness.css` guardrail stylesheet through the existing `HtmlInjectionMiddleware` asset flow.
- Tightens responsive layout, touch targets, drawer/modal safe-area behavior, small-screen typography, form controls, event feed links, leaderboard landscape handling, and standalone static pages.
- Improves mobile keyboard hints/autofill metadata for profile/application inputs and keeps dense leaderboard/event data scannable without horizontal page overflow.
- Follow-up regression pass fixed media-kit download button height and join-page clock documentation touch targets.

## Validation

- `dotnet build LongevityWorldCup.sln`
- `dotnet test LongevityWorldCup.sln` (no test projects in this solution; restore completed successfully)
- `git diff --check`
- Local browser regression audit over 18 scoped routes x 5 mobile/landscape viewports: 90 checks, 0 horizontal overflow failures, 0 touch-target failures.
- Verified rendered HTML loads `/css/mobile-roughness.css` through the versioned asset placeholder.

Note: in-app browser screenshot capture timed out during visual capture attempts, but DOM/viewport auditing completed successfully.
