### PR TITLE
[codex] Fix mobile badge centering

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/css/badges.css
+++ b/LongevityWorldCup.Website/wwwroot/css/badges.css
@@ -128,9 +128,9 @@ a.badge-class,.badge-class.badge-clickable,.badge-class[data-clickable="true"],.
 
 @media (max-width:768px){
     #detailsModal .modal-badge-strip{
-        display:grid;
-        grid-template-columns:repeat(3,minmax(0,1fr));
-        justify-items:center;
+        display:flex;
+        flex-wrap:wrap;
+        justify-content:center;
         align-items:start;
         width:calc(100% - 1.5rem)!important;
         max-width:calc(100% - 1.5rem)!important;
@@ -140,9 +140,10 @@ a.badge-class,.badge-class.badge-clickable,.badge-class[data-clickable="true"],.
         margin:.45rem auto .9rem;
     }
     #detailsModal .modal-badge-strip .modal-badge-item{
-        width:100%;
-        max-width:92px;
+        flex:0 1 92px;
+        width:92px;
         margin:0;
+        text-align:center;
     }
     #detailsModal .modal-badge-strip .badge-class{
         width:50px;


### PR DESCRIPTION
## Summary

Fixes mobile athlete badge strip alignment by replacing the fixed three-column grid with a centered wrapping flex layout.

## Why

The mobile grid placed partial badge rows into the first grid columns, so one- or two-badge rows could appear offset instead of centered. The new layout keeps full rows stable while centering partial rows.

## Impact

Mobile athlete profile badge rows now center consistently. Desktop badge layout is unchanged.

## Validation

- `dotnet test LongevityWorldCup.sln`
- Verified locally at `390x844` mobile viewport on `http://127.0.0.1:5297/`; Wen Z profile rendered 13 badges with the final one-badge row centered on the strip center.