### PR TITLE
[codex] Defer mobile flag filter rendering

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -1666,7 +1666,7 @@
             padding:1rem 1rem 1.75rem; padding-bottom:calc(env(safe-area-inset-bottom) + 1.75rem);
             transform:translateX(0); visibility:visible; pointer-events:auto; transition-delay:0s;
         }
-        .sidebar .filter-section{ display:block; }
+        .sidebar.expanded .filter-section{ display:block; }
         .sidebar .collapsed-title{ display:none; }
         .sidebar .sidebar-close{
             position:sticky; top:calc(env(safe-area-inset-top) + .9rem); right:auto; margin-left:auto; margin-bottom:-44px;


### PR DESCRIPTION
## Summary

- Keep mobile sidebar filter sections hidden until the drawer is actually expanded.
- Prevent hidden flag filter options from triggering first-load `flag-icons` SVG downloads.

## Why

The mobile drawer was off-canvas, but its filter sections were still `display:block`. The flag filter labels use `flag-icons` CSS background images, so browsers downloaded all rendered flag SVGs during initial mobile load, including very large files such as Serbia and Bolivia flags.

## Validation

- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -p:EnableScheduledJobs=false`
- Mobile Lighthouse spot check after the CSS change:
  - flag SVG first-load requests: `0`
  - flag SVG first-load bytes: `0`
  - image requests: `18`
  - total transfer: about `1,099 KiB`
  - LCP: `7.9s` in the local run