### PR TITLE
[codex] Require age guess in Guess My Age modal

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/partials/guess-my-age.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/guess-my-age.html
@@ -78,6 +78,11 @@
         display: none;
     }
 
+    #detailsModal .modal-content.guess-mode > #closeAthleteDetailsModal,
+    #detailsModal .modal-content.guess-mode > .modal-sticky-header {
+        display: none !important;
+    }
+
     /* during guess mode, hide everything under athlete-profile except pic, name & slider */
     /* .portrait-wrapper contains #modalProfilePic; keep it visible so the picture shows */
     .modal-content.guess-mode .athlete-profile > *:not(#modalProfilePic):not(#guessAgeContainer):not(.portrait-wrapper) {
@@ -1047,8 +1052,6 @@
     </div>
 
     <div class="gma-actions">
-        <button id="gmaSkipAll" class="gma-btn gma-btn--ghost" style="display: none;" title="The Guess my age game will no longer appear for any athlete">Skip all</button>
-        <button class="gma-btn gma-btn--ghost">Skip</button>
         <button class="gma-btn gma-btn--primary">Submit</button>
     </div>
 </div>
@@ -1316,21 +1319,7 @@
 
     });
 
-    // bind hideCard to _all_ ghost buttons (Skip & Skip All)
-    gmaCard.querySelectorAll('.gma-btn--ghost')
-        .forEach(btn => btn.addEventListener('click', hideCard));
-    const gmaSkipAll = document.getElementById('gmaSkipAll');
-    if (gmaSkipAll) {
-        gmaSkipAll.addEventListener('click', hideCard);
-    }
-
     function hideCard(e) {
-        // if they clicked “Skip All”, set global flag
-        const isSkipAll = e.currentTarget.id === 'gmaSkipAll';
-        if (isSkipAll) {
-            localStorage.setItem('gmaSkipAll', 'true');
-        }
-
         const modalContent = document.querySelector('.modal-content');
         const athleteSlug = modalContent.dataset.athleteSlug;
 
@@ -1340,13 +1329,12 @@
             : gmaRange.value;
 
         let allGuesses = JSON.parse(localStorage.getItem('gmaAllGuesses') || '{}');
-        const isSkip = e.currentTarget.classList.contains('gma-btn--ghost');
 
         allGuesses[athleteSlug] = {
-            value: isSkip ? null : guessValue,
-            skipped: isSkip,
-            first: !isSkip && Boolean(e.isFirstGuess),
-            exact: !isSkip && Boolean(e.isExactGuess)
+            value: guessValue,
+            skipped: false,
+            first: Boolean(e.isFirstGuess),
+            exact: Boolean(e.isExactGuess)
         };
         localStorage.setItem('gmaAllGuesses', JSON.stringify(allGuesses));
         updateYourGuess();  // ← Add this line

--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -2597,6 +2597,10 @@
         }
     }
 
+    function hasSubmittedGuessForGuessMyAge(guessData) {
+        return Boolean(guessData && guessData.skipped !== true && guessData.value != null);
+    }
+
     function getLeagueRouteState(pathname) {
         let normalizedPath = (pathname || '').trim().toLowerCase();
         while (normalizedPath.length > 1 && normalizedPath.endsWith('/')) {
@@ -5534,8 +5538,6 @@
                 gmaCard.classList.remove('gma-done');
                 // read your guesses from localStorage
                 const allGuesses = JSON.parse(localStorage.getItem('gmaAllGuesses') || '{}');
-                // check if the user has hit “Skip All”
-                const skipAll = localStorage.getItem('gmaSkipAll') === 'true';
 
                 const seen = sessionStorage.getItem('gmaSeen');
 
@@ -5543,29 +5545,14 @@
                     markAthleteSkippedForGuessMyAge(athleteSlug);
                     modalContent.classList.remove('guess-mode');
                     gmaCard.classList.add('gma-done');
-                } else if (skipAll) {
-                    // user opted out globally
-                    modalContent.classList.remove('guess-mode');
-                    gmaCard.classList.add('gma-done');
-                } else if (allGuesses.hasOwnProperty(athleteSlug)) {
-                    // already guessed or skipped this athlete
+                } else if (hasSubmittedGuessForGuessMyAge(allGuesses[athleteSlug])) {
+                    // already guessed this athlete
                     modalContent.classList.remove('guess-mode');
                     gmaCard.classList.add('gma-done');
                 } else {
                     // first time on *this* athlete
                     modalContent.classList.add('guess-mode');
                     sessionStorage.setItem('gmaSeen', 'true');
-                }
-
-                const gmaSkipAllBtn = document.getElementById('gmaSkipAll');
-                if (gmaSkipAllBtn) {
-                    // reveal “Skip All” once they've skipped at least one athlete,
-                    // but hide it if they already chose skip-all
-                    if (!skipAll && Object.values(allGuesses).some(g => g.skipped)) {
-                        gmaSkipAllBtn.style.display = 'inline-block';
-                    } else {
-                        gmaSkipAllBtn.style.display = 'none';
-                    }
                 }
 
                 // stash the slug for your submit/skip handler


### PR DESCRIPTION
## Summary
- Remove Skip and Skip all controls from the Guess My Age prompt.
- Hide the modal close controls while the athlete modal is in guess mode.
- Treat old skipped/local skip-all state as incomplete for normal athlete opens, so users must submit a guess before seeing the athlete details.

## Root cause
The prompt had its own skip controls, and the generic guess-mode hide rule lost to the modal close button's more specific ID styling, leaving an exit path visible.

## Validation
- `dotnet build LongevityWorldCup.sln`
- Browser check on `http://127.0.0.1:5298/`: fresh local storage shows only `Submit` in Guess My Age.
- Browser check with `gmaSkipAll=true` and a skipped `siim_land` record still opens `guess-mode`; close and sticky close controls compute to `display: none`.

## Screenshot
Captured locally for the Codex handoff: `guess-my-age-no-exit.png`.