### PR TITLE
[codex] Delay analytics until after first paint

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/partials/head.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/head.html
@@ -116,13 +116,35 @@ Must appear before any other script that initializes or relies on AOS.
 <script type="application/ld+json">{{SEO_STRUCTURED_DATA}}</script>
 
 <!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-PSSCLBW37H"></script>
 <script>
     window.dataLayer = window.dataLayer || [];
     function gtag() { dataLayer.push(arguments); }
     gtag('js', new Date());
 
     gtag('config', 'G-PSSCLBW37H');
+
+    (function () {
+        let googleTagLoaded = false;
+
+        function loadGoogleTag() {
+            if (googleTagLoaded) {
+                return;
+            }
+
+            googleTagLoaded = true;
+            const script = document.createElement('script');
+            script.async = true;
+            script.src = 'https://www.googletagmanager.com/gtag/js?id=G-PSSCLBW37H';
+            document.head.appendChild(script);
+        }
+
+        if ('requestAnimationFrame' in window) {
+            requestAnimationFrame(() => requestAnimationFrame(loadGoogleTag));
+        }
+
+        window.addEventListener('load', loadGoogleTag, { once: true });
+        window.setTimeout(loadGoogleTag, 3000);
+    })();
 </script>
 
 <script>


### PR DESCRIPTION
## Summary
- Keeps the `gtag` dataLayer queue available in the shared head partial.
- Defers loading the external Google Tag script until after first paint, with load and timeout fallbacks.
- Removes the static head `gtag.js` request from the critical render path.

## Why
The homepage audit showed `gtag.js` as a large third-party first-load transfer. No app code depends on analytics during initial render, so this preserves tracking behavior while reducing competition with critical page resources on slow connections.

## Validation
- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -p:EnableScheduledJobs=false`
- Local HTTP check confirmed the injected homepage has no static Google Tag script, keeps the `gtag` queue, and includes the dynamic delayed loader.