### PR TITLE
Fix application profile picture label state

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/onboarding/convergence.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/convergence.html
@@ -695,13 +695,17 @@
         }
 
         function updateProfileUploadButtons(nextButton, uploadProfileButton, cropAndSaveButton) {
+            if (uploadProfileButton) {
+                uploadProfileButton.innerHTML = `<i class="fa fa-image"></i>${profilePic ? 'Change profile picture' : 'Upload profile picture'}`;
+            }
+
             // Toggle "green" class for "Upload Profile Picture" button
             if (nextButton && nextButton.disabled) {
-                uploadProfileButton.classList.add('green');
-                cropAndSaveButton.classList.add('green');
+                if (uploadProfileButton) uploadProfileButton.classList.add('green');
+                if (cropAndSaveButton) cropAndSaveButton.classList.add('green');
             } else {
-                uploadProfileButton.classList.remove('green');
-                cropAndSaveButton.classList.remove('green');
+                if (uploadProfileButton) uploadProfileButton.classList.remove('green');
+                if (cropAndSaveButton) cropAndSaveButton.classList.remove('green');
             }
         }
 
@@ -1012,6 +1016,7 @@
                         // Enable Next button if profile picture exists
                         nextButton.disabled = false;
                     }
+                    updateUploadButtons();
 
                     // Attach event listeners for upload
                     attachUploadEventListeners();


### PR DESCRIPTION
## What changed

- Fixes the application profile-picture button label after #603 was merged before this final tweak landed.
- The application flow still starts with `Upload profile picture`.
- Once a profile picture has been saved/cropped, the same button now switches to `Change profile picture`.
- Adds null guards while updating the profile upload/crop button state.

## Verification

- `dotnet build LongevityWorldCup.sln`
- `node --check LongevityWorldCup.Website/wwwroot/js/proof-helpers.js`
- `git diff --check`