### PR TITLE
[codex] Make highlights links open in new tabs

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/js/custom-event-markup.js
+++ b/LongevityWorldCup.Website/wwwroot/js/custom-event-markup.js
@@ -223,7 +223,9 @@
                 return escapeHtml(resolvedText);
             },
             link: function (label, href) {
-                return '<a href="' + escapeHtml(href.trim()) + '" target="_top" rel="noopener">' + escapeHtml(label) + "</a>";
+                var target = opts.linkTarget || "_top";
+                var rel = opts.linkRel || "noopener";
+                return '<a href="' + escapeHtml(href.trim()) + '" target="' + escapeHtml(target) + '" rel="' + escapeHtml(rel) + '">' + escapeHtml(label) + "</a>";
             }
         });
     }
@@ -238,6 +240,8 @@
         var opts = options || {};
         return renderMarkup(text, {
             mentionResolver: opts.mentionResolver,
+            linkTarget: "_blank",
+            linkRel: "noopener noreferrer",
             mentionRenderer: function (slug, displayText) {
                 var href = typeof opts.mentionHrefResolver === "function"
                     ? opts.mentionHrefResolver(String(slug || "").trim())


### PR DESCRIPTION
## Summary

Updates custom event webpage markup so links rendered in Highlights open in a new browser tab. The lower-level renderer keeps its existing `_top` default, while the webpage renderer now passes `_blank` and `noopener noreferrer` for ordinary Markdown-style links, matching existing mention-link behavior.

## Impact

Users can click links in Highlights without navigating away from the current Longevity World Cup page. Existing non-webpage markup callers keep their default link target behavior.

## Validation

- Ran a direct Node-based render check for `CustomEventMarkup.renderWebpageMarkup(...)` to confirm ordinary links emit `target="_blank"` and `rel="noopener noreferrer"`.
- Confirmed `CustomEventMarkup.renderMarkup(...)` still emits the existing `target="_top"` default.
- Ran `dotnet build LongevityWorldCup.sln`.