### PR TITLE
[codex] Add QR image dimensions

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/index.html
+++ b/LongevityWorldCup.Website/wwwroot/index.html
@@ -1746,7 +1746,7 @@
                     </div>
                 </div>
                 <div class="qr-code-container" data-aos="fade" data-aos-duration="700" data-aos-delay="400">
-                    <img src="/assets/Donation25QR.png" alt="Donate with Bitcoin QR code" class="qr-code-img" loading="lazy" fetchpriority="low" decoding="async">
+                    <img src="/assets/Donation25QR.png" alt="Donate with Bitcoin QR code" class="qr-code-img" width="165" height="165" loading="lazy" fetchpriority="low" decoding="async">
                 </div>
                 <div class="btc-address">
                     <a id="btcAddressLink" href="#" target="_blank" rel="noopener" title="View Bitcoin donations" aria-label="View the Bitcoin donation address on mempool.space">


### PR DESCRIPTION
## Summary

Adds explicit intrinsic dimensions to the Bitcoin donation QR image on the homepage.

## Why

The QR image is lazy-loaded and responsive, but without `width` and `height` attributes the browser cannot reserve its aspect ratio from markup alone. The source asset is 165x165, so these attributes preserve the existing square layout while making layout reservation deterministic.

## Impact

No visual UI change expected. Existing CSS still controls the rendered size with `max-width: 200px`, `width: 100%`, and `height: auto`.

## Validation

- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -p:EnableScheduledJobs=false`