### PR TITLE
[codex] Add freepass application links

### DIFF
--- a/LongevityWorldCup.Website/Business/ApplicantData.cs
+++ b/LongevityWorldCup.Website/Business/ApplicantData.cs
@@ -14,6 +14,7 @@ namespace LongevityWorldCup.Website.Business
         public string? ChronoPhenoDifference { get; set; }
         public string? ChronoBortzDifference { get; set; }
         public string? SubmissionId { get; set; }
+        public string? FreePass { get; set; }
         public string? PersonalLink { get; set; }
         public string? ProfilePic { get; set; } // Base64 string
         public List<string>? ProofPics { get; set; } // List of Base64 strings

--- a/LongevityWorldCup.Website/Controllers/ApplicationController.cs
+++ b/LongevityWorldCup.Website/Controllers/ApplicationController.cs
@@ -220,6 +220,7 @@ namespace LongevityWorldCup.Website.Controllers
             string? accountEmail = applicantData.AccountEmail?.Trim();
             string? chronoPhenoDifference = applicantData.ChronoPhenoDifference?.Trim();
             string? chronoBortzDifference = applicantData.ChronoBortzDifference?.Trim();
+            var hasFreePass = applicantData.FreePass is not null;
 
             // Prepare the email body (excluding the images)
             // Moved this block after processing images to include paths
@@ -367,13 +368,15 @@ namespace LongevityWorldCup.Website.Controllers
                                     new ContentType("application", "zip"));
 
             // 3a) Prepare email body based on submission type
-            var paymentAmountUsd = applicantData.PaymentOffer?.AmountUsd ?? 0m;
+            var paymentAmountUsd = hasFreePass ? 0m : applicantData.PaymentOffer?.AmountUsd ?? 0m;
             var paymentCurrency = string.IsNullOrWhiteSpace(applicantData.PaymentOffer?.Currency)
                 ? "USD"
                 : applicantData.PaymentOffer!.Currency!.Trim().ToUpperInvariant();
-            var paymentDueText = paymentAmountUsd <= 0m
-                ? $"free ({paymentCurrency})"
-                : $"{paymentCurrency} {paymentAmountUsd:0.##}";
+            var paymentDueText = hasFreePass
+                ? $"free pass ({paymentCurrency})"
+                : paymentAmountUsd <= 0m
+                    ? $"free ({paymentCurrency})"
+                    : $"{paymentCurrency} {paymentAmountUsd:0.##}";
 
             var emailBody = BuildApplicationAuditEmailBody(
                 applicantData,
@@ -438,7 +441,7 @@ namespace LongevityWorldCup.Website.Controllers
                     Directory.Delete(tempRoot, recursive: true);
                 }
                 catch { /* ignore */ }
-                var requestedAmountUsd = applicantData.PaymentOffer?.AmountUsd ?? 0m;
+                var requestedAmountUsd = hasFreePass ? 0m : applicantData.PaymentOffer?.AmountUsd ?? 0m;
                 var paymentRequired = requestedAmountUsd > 0m;
                 if (!paymentRequired)
                 {
@@ -1001,6 +1004,7 @@ namespace LongevityWorldCup.Website.Controllers
                 .AppendLine($"Submitted at: {submittedAtUtc:yyyy-MM-dd HH:mm:ss 'UTC'}")
                 .AppendLine($"Attachment filename: {attachmentFilename}")
                 .AppendLine($"Payment due: {paymentDueText}")
+                .AppendLine($"Free pass: {FormatFreePassAuditValue(applicantData.FreePass)}")
                 .AppendLine()
                 .AppendLine("Changed fields:")
                 .AppendLine(changedFields)
@@ -1012,6 +1016,17 @@ namespace LongevityWorldCup.Website.Controllers
                     chronoBortzDifference));
 
             return sb.ToString();
+        }
+
+        private static string FormatFreePassAuditValue(string? freePass)
+        {
+            if (freePass is null)
+                return "none";
+
+            var trimmed = freePass.Trim();
+            return string.IsNullOrEmpty(trimmed)
+                ? "present (empty value)"
+                : FormatAuditValue(TrimForLog(trimmed, 500));
         }
 
         private static void AppendLegacyApplicationEmailIntro(

--- a/LongevityWorldCup.Website/wwwroot/onboarding/bortz-age.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/bortz-age.html
@@ -1378,6 +1378,10 @@
         const PENDING_PAYMENT_OFFER_KEY = 'pendingPaymentOffer';
         const BORTZ_LAB_GEO_CACHE_KEY = 'bortzLabGeoEligibility';
 
+        if (window.captureFreePassFromUrl) {
+            window.captureFreePassFromUrl();
+        }
+
         function initializeBortzLabAccessGate() {
             const panel = document.getElementById('bortzLabAccessPanel');
             const link = document.getElementById('bortzLabAccessLink');
@@ -2760,12 +2764,17 @@
                  window.location.href = '/proofs';
              } else {
                  if (!sessionStorage.getItem(PENDING_PAYMENT_OFFER_KEY)) {
-                     sessionStorage.setItem(PENDING_PAYMENT_OFFER_KEY, JSON.stringify({
+                     const paymentOffer = {
                          source: 'direct-bortz-age',
                          offerType: 'pro',
                          currency: 'USD',
                          amountUsd: 100
-                     }));
+                     };
+                     sessionStorage.setItem(PENDING_PAYMENT_OFFER_KEY, JSON.stringify(
+                         window.applyFreePassToPaymentOffer
+                             ? window.applyFreePassToPaymentOffer(paymentOffer)
+                             : paymentOffer
+                     ));
                  }
                  window.location.href = '/apply';
              }

--- a/LongevityWorldCup.Website/wwwroot/onboarding/convergence.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/convergence.html
@@ -685,6 +685,10 @@
         const PENDING_PAYMENT_OFFER_KEY = 'pendingPaymentOffer';
         const PENDING_PAYMENT_INVOICE_KEY = 'pendingPaymentInvoice';
         const PENDING_PAYMENT_INVOICE_STORAGE_KEY = 'pendingPaymentInvoicePersistent';
+
+        if (window.captureFreePassFromUrl) {
+            window.captureFreePassFromUrl();
+        }
         const urlParams = new URLSearchParams(window.location.search);
         const isFake = urlParams.get('fake') === '1';
 
@@ -827,6 +831,9 @@
             } catch (_) {
                 paymentOffer = null;
             }
+            if (window.applyFreePassToPaymentOffer) {
+                paymentOffer = window.applyFreePassToPaymentOffer(paymentOffer);
+            }
 
             // Create the applicant data object
             const applicantData = {
@@ -843,7 +850,8 @@
                 biomarkers: biomarkerData.Biomarkers,
                 profilePic: profilePic, // Base64 string
                 proofPics: proofPics, // Array of Base64 strings
-                paymentOffer: paymentOffer
+                paymentOffer: paymentOffer,
+                freePass: window.getFreePassValue ? window.getFreePassValue() : null
             };
 
             return applicantData;

--- a/LongevityWorldCup.Website/wwwroot/onboarding/join-game.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/join-game.html
@@ -831,8 +831,20 @@
       updateMainProgress(1);
       const PENDING_PAYMENT_OFFER_KEY = "pendingPaymentOffer";
 
+      if (window.captureFreePassFromUrl) {
+        window.captureFreePassFromUrl();
+      }
+
       function setPendingPaymentOffer(offer) {
-        sessionStorage.setItem(PENDING_PAYMENT_OFFER_KEY, JSON.stringify(offer));
+        const effectiveOffer = window.applyFreePassToPaymentOffer
+          ? window.applyFreePassToPaymentOffer(offer)
+          : offer;
+        sessionStorage.setItem(PENDING_PAYMENT_OFFER_KEY, JSON.stringify(effectiveOffer));
+      }
+
+      function getFreePassQuerySuffix() {
+        const value = window.getFreePassValue ? window.getFreePassValue() : null;
+        return value === null ? "" : `?freepass=${encodeURIComponent(value)}`;
       }
 
       function startAmateurApplication() {
@@ -842,7 +854,7 @@
           currency: "USD",
           amountUsd: 10
         });
-        window.location.href = "/pheno-age";
+        window.location.href = `/pheno-age${getFreePassQuerySuffix()}`;
       }
 
       function startProApplication() {
@@ -856,7 +868,7 @@
           currency: "USD",
           amountUsd
         });
-        window.location.href = "/bortz-age";
+        window.location.href = `/bortz-age${getFreePassQuerySuffix()}`;
       }
 
       function createPriceHtmlFallback(result) {
@@ -867,7 +879,29 @@
         return `<span class="pro-new-price">${oldText}</span>`;
       }
 
+      function renderFreePassPricing() {
+        if (!window.hasFreePass || !window.hasFreePass()) return false;
+
+        const amateurPrice = document.querySelector(".track-card:not(.pro) .entry-cell .pro-new-price");
+        const note = document.getElementById("proDiscountNote");
+        const breakdown = document.getElementById("proDiscountBreakdown");
+        const proEntryPrice = document.getElementById("proEntryPrice");
+        const proEntryCell = proEntryPrice && proEntryPrice.parentElement;
+        const amateurEntryCell = document.querySelector(".track-card:not(.pro) .entry-cell");
+        const goProJoinButton = document.getElementById("goProJoinButton");
+
+        if (amateurPrice) amateurPrice.textContent = "free";
+        if (proEntryPrice) proEntryPrice.innerHTML = '<span class="pro-new-price">free</span>';
+        if (breakdown) breakdown.textContent = "";
+        if (note) note.style.display = "none";
+        if (proEntryCell) proEntryCell.classList.remove("has-discount");
+        if (amateurEntryCell) amateurEntryCell.classList.remove("has-discount");
+        if (goProJoinButton) goProJoinButton.textContent = "Go pro";
+        return true;
+      }
+
       function renderProDiscountNote() {
+        if (renderFreePassPricing()) return;
         if (!window.proDiscounts || typeof window.proDiscounts.buildDiscountBreakdown !== "function") return;
 
         // Join-game is athlete-agnostic; only use browser-global discounts here.

--- a/LongevityWorldCup.Website/wwwroot/onboarding/pheno-age.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/pheno-age.html
@@ -1118,6 +1118,10 @@
         const bloodDrawDateInput = document.getElementById('blood-draw-date');
         const PENDING_PAYMENT_OFFER_KEY = 'pendingPaymentOffer';
 
+        if (window.captureFreePassFromUrl) {
+            window.captureFreePassFromUrl();
+        }
+
         if (bloodDrawDateInput) {
             const todayLocal = new Date();
             todayLocal.setHours(0, 0, 0, 0);
@@ -2118,12 +2122,17 @@
                  window.location.href = '/proofs';
              } else {
                  if (!sessionStorage.getItem(PENDING_PAYMENT_OFFER_KEY)) {
-                     sessionStorage.setItem(PENDING_PAYMENT_OFFER_KEY, JSON.stringify({
+                     const paymentOffer = {
                          source: 'direct-pheno-age',
                          offerType: 'amateur',
                          currency: 'USD',
                          amountUsd: 10
-                     }));
+                     };
+                     sessionStorage.setItem(PENDING_PAYMENT_OFFER_KEY, JSON.stringify(
+                         window.applyFreePassToPaymentOffer
+                             ? window.applyFreePassToPaymentOffer(paymentOffer)
+                             : paymentOffer
+                     ));
                  }
                  window.location.href = '/apply';
              }

--- a/LongevityWorldCup.Website/wwwroot/partials/head.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/head.html
@@ -57,6 +57,56 @@
     window.modulesReady = Promise.resolve();
 </script>
 
+<script>
+    window.LWC_FREE_PASS_SESSION_KEY = 'lwcFreePass';
+
+    window.captureFreePassFromUrl = function () {
+        const params = new URLSearchParams(window.location.search || '');
+        if (!params.has('freepass')) {
+            return window.getFreePassValue();
+        }
+
+        const rawValue = params.get('freepass');
+        const value = rawValue === null ? '' : String(rawValue);
+        try {
+            sessionStorage.setItem(window.LWC_FREE_PASS_SESSION_KEY, value);
+        } catch (_) {
+            window.__lwcFreePassValue = value;
+        }
+
+        return value;
+    };
+
+    window.getFreePassValue = function () {
+        try {
+            if (sessionStorage.getItem(window.LWC_FREE_PASS_SESSION_KEY) !== null) {
+                return sessionStorage.getItem(window.LWC_FREE_PASS_SESSION_KEY);
+            }
+        } catch (_) {
+        }
+
+        return Object.prototype.hasOwnProperty.call(window, '__lwcFreePassValue')
+            ? window.__lwcFreePassValue
+            : null;
+    };
+
+    window.hasFreePass = function () {
+        return window.getFreePassValue() !== null;
+    };
+
+    window.applyFreePassToPaymentOffer = function (offer) {
+        if (!window.hasFreePass()) {
+            return offer;
+        }
+
+        return Object.assign({}, offer || {}, {
+            source: offer && offer.source ? offer.source : 'freepass',
+            currency: offer && offer.currency ? offer.currency : 'USD',
+            amountUsd: 0
+        });
+    };
+</script>
+
 <!--
 Monkey-patch DOMContentLoaded to delay all handlers until modulesReady resolves.
 Ensures imported modules (like PhenoAge) are available before any DOM logic runs.

--- a/LongevityWorldCup.Website/wwwroot/play/character-customization.html
+++ b/LongevityWorldCup.Website/wwwroot/play/character-customization.html
@@ -334,6 +334,10 @@
 
         const PENDING_PAYMENT_OFFER_KEY = 'pendingPaymentOffer';
 
+        if (window.captureFreePassFromUrl) {
+            window.captureFreePassFromUrl();
+        }
+
         function getAthleteDisplayName() {
             if (athlete?.DisplayName && athlete.DisplayName.trim()) {
                 return athlete.DisplayName.trim();
@@ -343,7 +347,10 @@
         }
 
         function setPendingPaymentOffer(offer) {
-            sessionStorage.setItem(PENDING_PAYMENT_OFFER_KEY, JSON.stringify(offer));
+            const effectiveOffer = window.applyFreePassToPaymentOffer
+                ? window.applyFreePassToPaymentOffer(offer)
+                : offer;
+            sessionStorage.setItem(PENDING_PAYMENT_OFFER_KEY, JSON.stringify(effectiveOffer));
         }
 
         function clearPendingPaymentOffer() {
@@ -439,9 +446,14 @@
                         window.proDiscounts && typeof window.proDiscounts.buildDiscountBreakdown === 'function'
                             ? window.proDiscounts.buildDiscountBreakdown(athlete, { isOnLeaderboard: true })
                             : null;
+                    const goProPriceHtml = window.hasFreePass && window.hasFreePass()
+                        ? '<span class="pro-new-price">free</span>'
+                        : goProDiscountResult
+                            ? (typeof window.proDiscounts.createPriceHtml === 'function' ? window.proDiscounts.createPriceHtml(goProDiscountResult) : createPriceHtmlFallback(goProDiscountResult))
+                            : null;
                     const goProButton = createButton(
-                        goProDiscountResult
-                            ? `<span class="dashboard-action-label">Go pro for&nbsp;${typeof window.proDiscounts.createPriceHtml === 'function' ? window.proDiscounts.createPriceHtml(goProDiscountResult) : createPriceHtmlFallback(goProDiscountResult)}</span><i class="fas fa-bolt"></i>`
+                        goProPriceHtml
+                            ? `<span class="dashboard-action-label">Go pro for&nbsp;${goProPriceHtml}</span><i class="fas fa-bolt"></i>`
                             : '<span class="dashboard-action-label">Go pro for</span><i class="fas fa-bolt"></i>',
                         'option-button green',
                         '/bortz-age?update=1',

--- a/LongevityWorldCup.Website/wwwroot/play/proof-upload.html
+++ b/LongevityWorldCup.Website/wwwroot/play/proof-upload.html
@@ -461,6 +461,10 @@
         const PENDING_PAYMENT_INVOICE_KEY = 'pendingPaymentInvoice';
         const PENDING_PAYMENT_INVOICE_STORAGE_KEY = 'pendingPaymentInvoicePersistent';
 
+        if (window.captureFreePassFromUrl) {
+            window.captureFreePassFromUrl();
+        }
+
         function getAthleteDisplayName() {
             if (athlete?.DisplayName && athlete.DisplayName.trim()) {
                 return athlete.DisplayName.trim();
@@ -528,11 +532,15 @@
                     proofPics: proofPics,
                     paymentOffer: (() => {
                         try {
-                            return JSON.parse(sessionStorage.getItem(PENDING_PAYMENT_OFFER_KEY) || 'null');
+                            const paymentOffer = JSON.parse(sessionStorage.getItem(PENDING_PAYMENT_OFFER_KEY) || 'null');
+                            return window.applyFreePassToPaymentOffer
+                                ? window.applyFreePassToPaymentOffer(paymentOffer)
+                                : paymentOffer;
                         } catch (_) {
                             return null;
                         }
-                    })()
+                    })(),
+                    freePass: window.getFreePassValue ? window.getFreePassValue() : null
                 };
 
                 const submitButton = document.getElementById('submitButton');


### PR DESCRIPTION
## Summary

Adds support for `?freepass=...` links across the Pheno Age and Bortz Age application flows.

## What Changed

- Captures `freepass` from calculator, join, apply, dashboard, and proof upload pages.
- Carries the pass through session state and application/result submissions.
- Forces payment offers to zero when a free pass is present.
- Makes the backend authoritative by skipping BTCPay whenever `FreePass` is present.
- Includes the free pass value in the application audit email.

## Validation

- `dotnet test LongevityWorldCup.sln`
- `dotnet test LongevityWorldCup.sln --no-build`
- Local browser smoke test for `/join?freepass=anna-kovacs-92FJD`, `/bortz-age?freepass=...`, and `/pheno-age?freepass=...`.