### PR TITLE
[codex] Adjust application submit timeout

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/js/misc.js
+++ b/LongevityWorldCup.Website/wwwroot/js/misc.js
@@ -422,6 +422,8 @@ window.createApplicationSubmissionId = function () {
     return 'submission-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 10);
 };
 
+window.APPLICATION_SUBMISSION_TIMEOUT_MS = 180000;
+
 window.buildApplicationSubmissionReport = function (applicantData, submissionId, phase, submissionKind, error) {
     applicantData = applicantData || {};
     const proofs = Array.isArray(applicantData.proofPics) ? applicantData.proofPics : [];

--- a/LongevityWorldCup.Website/wwwroot/js/misc.js
+++ b/LongevityWorldCup.Website/wwwroot/js/misc.js
@@ -422,7 +422,7 @@ window.createApplicationSubmissionId = function () {
     return 'submission-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 10);
 };
 
-window.APPLICATION_SUBMISSION_TIMEOUT_MS = 180000;
+window.APPLICATION_SUBMISSION_TIMEOUT_MS = 50000;
 
 window.buildApplicationSubmissionReport = function (applicantData, submissionId, phase, submissionKind, error) {
     applicantData = applicantData || {};

--- a/LongevityWorldCup.Website/wwwroot/onboarding/convergence.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/convergence.html
@@ -1378,7 +1378,7 @@
                             'Content-Type': 'application/json'
                         },
                         body: JSON.stringify(applicantData)
-                    }, 21000) // timeout set to 21,000 ms (21 seconds)
+                    }, window.APPLICATION_SUBMISSION_TIMEOUT_MS || 180000)
                         .then(response => {
                             hideLoading();
                             if (response.ok) {

--- a/LongevityWorldCup.Website/wwwroot/play/edit-profile.html
+++ b/LongevityWorldCup.Website/wwwroot/play/edit-profile.html
@@ -724,7 +724,7 @@
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify(applicantData)
-                }, 21000)
+                }, window.APPLICATION_SUBMISSION_TIMEOUT_MS || 180000)
                     .then(response => {
                         hideLoading();
                         if (response.ok) {

--- a/LongevityWorldCup.Website/wwwroot/play/proof-upload.html
+++ b/LongevityWorldCup.Website/wwwroot/play/proof-upload.html
@@ -500,7 +500,7 @@
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify(applicantData)
-                }, 21000)
+                }, window.APPLICATION_SUBMISSION_TIMEOUT_MS || 180000)
                     .then(response => {
                         hideLoading();
                         if (response.ok) {


### PR DESCRIPTION
## Summary

Extends the client-side timeout for application submission requests from 21 seconds to 50 seconds and reuses the same timeout across full applications, result/proof uploads, and profile edit submissions.

## Root Cause

The production submission `d6458e6a-8676-4391-ac3e-815ea121afbc` was not failing on the backend. Server logs show the browser reported `Request timed out` at 2026-05-24 09:20:26 UTC, while the backend finished successfully at 2026-05-24 09:20:51 UTC. The old 21 second browser timeout expired before a large proof batch could finish uploading, optimizing, zipping, emailing, and creating payment state.

## Impact

Large applications get a timeout just above the observed slow successful submission window, reducing false failure alerts without giving requests an overly broad client-side allowance.

## Validation

- Confirmed production logs via SSH for the reported submission: started, client timeout report, then backend success.
- Ran `dotnet build .\LongevityWorldCup.sln` successfully after tightening the timeout to 50 seconds.
- Served `/apply` locally and verified the generated HTML includes the versioned `misc.js` module import carrying the shared timeout constant.