### PR TITLE
[codex] Fix CrowdAge reduction direction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Before making user-facing UI changes, read `DESIGN.md` and preserve its visual, 
 - If you change ranking logic on one side, you must review and update the other side so the logic stays identical.
 - The expected outcome is that the backend and frontend produce the same ordering and the same placements for the same data.
 - Bioage calculator rank previews are clock-specific: Pheno Age shows the Pheno-only field rank, and Bortz Age shows the Bortz-only field rank.
-- The Crowd Age leaderboard view is separate from Ultimate League ranking. Only athletes with at least 100 crowd guesses are eligible. It ranks eligible athletes by highest `chronologicalAge - CrowdAge` difference, then higher `CrowdCount`, then older date of birth, then name.
+- The Crowd Age leaderboard view is separate from Ultimate League ranking. Only athletes with at least 100 crowd guesses are eligible. It follows the same sign convention as other age-reduction columns: `CrowdAge - chronologicalAge`, with more negative values ranking higher, then higher `CrowdCount`, then older date of birth, then name.
 
 ## Ultimate League Ordering
 

--- a/LongevityWorldCup.Tests/CompetitionRankingTests.cs
+++ b/LongevityWorldCup.Tests/CompetitionRankingTests.cs
@@ -68,13 +68,13 @@ public class CompetitionRankingTests
     {
         var rows = new[]
         {
-            CrowdCandidate("larger_reduction", "Larger Reduction", crowdAge: 45, crowdAgeReduction: 25, crowdCount: 100, year: 1950),
-            CrowdCandidate("smaller_reduction", "Smaller Reduction", crowdAge: 30, crowdAgeReduction: 10, crowdCount: 200, year: 1950),
-            CrowdCandidate("same_reduction_more_guesses", "Same More", crowdAge: 40, crowdAgeReduction: 20, crowdCount: 200, year: 1960),
-            CrowdCandidate("same_reduction_fewer_guesses", "Same Fewer", crowdAge: 40, crowdAgeReduction: 20, crowdCount: 100, year: 1950),
-            CrowdCandidate("older_tie", "Older Tie", crowdAge: 40, crowdAgeReduction: 15, crowdCount: 100, year: 1940),
-            CrowdCandidate("younger_tie", "Younger Tie", crowdAge: 40, crowdAgeReduction: 15, crowdCount: 100, year: 1980),
-            CrowdCandidate("alphabetical", "Alphabetical", crowdAge: 40, crowdAgeReduction: 15, crowdCount: 100, year: 1980)
+            CrowdCandidate("larger_reduction", "Larger Reduction", crowdAge: 45, crowdAgeReduction: -25, crowdCount: 100, year: 1950),
+            CrowdCandidate("smaller_reduction", "Smaller Reduction", crowdAge: 30, crowdAgeReduction: -10, crowdCount: 200, year: 1950),
+            CrowdCandidate("same_reduction_more_guesses", "Same More", crowdAge: 40, crowdAgeReduction: -20, crowdCount: 200, year: 1960),
+            CrowdCandidate("same_reduction_fewer_guesses", "Same Fewer", crowdAge: 40, crowdAgeReduction: -20, crowdCount: 100, year: 1950),
+            CrowdCandidate("older_tie", "Older Tie", crowdAge: 40, crowdAgeReduction: -15, crowdCount: 100, year: 1940),
+            CrowdCandidate("younger_tie", "Younger Tie", crowdAge: 40, crowdAgeReduction: -15, crowdCount: 100, year: 1980),
+            CrowdCandidate("alphabetical", "Alphabetical", crowdAge: 40, crowdAgeReduction: -15, crowdCount: 100, year: 1980)
         };
 
         var sorted = CompetitionRanking.SortByCrowdAgeRules(rows).ToList();

--- a/LongevityWorldCup.Website/Business/AthleteDataService.cs
+++ b/LongevityWorldCup.Website/Business/AthleteDataService.cs
@@ -911,7 +911,7 @@ public class AthleteDataService : IDisposable
             }
 
             var chronologicalAge = CalculateAgeAtDate(dobUtc, asOf);
-            var crowdAgeReduction = chronologicalAge - crowdAge;
+            var crowdAgeReduction = crowdAge - chronologicalAge;
 
             list.Add(new CrowdAgeRankCandidate(slug, name, crowdAge, crowdAgeReduction, crowdCount, dobUtc));
         }

--- a/LongevityWorldCup.Website/Business/CompetitionRanking.cs
+++ b/LongevityWorldCup.Website/Business/CompetitionRanking.cs
@@ -48,7 +48,7 @@ public static class CompetitionRanking
     public static IOrderedEnumerable<CrowdAgeRankCandidate> SortByCrowdAgeRules(IEnumerable<CrowdAgeRankCandidate> rows)
     {
         return rows
-            .OrderByDescending(t => t.CrowdAgeReduction)
+            .OrderBy(t => t.CrowdAgeReduction)
             .ThenByDescending(t => t.CrowdCount)
             .ThenBy(t => t.DobUtc)
             .ThenBy(t => t.Name, StringComparer.Ordinal);

--- a/LongevityWorldCup.Website/wwwroot/js/misc.js
+++ b/LongevityWorldCup.Website/wwwroot/js/misc.js
@@ -161,14 +161,14 @@ window.compareAthleteRankPhenoOnly = function (a, b) {
 };
 
 /**
- * Crowd Age comparator: higher chronological age minus median crowd age is better, with more guesses winning ties.
+ * Crowd Age comparator: lower median crowd age minus chronological age is better, with more guesses winning ties.
  * Used only for the Crowd Age view; Ultimate League ordering still follows compareAthleteRank.
  */
 window.compareAthleteRankCrowdAge = function (a, b) {
     const aReduction = Number.isFinite(a.crowdAgeReduction) ? a.crowdAgeReduction : -Infinity;
     const bReduction = Number.isFinite(b.crowdAgeReduction) ? b.crowdAgeReduction : -Infinity;
-    if (aReduction > bReduction) return -1;
-    if (aReduction < bReduction) return 1;
+    if (aReduction < bReduction) return -1;
+    if (aReduction > bReduction) return 1;
 
     const aCount = Number.isFinite(a.crowdCount) ? a.crowdCount : 0;
     const bCount = Number.isFinite(b.crowdCount) ? b.crowdCount : 0;

--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -486,6 +486,14 @@
     @media (min-width: 769px){
         .leaderboard-toolbar{ flex-wrap:nowrap; }
     }
+    .ranking-explanation{
+        display:none; width:100%; box-sizing:border-box; margin:.25rem 0 1rem; padding:.72rem .9rem;
+        color:#4d5963; background:rgba(255,255,255,.78); border:1px solid rgba(0,188,212,.18);
+        border-left:4px solid var(--primary-color); border-radius:8px; box-shadow:0 6px 14px rgba(0,0,0,.06);
+        font-size:.95rem; line-height:1.42;
+    }
+    .ranking-explanation.is-visible{ display:block; }
+    .ranking-explanation strong{ color:var(--primary-color); }
     .search-wrapper{ display:flex; justify-content:flex-end; margin-bottom:1rem; }
     .search-container{ position:relative; max-width:250px; width:100%; min-height:44px; margin-right:.5rem; }
     #athleteSearch{
@@ -2257,6 +2265,8 @@
             </div>
         </div>
 
+        <div class="ranking-explanation" id="rankingExplanation" aria-live="polite"></div>
+
         <div class="leaderboard">
             <div class="sidebar" id="leaderboardFilters">
                 <button class="sidebar-close" aria-label="Hide leagues" title="Hide leagues"><i class="fa fa-times"></i></button>
@@ -2688,6 +2698,31 @@
         localStorage.setItem('gmaAllGuesses', JSON.stringify(allGuesses));
     }
 
+    function markAthletesSkippedForGuessMyAgeIfUnset(athletes) {
+        if (!Array.isArray(athletes) || athletes.length === 0) {
+            return;
+        }
+
+        const allGuesses = JSON.parse(localStorage.getItem('gmaAllGuesses') || '{}');
+        let changed = false;
+        athletes.forEach(athlete => {
+            const athleteSlug = athlete && athlete.name;
+            if (!athleteSlug) return;
+
+            const normalizedAthleteSlug = typeof window.slugifyName === 'function'
+                ? window.slugifyName(athleteSlug, true)
+                : athleteSlug;
+            if (allGuesses[normalizedAthleteSlug]) return;
+
+            allGuesses[normalizedAthleteSlug] = { value: null, skipped: true, first: false, exact: false };
+            changed = true;
+        });
+
+        if (changed) {
+            localStorage.setItem('gmaAllGuesses', JSON.stringify(allGuesses));
+        }
+    }
+
     function markAthleteSkippedIfInURL() {
         const params = new URLSearchParams(window.location.search);
         let athleteSlug = null;
@@ -2985,7 +3020,7 @@
 
                     const crowdAge = athlete.CrowdAge;
                     const crowdCount = athlete.CrowdCount;
-                    const crowdAgeReduction = Number.isFinite(crowdAge) ? chronologicalAgeNow - crowdAge : null;
+                    const crowdAgeReduction = Number.isFinite(crowdAge) ? crowdAge - chronologicalAgeNow : null;
                     const completeBiomarkerSets = athlete.Biomarkers.filter(isCompleteBiomarkerSet);
 
                     // Get birth year and generation
@@ -4574,6 +4609,7 @@
         const currentLeaderboardView = viewRadio ? viewRadio.value : 'ultimate';
         syncAgingClockFilters(currentLeaderboardView);
         updateActiveFilterSections();
+        updateRankingExplanation(currentLeaderboardView);
 
         const hasBortz = (a) => a.bortzAgeReduction != null && Number.isFinite(a.bortzAgeReduction);
         const hasCrowdAge = (a) => a.crowdCount >= CROWD_AGE_LEADERBOARD_MINIMUM_GUESS_COUNT && Number.isFinite(a.crowdAgeReduction);
@@ -4795,6 +4831,9 @@
         const tableVisibleAthletes = hidePodiumRowsInTable
             ? filteredAthletes.filter(athlete => athlete.rank > 3)
             : filteredAthletes;
+        if (currentLeaderboardView === 'crowd') {
+            markAthletesSkippedForGuessMyAgeIfUnset(tableVisibleAthletes);
+        }
 
         // Show tier separator when both pro and amateur rows are visible in the table (first amateur after at least one pro); hide for clock views.
         // Use tableVisibleAthletes order (not DOM order) so homepage podium rows do not keep the separator alive after their table rows are hidden.
@@ -4923,6 +4962,21 @@
         }
 
         history.replaceState({}, "", url.toString());
+    }
+
+    function updateRankingExplanation(currentLeaderboardView) {
+        const explanation = document.getElementById('rankingExplanation');
+        if (!explanation) return;
+
+        const explanations = {
+            bortz: '<strong>BortzAge</strong> estimates biological age from advanced blood-test markers.',
+            pheno: '<strong>PhenoAge</strong> estimates biological age from common blood-test markers.',
+            crowd: '<strong>CrowdAge</strong> is a visual age estimate from visitors; athletes qualify once they pass 100 guesses.'
+        };
+
+        const html = explanations[currentLeaderboardView] || '';
+        explanation.innerHTML = html;
+        explanation.classList.toggle('is-visible', html.length > 0);
     }
 
     function updateCollapsedTitle(selectedDivisions, selectedFlags, selectedGenerations, selectedExclusiveLeagues, selectedLeagueTracks, currentLeaderboardView) {


### PR DESCRIPTION
## Summary

- Flip CrowdAge reduction to use the same sign convention as other clocks: `CrowdAge - chronologicalAge`, where more negative values rank higher.
- Update frontend and backend CrowdAge sorting to match.
- Add CrowdAge leaderboard exposure to the Guess My Age skip state so displayed athletes are not later guessable.
- Add concise clock explanations above the leaderboard when BortzAge, PhenoAge, or CrowdAge is selected.

## Validation

- `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --no-restore`
- Browser smoke checks on local `/leaderboard` and `/league/crowd` while developing.