### PR TITLE
[codex] Polish newsletter placeholder

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/index.html
+++ b/LongevityWorldCup.Website/wwwroot/index.html
@@ -1828,7 +1828,7 @@
             </p>
 
             <form id="newsletter-form">
-                <input type="email" id="emailInput" class="shared-email-input" placeholder="why_am_i_doing_this@help.com" required>
+                <input type="email" id="emailInput" class="shared-email-input" placeholder="athlete@example.com" required>
                 <button type="submit" class="enhanced-subscribe-btn shared-email-button" aria-label="Subscribe to the Longevity World&nbsp;Cup newsletter">
                     <i class="fas fa-paper-plane"></i> Subscribe
                 </button>


### PR DESCRIPTION
## Summary

- Replaces the playful newsletter email placeholder with a neutral example address.

## Why

This improves the homepage first impression by keeping the public-facing newsletter form more polished and professional.

## Validation

- Checked the focused homepage diff.
- Ran `git diff --check` successfully; Git reported only the repository's line-ending warning for the edited HTML file.