### PR TITLE
[codex] Polish homepage first impression

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/partials/header.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/header.html
@@ -756,7 +756,7 @@
              decoding="async">
         <div class="bannertext">Longevity World&nbsp;Cup</div>
         <span class="tagline">
-            ascend to longevitymaxxing
+            longevity leaderboards
         </span>
     </a>
     <button onclick="window.location.href='/play'" class="join-game" aria-label="Play the game">

--- a/LongevityWorldCup.Website/wwwroot/play/menu.html
+++ b/LongevityWorldCup.Website/wwwroot/play/menu.html
@@ -26,20 +26,24 @@
             overflow: hidden;
             display: block;
             margin: 0 auto;
-            border: 1px solid rgba(15, 23, 42, 0.2);
-            border-radius: 8px;
-            background: #111614;
+            border-radius: 6px;
+            background: transparent;
             box-shadow: 0 10px 24px rgba(15, 23, 42, 0.16);
         }
 
             .img-crop .illustration {
                 box-sizing: border-box;
                 width: 100%; /* same width behavior */
+                max-width: none;
                 height: auto;
                 display: block;
+                margin: 0;
                 position: relative;
                 top: 50%;
                 transform: translateY(-50%); /* equal crop top/bottom */
+                border: 0;
+                border-radius: 6px;
+                box-shadow: none;
             }
 
         .play-menu-actions {


### PR DESCRIPTION
## Summary
- Rename the header tagline to "longevity leaderboards" for clearer first-impression positioning.
- Remove the extra wrapper frame styling around the play menu poster so the existing "Just Track It" image sits cleanly.

## Validation
- Ran `dotnet build LongevityWorldCup.sln` successfully.
- Reloaded `/play` locally and checked the poster framing in the in-app browser.
