### PR TITLE
[codex] Remove validator from homepage paths

### DIFF
--- a/LongevityWorldCup.Website/Middleware/HtmlInjectionMiddleware.cs
+++ b/LongevityWorldCup.Website/Middleware/HtmlInjectionMiddleware.cs
@@ -189,7 +189,7 @@ $@"<script type=""module"">
             if (IsLeagueRoute(path) || IsAthleteRoute(path))
             {
                 return new HeadAssetConfig(
-                    IncludeValidator: true,
+                    IncludeValidator: false,
                     IncludeChartJs: true,
                     ModulePaths:
                     [
@@ -206,7 +206,7 @@ $@"<script type=""module"">
             return path.ToLowerInvariant() switch
             {
                 "/" or "/index.html" => new HeadAssetConfig(
-                    IncludeValidator: true,
+                    IncludeValidator: false,
                     IncludeChartJs: true,
                     ModulePaths:
                     [
@@ -219,7 +219,7 @@ $@"<script type=""module"">
                         "/js/age-visualization.js"
                     ]),
                 "/leaderboard/leaderboard.html" => new HeadAssetConfig(
-                    IncludeValidator: true,
+                    IncludeValidator: false,
                     IncludeChartJs: true,
                     ModulePaths:
                     [

--- a/LongevityWorldCup.Website/wwwroot/index.html
+++ b/LongevityWorldCup.Website/wwwroot/index.html
@@ -2078,13 +2078,14 @@
             e.preventDefault();
 
             const emailInput = newsletterEmailInput.value.trim();
+            newsletterEmailInput.value = emailInput;
             newsletterEmailInput.blur();
 
             if (newsletterSubmitButton.disabled) {
                 return;
             }
 
-            if (validator.isEmail(emailInput)) {
+            if (newsletterEmailInput.checkValidity()) {
                 const originalButtonHtml = newsletterSubmitButton.innerHTML;
                 newsletterSubmitButton.disabled = true;
                 newsletterSubmitButton.classList.add('is-loading');

--- a/LongevityWorldCup.Website/wwwroot/js/misc.js
+++ b/LongevityWorldCup.Website/wwwroot/js/misc.js
@@ -1,6 +1,7 @@
 window.getIcon = function (link) {
     // Normalize the link to lowercase for case-insensitive matching
     const normalizedLink = link.toLowerCase().trim();
+    const isEmailLike = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalizedLink);
 
     // Mapping of link identifiers to Font Awesome icon classes
     const iconMap = {
@@ -43,7 +44,7 @@ window.getIcon = function (link) {
     };
 
     // Check for email first
-    if (validator.isEmail(normalizedLink)) {
+    if (isEmailLike) {
         return iconMap.email;
     }
 


### PR DESCRIPTION
## Summary
- replace homepage newsletter validation with the native email input validity check
- replace `misc.js` email icon detection with a local email pattern
- stop including validator.js on homepage, leaderboard, league, and athlete routes while keeping it on form-heavy pages

## Validation
- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -p:EnableScheduledJobs=false`
- rendered local pages and verified:
  - homepage: no validator script
  - leaderboard: no validator script
  - onboarding convergence: validator script still present
  - edit profile: validator script still present
