### PR TITLE
[codex] Fix mobile highlight claim wrapping

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
@@ -684,6 +684,12 @@
         .events-board:not(.athlete-scroll) td.event-message .event-message-cell .more-link{
             white-space:nowrap;
         }
+        .events-board:not(.athlete-scroll) .badge-with-from.show-from{
+            display:contents;
+        }
+        .events-board:not(.athlete-scroll) .badge-with-from.show-from .badge-class{
+            align-self:center;
+        }
         .events-board:not(.athlete-scroll) .event-inline-text{
             line-height:1.3;
         }


### PR DESCRIPTION
## Summary
- fixes mobile Highlights claim wrapping after the desktop badge alignment change
- lets the visible claim badge and donor text wrap as separate inline pieces on narrow non-athlete-scroll event boards
- keeps the desktop badge-from wrapper centered as before

## Validation
- dotnet build LongevityWorldCup.sln
- dotnet test LongevityWorldCup.sln --no-build
- local production-mode browser checks at 365px and 1280px viewport widths