### PR TITLE
[codex] Make leaderboard rankings crawlable

### DIFF
--- a/LongevityWorldCup.Tests/LeaderboardHtmlRendererTests.cs
+++ b/LongevityWorldCup.Tests/LeaderboardHtmlRendererTests.cs
@@ -1,0 +1,103 @@
+using LongevityWorldCup.Website.Business;
+using LongevityWorldCup.Website.Tools;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public class LeaderboardHtmlRendererTests
+{
+    [Fact]
+    public void RenderRows_RendersAllRowsWithoutCutoff()
+    {
+        var rows = Enumerable.Range(1, 35)
+            .Select(i => Row(i, $"athlete_{i}", i <= 30 ? "Pro" : "Amateur"))
+            .ToList();
+
+        var html = LeaderboardHtmlRenderer.RenderRows(new LeaderboardSnapshot(rows));
+
+        Assert.Equal(35, CountOccurrences(html, "server-rendered-leaderboard-row"));
+        Assert.Contains("id=\"rank-35\"", html);
+        Assert.Contains("tier-amateur", html);
+    }
+
+    [Fact]
+    public void RenderRows_EscapesContentAndAttributes()
+    {
+        var snapshot = new LeaderboardSnapshot([
+            Row(
+                rank: 1,
+                slug: "evil",
+                track: "Pro",
+                displayName: "<script>alert(1)</script> \"Name\"",
+                athletePath: "/athlete/evil",
+                thumbnail: "/generated/thumbs/athletes/evil.webp?v=1&x=<bad>",
+                mediaContact: "https://example.com/?q=<script>")
+        ]);
+
+        var html = LeaderboardHtmlRenderer.RenderRows(snapshot);
+
+        Assert.DoesNotContain("<script>", html);
+        Assert.Contains("&lt;script&gt;alert(1)&lt;/script&gt; &quot;Name&quot;", html);
+        Assert.Contains("evil.webp?v=1&amp;x=&lt;bad&gt;", html);
+        Assert.Contains("https://example.com/?q=&lt;script&gt;", html);
+    }
+
+    [Fact]
+    public void RenderRows_OnlyRendersGeneratedThumbnails()
+    {
+        var snapshot = new LeaderboardSnapshot([
+            Row(1, "generated", "Pro", thumbnail: "/generated/thumbs/athletes/generated.webp?v=1"),
+            Row(2, "athlete", "Pro", thumbnail: "/athletes/athlete/athlete.webp?v=1")
+        ]);
+
+        var html = LeaderboardHtmlRenderer.RenderRows(snapshot);
+
+        Assert.Contains("/generated/thumbs/athletes/generated.webp?v=1", html);
+        Assert.DoesNotContain("/athletes/athlete/athlete.webp?v=1", html);
+    }
+
+    private static LeaderboardSnapshotRow Row(
+        int rank,
+        string slug,
+        string track,
+        string displayName = "",
+        string athletePath = "",
+        string? thumbnail = null,
+        string mediaContact = "")
+    {
+        var name = string.IsNullOrWhiteSpace(displayName) ? $"Athlete {rank}" : displayName;
+        var path = string.IsNullOrWhiteSpace(athletePath) ? $"/athlete/{slug.Replace('_', '-')}" : athletePath;
+        return new LeaderboardSnapshotRow(
+            Rank: rank,
+            Slug: slug,
+            RouteSlug: slug.Replace('_', '-'),
+            DisplayName: name,
+            AthletePath: path,
+            AthleteUrl: $"https://longevityworldcup.com{path}",
+            Track: track,
+            Tier: track.ToLowerInvariant(),
+            EffectiveAgeReductionYears: -rank,
+            LowestBortzAge: track == "Pro" ? 40 : null,
+            LowestPhenoAge: 45,
+            ChronologicalAge: 50,
+            Division: "Open",
+            Generation: "Millennials",
+            Flag: "",
+            ExclusiveLeague: "",
+            MediaContact: mediaContact,
+            LeaderboardThumbnailUrl: thumbnail);
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = haystack.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+
+        return count;
+    }
+}

--- a/LongevityWorldCup.Tests/LeaderboardHtmlRendererTests.cs
+++ b/LongevityWorldCup.Tests/LeaderboardHtmlRendererTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Nodes;
 using LongevityWorldCup.Website.Business;
 using LongevityWorldCup.Website.Tools;
 using Xunit;
@@ -56,6 +57,34 @@ public class LeaderboardHtmlRendererTests
         Assert.DoesNotContain("/athletes/athlete/athlete.webp?v=1", html);
     }
 
+    [Fact]
+    public void BuildAndRender_PreservesProBeforeAmateurRowsFromSharedSnapshot()
+    {
+        var ranked = new JsonArray
+        {
+            Ranked("first_pro", "First Pro", -1, lowestBortzAge: 40),
+            Ranked("second_pro", "Second Pro", 1, lowestBortzAge: 55),
+            Ranked("first_amateur", "First Amateur", -100),
+            Ranked("second_amateur", "Second Amateur", -99)
+        };
+        var athletes = new JsonArray
+        {
+            Athlete("first_amateur", "First Amateur", mediaContact: "first.amateur@example.com"),
+            Athlete("second_amateur", "Second Amateur"),
+            Athlete("first_pro", "First Pro"),
+            Athlete("second_pro", "Second Pro")
+        };
+
+        var snapshot = LeaderboardSnapshotBuilder.Build(ranked, athletes);
+        var html = LeaderboardHtmlRenderer.RenderRows(snapshot);
+
+        Assert.Equal(["pro", "pro", "amateur", "amateur"], snapshot.Rows.Select(row => row.Tier).ToArray());
+        Assert.True(html.IndexOf("id=\"rank-2\"", StringComparison.Ordinal) < html.IndexOf("id=\"rank-3\"", StringComparison.Ordinal));
+        Assert.DoesNotContain("tier-pro", html[html.IndexOf("tier-amateur", StringComparison.Ordinal)..]);
+        Assert.DoesNotContain("first.amateur@example.com", html);
+        Assert.DoesNotContain("mailto:", html);
+    }
+
     private static LeaderboardSnapshotRow Row(
         int rank,
         string slug,
@@ -86,6 +115,41 @@ public class LeaderboardHtmlRendererTests
             ExclusiveLeague: "",
             MediaContact: mediaContact,
             LeaderboardThumbnailUrl: thumbnail);
+    }
+
+    private static JsonObject Ranked(string slug, string name, double ageDifference, double? lowestBortzAge = null)
+    {
+        var row = new JsonObject
+        {
+            ["AthleteSlug"] = slug,
+            ["Name"] = name,
+            ["ChronologicalAge"] = 50.0,
+            ["LowestPhenoAge"] = 45.0,
+            ["AgeDifference"] = ageDifference
+        };
+        if (lowestBortzAge.HasValue)
+        {
+            row["LowestBortzAge"] = lowestBortzAge.Value;
+        }
+
+        return row;
+    }
+
+    private static JsonObject Athlete(string slug, string displayName, string mediaContact = "")
+    {
+        return new JsonObject
+        {
+            ["AthleteSlug"] = slug,
+            ["DisplayName"] = displayName,
+            ["Division"] = "Open",
+            ["MediaContact"] = mediaContact,
+            ["DateOfBirth"] = new JsonObject
+            {
+                ["Year"] = 1985,
+                ["Month"] = 1,
+                ["Day"] = 1
+            }
+        };
     }
 
     private static int CountOccurrences(string haystack, string needle)

--- a/LongevityWorldCup.Tests/LeaderboardSnapshotBuilderTests.cs
+++ b/LongevityWorldCup.Tests/LeaderboardSnapshotBuilderTests.cs
@@ -1,0 +1,154 @@
+using System.Text.Json.Nodes;
+using LongevityWorldCup.Website.Business;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public class LeaderboardSnapshotBuilderTests
+{
+    [Fact]
+    public void Build_PreservesRankedOrderAndPublicFields()
+    {
+        var ranked = new JsonArray
+        {
+            Ranked("pro_athlete", "Pro Athlete", -3.25, lowestBortzAge: 40.2),
+            Ranked("amateur_athlete", "Amateur Athlete", -20.0)
+        };
+        var athletes = new JsonArray
+        {
+            Athlete(
+                "amateur_athlete",
+                displayName: "Amateur Display",
+                mediaContact: "amateur@example.com",
+                leaderboardThumb: "/generated/thumbs/athletes/amateur.webp?v=1"),
+            Athlete(
+                "pro_athlete",
+                displayName: "Pro Display",
+                mediaContact: "https://example.com/pro",
+                leaderboardThumb: "/generated/thumbs/athletes/pro.webp?v=2")
+        };
+
+        var snapshot = LeaderboardSnapshotBuilder.Build(ranked, athletes);
+
+        Assert.Equal(2, snapshot.Rows.Count);
+        Assert.Equal("pro_athlete", snapshot.Rows[0].Slug);
+        Assert.Equal(1, snapshot.Rows[0].Rank);
+        Assert.Equal("pro-athlete", snapshot.Rows[0].RouteSlug);
+        Assert.Equal("/athlete/pro-athlete", snapshot.Rows[0].AthletePath);
+        Assert.Equal("https://longevityworldcup.com/athlete/pro-athlete", snapshot.Rows[0].AthleteUrl);
+        Assert.Equal("Pro", snapshot.Rows[0].Track);
+        Assert.Equal("pro", snapshot.Rows[0].Tier);
+        Assert.Equal("Pro Display", snapshot.Rows[0].DisplayName);
+        Assert.Equal("https://example.com/pro", snapshot.Rows[0].MediaContact);
+        Assert.Equal("/generated/thumbs/athletes/pro.webp?v=2", snapshot.Rows[0].LeaderboardThumbnailUrl);
+
+        Assert.Equal("amateur_athlete", snapshot.Rows[1].Slug);
+        Assert.Equal(2, snapshot.Rows[1].Rank);
+        Assert.Equal("Amateur", snapshot.Rows[1].Track);
+        Assert.Equal("amateur", snapshot.Rows[1].Tier);
+        Assert.Equal("Amateur Display", snapshot.Rows[1].DisplayName);
+        Assert.Equal("", snapshot.Rows[1].MediaContact);
+    }
+
+    [Fact]
+    public void Build_DoesNotReorderRankedRows()
+    {
+        var ranked = new JsonArray
+        {
+            Ranked("amateur_first", "Amateur First", -100.0),
+            Ranked("pro_second", "Pro Second", 100.0, lowestBortzAge: 60.0)
+        };
+        var athletes = new JsonArray
+        {
+            Athlete("amateur_first", displayName: "Amateur First"),
+            Athlete("pro_second", displayName: "Pro Second")
+        };
+
+        var snapshot = LeaderboardSnapshotBuilder.Build(ranked, athletes);
+
+        Assert.Equal("amateur_first", snapshot.Rows[0].Slug);
+        Assert.Equal("pro_second", snapshot.Rows[1].Slug);
+    }
+
+    [Fact]
+    public void Build_SanitizesTextFieldsForSingleLineConsumers()
+    {
+        var ranked = new JsonArray
+        {
+            Ranked("messy", "Fallback Name", -1.0)
+        };
+        var athletes = new JsonArray
+        {
+            Athlete(
+                "messy",
+                displayName: "  Display\r\nName  ",
+                division: "  Open\r\nLeague ",
+                flag: " Flag\r\nName ",
+                mediaContact: " contact@example.com ")
+        };
+
+        var snapshot = LeaderboardSnapshotBuilder.Build(ranked, athletes);
+        var row = Assert.Single(snapshot.Rows);
+
+        Assert.Equal("Display  Name", row.DisplayName);
+        Assert.Equal("Open  League", row.Division);
+        Assert.Equal("Flag  Name", row.Flag);
+        Assert.Equal("", row.MediaContact);
+    }
+
+    private static JsonObject Ranked(string slug, string name, double ageDifference, double? lowestBortzAge = null)
+    {
+        var row = new JsonObject
+        {
+            ["AthleteSlug"] = slug,
+            ["Name"] = name,
+            ["ChronologicalAge"] = 50.0,
+            ["LowestPhenoAge"] = 45.0,
+            ["AgeDifference"] = ageDifference
+        };
+        if (lowestBortzAge.HasValue)
+        {
+            row["LowestBortzAge"] = lowestBortzAge.Value;
+        }
+
+        return row;
+    }
+
+    private static JsonObject Athlete(
+        string slug,
+        string displayName,
+        string division = "Open",
+        string generation = "",
+        string flag = "",
+        string exclusiveLeague = "",
+        string mediaContact = "",
+        string leaderboardThumb = "")
+    {
+        var athlete = new JsonObject
+        {
+            ["AthleteSlug"] = slug,
+            ["DisplayName"] = displayName,
+            ["Division"] = division,
+            ["Flag"] = flag,
+            ["ExclusiveLeague"] = exclusiveLeague,
+            ["MediaContact"] = mediaContact,
+            ["ProfilePicLeaderboardThumb"] = leaderboardThumb
+        };
+
+        if (!string.IsNullOrWhiteSpace(generation))
+        {
+            athlete["Generation"] = generation;
+        }
+        else
+        {
+            athlete["DateOfBirth"] = new JsonObject
+            {
+                ["Year"] = 1985,
+                ["Month"] = 1,
+                ["Day"] = 1
+            };
+        }
+
+        return athlete;
+    }
+}

--- a/LongevityWorldCup.Website/Business/LeaderboardFactsService.cs
+++ b/LongevityWorldCup.Website/Business/LeaderboardFactsService.cs
@@ -1,7 +1,5 @@
 using System.Globalization;
 using System.Text;
-using System.Text.Json.Nodes;
-using System.Text.RegularExpressions;
 using LongevityWorldCup.Website.Tools;
 using Microsoft.Extensions.Caching.Memory;
 
@@ -9,11 +7,11 @@ namespace LongevityWorldCup.Website.Business;
 
 public sealed class LeaderboardFactsService(AthleteDataService athletes, IMemoryCache cache)
 {
+    private const string SnapshotCacheKey = "leaderboard-snapshot-v1";
     private const string CacheKey = "leaderboard-facts-markdown-v1";
     private const string AthleteNamesCacheKey = "athlete-names-markdown-v1";
     private const string SiteBaseUrl = "https://longevityworldcup.com";
     private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(5);
-    private static readonly Regex EmailLike = new(@"^[^\s@]+@[^\s@]+\.[^\s@]+$", RegexOptions.Compiled);
 
     private static readonly (string Slug, string DisplayName)[] LeagueSections =
     [
@@ -30,6 +28,18 @@ public sealed class LeaderboardFactsService(AthleteDataService athletes, IMemory
         ("gen-alpha", "Gen Alpha League"),
         ("prosperan", "Prosperan League")
     ];
+
+    public LeaderboardSnapshot GetLeaderboardSnapshot()
+    {
+        return cache.GetOrCreate(SnapshotCacheKey, entry =>
+        {
+            entry.AbsoluteExpirationRelativeToNow = CacheDuration;
+            return LeaderboardSnapshotBuilder.Build(
+                athletes.GetRankingsOrder(),
+                athletes.GetAthletesSnapshot(),
+                SiteBaseUrl);
+        })!;
+    }
 
     public LeaderboardFactsDocument GetLeaderboardMarkdown()
     {
@@ -55,7 +65,7 @@ public sealed class LeaderboardFactsService(AthleteDataService athletes, IMemory
 
     private string RenderMarkdown(DateTimeOffset generatedAtUtc)
     {
-        var rows = BuildRows();
+        var rows = GetLeaderboardSnapshot().Rows;
         var rowsBySlug = rows.ToDictionary(row => row.Slug, StringComparer.OrdinalIgnoreCase);
         var sb = new StringBuilder();
 
@@ -106,7 +116,7 @@ public sealed class LeaderboardFactsService(AthleteDataService athletes, IMemory
     {
         var sb = new StringBuilder();
         var number = 1;
-        foreach (var row in BuildRows())
+        foreach (var row in GetLeaderboardSnapshot().Rows)
         {
             sb.AppendLine($"{number.ToString(CultureInfo.InvariantCulture)}. {SanitizeLine(row.DisplayName)}");
             number++;
@@ -115,56 +125,7 @@ public sealed class LeaderboardFactsService(AthleteDataService athletes, IMemory
         return sb.ToString();
     }
 
-    private IReadOnlyList<LeaderboardFactRow> BuildRows()
-    {
-        var ranked = athletes.GetRankingsOrder();
-        var snapshot = athletes.GetAthletesSnapshot();
-        var extraBySlug = snapshot
-            .OfType<JsonObject>()
-            .Select(BuildExtra)
-            .Where(extra => !string.IsNullOrWhiteSpace(extra.Slug))
-            .ToDictionary(extra => extra.Slug, StringComparer.OrdinalIgnoreCase);
-
-        var rows = new List<LeaderboardFactRow>();
-        var rank = 0;
-        foreach (var node in ranked.OfType<JsonObject>())
-        {
-            var slug = GetString(node, "AthleteSlug");
-            if (string.IsNullOrWhiteSpace(slug))
-            {
-                continue;
-            }
-
-            rank++;
-            extraBySlug.TryGetValue(slug, out var extra);
-            extra ??= AthleteExtra.Empty;
-            var name = FirstNonEmpty(extra.DisplayName, GetString(node, "Name"), slug);
-            var hasBortz = TryGetDouble(node, "LowestBortzAge", out var lowestBortzAge);
-            TryGetDouble(node, "LowestPhenoAge", out var lowestPhenoAge);
-            TryGetDouble(node, "ChronologicalAge", out var chronologicalAge);
-            TryGetDouble(node, "AgeDifference", out var ageDifference);
-
-            rows.Add(new LeaderboardFactRow(
-                Rank: rank,
-                Slug: slug,
-                DisplayName: name,
-                AthleteUrl: $"{SiteBaseUrl}/athlete/{slug.Replace('_', '-')}",
-                Track: hasBortz ? "Pro" : "Amateur",
-                EffectiveAgeReductionYears: ageDifference,
-                LowestBortzAge: hasBortz ? lowestBortzAge : null,
-                LowestPhenoAge: lowestPhenoAge,
-                ChronologicalAge: chronologicalAge,
-                Division: extra.Division,
-                Generation: extra.Generation,
-                Flag: extra.Flag,
-                ExclusiveLeague: extra.ExclusiveLeague,
-                MediaContact: FilterMediaContact(extra.MediaContact)));
-        }
-
-        return rows;
-    }
-
-    private void AppendLeagueLeaders(StringBuilder sb, IReadOnlyDictionary<string, LeaderboardFactRow> rowsBySlug)
+    private void AppendLeagueLeaders(StringBuilder sb, IReadOnlyDictionary<string, LeaderboardSnapshotRow> rowsBySlug)
     {
         sb.AppendLine("## League Leaders");
         sb.AppendLine();
@@ -189,7 +150,7 @@ public sealed class LeaderboardFactsService(AthleteDataService athletes, IMemory
         sb.AppendLine();
     }
 
-    private static void AppendRankingTable(StringBuilder sb, string title, IEnumerable<LeaderboardFactRow> rows)
+    private static void AppendRankingTable(StringBuilder sb, string title, IEnumerable<LeaderboardSnapshotRow> rows)
     {
         sb.AppendLine($"## {title}");
         sb.AppendLine();
@@ -203,30 +164,6 @@ public sealed class LeaderboardFactsService(AthleteDataService athletes, IMemory
         }
 
         sb.AppendLine();
-    }
-
-    private static AthleteExtra BuildExtra(JsonObject athlete)
-    {
-        var slug = GetString(athlete, "AthleteSlug");
-        return new AthleteExtra(
-            Slug: slug,
-            DisplayName: FirstNonEmpty(GetString(athlete, "DisplayName"), GetString(athlete, "Name"), slug),
-            Division: GetString(athlete, "Division"),
-            Generation: GenerationResolver.ResolveFromAthleteJson(athlete) ?? "",
-            Flag: GetString(athlete, "Flag"),
-            ExclusiveLeague: GetString(athlete, "ExclusiveLeague"),
-            MediaContact: GetString(athlete, "MediaContact"));
-    }
-
-    private static string FilterMediaContact(string mediaContact)
-    {
-        if (string.IsNullOrWhiteSpace(mediaContact))
-        {
-            return "";
-        }
-
-        var trimmed = mediaContact.Trim();
-        return EmailLike.IsMatch(trimmed) ? "" : trimmed;
     }
 
     private static string MarkdownLink(string text, string url)
@@ -270,55 +207,6 @@ public sealed class LeaderboardFactsService(AthleteDataService athletes, IMemory
     {
         return value.HasValue ? value.Value.ToString("0.##", CultureInfo.InvariantCulture) : "";
     }
-
-    private static string FirstNonEmpty(params string?[] values)
-    {
-        return values.FirstOrDefault(value => !string.IsNullOrWhiteSpace(value))?.Trim() ?? "";
-    }
-
-    private static string GetString(JsonObject obj, string propertyName)
-    {
-        return obj[propertyName] is JsonValue value && value.TryGetValue<string>(out var result)
-            ? result?.Trim() ?? ""
-            : "";
-    }
-
-    private static bool TryGetDouble(JsonObject obj, string propertyName, out double value)
-    {
-        value = 0;
-        return obj[propertyName] is JsonValue jsonValue &&
-               jsonValue.TryGetValue<double>(out value) &&
-               !double.IsNaN(value) &&
-               !double.IsInfinity(value);
-    }
-
-    private sealed record AthleteExtra(
-        string Slug,
-        string DisplayName,
-        string Division,
-        string Generation,
-        string Flag,
-        string ExclusiveLeague,
-        string MediaContact)
-    {
-        public static readonly AthleteExtra Empty = new("", "", "", "", "", "", "");
-    }
-
-    private sealed record LeaderboardFactRow(
-        int Rank,
-        string Slug,
-        string DisplayName,
-        string AthleteUrl,
-        string Track,
-        double? EffectiveAgeReductionYears,
-        double? LowestBortzAge,
-        double? LowestPhenoAge,
-        double? ChronologicalAge,
-        string Division,
-        string Generation,
-        string Flag,
-        string ExclusiveLeague,
-        string MediaContact);
 }
 
 public sealed record LeaderboardFactsDocument(string Markdown, DateTimeOffset LastModifiedUtc);

--- a/LongevityWorldCup.Website/Business/LeaderboardSnapshot.cs
+++ b/LongevityWorldCup.Website/Business/LeaderboardSnapshot.cs
@@ -1,0 +1,164 @@
+using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
+using LongevityWorldCup.Website.Tools;
+
+namespace LongevityWorldCup.Website.Business;
+
+public sealed record LeaderboardSnapshot(IReadOnlyList<LeaderboardSnapshotRow> Rows);
+
+public sealed record LeaderboardSnapshotRow(
+    int Rank,
+    string Slug,
+    string RouteSlug,
+    string DisplayName,
+    string AthletePath,
+    string AthleteUrl,
+    string Track,
+    string Tier,
+    double? EffectiveAgeReductionYears,
+    double? LowestBortzAge,
+    double? LowestPhenoAge,
+    double? ChronologicalAge,
+    string Division,
+    string Generation,
+    string Flag,
+    string ExclusiveLeague,
+    string MediaContact,
+    string? LeaderboardThumbnailUrl);
+
+public static class LeaderboardSnapshotBuilder
+{
+    private const string DefaultSiteBaseUrl = "https://longevityworldcup.com";
+    private static readonly Regex EmailLike = new(@"^[^\s@]+@[^\s@]+\.[^\s@]+$", RegexOptions.Compiled);
+
+    public static LeaderboardSnapshot Build(JsonArray rankedRows, JsonArray athletesSnapshot, string siteBaseUrl = DefaultSiteBaseUrl)
+    {
+        var normalizedSiteBaseUrl = string.IsNullOrWhiteSpace(siteBaseUrl)
+            ? DefaultSiteBaseUrl
+            : siteBaseUrl.TrimEnd('/');
+        var extraBySlug = athletesSnapshot
+            .OfType<JsonObject>()
+            .Select(BuildExtra)
+            .Where(extra => !string.IsNullOrWhiteSpace(extra.Slug))
+            .ToDictionary(extra => extra.Slug, StringComparer.OrdinalIgnoreCase);
+
+        var rows = new List<LeaderboardSnapshotRow>();
+        var rank = 0;
+        foreach (var node in rankedRows.OfType<JsonObject>())
+        {
+            var slug = GetString(node, "AthleteSlug");
+            if (string.IsNullOrWhiteSpace(slug))
+            {
+                continue;
+            }
+
+            rank++;
+            extraBySlug.TryGetValue(slug, out var extra);
+            extra ??= AthleteExtra.Empty;
+            var routeSlug = slug.Replace('_', '-');
+            var athletePath = $"/athlete/{routeSlug}";
+            var displayName = FirstNonEmpty(extra.DisplayName, GetString(node, "Name"), slug);
+            var hasBortz = TryGetDouble(node, "LowestBortzAge", out var lowestBortzAge);
+            var track = hasBortz ? "Pro" : "Amateur";
+
+            TryGetDouble(node, "LowestPhenoAge", out var lowestPhenoAge);
+            TryGetDouble(node, "ChronologicalAge", out var chronologicalAge);
+            TryGetDouble(node, "AgeDifference", out var ageDifference);
+
+            rows.Add(new LeaderboardSnapshotRow(
+                Rank: rank,
+                Slug: slug,
+                RouteSlug: routeSlug,
+                DisplayName: displayName,
+                AthletePath: athletePath,
+                AthleteUrl: $"{normalizedSiteBaseUrl}{athletePath}",
+                Track: track,
+                Tier: track.ToLowerInvariant(),
+                EffectiveAgeReductionYears: ageDifference,
+                LowestBortzAge: hasBortz ? lowestBortzAge : null,
+                LowestPhenoAge: lowestPhenoAge,
+                ChronologicalAge: chronologicalAge,
+                Division: extra.Division,
+                Generation: extra.Generation,
+                Flag: extra.Flag,
+                ExclusiveLeague: extra.ExclusiveLeague,
+                MediaContact: FilterMediaContact(extra.MediaContact),
+                LeaderboardThumbnailUrl: FirstNonEmpty(extra.ProfilePicLeaderboardThumb, extra.ProfilePicThumb, extra.ProfilePic)));
+        }
+
+        return new LeaderboardSnapshot(rows);
+    }
+
+    private static AthleteExtra BuildExtra(JsonObject athlete)
+    {
+        var slug = GetString(athlete, "AthleteSlug");
+        return new AthleteExtra(
+            Slug: slug,
+            DisplayName: FirstNonEmpty(GetString(athlete, "DisplayName"), GetString(athlete, "Name"), slug),
+            Division: GetString(athlete, "Division"),
+            Generation: GenerationResolver.ResolveFromAthleteJson(athlete) ?? "",
+            Flag: GetString(athlete, "Flag"),
+            ExclusiveLeague: GetString(athlete, "ExclusiveLeague"),
+            MediaContact: GetString(athlete, "MediaContact"),
+            ProfilePic: GetString(athlete, "ProfilePic"),
+            ProfilePicThumb: GetString(athlete, "ProfilePicThumb"),
+            ProfilePicLeaderboardThumb: GetString(athlete, "ProfilePicLeaderboardThumb"));
+    }
+
+    private static string FilterMediaContact(string mediaContact)
+    {
+        if (string.IsNullOrWhiteSpace(mediaContact))
+        {
+            return "";
+        }
+
+        var trimmed = mediaContact.Trim();
+        return EmailLike.IsMatch(trimmed) ? "" : trimmed;
+    }
+
+    private static string FirstNonEmpty(params string?[] values)
+    {
+        return values.FirstOrDefault(value => !string.IsNullOrWhiteSpace(value))?.Trim() ?? "";
+    }
+
+    private static string GetString(JsonObject obj, string propertyName)
+    {
+        return obj[propertyName] is JsonValue value && value.TryGetValue<string>(out var result)
+            ? SanitizeText(result)
+            : "";
+    }
+
+    private static string SanitizeText(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value)
+            ? ""
+            : value
+                .Replace("\r", " ", StringComparison.Ordinal)
+                .Replace("\n", " ", StringComparison.Ordinal)
+                .Trim();
+    }
+
+    private static bool TryGetDouble(JsonObject obj, string propertyName, out double value)
+    {
+        value = 0;
+        return obj[propertyName] is JsonValue jsonValue &&
+               jsonValue.TryGetValue<double>(out value) &&
+               !double.IsNaN(value) &&
+               !double.IsInfinity(value);
+    }
+
+    private sealed record AthleteExtra(
+        string Slug,
+        string DisplayName,
+        string Division,
+        string Generation,
+        string Flag,
+        string ExclusiveLeague,
+        string MediaContact,
+        string ProfilePic,
+        string ProfilePicThumb,
+        string ProfilePicLeaderboardThumb)
+    {
+        public static readonly AthleteExtra Empty = new("", "", "", "", "", "", "", "", "", "");
+    }
+}

--- a/LongevityWorldCup.Website/Middleware/HtmlInjectionMiddleware.cs
+++ b/LongevityWorldCup.Website/Middleware/HtmlInjectionMiddleware.cs
@@ -7,14 +7,19 @@ using System.Text.RegularExpressions;
 
 namespace LongevityWorldCup.Website.Middleware
 {
-    public class HtmlInjectionMiddleware(RequestDelegate next, AthleteOgImageService athleteOgImages, LeagueOgImageService leagueOgImages, AssetVersionProvider assetVersionProvider)
+    public class HtmlInjectionMiddleware(RequestDelegate next, AthleteOgImageService athleteOgImages, LeagueOgImageService leagueOgImages, AssetVersionProvider assetVersionProvider, LeaderboardFactsService leaderboardFacts, ILogger<HtmlInjectionMiddleware> logger)
     {
         private readonly RequestDelegate _next = next;
         private readonly AthleteOgImageService _athleteOgImages = athleteOgImages;
         private readonly LeagueOgImageService _leagueOgImages = leagueOgImages;
         private readonly AssetVersionProvider _assetVersionProvider = assetVersionProvider;
+        private readonly LeaderboardFactsService _leaderboardFacts = leaderboardFacts;
+        private readonly ILogger<HtmlInjectionMiddleware> _logger = logger;
         private const string SiteBaseUrl = "https://longevityworldcup.com";
         private const string DefaultOgImagePath = "/assets/og-image.png";
+        private const string LeaderboardRowsStartMarker = "<!--LEADERBOARD-TBODY-ROWS-START-->";
+        private const string LeaderboardRowsEndMarker = "<!--LEADERBOARD-TBODY-ROWS-END-->";
+        private const string LeaderboardSkeletonTbodyOpenTag = "<tbody class=\"loading-skeleton\" aria-busy=\"true\">";
         private static readonly HashSet<string> IndexableRoutes = new(StringComparer.OrdinalIgnoreCase)
         {
             "/",
@@ -69,6 +74,7 @@ namespace LongevityWorldCup.Website.Middleware
 
                     // Replace placeholders within leaderboardContent first (since it contains nested placeholders)
                     leaderboardContent = leaderboardContent.Replace("<!--AGE-VISUALIZATION-->", ageVisualization);
+                    leaderboardContent = ApplyLeaderboardRows(leaderboardContent, context);
 
                     // Replace placeholders with header and footer content
                     bodyContent = bodyContent
@@ -138,6 +144,54 @@ namespace LongevityWorldCup.Website.Middleware
                 .Replace("{{ASSET_PRO_DISCOUNTS_JS}}", _assetVersionProvider.AppendVersion("/js/pro-discounts.js"))
                 .Replace("{{ASSET_PROOF_HELPERS_JS}}", _assetVersionProvider.AppendVersion("/js/proof-helpers.js"))
                 .Replace("{{ASSET_AGE_VISUALIZATION_JS}}", _assetVersionProvider.AppendVersion("/js/age-visualization.js"));
+        }
+
+        private string ApplyLeaderboardRows(string html, HttpContext context)
+        {
+            if (!ShouldRenderLeaderboardRows(context))
+            {
+                return html;
+            }
+
+            try
+            {
+                var rowsHtml = LeaderboardHtmlRenderer.RenderRows(_leaderboardFacts.GetLeaderboardSnapshot());
+                return string.IsNullOrWhiteSpace(rowsHtml)
+                    ? html
+                    : ReplaceLeaderboardRows(html, rowsHtml);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Falling back to leaderboard skeleton rows after server row rendering failed.");
+                return html;
+            }
+        }
+
+        private static string ReplaceLeaderboardRows(string html, string rowsHtml)
+        {
+            var start = html.IndexOf(LeaderboardRowsStartMarker, StringComparison.Ordinal);
+            var end = html.IndexOf(LeaderboardRowsEndMarker, StringComparison.Ordinal);
+            if (start < 0 || end < 0 || end <= start)
+            {
+                return html;
+            }
+
+            var rowsStart = start + LeaderboardRowsStartMarker.Length;
+            var replacedRows = html
+                .Remove(rowsStart, end - rowsStart)
+                .Insert(rowsStart, $"{Environment.NewLine}{rowsHtml}                ");
+
+            return replacedRows.Replace(
+                LeaderboardSkeletonTbodyOpenTag,
+                $"<tbody {LeaderboardHtmlRenderer.ServerRenderedTbodyAttributes}>",
+                StringComparison.Ordinal);
+        }
+
+        private static bool ShouldRenderLeaderboardRows(HttpContext context)
+        {
+            var canonicalPath = RouteCanonicalization.GetCanonicalPath(context.Request.Path.Value);
+            return string.Equals(canonicalPath, "/leaderboard", StringComparison.OrdinalIgnoreCase) &&
+                   !context.Request.QueryString.HasValue;
         }
 
         private string ApplySharedAssetPlaceholders(string html)

--- a/LongevityWorldCup.Website/Tools/LeaderboardHtmlRenderer.cs
+++ b/LongevityWorldCup.Website/Tools/LeaderboardHtmlRenderer.cs
@@ -1,0 +1,111 @@
+using System.Globalization;
+using System.Net;
+using System.Text;
+using LongevityWorldCup.Website.Business;
+
+namespace LongevityWorldCup.Website.Tools;
+
+public static class LeaderboardHtmlRenderer
+{
+    public const string ServerRenderedTbodyAttributes = "data-server-rendered=\"true\" aria-busy=\"false\"";
+
+    public static string RenderRows(LeaderboardSnapshot snapshot)
+    {
+        if (snapshot.Rows.Count == 0)
+        {
+            return "";
+        }
+
+        var sb = new StringBuilder();
+        foreach (var row in snapshot.Rows)
+        {
+            AppendRow(sb, row);
+        }
+
+        return sb.ToString();
+    }
+
+    private static void AppendRow(StringBuilder sb, LeaderboardSnapshotRow row)
+    {
+        var tier = string.Equals(row.Tier, "pro", StringComparison.OrdinalIgnoreCase) ? "pro" : "amateur";
+        var rank = row.Rank.ToString(CultureInfo.InvariantCulture);
+        var athletePath = EncodeAttribute(row.AthletePath);
+        var displayName = EncodeText(row.DisplayName);
+        var ageReduction = EncodeText(FormatYears(row.EffectiveAgeReductionYears));
+        var thumbnail = IsGeneratedAssetUrl(row.LeaderboardThumbnailUrl)
+            ? row.LeaderboardThumbnailUrl
+            : null;
+
+        sb.Append("                <tr id=\"rank-")
+            .Append(rank)
+            .Append("\" class=\"tier-")
+            .Append(tier)
+            .Append(" server-rendered-leaderboard-row\" data-tier=\"")
+            .Append(tier)
+            .Append("\" data-athlete-name=\"")
+            .Append(EncodeAttribute(row.DisplayName))
+            .AppendLine("\">");
+        sb.Append("                    <td data-label=\"Rank\" class=\"rank-td\"><span class=\"rank\">")
+            .Append(rank)
+            .AppendLine("</span></td>");
+        sb.AppendLine("                    <td data-label=\"Athlete\" class=\"athlete-td\">");
+        if (!string.IsNullOrWhiteSpace(thumbnail))
+        {
+            sb.Append("                        <span class=\"portrait-wrapper\"><img src=\"")
+                .Append(EncodeAttribute(thumbnail))
+                .Append("\" alt=\"")
+                .Append(EncodeAttribute($"{row.DisplayName} portrait"))
+                .AppendLine("\" class=\"portrait\" loading=\"lazy\"></span>");
+        }
+        sb.Append("                        <a class=\"athlete-name\" href=\"")
+            .Append(athletePath)
+            .Append("\">")
+            .Append(displayName)
+            .AppendLine("</a>");
+        sb.AppendLine("                    </td>");
+        sb.AppendLine("                    <td data-label=\"Sponsor\" class=\"sponsor-td\"></td>");
+        sb.Append("                    <td data-label=\"Age reduction\" class=\"age-reduction-td\"><span class=\"age-reduction\">")
+            .Append(ageReduction)
+            .AppendLine("</span></td>");
+        sb.Append("                    <td data-label=\"Media contact\" class=\"media-contact-td\">")
+            .Append(RenderMediaContact(row))
+            .AppendLine("</td>");
+        sb.AppendLine("                </tr>");
+    }
+
+    private static string RenderMediaContact(LeaderboardSnapshotRow row)
+    {
+        if (string.IsNullOrWhiteSpace(row.MediaContact))
+        {
+            return "";
+        }
+
+        var href = row.MediaContact.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
+                   row.MediaContact.StartsWith("https://", StringComparison.OrdinalIgnoreCase)
+            ? row.MediaContact
+            : $"https://{row.MediaContact}";
+
+        return $"<a href=\"{EncodeAttribute(href)}\" target=\"_blank\" rel=\"noopener\" class=\"media-contact\">Contact</a>";
+    }
+
+    private static bool IsGeneratedAssetUrl(string? url)
+    {
+        return !string.IsNullOrWhiteSpace(url) &&
+               url.StartsWith("/generated/", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string FormatYears(double? value)
+    {
+        return value.HasValue ? $"{value.Value.ToString("+#0.0;-#0.0;0.0", CultureInfo.InvariantCulture)} years" : "";
+    }
+
+    private static string EncodeText(string value)
+    {
+        return WebUtility.HtmlEncode(value ?? "");
+    }
+
+    private static string EncodeAttribute(string? value)
+    {
+        return WebUtility.HtmlEncode(value ?? "");
+    }
+}

--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -2350,6 +2350,7 @@
                 </tr>
                 </thead>
                 <tbody class="loading-skeleton" aria-busy="true">
+<!--LEADERBOARD-TBODY-ROWS-START-->
                 <tr class="leaderboard-skeleton-row" aria-hidden="true">
                     <td data-label="Rank" class="rank-td"><span class="rank skeleton-shimmer"></span></td>
                     <td data-label="Athlete" class="athlete-td">
@@ -2410,6 +2411,7 @@
                     <td data-label="Age reduction" class="age-reduction-td"><span class="age-reduction leaderboard-skeleton-block skeleton-shimmer"></span></td>
                     <td data-label="Media contact" class="media-contact-td"><span class="leaderboard-skeleton-block skeleton-shimmer"></span></td>
                 </tr>
+<!--LEADERBOARD-TBODY-ROWS-END-->
                 </tbody>
             </table>
         </div>
@@ -3585,6 +3587,8 @@
                 const tableBody = document.querySelector('.leaderboard table tbody');
                 tableBody.classList.remove('loading-skeleton');
                 tableBody.setAttribute('aria-busy', 'false');
+                tableBody.removeAttribute('data-server-rendered');
+                tableBody.removeAttribute('data-hydrating');
                 const remainingAthletes = athleteResults;
 
                 tableBody.innerHTML = ''; // Clear existing table rows
@@ -3776,7 +3780,10 @@
                 if (tableBody) {
                     tableBody.classList.remove('loading-skeleton');
                     tableBody.setAttribute('aria-busy', 'false');
-                    tableBody.innerHTML = '<tr><td colspan="5" class="no-results">Failed to load leaderboard.</td></tr>';
+                    tableBody.removeAttribute('data-hydrating');
+                    if (!hasServerRenderedLeaderboardRows(tableBody)) {
+                        tableBody.innerHTML = '<tr><td colspan="5" class="no-results">Failed to load leaderboard.</td></tr>';
+                    }
                 }
                 const podium = document.querySelector('.podium');
                 if (podium) {
@@ -3828,6 +3835,12 @@
         `).join('');
     }
 
+    function hasServerRenderedLeaderboardRows(tableBody) {
+        return !!tableBody &&
+            tableBody.getAttribute('data-server-rendered') === 'true' &&
+            !!tableBody.querySelector('tr.server-rendered-leaderboard-row');
+    }
+
     function setLeaderboardLoadingState(includePodium, maxAthletes) {
         const podium = document.querySelector('.podium');
         if (podium) {
@@ -3844,6 +3857,12 @@
 
         const tableBody = document.querySelector('.leaderboard table tbody');
         if (!tableBody) return;
+        if (hasServerRenderedLeaderboardRows(tableBody)) {
+            tableBody.classList.remove('loading-skeleton');
+            tableBody.setAttribute('aria-busy', 'true');
+            tableBody.setAttribute('data-hydrating', 'true');
+            return;
+        }
 
         const skeletonCount = Number.isFinite(maxAthletes)
             ? Math.min(Math.max(maxAthletes, 4), 10)


### PR DESCRIPTION
## Summary
- Server-render the full current Ultimate League leaderboard into the initial clean `/leaderboard` `<tbody>` with semantic rank, athlete link, tier, age reduction, optional generated thumbnail, and safe public contact markup.
- Keep the existing skeleton rows as the fallback for non-canonical leaderboard routes, shared partial use outside clean `/leaderboard`, empty snapshots, or server rendering failure.
- Do not change ranking rules, `robots.txt`, or static asset loading behavior.

## Shared Snapshot Source
- Added a reusable `LeaderboardSnapshot` built from `AthleteDataService.GetRankingsOrder()` plus public athlete snapshot metadata.
- Refactored `LeaderboardFactsService` so `/ai/leaderboard.md`, athlete names markdown, and server-rendered leaderboard HTML read from the same snapshot rows.
- Kept email-like media contacts filtered out and covered ordering, public fields, sanitization, no top-N cutoff, Pro-before-Amateur rendering, and generated-thumbnail handling in focused tests.

## Hydration And Fallback Behavior
- `LoadLeaderboard()` leaves server-rendered rows visible while `/api/data/athletes` is pending instead of replacing them with skeleton rows.
- Successful hydration replaces server rows with the normal interactive client-rendered rows and removes the server-rendered marker, avoiding duplicate athlete rows.
- Failed athlete API fetches keep the server-rendered leaderboard visible instead of replacing it with an error-only or blank table.
- Existing interactive behavior remains client-owned after hydration: search, filters, Overall/Bortz/Pheno switching, modal opening, rank anchors, tier separator behavior, and responsive/mobile table layout.

## Verification Matrix
| Area | Status | Notes |
| --- | --- | --- |
| `dotnet test LongevityWorldCup.sln --no-restore` | PASS | 18 tests passed. |
| `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --no-restore` | PASS | 18 tests passed. |
| `dotnet build LongevityWorldCup.sln --no-restore` | PASS | 0 warnings, 0 errors. |
| `git diff --check origin/master...HEAD` | PASS | No whitespace errors. |
| Working tree hygiene | PASS | `git status` clean on `codex/crawlable-leaderboard-rankings`. |
| Intended files only | PASS | Branch diff is limited to snapshot, renderer, middleware, leaderboard partial hydration, and tests. |
| Generated/cache/build artifacts | PASS | No untracked files; no tracked `bin`, `obj`, cache, log, or build artifacts in the branch diff. |
| README/docs/AGENTS.md | PASS | No README/docs changes; `AGENTS.md` guidance remains accurate, so no update was needed. |
| Raw `/leaderboard` no-JS output | PASS | 200 response with 201 real server-rendered rows, including `rank-1`, `rank-2`, `rank-3`, athlete names, `/athlete/...` links, and age reduction text. |
| Raw row count | PASS | Raw `<tbody>` row count equals the shared backend snapshot / `/ai/leaderboard.md` Ultimate League row count: 201. |
| Raw row order | PASS | Raw row order exactly matched the shared snapshot-backed `/ai/leaderboard.md` order for all rows checked, including first 20 by rank, athlete, track, and age reduction. |
| Pro-before-Amateur raw order | PASS | All Pro rows appeared before Amateur rows; first Amateur row appeared immediately after the last Pro row. |
| Stable rank anchors | PASS | Every server-rendered row has `id="rank-N"`; `rank-1` through `rank-10` verified. |
| Canonical athlete links | PASS | Server-rendered athlete links use canonical `/athlete/{slug-with-hyphens}` paths. |
| No spammy SEO content | PASS | No hidden SEO copy, fake FAQ, keyword stuffing, or SEO-only paragraphs were added. |
| SEO/crawler metadata | PASS | `/leaderboard` remains `index, follow`; canonical remains `https://longevityworldcup.com/leaderboard`; alternate markdown link to `/ai/leaderboard.md` remains present. |
| `robots.txt` policy | PASS | `robots.txt` is unchanged; `/api/` remains disallowed. |
| Structured data | PASS | Existing `Organization`, `WebSite`, `WebPage`, and `BreadcrumbList` JSON-LD remain. No `@type: "ItemList"` was added; ItemList remains optional and deferred. |
| `/ai/leaderboard.md` alignment | PASS | `/ai/leaderboard.md` still works and is generated from the same shared snapshot source as server-rendered rows. |
| Backend ranking source | PASS | Shared snapshot derives from `AthleteDataService.GetRankingsOrder()` and does not duplicate ranking extraction in middleware. |
| Public contact filtering | PASS | Email-like contacts remain filtered out of public machine-readable/server-rendered facts. |
| HTML escaping/sanitization | PASS | Renderer tests cover escaped content/attributes and generated-thumbnail restrictions. |
| Pending API hydration behavior | PASS | With `/api/data/athletes` held pending by a local proxy, 201 server-rendered rows stayed visible; no skeleton replacement. |
| Failed API hydration behavior | PASS | With `/api/data/athletes` forced to fail, 201 server-rendered rows stayed visible; no error-only table and no endless skeleton. |
| Successful hydration | PASS | Hydrated page had 201 client athlete rows, one expected tier separator, no duplicate athlete rows, no stale server-only rows, and no new console errors. |
| Hydrated order | PASS | Hydrated default Overall top order matched the shared backend snapshot; Pro rows remained before Amateur rows. |
| Core interactions | PASS | Search via URL state and clear button, division/generation/flag/exclusive filters, Overall/Bortz/Pheno switching, switching back to Overall, athlete modal opening, supported direct/query athlete routes, `#rank-10`, tier separator behavior, and no duplicates after filtering/switching were verified. |
| Search input typing | NOT RUN | Browser automation `locator.fill()` / `locator.type()` failed because the Browser Use virtual clipboard was unavailable. Closest practical check used `?search=Siim` plus the visible clear button. Remaining manual check: type in the search box in a normal browser. |
| Raw HTML size | PASS | Measured against temporary `origin/master` worktree: 445,660 bytes before, 635,378 bytes after, +189,718 bytes. |
| Gzipped response size | PASS | Actual local gzip wire body: 103,056 bytes before, 116,093 bytes after, +13,037 bytes. |
| Local response time | PASS | Warm local median: 39.55 ms before, 52.17 ms after, +12.62 ms. |
| Snapshot caching | PASS | Snapshot is cached in `IMemoryCache` for 5 minutes, consistent with `/ai/leaderboard.md`; clean `/leaderboard` calls the shared snapshot once and renders from it. |
| Athlete reload freshness | PASS | Athlete reloads naturally refresh after the existing 5-minute shared snapshot cache window, matching `/ai/leaderboard.md` behavior. |
| Static assets | PASS | No new static asset files; no new large inline scripts/styles; no new unversioned static asset dependencies. |

## Known Limitations
- The no-JS table is intentionally modest and link-first; advanced interactivity such as filters, modal details, badges, and dynamic clock switching still requires successful client hydration.
- Raw order verification used `/ai/leaderboard.md`, which is generated from the same shared snapshot sourced from `GetRankingsOrder()`, rather than adding a temporary diagnostic endpoint.
- Server-rendered thumbnails are only emitted for stable generated thumbnail URLs; original `/athletes/...` profile images remain client-rendered after hydration.
- Browser automation could not type into the search input because its virtual clipboard support was unavailable; query-state search plus clearing was verified, and manual typing in a normal browser remains the only unrun interaction check.
