### PR TITLE
Fix proof camera capture hint

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/onboarding/convergence.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/convergence.html
@@ -587,7 +587,7 @@
                         <span class="upload-choice-divider" aria-hidden="true">or</span>
                         <button type="button" id="uploadButton" class="option-button grey">
                             <i class="fa fa-image"></i>
-                            Upload photo
+                            Upload profile picture
                         </button>
                     </div>
                 </div>
@@ -606,15 +606,15 @@
                 <legend>Proof upload</legend>
                 <div class="convergence-upload-action">
                     <input type="file" id="proofPicInput" accept="image/*,application/pdf" style="display: none;" multiple>
-                    <input type="file" id="proofCameraInput" accept="image/*" capture="environment" style="display: none;" multiple>
+                    <input type="file" id="proofCameraInput" accept="image/*" capture="environment" style="display: none;">
                     <button type="button" id="takeProofPhotoButton" class="option-button grey camera-capture-action">
                         <i class="fa fa-camera"></i>
-                        Take photo
+                        Take proof photo
                     </button>
                     <span class="upload-choice-divider" aria-hidden="true">or</span>
                     <button type="button" id="uploadProofButton" class="option-button grey">
                         <i class="fa fa-file-upload"></i>
-                        Upload proof files
+                        Upload proofs
                     </button>
                 </div>
                 <!-- Proof Image Container -->

--- a/LongevityWorldCup.Website/wwwroot/play/edit-profile.html
+++ b/LongevityWorldCup.Website/wwwroot/play/edit-profile.html
@@ -382,7 +382,7 @@
                 <span class="upload-choice-divider" aria-hidden="true">or</span>
                 <button type="button" id="changeProfilePicButton" class="option-button grey">
                     <i class="fa fa-image"></i>
-                    Change photo
+                    Change profile picture
                 </button>
                 <input type="file" id="profilePicInputModal" accept="image/*" style="display: none;">
                 <input type="file" id="profileCameraInputModal" accept="image/*" capture="user" style="display: none;">

--- a/LongevityWorldCup.Website/wwwroot/play/proof-upload.html
+++ b/LongevityWorldCup.Website/wwwroot/play/proof-upload.html
@@ -363,15 +363,15 @@
 
         <div class="options-container proof-upload-primary-action" data-aos="fade" data-aos-duration="700" data-aos-delay="450">
             <input type="file" id="proofPicInput" accept="image/*,application/pdf" style="display: none;" multiple>
-            <input type="file" id="proofCameraInput" accept="image/*" capture="environment" style="display: none;" multiple>
+            <input type="file" id="proofCameraInput" accept="image/*" capture="environment" style="display: none;">
             <button type="button" id="takeProofPhotoButton" class="option-button grey green camera-capture-action">
                 <i class="fa fa-camera"></i>
-                Take photo
+                Take proof photo
             </button>
             <span class="upload-choice-divider" aria-hidden="true">or</span>
             <button type="button" id="uploadProofButton" class="option-button grey green">
                 <i class="fa fa-file-upload"></i>
-                Upload proof files
+                Upload proofs
             </button>
         </div>
 


### PR DESCRIPTION
## What changed

- Removed `multiple` from the dedicated proof camera inputs in both the existing-athlete proof upload page and the new application proof stage.
- Kept `capture="environment"` on those proof camera inputs so mobile browsers get the clearest rear-camera hint.
- Reworded proof actions to separate intent more clearly: `Take proof photo` for a new camera capture, and `Upload proofs` for saved photos/screenshots/PDFs/files.
- Restored explicit profile-picture wording: existing-athlete edit profile says `Change profile picture`; the new application flow starts as `Upload profile picture` and changes to `Change profile picture` after a profile picture has been saved.
- Left the regular proof picker unchanged with `accept="image/*,application/pdf"` and `multiple`, so PDFs, image proof files, and multi-file proof uploads still work.

## Verification

- `dotnet build LongevityWorldCup.sln`
- `node --check LongevityWorldCup.Website/wwwroot/js/proof-helpers.js`
- `git diff --check`
- Restarted local site at `http://localhost:5080/apply?fake=1`.
- Confirmed markup has `capture="environment"` without `multiple` on proof camera inputs, while proof file pickers still have image/PDF + multiple-file support.
- Confirmed profile buttons use profile-picture wording and the application upload button switches to change wording once `profilePic` exists.

## Notes

This is a follow-up to #598. `capture` is still a browser-level hint, and the OS may still offer camera inside its generic file picker, but the dedicated proof camera path now gives the browser the cleanest possible rear-camera request while the secondary proof action uses plural wording for the multi-proof path.