### PR TITLE
[codex] Fix leaderboard portrait shrinking

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -653,6 +653,17 @@
 
     /* PRO badge overlay – table only (not on podium); white text, black frame */
     .portrait-wrapper{ position:relative; display:inline-block; }
+    .leaderboard .athlete-td .portrait-wrapper{
+        position:relative;
+        display:inline-block;
+        flex:0 0 var(--portrait-size);
+        width:var(--portrait-size);
+        min-width:var(--portrait-size);
+    }
+    .leaderboard .athlete-td .portrait-wrapper .rank-change{
+        width:var(--portrait-size);
+        min-width:var(--portrait-size);
+    }
     .pro-badge{
         display:none;
         position:absolute;


### PR DESCRIPTION
## Summary

Fixes leaderboard athlete portraits sometimes rendering as tall, skinny images when rows have many adjacent badges or rank-change indicators.

## Root Cause

The athlete cell is a flex row. Portraits with the rank-change/new-athlete wrapper could become shrinkable flex content, and the global image max-width rule then squeezed the portrait width while the explicit height remained fixed.

## Changes

- Reserves a fixed, non-shrinking square slot for leaderboard table portrait wrappers.
- Applies the same fixed width to rank-change wrapped portraits.
- Scopes the rule to `.leaderboard .athlete-td` so modal profile portrait sizing is unchanged.

## Validation

- `dotnet build LongevityWorldCup.sln`
- `dotnet test LongevityWorldCup.sln --no-build`
- Local browser verification on `/leaderboard?filters=Pheno%20Age`: badge-heavy rows kept `60x60` portraits, while the modal portrait wrapper retained its normal `62%` sizing.