### PR TITLE
[codex] Fix highlight claim badge alignment

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
@@ -510,7 +510,7 @@
     .events-board .others-wrapper:hover .others-flyout{display:block}
     .events-board .others-flyout a{color:var(--primary-color);text-decoration:underline}
 
-    .events-board .badge-with-from{display:inline-flex;align-items:center;position:relative;white-space:normal}
+    .events-board .badge-with-from{display:inline-flex;align-items:center;align-self:center;position:relative;white-space:normal}
     .events-board .badge-with-from .badge-from{
         max-width:0;opacity:0;overflow:hidden;white-space:nowrap;margin-left:0;
         transition:max-width .25s ease,opacity .25s ease,margin-left .25s ease


### PR DESCRIPTION
## Summary
- centers the badge-and-donor wrapper used by Highlights claim rows
- prevents baseline synthesis from shifting badge claim tokens when the homepage highlights list wraps

## Root cause
The claim badge wrapper is an inline flex item inside baseline-aligned event message rows. When the wrapper starts with a graphic badge, browsers can synthesize a baseline from the badge box instead of the following text, causing production-only vertical drift.

## Validation
- dotnet build LongevityWorldCup.sln
- dotnet test LongevityWorldCup.sln --no-build
- local production-mode visual check at http://localhost:5123