### PR TITLE
[codex] Hide zero-count flag filters

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -4448,6 +4448,13 @@
         if (input) {
             input.disabled = count === 0 && !input.checked;
         }
+
+        if (label.hasAttribute('data-flag-key')) {
+            const listItem = label.closest('li');
+            if (listItem) {
+                listItem.hidden = count === 0 && !input?.checked;
+            }
+        }
     }
 
     function updateViewAllAthletesButton(count) {


### PR DESCRIPTION
## Summary
- Hide unchecked zero-count rows only in the Flags filter section.
- Preserve existing muted/disabled count behavior for generations, divisions, tracks, and other filters.
- Keep selected flag filters visible even if their current count reaches zero, so they remain clearable.

## Validation
- `dotnet test LongevityWorldCup.sln`
- Local browser check on `http://localhost:5297/`: selecting Bortz hid 70 zero-count flag rows, left no visible zero-count flags, and kept the change scoped to flag rows.