### PR TITLE
[codex] Tolerate image optimization failures

### DIFF
--- a/LongevityWorldCup.Tests/ApplicationImageOptimizationTests.cs
+++ b/LongevityWorldCup.Tests/ApplicationImageOptimizationTests.cs
@@ -1,0 +1,39 @@
+using LongevityWorldCup.Website.Controllers;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Reflection;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public class ApplicationImageOptimizationTests
+{
+    [Fact]
+    public void CorruptButSubmittedPngFallsBackToOriginalBytes()
+    {
+        const string corruptTinyPng = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9pQ9JxwAAAAASUVORK5CYII=";
+        var bytes = Convert.FromBase64String(corruptTinyPng);
+        var controller = new ApplicationController(new TestWebHostEnvironment(), NullLogger<HomeController>.Instance);
+        var method = typeof(ApplicationController).GetMethod("OptimizeProfileImage", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.NotNull(method);
+
+        var result = method!.Invoke(controller, [(bytes, "image/png", "png"), "test-submission"]);
+
+        Assert.NotNull(result);
+        Assert.True((bool)result!.GetType().GetProperty("Success")!.GetValue(result)!);
+        Assert.Equal("png", result.GetType().GetProperty("Extension")!.GetValue(result));
+        Assert.Equal(bytes, (byte[])result.GetType().GetProperty("Bytes")!.GetValue(result)!);
+    }
+
+    private sealed class TestWebHostEnvironment : IWebHostEnvironment
+    {
+        public string ApplicationName { get; set; } = "LongevityWorldCup.Tests";
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+        public string EnvironmentName { get; set; } = "Test";
+        public string WebRootPath { get; set; } = AppContext.BaseDirectory;
+        public IFileProvider WebRootFileProvider { get; set; } = new NullFileProvider();
+    }
+}

--- a/LongevityWorldCup.Website/Controllers/ApplicationController.cs
+++ b/LongevityWorldCup.Website/Controllers/ApplicationController.cs
@@ -79,8 +79,9 @@ namespace LongevityWorldCup.Website.Controllers
         private const int MaxBase64Length = 10 * 1024 * 1024; // 10 MB
         private const int ProfileImageMaxDimension = 2048;
         private const int ProofImageMaxDimension = 2560;
-        private const int ExistingWebpProfilePassthroughBytes = 1 * 1024 * 1024;
+        private const int ExistingWebpProfilePassthroughBytes = 4 * 1024 * 1024;
         private const int ExistingWebpProofPassthroughBytes = 2 * 1024 * 1024;
+        private const int OriginalImageFallbackBytes = 10 * 1024 * 1024;
 
         // Helper method to parse Base64 image strings and extract bytes, content type, and extension
         private static (byte[]? bytes, string? contentType, string? extension) ParseBase64Image(string base64String)
@@ -1600,6 +1601,21 @@ namespace LongevityWorldCup.Website.Controllers
             }
             catch (Exception ex)
             {
+                if (CanSaveOriginalImageAfterOptimizationFailure(imageData))
+                {
+                    _logger.LogWarning(
+                        "Image optimization failed with {ExceptionType}: {ExceptionMessage}. Saving original submitted image. SubmissionId={SubmissionId} ProofIndex={ProofIndex} ContentType={ContentType} Extension={Extension} Bytes={Bytes}",
+                        ex.GetType().Name,
+                        TrimForLog(ex.Message, 160),
+                        submissionId,
+                        proofIndex,
+                        imageData.contentType,
+                        imageData.extension,
+                        imageData.bytes.Length);
+
+                    return ImageOptimizationResult.Ok(imageData.bytes, imageData.contentType, imageData.extension);
+                }
+
                 _logger.LogError(
                     ex,
                     "Image optimization failed. SubmissionId={SubmissionId} ProofIndex={ProofIndex} ContentType={ContentType} Extension={Extension} Bytes={Bytes}",
@@ -1610,6 +1626,21 @@ namespace LongevityWorldCup.Website.Controllers
                     imageData.bytes.Length);
                 return ImageOptimizationResult.Failure(userErrorMessage);
             }
+        }
+
+        private static bool CanSaveOriginalImageAfterOptimizationFailure(
+            (byte[]? bytes, string? contentType, string? extension) imageData)
+        {
+            if (imageData.bytes is null || imageData.contentType is null || imageData.extension is null)
+                return false;
+
+            if (imageData.bytes.Length > OriginalImageFallbackBytes)
+                return false;
+
+            return imageData.extension.Equals("png", StringComparison.OrdinalIgnoreCase)
+                || imageData.extension.Equals("jpg", StringComparison.OrdinalIgnoreCase)
+                || imageData.extension.Equals("jpeg", StringComparison.OrdinalIgnoreCase)
+                || imageData.extension.Equals("webp", StringComparison.OrdinalIgnoreCase);
         }
 
         [GeneratedRegex(@"data:(?<type>.+?);base64,(?<data>.+)")]

--- a/LongevityWorldCup.Website/wwwroot/js/misc.js
+++ b/LongevityWorldCup.Website/wwwroot/js/misc.js
@@ -372,6 +372,9 @@ window.optimizeImageClient = async function (dataUri, options) {
     const targetMaxBytes = Number.isFinite(options.targetMaxBytes) && options.targetMaxBytes > 0
         ? options.targetMaxBytes
         : null;
+    const minQuality = Number.isFinite(options.minQuality) ? options.minQuality : 0.76;
+    const minResizeQuality = Number.isFinite(options.minResizeQuality) ? options.minResizeQuality : 0.72;
+    const minMaxSize = Number.isFinite(options.minMaxSize) ? options.minMaxSize : 2048;
 
     const encode = async (maxSize, quality) => {
         let { width, height } = img;
@@ -394,17 +397,17 @@ window.optimizeImageClient = async function (dataUri, options) {
     let optimizedBlob = null;
     let maxSize = initialMaxSize;
     let quality = initialQuality;
-    for (let attempt = 0; attempt < 5; attempt++) {
+    for (let attempt = 0; attempt < 8; attempt++) {
         optimizedBlob = await encode(maxSize, quality);
         if (!optimizedBlob || !targetMaxBytes || optimizedBlob.size <= targetMaxBytes) {
             break;
         }
 
-        if (quality > 0.76) {
-            quality = Math.max(0.76, quality - 0.06);
-        } else if (maxSize > 2048) {
-            maxSize = Math.max(2048, Math.round(maxSize * 0.86));
-            quality = Math.max(0.72, quality - 0.04);
+        if (quality > minQuality) {
+            quality = Math.max(minQuality, quality - 0.06);
+        } else if (maxSize > minMaxSize) {
+            maxSize = Math.max(minMaxSize, Math.round(maxSize * 0.86));
+            quality = Math.max(minResizeQuality, quality - 0.04);
         } else {
             break;
         }
@@ -435,6 +438,15 @@ window.optimizeImageClient = async function (dataUri, options) {
         contentType: optimizedContentType,
         extension: optimizedContentType.split('/')[1]
     };
+};
+
+window.PROFILE_IMAGE_OPTIMIZATION_OPTIONS = {
+    maxSize: 1024,
+    minMaxSize: 640,
+    quality: 0.82,
+    minQuality: 0.68,
+    minResizeQuality: 0.68,
+    targetMaxBytes: 900 * 1024
 };
 
 window.createApplicationSubmissionId = function () {

--- a/LongevityWorldCup.Website/wwwroot/onboarding/convergence.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/convergence.html
@@ -1561,7 +1561,7 @@
                         });
 
                         const raw = croppedCanvas.toDataURL('image/png');
-                        const { dataUrl } = await window.optimizeImageClient(raw);
+                        const { dataUrl } = await window.optimizeImageClient(raw, window.PROFILE_IMAGE_OPTIMIZATION_OPTIONS);
                         const croppedImageDataURL = dataUrl || raw;
                         document.getElementById('illustrationPicture').style.display = 'none';
                         document.getElementById('profileImage').style.display = '';

--- a/LongevityWorldCup.Website/wwwroot/play/edit-profile.html
+++ b/LongevityWorldCup.Website/wwwroot/play/edit-profile.html
@@ -1035,7 +1035,7 @@
                 height: 1024,
             });
             const raw = canvas.toDataURL('image/png');
-            const { dataUrl } = await window.optimizeImageClient(raw);
+            const { dataUrl } = await window.optimizeImageClient(raw, window.PROFILE_IMAGE_OPTIMIZATION_OPTIONS);
             const newSrc = dataUrl || raw;
             const imgEl = document.querySelector('.illustration');
             imgEl.src = newSrc;


### PR DESCRIPTION
## Summary
- fall back to saving original submitted PNG/JPEG/WebP bytes when server-side image optimization fails
- keep profile WebP passthrough aligned with browser-compressed profile images
- add shared profile client optimization options for application and edit-profile flows
- add a regression test for the existing fake PNG fixture that ImageSharp refuses to re-encode

## Root Cause
The `?fake=1` default profile image has a PNG signature but fails ImageSharp's strict PNG CRC validation during optimization. The application endpoint treated optimization failure as submission failure, so valid-looking submitted image bytes could block the whole application.

## Validation
- `dotnet test LongevityWorldCup.sln`
- local smoke POST using the same fake PNG reached the normal application flow and only failed later on local SMTP configuration