### PR TITLE
[codex] Version injected local assets

### DIFF
--- a/LongevityWorldCup.Website/Middleware/HtmlInjectionMiddleware.cs
+++ b/LongevityWorldCup.Website/Middleware/HtmlInjectionMiddleware.cs
@@ -86,6 +86,7 @@ namespace LongevityWorldCup.Website.Middleware
                         .Replace("{{ASSET_CUSTOM_EVENT_IMAGE}}", _assetVersionProvider.AppendVersion("/assets/custom_event.png"))
                         .Replace("{{ASSET_POPPINS_REGULAR}}", _assetVersionProvider.AppendVersion("/assets/fonts/Poppins-Regular.ttf"))
                         .Replace("{{ASSET_POPPINS_BOLD}}", _assetVersionProvider.AppendVersion("/assets/fonts/Poppins-Bold.ttf"));
+                    bodyContent = ApplySharedAssetPlaceholders(bodyContent);
                     bodyContent = ReplacePageTitle(bodyContent, seo.PageTitle);
 
                     if (ShouldRemoveJoinGameButtons(path))
@@ -142,7 +143,17 @@ namespace LongevityWorldCup.Website.Middleware
         private string ApplySharedAssetPlaceholders(string html)
         {
             return html
-                .Replace("{{ASSET_FAVICON_128}}", _assetVersionProvider.AppendVersion("/assets/favicon-128x128.png"));
+                .Replace("{{ASSET_FAVICON_128}}", _assetVersionProvider.AppendVersion("/assets/favicon-128x128.png"))
+                .Replace("{{ASSET_ROBOTO_LIGHT}}", _assetVersionProvider.AppendVersion("/assets/fonts/Roboto-Light.woff2"))
+                .Replace("{{ASSET_ROBOTO_REGULAR}}", _assetVersionProvider.AppendVersion("/assets/fonts/Roboto-Regular.woff2"))
+                .Replace("{{ASSET_ROBOTO_BOLD}}", _assetVersionProvider.AppendVersion("/assets/fonts/Roboto-Bold.woff2"))
+                .Replace("{{ASSET_ORBITRON_BOLD}}", _assetVersionProvider.AppendVersion("/assets/fonts/Orbitron-Bold.woff2"))
+                .Replace("{{ASSET_MERCH_MUG}}", _assetVersionProvider.AppendVersion("/assets/content-images/merch/mug.webp"))
+                .Replace("{{ASSET_MERCH_HOODIE}}", _assetVersionProvider.AppendVersion("/assets/content-images/merch/hoodie.webp"))
+                .Replace("{{ASSET_MERCH_CAP}}", _assetVersionProvider.AppendVersion("/assets/content-images/merch/cap.webp"))
+                .Replace("{{ASSET_DONATION_QR}}", _assetVersionProvider.AppendVersion("/assets/Donation25QR.png"))
+                .Replace("{{ASSET_HD_LOGO_THUMB_SM}}", _assetVersionProvider.AppendVersion("/assets/HdLogo_thumb_sm.png"))
+                .Replace("{{ASSET_TROLLFACE}}", _assetVersionProvider.AppendVersion("/assets/content-images/trollface.png"));
         }
 
         private string ApplySharedCssPlaceholders(string html)

--- a/LongevityWorldCup.Website/wwwroot/index.html
+++ b/LongevityWorldCup.Website/wwwroot/index.html
@@ -1559,7 +1559,7 @@
                                rel="noopener"
                                aria-label="Open White glossy mug in the Longevity World Cup merch store">
                                 <img class="lwc-merch-thumb"
-                                     src="/assets/content-images/merch/mug.webp"
+                                     src="{{ASSET_MERCH_MUG}}"
                                      alt="White glossy mug in the Longevity World Cup merch store">
                                 <span class="lwc-merch-item-copy">
                                     <span class="lwc-merch-item-title">White glossy mug</span>
@@ -1572,7 +1572,7 @@
                                rel="noopener"
                                aria-label="Open Organic cotton hoodie in the Longevity World Cup merch store">
                                 <img class="lwc-merch-thumb"
-                                     src="/assets/content-images/merch/hoodie.webp"
+                                     src="{{ASSET_MERCH_HOODIE}}"
                                      alt="Organic cotton hoodie in the Longevity World Cup merch store">
                                 <span class="lwc-merch-item-copy">
                                     <span class="lwc-merch-item-title">Organic cotton hoodie</span>
@@ -1585,7 +1585,7 @@
                                rel="noopener"
                                aria-label="Open Organic cotton cap in the Longevity World Cup merch store">
                                 <img class="lwc-merch-thumb"
-                                     src="/assets/content-images/merch/cap.webp"
+                                     src="{{ASSET_MERCH_CAP}}"
                                      alt="Organic cotton cap in the Longevity World Cup merch store">
                                 <span class="lwc-merch-item-copy">
                                     <span class="lwc-merch-item-title">Organic cotton cap</span>
@@ -1601,7 +1601,7 @@
                                    rel="noopener"
                                    aria-label="Open White glossy mug in the Longevity World Cup merch store">
                                     <img class="lwc-merch-thumb"
-                                         src="/assets/content-images/merch/mug.webp"
+                                         src="{{ASSET_MERCH_MUG}}"
                                          alt="White glossy mug in the Longevity World Cup merch store">
                                     <span class="lwc-merch-item-copy">
                                         <span class="lwc-merch-item-title">White glossy mug</span>
@@ -1614,7 +1614,7 @@
                                    rel="noopener"
                                    aria-label="Open Organic cotton hoodie in the Longevity World Cup merch store">
                                     <img class="lwc-merch-thumb"
-                                         src="/assets/content-images/merch/hoodie.webp"
+                                         src="{{ASSET_MERCH_HOODIE}}"
                                          alt="Organic cotton hoodie in the Longevity World Cup merch store">
                                     <span class="lwc-merch-item-copy">
                                         <span class="lwc-merch-item-title">Organic cotton hoodie</span>
@@ -1627,7 +1627,7 @@
                                    rel="noopener"
                                    aria-label="Open Organic cotton cap in the Longevity World Cup merch store">
                                     <img class="lwc-merch-thumb"
-                                         src="/assets/content-images/merch/cap.webp"
+                                         src="{{ASSET_MERCH_CAP}}"
                                          alt="Organic cotton cap in the Longevity World Cup merch store">
                                     <span class="lwc-merch-item-copy">
                                         <span class="lwc-merch-item-title">Organic cotton cap</span>
@@ -1746,7 +1746,7 @@
                     </div>
                 </div>
                 <div class="qr-code-container" data-aos="fade" data-aos-duration="700" data-aos-delay="400">
-                    <img src="/assets/Donation25QR.png" alt="Donate with Bitcoin QR code" class="qr-code-img" width="165" height="165" loading="lazy" fetchpriority="low" decoding="async">
+                    <img src="{{ASSET_DONATION_QR}}" alt="Donate with Bitcoin QR code" class="qr-code-img" width="165" height="165" loading="lazy" fetchpriority="low" decoding="async">
                 </div>
                 <div class="btc-address">
                     <a id="btcAddressLink" href="#" target="_blank" rel="noopener" title="View Bitcoin donations" aria-label="View the Bitcoin donation address on mempool.space">

--- a/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
@@ -1580,7 +1580,7 @@
                 } else if (r.type === EVENT_TYPE.AthleteCountMilestone) {
                     avatarHtml = `<div class="avatar-fallback milestone-people-avatar" title="Milestone" aria-label="Milestone"><i class="fa-solid fa-people-group" aria-hidden="true"></i></div>`;
                 } else if (r.type === EVENT_TYPE.CustomEvent) {
-                    const logo = "/assets/HdLogo_thumb_sm.png";
+                    const logo = "{{ASSET_HD_LOGO_THUMB_SM}}";
                     avatarHtml = `<span class="avatar-disabled" title="Longevity World Cup" aria-label="Longevity World Cup"><img class="avatar custom-event-avatar" src="${esc(logo)}" alt="Longevity World Cup" title="Longevity World Cup" ${avatarLoadingAttrs} decoding="async" referrerpolicy="no-referrer"></span>`;
                 } else {
                     avatarHtml = `<div class="avatar-fallback" title="Event">★</div>`;

--- a/LongevityWorldCup.Website/wwwroot/partials/guess-my-age.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/guess-my-age.html
@@ -1411,7 +1411,7 @@
         trollDiv.id = 'gmaTrollfaceContainer';
         trollDiv.className = 'gma-trollface-container';
         const trollImg = document.createElement('img');
-        trollImg.src = '/assets/content-images/trollface.png';
+        trollImg.src = '{{ASSET_TROLLFACE}}';
         trollImg.alt = 'Trollface';
         trollDiv.appendChild(trollImg);
         modalContent.appendChild(trollDiv);

--- a/LongevityWorldCup.Website/wwwroot/partials/header.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/header.html
@@ -21,7 +21,7 @@
         font-style: normal;
         font-weight: 300;
         font-display: swap;
-        src: url('/assets/fonts/Roboto-Light.woff2') format('woff2');
+        src: url('{{ASSET_ROBOTO_LIGHT}}') format('woff2');
     }
 
     @font-face {
@@ -29,7 +29,7 @@
         font-style: normal;
         font-weight: 400;
         font-display: swap;
-        src: url('/assets/fonts/Roboto-Regular.woff2') format('woff2');
+        src: url('{{ASSET_ROBOTO_REGULAR}}') format('woff2');
     }
 
     @font-face {
@@ -37,7 +37,7 @@
         font-style: normal;
         font-weight: 700;
         font-display: swap;
-        src: url('/assets/fonts/Roboto-Bold.woff2') format('woff2');
+        src: url('{{ASSET_ROBOTO_BOLD}}') format('woff2');
     }
 
     /* Orbitron Font Face */
@@ -46,7 +46,7 @@
         font-style: normal;
         font-weight: 700;
         font-display: swap;
-        src: url('/assets/fonts/Orbitron-Bold.woff2') format('woff2');
+        src: url('{{ASSET_ORBITRON_BOLD}}') format('woff2');
     }
 
     .tagline {

--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -2578,7 +2578,7 @@
     let athleteResults = [];
     let athletesOrderedByPace;
     let athletesOrderedByBortzPace;
-    const defaultProfilePic = '/assets/HdLogo_thumb_sm.png';
+    const defaultProfilePic = '{{ASSET_HD_LOGO_THUMB_SM}}';
 
     const currentSeasonStartDate = new Date(new Date().getFullYear(), 0, 1);
 


### PR DESCRIPTION
## Summary
- Route injected local font, merch, QR, fallback logo, and guess-my-age image URLs through existing asset version placeholders.
- Reuse AssetVersionProvider so those assets receive cache-busted immutable URLs when rendered by HtmlInjectionMiddleware.

## Validation
- dotnet build LongevityWorldCup.Website/LongevityWorldCup.Website.csproj -p:EnableScheduledJobs=false
- Rendered local homepage and verified no ASSET placeholders leaked and targeted raw URLs were no longer emitted unversioned.