### PR TITLE
[codex] Improve mobile camera upload hints

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/js/proof-helpers.js
+++ b/LongevityWorldCup.Website/wwwroot/js/proof-helpers.js
@@ -99,8 +99,10 @@ window.getProofChecklistLabelsFromSession = function () {
     }
 };
 
-window.setupProofUploadHTML = function (nextButton, uploadProofButton, proofPicInput, proofImageContainer, proofPics, biomarkerChecklistContainer, biomarkers) {
+window.setupProofUploadHTML = function (nextButton, uploadProofButton, proofPicInput, proofImageContainer, proofPics, biomarkerChecklistContainer, biomarkers, options) {
     nextButton.disabled = true;
+    const cameraButton = options && options.cameraButton;
+    const cameraInput = options && options.cameraInput;
     const proofOptimizationOptions = {
         maxSize: 2560,
         quality: 0.88,
@@ -127,85 +129,102 @@ window.setupProofUploadHTML = function (nextButton, uploadProofButton, proofPicI
         uploadProofButton.setAttribute('data-listener', 'true');
     }
 
-    // Handle the image upload (without cropping)
-    if (proofPicInput && !proofPicInput.hasAttribute('data-listener')) {
-        proofPicInput.addEventListener('change', async function (event) {
-            showLoading();
-            try {
-                const files = event.target.files;
-                if (files.length > 0) {
-                    // Limit the total number of images to 9
-                    if (proofPics.length + files.length > 9) {
-                        customAlert('You can upload a maximum of 9 images.');
-                        return;
+    if (cameraButton && cameraInput && !cameraButton.hasAttribute('data-listener')) {
+        cameraButton.addEventListener('click', function () {
+            cameraInput.click();
+        });
+        cameraButton.setAttribute('data-listener', 'true');
+    }
+
+    const handleProofFiles = async function (files, input) {
+        showLoading();
+        try {
+            if (files.length > 0) {
+                // Limit the total number of images to 9
+                if (proofPics.length + files.length > 9) {
+                    customAlert('You can upload a maximum of 9 images.');
+                    return;
+                }
+
+                // helper to read a File as dataURL
+                const readDataURL = file => new Promise((res, rej) => {
+                    const r = new FileReader();
+                    r.onload = e => res(e.target.result);
+                    r.onerror = rej;
+                    r.readAsDataURL(file);
+                });
+
+                // process one by one to preserve order
+                for (const file of Array.from(files)) {
+                    const raw = await readDataURL(file);
+                    if (file.type === 'application/pdf') {
+                        // read file as arrayBuffer
+                        const arrayBuffer = await file.arrayBuffer();
+                        // load PDF
+                        const loadingTask = pdfjsLib.getDocument({ data: arrayBuffer });
+                        const pdfDoc = await loadingTask.promise;
+                        // render each page
+                        for (let pageNum = 1; pageNum <= pdfDoc.numPages; pageNum++) {
+                            const page = await pdfDoc.getPage(pageNum);
+                            const viewport = page.getViewport({ scale: 1.5 });
+                            const canvas = document.createElement('canvas');
+                            canvas.width = viewport.width;
+                            canvas.height = viewport.height;
+                            const context = canvas.getContext('2d');
+                            await page.render({ canvasContext: context, viewport }).promise;
+                            const rawPage = canvas.toDataURL();
+                            const { dataUrl: optimizedPage } = await window.optimizeImageClient(rawPage, proofOptimizationOptions);
+                            if (optimizedPage) {
+                                proofPics.push(optimizedPage);
+                            }
+                        }
+                        updateProofImageContainer(proofImageContainer, nextButton, proofPics, uploadProofButton, cameraButton);
+                        checkProofImages(nextButton, proofPics, uploadProofButton, cameraButton);
+                        continue;
                     }
 
-                    // helper to read a File as dataURL
-                    const readDataURL = file => new Promise((res, rej) => {
-                        const r = new FileReader();
-                        r.onload = e => res(e.target.result);
-                        r.onerror = rej;
-                        r.readAsDataURL(file);
-                    });
-
-                    // process one by one to preserve order
-                    for (const file of Array.from(files)) {
-                        const raw = await readDataURL(file);
-                        if (file.type === 'application/pdf') {
-                            // read file as arrayBuffer
-                            const arrayBuffer = await file.arrayBuffer();
-                            // load PDF
-                            const loadingTask = pdfjsLib.getDocument({ data: arrayBuffer });
-                            const pdfDoc = await loadingTask.promise;
-                            // render each page
-                            for (let pageNum = 1; pageNum <= pdfDoc.numPages; pageNum++) {
-                                const page = await pdfDoc.getPage(pageNum);
-                                const viewport = page.getViewport({ scale: 1.5 });
-                                const canvas = document.createElement('canvas');
-                                canvas.width = viewport.width;
-                                canvas.height = viewport.height;
-                                const context = canvas.getContext('2d');
-                                await page.render({ canvasContext: context, viewport }).promise;
-                                const rawPage = canvas.toDataURL();
-                                const { dataUrl: optimizedPage } = await window.optimizeImageClient(rawPage, proofOptimizationOptions);
-                                if (optimizedPage) {
-                                    proofPics.push(optimizedPage);
-                                }
-                            }
-                            updateProofImageContainer(proofImageContainer, nextButton, proofPics, uploadProofButton);
-                            checkProofImages(nextButton, proofPics, uploadProofButton);
-                            continue;
-                        }
-
-                        const { dataUrl } = await window.optimizeImageClient(raw, proofOptimizationOptions);
-                        if (dataUrl) {
-                            proofPics.push(dataUrl);
-                            updateProofImageContainer(proofImageContainer, nextButton, proofPics, uploadProofButton);
-                            checkProofImages(nextButton, proofPics, uploadProofButton);
-                        }
+                    const { dataUrl } = await window.optimizeImageClient(raw, proofOptimizationOptions);
+                    if (dataUrl) {
+                        proofPics.push(dataUrl);
+                        updateProofImageContainer(proofImageContainer, nextButton, proofPics, uploadProofButton, cameraButton);
+                        checkProofImages(nextButton, proofPics, uploadProofButton, cameraButton);
                     }
                 }
-                // Reset the file input's value to allow re-uploading the same file if needed
-                proofPicInput.value = "";
-            } finally {
-                hideLoading();
             }
+            // Reset the file input's value to allow re-uploading the same file if needed
+            input.value = "";
+        } finally {
+            hideLoading();
+        }
+    };
+
+    // Handle proof uploads (without cropping)
+    if (proofPicInput && !proofPicInput.hasAttribute('data-listener')) {
+        proofPicInput.addEventListener('change', async function (event) {
+            await handleProofFiles(event.target.files, proofPicInput);
         });
         proofPicInput.setAttribute('data-listener', 'true');
+    }
+
+    if (cameraInput && !cameraInput.hasAttribute('data-listener')) {
+        cameraInput.addEventListener('change', async function (event) {
+            await handleProofFiles(event.target.files, cameraInput);
+        });
+        cameraInput.setAttribute('data-listener', 'true');
     }
 
     proofImageContainer.style.display = 'block';
 
     // Display any existing proof images
-    updateProofImageContainer(proofImageContainer, nextButton, proofPics, uploadProofButton);
+    updateProofImageContainer(proofImageContainer, nextButton, proofPics, uploadProofButton, cameraButton);
 
     generateBiomarkerChecklist(biomarkerChecklistContainer, biomarkers);
 
     // Check if proof images already exist
-    checkProofImages(nextButton, proofPics, uploadProofButton);
+    checkProofImages(nextButton, proofPics, uploadProofButton, cameraButton);
 }
 
-function updateProofImageContainer(container, nextButton, proofPics, uploadProofButton) {
+function updateProofImageContainer(container, nextButton, proofPics, uploadProofButton, cameraButton) {
     container.innerHTML = '';
     // Use the global `proofPics` variable directly
     if (proofPics.length > 0) {
@@ -224,9 +243,9 @@ function updateProofImageContainer(container, nextButton, proofPics, uploadProof
             removeButton.style = 'position: absolute; top: 5px; right: 5px; background-color: rgba(255, 0, 0, 0.7); color: var(--light-text-color); border: none; border-radius: 3px; cursor: pointer;';
             removeButton.addEventListener('click', function () {
                 proofPics.splice(i, 1);
-                updateProofImageContainer(container, nextButton, proofPics, uploadProofButton);
+                updateProofImageContainer(container, nextButton, proofPics, uploadProofButton, cameraButton);
                 // Check proof images
-                checkProofImages(nextButton, proofPics, uploadProofButton);
+                checkProofImages(nextButton, proofPics, uploadProofButton, cameraButton);
             });
 
             imgContainer.appendChild(img);
@@ -236,21 +255,21 @@ function updateProofImageContainer(container, nextButton, proofPics, uploadProof
     }
 }
 
-function checkProofImages(nextButton, proofPics, uploadProofButton) {
+function checkProofImages(nextButton, proofPics, uploadProofButton, cameraButton) {
     if (proofPics.length > 0) {
         nextButton.disabled = false;
-        updateProofUploadButtons(nextButton, uploadProofButton);
+        updateProofUploadButtons(nextButton, uploadProofButton, cameraButton);
     } else {
         nextButton.disabled = true;
-        updateProofUploadButtons(nextButton, uploadProofButton);
+        updateProofUploadButtons(nextButton, uploadProofButton, cameraButton);
     }
 }
 
-window.updateProofUploadButtons = function (nextButton, uploadProofButton) {
-    // Toggle "green" class for "Upload Profile Picture" button
+window.updateProofUploadButtons = function (nextButton, uploadProofButton, cameraButton) {
     if (!nextButton || !uploadProofButton) return;
     // second argument to toggle is a boolean: add if true, remove if false
     uploadProofButton.classList.toggle('green', nextButton.disabled);
+    if (cameraButton) cameraButton.classList.toggle('green', nextButton.disabled);
 }
 
 function generateBiomarkerChecklist(biomarkerChecklistContainer, biomarkers) {

--- a/LongevityWorldCup.Website/wwwroot/onboarding/convergence.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/convergence.html
@@ -155,6 +155,39 @@
             box-sizing: border-box;
         }
 
+        #proofUploadSection .camera-capture-action {
+            display: none;
+        }
+
+        #takeProfileSelfieButton {
+            display: none;
+        }
+
+        .upload-choice-divider {
+            display: none;
+            align-items: center;
+            justify-content: center;
+            gap: 0.65rem;
+            min-height: 1.25rem;
+            color: #64748b;
+            font-size: 0.85rem;
+            font-weight: 700;
+            line-height: 1;
+            text-transform: uppercase;
+        }
+
+        .upload-choice-divider::before,
+        .upload-choice-divider::after {
+            content: "";
+            height: 1px;
+            flex: 1 1 auto;
+            background: rgba(100, 116, 139, 0.22);
+        }
+
+        .convergence-upload-action .option-button i {
+            margin-right: 0.45rem;
+        }
+
         .convergence-crop-preview {
             width: min(100%, 408px);
             max-width: 408px;
@@ -452,6 +485,17 @@
             }
         }
 
+        @media (pointer: coarse) {
+            #takeProfileSelfieButton,
+            #proofUploadSection .camera-capture-action {
+                display: inline-flex;
+            }
+
+            .upload-choice-divider {
+                display: flex;
+            }
+        }
+
     </style>
 </head>
 <body>
@@ -535,7 +579,16 @@
                     </ol>
                     <div class="convergence-upload-action">
                         <input type="file" id="profilePicInput" accept="image/*" style="display: none;">
-                        <button type="button" id="uploadButton" class="option-button grey">Upload profile picture</button>
+                        <input type="file" id="profileCameraInput" accept="image/*" capture="user" style="display: none;">
+                        <button type="button" id="takeProfileSelfieButton" class="option-button grey">
+                            <i class="fa fa-camera"></i>
+                            Take selfie
+                        </button>
+                        <span class="upload-choice-divider" aria-hidden="true">or</span>
+                        <button type="button" id="uploadButton" class="option-button grey">
+                            <i class="fa fa-image"></i>
+                            Upload photo
+                        </button>
                     </div>
                 </div>
                 <div id="croppingPart" style="display:none">
@@ -553,7 +606,16 @@
                 <legend>Proof upload</legend>
                 <div class="convergence-upload-action">
                     <input type="file" id="proofPicInput" accept="image/*,application/pdf" style="display: none;" multiple>
-                    <button type="button" id="uploadProofButton" class="option-button grey">Upload proofs</button>
+                    <input type="file" id="proofCameraInput" accept="image/*" capture="environment" style="display: none;" multiple>
+                    <button type="button" id="takeProofPhotoButton" class="option-button grey camera-capture-action">
+                        <i class="fa fa-camera"></i>
+                        Take photo
+                    </button>
+                    <span class="upload-choice-divider" aria-hidden="true">or</span>
+                    <button type="button" id="uploadProofButton" class="option-button grey">
+                        <i class="fa fa-file-upload"></i>
+                        Upload proof files
+                    </button>
                 </div>
                 <!-- Proof Image Container -->
                 <div id="proofImageContainer"></div>
@@ -623,12 +685,13 @@
 
         function updateUploadButtons() {
             const uploadProofButton = document.getElementById('uploadProofButton');
+            const takeProofPhotoButton = document.getElementById('takeProofPhotoButton');
             const uploadProfileButton = document.getElementById('uploadButton');
             const cropAndSaveButton = document.getElementById('cropButton');
             const nextButton = document.getElementById('nextButton');
 
             updateProfileUploadButtons(nextButton, uploadProfileButton, cropAndSaveButton);
-            window.updateProofUploadButtons(nextButton, uploadProofButton);
+            window.updateProofUploadButtons(nextButton, uploadProofButton, takeProofPhotoButton);
         }
 
         function updateProfileUploadButtons(nextButton, uploadProfileButton, cropAndSaveButton) {
@@ -966,7 +1029,9 @@
                     nextButton.innerHTML = 'Next&nbsp;<i class="fas fa-arrow-right"></i>';
 
                     const uploadProofButton = document.getElementById('uploadProofButton');
+                    const takeProofPhotoButton = document.getElementById('takeProofPhotoButton');
                     const proofPicInput = document.getElementById('proofPicInput');
+                    const proofCameraInput = document.getElementById('proofCameraInput');
                     const proofImageContainer = document.getElementById('proofImageContainer');
                     const biomarkerChecklistContainer = document.getElementById('biomarker-checklist');
 
@@ -979,7 +1044,11 @@
                         proofImageContainer,
                         proofPics,
                         biomarkerChecklistContainer,
-                        checklistLabels
+                        checklistLabels,
+                        {
+                            cameraButton: takeProofPhotoButton,
+                            cameraInput: proofCameraInput
+                        }
                     );
 
                     break;
@@ -1396,6 +1465,14 @@
                 uploadButton.setAttribute('data-listener', 'true');
             }
 
+            const takeProfileSelfieButton = document.getElementById('takeProfileSelfieButton');
+            if (takeProfileSelfieButton && !takeProfileSelfieButton.hasAttribute('data-listener')) {
+                takeProfileSelfieButton.addEventListener('click', function () {
+                    document.getElementById('profileCameraInput').click();
+                });
+                takeProfileSelfieButton.setAttribute('data-listener', 'true');
+            }
+
             // Add click event to the image to trigger file selection
             const illustrationImage = document.getElementById('illustrationImage');
             if (illustrationImage && !illustrationImage.hasAttribute('data-listener')) {
@@ -1407,45 +1484,47 @@
 
             // Handle the image upload and initialize Cropper.js
             const profilePicInput = document.getElementById('profilePicInput');
+            const profileCameraInput = document.getElementById('profileCameraInput');
             let cropper; // Declare Cropper instance at a higher scope
 
+            function handleProfileUploadChange(event) {
+                if (!event.target.files.length) return; // Reset if no file selected
+                const file = event.target.files[0];
+                if (file) {
+                    const reader = new FileReader();
+                    reader.onload = function (e) {
+                        // Disable "Next" button while cropping
+                        const nextButton = document.getElementById('nextButton');
+                        nextButton.disabled = true;
+                        updateUploadButtons();
+
+                        document.getElementById('cropperImage').src = e.target.result;
+
+                        document.getElementById('uploadPart').style.display = 'none';
+                        document.getElementById('croppingPart').style.display = 'block';
+
+                        // Initialize Cropper only once
+                        if (!cropper) {
+                            cropper = new Cropper(document.getElementById('cropperImage'), {
+                                aspectRatio: 1,
+                                viewMode: 1,
+                                autoCropArea: 1,
+                                movable: true,
+                                zoomable: true,
+                                rotatable: false,
+                                scalable: false,
+                                cropBoxResizable: true,
+                                minCropBoxWidth: 200,
+                                minCropBoxHeight: 150,
+                            });
+                        }
+                    };
+                    reader.readAsDataURL(file);
+                }
+            }
+
             if (profilePicInput && !profilePicInput.hasAttribute('data-listener')) {
-                profilePicInput.addEventListener('change', function (event) {
-                    if (!event.target.files.length) return; // Reset if no file selected
-                    const file = event.target.files[0];
-                    if (file) {
-                        const reader = new FileReader();
-                        reader.onload = function (e) {
-                            // Disable "Next" button while cropping
-                            const nextButton = document.getElementById('nextButton');
-                            nextButton.disabled = true;
-                            updateUploadButtons();
-
-                            document.getElementById('cropperImage').src = e.target.result;
-
-                            document.getElementById('uploadPart').style.display = 'none';
-                            document.getElementById('croppingPart').style.display = 'block';
-
-                            // Initialize Cropper only once
-                            if (!cropper) {
-                                cropper = new Cropper(document.getElementById('cropperImage'), {
-                                    aspectRatio: 1,
-                                    viewMode: 1,
-                                    autoCropArea: 1,
-                                    movable: true,
-                                    zoomable: true,
-                                    rotatable: false,
-                                    scalable: false,
-                                    cropBoxResizable: true,
-                                    minCropBoxWidth: 200,
-                                    minCropBoxHeight: 150,
-                                });
-                            }
-                        };
-                        reader.readAsDataURL(file);
-                    }
-                });
-
+                profilePicInput.addEventListener('change', handleProfileUploadChange);
                 // Add the crop button event listener once
                 document.getElementById('cropButton').addEventListener('click', async function () {
                     if (cropper) {
@@ -1476,6 +1555,11 @@
                 });
 
                 profilePicInput.setAttribute('data-listener', 'true');
+            }
+
+            if (profileCameraInput && !profileCameraInput.hasAttribute('data-listener')) {
+                profileCameraInput.addEventListener('change', handleProfileUploadChange);
+                profileCameraInput.setAttribute('data-listener', 'true');
             }
         }
 

--- a/LongevityWorldCup.Website/wwwroot/play/edit-profile.html
+++ b/LongevityWorldCup.Website/wwwroot/play/edit-profile.html
@@ -253,6 +253,49 @@
             flex: 1 1 0;
         }
 
+        #changeProfilePicWrapper {
+            flex-direction: column;
+            align-items: stretch;
+        }
+
+        .upload-choice-divider {
+            display: none;
+            align-items: center;
+            justify-content: center;
+            gap: 0.65rem;
+            min-height: 1.25rem;
+            color: #64748b;
+            font-size: 0.85rem;
+            font-weight: 700;
+            line-height: 1;
+            text-transform: uppercase;
+        }
+
+        .upload-choice-divider::before,
+        .upload-choice-divider::after {
+            content: "";
+            height: 1px;
+            flex: 1 1 auto;
+            background: rgba(100, 116, 139, 0.22);
+        }
+
+        #changeProfilePicWrapper .option-button {
+            width: 100%;
+            max-width: none;
+        }
+
+        #changeProfilePicWrapper .option-button i {
+            margin-right: 0.45rem;
+        }
+
+        #takeProfileSelfieButton {
+            display: none;
+        }
+
+        #restoreProfilePicButton {
+            align-self: center;
+        }
+
         .icon-only {
             flex: 0 0 44px;
             width: 44px;
@@ -305,6 +348,17 @@
             #changeProfileCropperImage {
                 max-height: min(48vh, 320px);
             }
+
+        }
+
+        @media (pointer: coarse) {
+            .upload-choice-divider {
+                display: flex;
+            }
+
+            #takeProfileSelfieButton {
+                display: inline-flex;
+            }
         }
     </style>
 </head>
@@ -321,10 +375,17 @@
         </div>
         <div id="editOptionsGroup" cdata-aos="fade" data-aos-duration="700" data-aos-delay="350">
             <div id="changeProfilePicWrapper" class="options-container inline-option-group">
-                <button id="changeProfilePicButton" class="option-button grey">
-                    Change profile picture
+                <button type="button" id="takeProfileSelfieButton" class="option-button grey">
+                    <i class="fa fa-camera"></i>
+                    Take selfie
+                </button>
+                <span class="upload-choice-divider" aria-hidden="true">or</span>
+                <button type="button" id="changeProfilePicButton" class="option-button grey">
+                    <i class="fa fa-image"></i>
+                    Change photo
                 </button>
                 <input type="file" id="profilePicInputModal" accept="image/*" style="display: none;">
+                <input type="file" id="profileCameraInputModal" accept="image/*" capture="user" style="display: none;">
                 <button id="restoreProfilePicButton" class="option-button icon-only" style="display:none" title="Restore profile picture">
                     <i class="fa fa-undo"></i>
                 </button>
@@ -866,10 +927,17 @@
 
         const changeProfileBtn = document.getElementById('changeProfilePicButton');
         const changeProfileInput = document.getElementById('profilePicInputModal');
+        const takeProfileSelfieBtn = document.getElementById('takeProfileSelfieButton');
+        const profileCameraInput = document.getElementById('profileCameraInputModal');
         changeProfileBtn.addEventListener('click', () => {
             changeProfileInput.click();
         });
-        changeProfileInput.addEventListener('change', (e) => {
+
+        takeProfileSelfieBtn.addEventListener('click', () => {
+            profileCameraInput.click();
+        });
+
+        function handleProfilePictureSelection(e) {
             const file = e.target.files[0];
             if (!file) return;
             const reader = new FileReader();
@@ -889,7 +957,10 @@
                 });
             };
             reader.readAsDataURL(file);
-        });
+        }
+
+        changeProfileInput.addEventListener('change', handleProfilePictureSelection);
+        profileCameraInput.addEventListener('change', handleProfilePictureSelection);
 
         // Crop & Cancel handlers for change-profile
         const cropBtn = document.getElementById('changeProfileCropButton');
@@ -915,6 +986,7 @@
             document.body.classList.remove('no-scroll');
             document.getElementById('changeProfileCropperModal').style.display = 'none';
             changeProfileInput.value = '';
+            profileCameraInput.value = '';
         });
         cancelBtn.addEventListener('click', () => {
             window.changeProfileCropper.destroy();
@@ -922,6 +994,7 @@
             document.body.classList.remove('no-scroll');
             document.getElementById('changeProfileCropperModal').style.display = 'none';
             changeProfileInput.value = '';
+            profileCameraInput.value = '';
         });
 
         function updateSubmitButtonState() {

--- a/LongevityWorldCup.Website/wwwroot/play/proof-upload.html
+++ b/LongevityWorldCup.Website/wwwroot/play/proof-upload.html
@@ -113,6 +113,35 @@
             box-shadow: 0 6px 12px rgba(15, 23, 42, 0.14);
         }
 
+        .proof-upload-primary-action .camera-capture-action {
+            display: none;
+        }
+
+        .proof-upload-primary-action .upload-choice-divider {
+            display: none;
+            align-items: center;
+            justify-content: center;
+            gap: 0.65rem;
+            min-height: 1.25rem;
+            color: #64748b;
+            font-size: 0.85rem;
+            font-weight: 700;
+            line-height: 1;
+            text-transform: uppercase;
+        }
+
+        .proof-upload-primary-action .upload-choice-divider::before,
+        .proof-upload-primary-action .upload-choice-divider::after {
+            content: "";
+            height: 1px;
+            flex: 1 1 auto;
+            background: rgba(100, 116, 139, 0.22);
+        }
+
+        .proof-upload-primary-action .option-button i {
+            margin-right: 0.45rem;
+        }
+
         .proof-upload-primary-action .option-button.green {
             box-shadow: 0 6px 12px rgba(46, 125, 50, 0.18);
         }
@@ -306,6 +335,16 @@
                 padding: 0.8rem 0.95rem;
             }
         }
+
+        @media (pointer: coarse) {
+            .proof-upload-primary-action .camera-capture-action {
+                display: inline-flex;
+            }
+
+            .proof-upload-primary-action .upload-choice-divider {
+                display: flex;
+            }
+        }
     </style>
 </head>
 <body>
@@ -324,8 +363,15 @@
 
         <div class="options-container proof-upload-primary-action" data-aos="fade" data-aos-duration="700" data-aos-delay="450">
             <input type="file" id="proofPicInput" accept="image/*,application/pdf" style="display: none;" multiple>
+            <input type="file" id="proofCameraInput" accept="image/*" capture="environment" style="display: none;" multiple>
+            <button type="button" id="takeProofPhotoButton" class="option-button grey green camera-capture-action">
+                <i class="fa fa-camera"></i>
+                Take photo
+            </button>
+            <span class="upload-choice-divider" aria-hidden="true">or</span>
             <button type="button" id="uploadProofButton" class="option-button grey green">
-                Upload proofs
+                <i class="fa fa-file-upload"></i>
+                Upload proof files
             </button>
         </div>
 
@@ -393,13 +439,18 @@
 
             var submitButton = document.getElementById('submitButton');
             const uploadProofButton = document.getElementById('uploadProofButton');
+            const takeProofPhotoButton = document.getElementById('takeProofPhotoButton');
             const proofPicInput = document.getElementById('proofPicInput');
+            const proofCameraInput = document.getElementById('proofCameraInput');
             const proofImageContainer = document.getElementById('proofImageContainer');
             const biomarkerChecklistContainer = document.getElementById('biomarker-checklist');
 
             // Proof Tracker: biomarkers present in sessionStorage, ordered by bortz-age UI
             const checklistItems = window.getProofChecklistLabelsFromSession && window.getProofChecklistLabelsFromSession() || [];
-            window.setupProofUploadHTML(submitButton, uploadProofButton, proofPicInput, proofImageContainer, proofPics, biomarkerChecklistContainer, checklistItems);
+            window.setupProofUploadHTML(submitButton, uploadProofButton, proofPicInput, proofImageContainer, proofPics, biomarkerChecklistContainer, checklistItems, {
+                cameraButton: takeProofPhotoButton,
+                cameraInput: proofCameraInput
+            });
 
             submitButton.addEventListener('click', async function () {
                 if (!athlete || !athlete.Name) {
@@ -434,8 +485,10 @@
 
                 const submitButton = document.getElementById('submitButton');
                 const uploadProofButton = document.getElementById('uploadProofButton');
+                const takeProofPhotoButton = document.getElementById('takeProofPhotoButton');
                 submitButton.disabled = true;
                 uploadProofButton.disabled = true;
+                if (takeProofPhotoButton) takeProofPhotoButton.disabled = true;
                 submitButton.textContent = 'Submitting...';
                 showLoading();
 
@@ -490,6 +543,7 @@
                                 customAlert(`Failed to submit results. Please try again later.\n\n${badResponse}`).then(() => {
                                     submitButton.disabled = false;
                                     uploadProofButton.disabled = false;
+                                    if (takeProofPhotoButton) takeProofPhotoButton.disabled = false;
                                     setSubmitButtonLabel();
                                 });
                             });
@@ -506,6 +560,7 @@
                         customAlert(`An error occurred:\n\n${error}`).then(() => {
                             submitButton.disabled = false;
                             uploadProofButton.disabled = false;
+                            if (takeProofPhotoButton) takeProofPhotoButton.disabled = false;
                             setSubmitButtonLabel();
                         });
                     });


### PR DESCRIPTION
## What changed

- Added mobile/coarse-pointer camera choices for both existing-athlete pages and the new application flow.
- Profile-photo flows now expose a front/selfie camera path (`capture="user"`) as `Take selfie`.
- Existing-athlete edit profile keeps the replacement action phrased as `Change photo`; the new application flow keeps `Upload photo`.
- Proof-photo flows now expose a rear/environment camera path (`capture="environment"`) as `Take photo`, with the regular `Upload proof files` picker still accepting images and PDFs.
- Made the choice relationship explicit with camera/upload icons and an `or` divider, while keeping camera-labeled buttons hidden on desktop where they fall back to a normal file picker.
- Preserved proof PDF uploads and multi-file proof uploads; proof camera inputs are also marked `multiple` where supported, and the shared handler resets inputs so repeated proof photos can be added one after another.

## Verification

- `dotnet build LongevityWorldCup.sln`
- `node --check LongevityWorldCup.Website/wwwroot/js/proof-helpers.js`
- `git diff --check`
- Restarted the local site at `http://localhost:5080/apply?fake=1`.
- Browser-verified existing-athlete profile uses `capture="user"` and shows `Take selfie` / `or` / `Change photo` on mobile-width review.
- Browser-verified existing-athlete proof upload uses `capture="environment"`, keeps `accept="image/*,application/pdf"`, and keeps `multiple` on the proof file picker.
- Browser-verified new application profile and proof stages show the same mobile choice UI.

## Screenshots / recording

Mobile screenshots were captured locally in Codex for profile and proof upload review; not committed to the repo.

Closes #124