### PR TITLE
[codex] Align athlete why frame width

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -1064,7 +1064,7 @@
         text-shadow: 0 2px 16px rgba(0,0,0,.45);
     }
     #detailsModal #athleteBio{
-        max-width: 560px;
+        width: min(100%, var(--athlete-modal-section-width));
         color: rgba(255,255,255,.74);
         line-height: 1.55;
         margin: 1rem auto 1.45rem;


### PR DESCRIPTION
## Summary
- Align the athlete profile Why frame with the shared athlete modal section width.
- Keeps the existing mobile width overrides unchanged.

## Root cause
The Why text frame was capped at a hard-coded `560px`, while the surrounding modal sections use `--athlete-modal-section-width` (`640px`). That made the frame visibly narrower than the radar and stats sections on athlete profiles.

## Validation
- `dotnet test LongevityWorldCup.sln`
- Local browser check on Ron Lugbill's profile: Why frame, age radar, and stats frame each measured `640px` wide with the same left edge.