### PR TITLE
[codex] Lazy-load Chart.js for athlete modals

### DIFF
--- a/LongevityWorldCup.Website/Middleware/HtmlInjectionMiddleware.cs
+++ b/LongevityWorldCup.Website/Middleware/HtmlInjectionMiddleware.cs
@@ -155,11 +155,6 @@ namespace LongevityWorldCup.Website.Middleware
         {
             var sb = new StringBuilder();
 
-            if (config.IncludeChartJs)
-            {
-                sb.AppendLine("<script src=\"https://cdn.jsdelivr.net/npm/chart.js\" crossorigin=\"anonymous\" defer></script>");
-            }
-
             if (config.IncludeValidator)
             {
                 sb.AppendLine("<script src=\"https://cdn.jsdelivr.net/npm/validator@13.9.0/validator.min.js\" crossorigin=\"anonymous\" defer></script>");
@@ -190,7 +185,6 @@ $@"<script type=""module"">
             {
                 return new HeadAssetConfig(
                     IncludeValidator: false,
-                    IncludeChartJs: true,
                     ModulePaths:
                     [
                         "/js/misc.js",
@@ -207,7 +201,6 @@ $@"<script type=""module"">
             {
                 "/" or "/index.html" => new HeadAssetConfig(
                     IncludeValidator: false,
-                    IncludeChartJs: true,
                     ModulePaths:
                     [
                         "/js/misc.js",
@@ -220,7 +213,6 @@ $@"<script type=""module"">
                     ]),
                 "/leaderboard/leaderboard.html" => new HeadAssetConfig(
                     IncludeValidator: false,
-                    IncludeChartJs: true,
                     ModulePaths:
                     [
                         "/js/misc.js",
@@ -233,7 +225,6 @@ $@"<script type=""module"">
                     ]),
                 "/event-board/event-board.html" => new HeadAssetConfig(
                     IncludeValidator: false,
-                    IncludeChartJs: false,
                     ModulePaths:
                     [
                         "/js/misc.js",
@@ -243,7 +234,6 @@ $@"<script type=""module"">
                     ]),
                 "/event-board-embed.html" => new HeadAssetConfig(
                     IncludeValidator: false,
-                    IncludeChartJs: false,
                     ModulePaths:
                     [
                         "/js/misc.js",
@@ -253,7 +243,6 @@ $@"<script type=""module"">
                     ]),
                 "/play/edit-profile.html" => new HeadAssetConfig(
                     IncludeValidator: true,
-                    IncludeChartJs: false,
                     ModulePaths:
                     [
                         "/js/misc.js",
@@ -262,7 +251,6 @@ $@"<script type=""module"">
                     ]),
                 "/play/proof-upload.html" => new HeadAssetConfig(
                     IncludeValidator: false,
-                    IncludeChartJs: false,
                     ModulePaths:
                     [
                         "/js/misc.js",
@@ -270,14 +258,12 @@ $@"<script type=""module"">
                     ]),
                 "/play/character-selection.html" => new HeadAssetConfig(
                     IncludeValidator: false,
-                    IncludeChartJs: false,
                     ModulePaths:
                     [
                         "/js/misc.js"
                     ]),
                 "/play/character-customization.html" => new HeadAssetConfig(
                     IncludeValidator: false,
-                    IncludeChartJs: false,
                     ModulePaths:
                     [
                         "/js/misc.js",
@@ -289,7 +275,6 @@ $@"<script type=""module"">
                     ]),
                 "/onboarding/pheno-age.html" => new HeadAssetConfig(
                     IncludeValidator: false,
-                    IncludeChartJs: false,
                     ModulePaths:
                     [
                         "/js/misc.js",
@@ -298,7 +283,6 @@ $@"<script type=""module"">
                     ]),
                 "/onboarding/bortz-age.html" => new HeadAssetConfig(
                     IncludeValidator: false,
-                    IncludeChartJs: false,
                     ModulePaths:
                     [
                         "/js/misc.js",
@@ -308,7 +292,6 @@ $@"<script type=""module"">
                     ]),
                 "/onboarding/convergence.html" => new HeadAssetConfig(
                     IncludeValidator: true,
-                    IncludeChartJs: false,
                     ModulePaths:
                     [
                         "/js/misc.js",
@@ -318,7 +301,6 @@ $@"<script type=""module"">
                     ]),
                 "/onboarding/join-game.html" => new HeadAssetConfig(
                     IncludeValidator: false,
-                    IncludeChartJs: false,
                     ModulePaths:
                     [
                         "/js/misc.js",
@@ -725,9 +707,9 @@ $@"<script type=""module"">
             string OgImageUrl
         );
 
-        private sealed record HeadAssetConfig(bool IncludeValidator, bool IncludeChartJs, IReadOnlyList<string> ModulePaths)
+        private sealed record HeadAssetConfig(bool IncludeValidator, IReadOnlyList<string> ModulePaths)
         {
-            public static readonly HeadAssetConfig Empty = new(false, false, Array.Empty<string>());
+            public static readonly HeadAssetConfig Empty = new(false, Array.Empty<string>());
         }
     }
 }

--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -3931,6 +3931,37 @@
     let savedBodyScroll = 0;
     let savedBodyBackground = '';
     let currentAthleteModalRequestId = 0;
+    const chartJsSrc = 'https://cdn.jsdelivr.net/npm/chart.js';
+
+    window.ensureChartJs = window.ensureChartJs || function () {
+        if (typeof window.Chart === 'function') {
+            return Promise.resolve(true);
+        }
+
+        if (window.__chartJsPromise) {
+            return window.__chartJsPromise;
+        }
+
+        window.__chartJsPromise = new Promise(resolve => {
+            const script = document.createElement('script');
+            script.src = chartJsSrc;
+            script.async = true;
+            script.crossOrigin = 'anonymous';
+            script.onload = () => resolve(typeof window.Chart === 'function');
+            script.onerror = () => {
+                console.error('Failed to load Chart.js');
+                resolve(false);
+            };
+            document.head.appendChild(script);
+        }).then(loaded => {
+            if (!loaded) {
+                window.__chartJsPromise = null;
+            }
+            return loaded;
+        });
+
+        return window.__chartJsPromise;
+    };
 
     function ensureAthleteModalDeferredSections() {
         if (document.getElementById('events-frame') && document.getElementById('athlete-biomarkers') && document.getElementById('athlete-proofs')) {
@@ -5641,21 +5672,30 @@
                 // Create biomarker chart after modal is visible so the canvas has non-zero dimensions (fixes chart sizing when created while modal was hidden).
                 requestAnimationFrame(function() {
                     if (requestId !== currentAthleteModalRequestId) return;
-                    generateAgeVisualization(bioAge, chronoAge, athleteData, athleteResults);
-                    generateBiomarkerChart(fullAthleteData);
-                    // Force Chart.js to re-measure after layout; hover triggers this internally, so do it explicitly (second rAF + ResizeObserver fallback).
-                    requestAnimationFrame(function() {
+
+                    window.ensureChartJs().then(function(chartLoaded) {
                         if (requestId !== currentAthleteModalRequestId) return;
-                        if (window.biomarkerChartInstance) window.biomarkerChartInstance.resize();
-                    });
-                    var chartContainer = document.getElementById('athlete-biomarkers');
-                    if (chartContainer && window.biomarkerChartInstance) {
-                        if (window.biomarkerChartResizeObserver) window.biomarkerChartResizeObserver.disconnect();
-                        window.biomarkerChartResizeObserver = new ResizeObserver(function() {
+
+                        generateAgeVisualization(bioAge, chronoAge, athleteData, athleteResults);
+                        if (chartLoaded) {
+                            generateBiomarkerChart(fullAthleteData);
+                        }
+
+                        // Force Chart.js to re-measure after layout; hover triggers this internally, so do it explicitly (second rAF + ResizeObserver fallback).
+                        requestAnimationFrame(function() {
+                            if (requestId !== currentAthleteModalRequestId) return;
                             if (window.biomarkerChartInstance) window.biomarkerChartInstance.resize();
                         });
-                        window.biomarkerChartResizeObserver.observe(chartContainer);
-                    }
+
+                        var chartContainer = document.getElementById('athlete-biomarkers');
+                        if (chartContainer && window.biomarkerChartInstance) {
+                            if (window.biomarkerChartResizeObserver) window.biomarkerChartResizeObserver.disconnect();
+                            window.biomarkerChartResizeObserver = new ResizeObserver(function() {
+                                if (window.biomarkerChartInstance) window.biomarkerChartInstance.resize();
+                            });
+                            window.biomarkerChartResizeObserver.observe(chartContainer);
+                        }
+                    });
                 });
                 if (!modalContent) {
                     console.error('Modal content element not found');


### PR DESCRIPTION
## Summary
- remove eager Chart.js loading from injected page heads
- add a cached `window.ensureChartJs()` loader for athlete modal chart rendering
- gate radar and biomarker chart construction behind the loader while preserving stale modal request checks and fallback behavior

## Validation
- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -p:EnableScheduledJobs=false`
- headless Chrome smoke test confirmed `/` has no Chart.js script/global on initial load
- headless Chrome smoke test confirmed `/athlete/ron-lugbill` loads Chart.js and creates the modal biomarker chart after the loader resolves
