### PR TITLE
[codex] Use frequency order in edit-profile flags

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/play/edit-profile.html
+++ b/LongevityWorldCup.Website/wwwroot/play/edit-profile.html
@@ -621,13 +621,14 @@
 
             // Fetch and prepare flag list
             let availableFlags = [];
-            fetch('/api/data/flags')
-                .then(r => r.json())
-                .then(flags => {
+            Promise.all([
+                fetch('/api/data/flags').then(r => r.json()),
+                window.getSharedAthletes ? window.getSharedAthletes() : fetch('/api/data/athletes').then(r => r.json())
+            ])
+                .then(([flags, athletes]) => {
                     availableFlags = window.LwcFlags
-                        .buildFlagOptions(flags, [])
-                        .map(option => option.name)
-                        .sort((a, b) => a.localeCompare(b));
+                        .buildFlagOptions(flags, athletes)
+                        .map(option => option.name);
                     const currentFlag = window.LwcFlags.getCanonicalFlagName(athlete.Flag);
                     if (currentFlag && !availableFlags.includes(currentFlag)) availableFlags.push(currentFlag);
                     flagInput.value = athlete.Flag;


### PR DESCRIPTION
## What changed

- Updated the edit-profile flag picker to build options with the current athletes dataset.
- Removed the extra alphabetical sort so edit-profile keeps the same frequency-first, canonicalized order as onboarding and leaderboard flags.

## Validation

- `dotnet test LongevityWorldCup.sln`
- `git diff --check`
