### PR TITLE
[codex] Fix mobile badge description taps

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/css/badges.css
+++ b/LongevityWorldCup.Website/wwwroot/css/badges.css
@@ -69,6 +69,8 @@ a.badge-class:focus-visible,.badge-class.badge-clickable:focus-visible,.badge-cl
 .modal-badge-name .modal-badge-detail{display:none}
 .modal-badge-item:hover .modal-badge-detail,.modal-badge-item.expanded .modal-badge-detail{display:block}
 .modal-badge-item:hover .modal-badge-name,.modal-badge-item.expanded .modal-badge-name{-webkit-line-clamp:unset;max-height:none;overflow:visible}
+.modal-badge-item[role="button"]{cursor:pointer}
+.modal-badge-item[role="button"]:focus-visible{outline:3px solid rgba(0,188,212,.72);outline-offset:4px;border-radius:14px}
 #detailsModal .modal-badge-strip{
     width:min(100%, var(--athlete-modal-section-width, 680px));
     box-sizing:border-box;
@@ -156,13 +158,21 @@ a.badge-class,.badge-class.badge-clickable,.badge-class[data-clickable="true"],.
         font-size:.66rem;
         line-height:1.12;
     }
-    #detailsModal .modal-badge-item:hover .modal-badge-detail{
+    #detailsModal .modal-badge-item:hover:not(.expanded) .modal-badge-detail{
         display:none;
     }
-    #detailsModal .modal-badge-item:hover .modal-badge-name{
+    #detailsModal .modal-badge-item:hover:not(.expanded) .modal-badge-name{
         -webkit-line-clamp:3;
         max-height:none;
         overflow:hidden;
+    }
+    #detailsModal .modal-badge-item.expanded .modal-badge-detail{
+        display:block;
+    }
+    #detailsModal .modal-badge-item.expanded .modal-badge-name{
+        -webkit-line-clamp:unset;
+        max-height:none;
+        overflow:visible;
     }
     #detailsModal .badge-class{pointer-events:none;cursor:default}
     #detailsModal .badge-class.badge-podcast{pointer-events:auto!important;cursor:pointer!important}

--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -6050,6 +6050,10 @@
 
             const wrapper = document.createElement('div');
             wrapper.classList.add('modal-badge-item');
+            wrapper.setAttribute('role', 'button');
+            wrapper.setAttribute('tabindex', '0');
+            wrapper.setAttribute('aria-expanded', 'false');
+            wrapper.setAttribute('aria-label', fullTitle ? `Show badge details: ${fullTitle}` : 'Show badge details');
             wrapper.appendChild(badge);
 
             const label = document.createElement('div');
@@ -6063,9 +6067,19 @@
             }
             wrapper.appendChild(label);
 
-            // enable click/tap to expand full text
-            wrapper.addEventListener('click', () => {
-                wrapper.classList.toggle('expanded');
+            const toggleBadgeDetails = (event) => {
+                if (event.target.closest('a.badge-podcast')) return;
+
+                const isExpanded = wrapper.classList.toggle('expanded');
+                wrapper.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
+            };
+
+            wrapper.addEventListener('click', toggleBadgeDetails);
+            wrapper.addEventListener('keydown', (event) => {
+                if (event.key !== 'Enter' && event.key !== ' ') return;
+
+                event.preventDefault();
+                toggleBadgeDetails(event);
             });
             modalBadgeSection.appendChild(wrapper);
         });


### PR DESCRIPTION
## Summary
- Make expanded modal badges win over sticky mobile hover styling so descriptions reliably appear after a tap.
- Add explicit expanded state and keyboard activation to modal badge wrappers while preserving podcast link behavior.

## Root Cause
On touch devices, a tapped badge item can remain in `:hover`. The mobile CSS hid badge details for hovered items, which overrode the `.expanded` tap state.

## Validation
- `dotnet test LongevityWorldCup.sln`
- Mobile browser smoke test at 390px width on local site: opened `/athlete/jay-roach`, tapped the first modal badge, and confirmed `aria-expanded="true"`, detail text visible with `display: block`, and unclamped text.