### PR TITLE
[codex] Add Custom Event Designer direct posting

### DIFF
--- a/LongevityWorldCup.Documentation/CustomEvent.md
+++ b/LongevityWorldCup.Documentation/CustomEvent.md
@@ -1,3 +1,83 @@
+## Run from the designer page direct post
+
+Open:
+
+```text
+/internal/custom-event-designer.html
+```
+
+Direct posting is disabled until the server config contains a hash in `CustomEventDesignerSecretHash`.
+
+To configure it on the Linux server:
+
+1. Choose a temporary posting secret.
+2. Enter it in the designer page `Secret` field.
+3. Click `Generate Config Hash`.
+4. Copy the generated hash into `/var/www/LongevityWorldCup/publish/config.json` as `CustomEventDesignerSecretHash`.
+5. Restart the website so the config is reloaded:
+
+```sh
+sudo systemctl restart longevityworldcup.service
+sudo systemctl status longevityworldcup.service
+```
+
+The config stores only the hash. Do not store the plain secret in config, logs, shell history, or documentation.
+
+Fill in:
+
+- `Title`
+- `Content`
+- target platforms
+- `Webpage` if the post should also appear on `/events`
+- `Secret`
+
+Then click `Post Event`.
+
+Behavior:
+
+- if `Webpage` is enabled, the post is stored in the DB and also appears on the public event feed
+- if `Webpage` is disabled, the post is still stored in the DB, but it stays hidden from the public website
+- hidden website posts can still be sent to Slack / X / Threads / Facebook
+- when `Webpage` is disabled, social post generation does not include a public event URL
+- selected social destinations are stored as pending by setting their `Processed` column to `0`
+- unselected social destinations are stored as already processed by setting their `Processed` column to `1`
+
+## Safe live-test checklist
+
+Use the smallest possible blast radius for the first live test.
+
+1. Save the current `CustomEventDesignerSecretHash` value.
+2. Generate a hash from a temporary secret and put that hash in `/var/www/LongevityWorldCup/publish/config.json`.
+3. Restart the website with `sudo systemctl restart longevityworldcup.service`.
+4. Open `/internal/custom-event-designer.html`.
+5. Use a harmless title such as `Test event - delete me`.
+6. Select `Webpage` only and clear Slack, X, Threads, and Facebook.
+7. Click `Post Event`.
+8. Confirm the response shows an event id.
+9. Confirm the event appears on the public event feed.
+10. Copy the cleanup SQL from the designer page and delete the test row if it should not remain public.
+11. Roll back by restoring the previous `CustomEventDesignerSecretHash` value, or clearing it to disable direct posting.
+12. Restart the website again so rollback takes effect.
+
+Linux production paths:
+
+- Config: `/var/www/LongevityWorldCup/publish/config.json`
+- Database: `/var/www/.longevityworldcup/LongevityWorldCup.db`
+- Service: `longevityworldcup.service`
+- App logs:
+
+```sh
+sudo journalctl -u longevityworldcup.service -n 100 --no-pager
+```
+
+Cleanup SQL format:
+
+```bash
+sudo sqlite3 /var/www/.longevityworldcup/LongevityWorldCup.db "DELETE FROM Events WHERE Id = 'ID_GOES_HERE';"
+```
+
+If the test accidentally used a social destination, inspect the corresponding processed column before deleting the row. A selected social target is pending while its processed column is `0`.
+
 ## Run from the designer page payload
 
 Open:

--- a/LongevityWorldCup.Tests/CustomEventDeliveryTargetsTests.cs
+++ b/LongevityWorldCup.Tests/CustomEventDeliveryTargetsTests.cs
@@ -1,0 +1,123 @@
+using LongevityWorldCup.Website.Business;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class CustomEventDeliveryTargetsTests
+{
+    public static IEnumerable<object[]> DefaultStorageFlagCases()
+    {
+        yield return
+        [
+            "visible, no configured social platforms",
+            true,
+            false,
+            false,
+            false,
+            new CustomEventStorageFlags(1, 0, 1, 1, 1)
+        ];
+        yield return
+        [
+            "hidden, all social platforms configured",
+            false,
+            true,
+            true,
+            true,
+            new CustomEventStorageFlags(0, 0, 0, 0, 0)
+        ];
+        yield return
+        [
+            "visible, mixed configured social platforms",
+            true,
+            true,
+            false,
+            true,
+            new CustomEventStorageFlags(1, 0, 0, 1, 0)
+        ];
+    }
+
+    public static IEnumerable<object[]> StorageFlagCases()
+    {
+        yield return
+        [
+            "webpage only",
+            new CustomEventDeliveryTargets(true, false, false, false, false),
+            new CustomEventStorageFlags(1, 1, 1, 1, 1)
+        ];
+        yield return
+        [
+            "Slack only",
+            new CustomEventDeliveryTargets(false, true, false, false, false),
+            new CustomEventStorageFlags(0, 0, 1, 1, 1)
+        ];
+        yield return
+        [
+            "X only",
+            new CustomEventDeliveryTargets(false, false, true, false, false),
+            new CustomEventStorageFlags(0, 1, 0, 1, 1)
+        ];
+        yield return
+        [
+            "Threads only",
+            new CustomEventDeliveryTargets(false, false, false, true, false),
+            new CustomEventStorageFlags(0, 1, 1, 0, 1)
+        ];
+        yield return
+        [
+            "Facebook only",
+            new CustomEventDeliveryTargets(false, false, false, false, true),
+            new CustomEventStorageFlags(0, 1, 1, 1, 0)
+        ];
+        yield return
+        [
+            "all selected",
+            new CustomEventDeliveryTargets(true, true, true, true, true),
+            new CustomEventStorageFlags(1, 0, 0, 0, 0)
+        ];
+        yield return
+        [
+            "none selected",
+            new CustomEventDeliveryTargets(false, false, false, false, false),
+            new CustomEventStorageFlags(0, 1, 1, 1, 1)
+        ];
+    }
+
+    [Theory]
+    [MemberData(nameof(StorageFlagCases))]
+    public void ToStorageFlags_MapsCheckboxDestinationsToEventsColumns(
+        string _,
+        CustomEventDeliveryTargets targets,
+        CustomEventStorageFlags expected)
+    {
+        var actual = targets.ToStorageFlags();
+
+        Assert.Equal(expected.VisibleOnWebsite, actual.VisibleOnWebsite);
+        Assert.Equal(expected.SlackProcessed, actual.SlackProcessed);
+        Assert.Equal(expected.XProcessed, actual.XProcessed);
+        Assert.Equal(expected.ThreadsProcessed, actual.ThreadsProcessed);
+        Assert.Equal(expected.FacebookProcessed, actual.FacebookProcessed);
+    }
+
+    [Theory]
+    [MemberData(nameof(DefaultStorageFlagCases))]
+    public void ForDefaultCustomEvent_PreservesLegacyNonDesignerDefaults(
+        string _,
+        bool visibleOnWebsite,
+        bool xConfigured,
+        bool threadsConfigured,
+        bool facebookConfigured,
+        CustomEventStorageFlags expected)
+    {
+        var actual = CustomEventStorageFlags.ForDefaultCustomEvent(
+            visibleOnWebsite,
+            xConfigured,
+            threadsConfigured,
+            facebookConfigured);
+
+        Assert.Equal(expected.VisibleOnWebsite, actual.VisibleOnWebsite);
+        Assert.Equal(expected.SlackProcessed, actual.SlackProcessed);
+        Assert.Equal(expected.XProcessed, actual.XProcessed);
+        Assert.Equal(expected.ThreadsProcessed, actual.ThreadsProcessed);
+        Assert.Equal(expected.FacebookProcessed, actual.FacebookProcessed);
+    }
+}

--- a/LongevityWorldCup.Tests/SecretHashVerifierTests.cs
+++ b/LongevityWorldCup.Tests/SecretHashVerifierTests.cs
@@ -1,0 +1,54 @@
+using LongevityWorldCup.Website.Tools;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public class SecretHashVerifierTests
+{
+    [Fact]
+    public void CreateHash_VerifiesMatchingSecret()
+    {
+        var hash = SecretHashVerifier.CreateHash("correct horse battery staple");
+
+        var result = SecretHashVerifier.Verify("correct horse battery staple", hash);
+
+        Assert.Equal(SecretVerificationResult.Verified, result);
+    }
+
+    [Fact]
+    public void Verify_AcceptsBrowserWebCryptoHashFormat()
+    {
+        const string browserGeneratedHash = "pbkdf2-sha256:210000:AAECAwQFBgcICQoLDA0ODw==:S2Nb9dGpdHVFr+Ve1cxBYyXfCBotB9wl2rjY0IN3X2w=";
+
+        var result = SecretHashVerifier.Verify("browser-style secret", browserGeneratedHash);
+
+        Assert.Equal(SecretVerificationResult.Verified, result);
+    }
+
+    [Fact]
+    public void Verify_RejectsWrongSecret()
+    {
+        var hash = SecretHashVerifier.CreateHash("correct horse battery staple");
+
+        var result = SecretHashVerifier.Verify("wrong secret", hash);
+
+        Assert.Equal(SecretVerificationResult.Mismatch, result);
+    }
+
+    [Fact]
+    public void Verify_DistinguishesMissingAndInvalidConfig()
+    {
+        Assert.Equal(SecretVerificationResult.NotConfigured, SecretHashVerifier.Verify("secret", ""));
+        Assert.Equal(SecretVerificationResult.InvalidHash, SecretHashVerifier.Verify("secret", "not-a-valid-hash"));
+    }
+
+    [Fact]
+    public void Verify_RejectsWeakHashParameters()
+    {
+        var weak = "pbkdf2-sha256:1:AQID:BAUG";
+
+        var result = SecretHashVerifier.Verify("secret", weak);
+
+        Assert.Equal(SecretVerificationResult.InvalidHash, result);
+    }
+}

--- a/LongevityWorldCup.Website/Business/EventDataService.cs
+++ b/LongevityWorldCup.Website/Business/EventDataService.cs
@@ -30,6 +30,40 @@ public enum EventType
     SeasonFinalResult = 7
 }
 
+public sealed record CustomEventDeliveryTargets(
+    bool SendToWebpage,
+    bool SendToSlack,
+    bool SendToX,
+    bool SendToThreads,
+    bool SendToFacebook)
+{
+    public CustomEventStorageFlags ToStorageFlags() => new(
+        VisibleOnWebsite: SendToWebpage ? 1 : 0,
+        SlackProcessed: SendToSlack ? 0 : 1,
+        XProcessed: SendToX ? 0 : 1,
+        ThreadsProcessed: SendToThreads ? 0 : 1,
+        FacebookProcessed: SendToFacebook ? 0 : 1);
+}
+
+public sealed record CustomEventStorageFlags(
+    int VisibleOnWebsite,
+    int SlackProcessed,
+    int XProcessed,
+    int ThreadsProcessed,
+    int FacebookProcessed)
+{
+    public static CustomEventStorageFlags ForDefaultCustomEvent(
+        bool visibleOnWebsite,
+        bool xConfigured,
+        bool threadsConfigured,
+        bool facebookConfigured) => new(
+            VisibleOnWebsite: visibleOnWebsite ? 1 : 0,
+            SlackProcessed: 0,
+            XProcessed: xConfigured ? 0 : 1,
+            ThreadsProcessed: threadsConfigured ? 0 : 1,
+            FacebookProcessed: facebookConfigured ? 0 : 1);
+}
+
 public sealed class NonRetryableCustomEventDispatchException : Exception
 {
     public NonRetryableCustomEventDispatchException(string message) : base(message)
@@ -1235,7 +1269,13 @@ public sealed class EventDataService : IDisposable
         }
     }
 
-    public void CreateCustomEvent(string titleRaw, string contentRaw, DateTime? occurredAtUtc = null, double relevance = 15d, bool visibleOnWebsite = true)
+    public string CreateCustomEvent(
+        string titleRaw,
+        string contentRaw,
+        DateTime? occurredAtUtc = null,
+        double relevance = 15d,
+        bool visibleOnWebsite = true,
+        CustomEventDeliveryTargets? deliveryTargets = null)
     {
         if (string.IsNullOrWhiteSpace(titleRaw)) throw new ArgumentNullException(nameof(titleRaw));
         contentRaw ??= "";
@@ -1243,6 +1283,12 @@ public sealed class EventDataService : IDisposable
         var combinedRaw = titleRaw + "\n\n" + contentRaw;
         var occurredAt = EnsureUtc(occurredAtUtc ?? DateTime.UtcNow).ToString("o");
         var eventId = Guid.NewGuid().ToString("N");
+        var storageFlags = deliveryTargets?.ToStorageFlags()
+            ?? CustomEventStorageFlags.ForDefaultCustomEvent(
+                visibleOnWebsite,
+                _xEvents.IsConfigured,
+                _threadsEvents.IsConfigured,
+                _facebookEvents.IsConfigured);
 
         int created = 0;
 
@@ -1254,18 +1300,19 @@ public sealed class EventDataService : IDisposable
             insertCmd.Transaction = tx;
             insertCmd.CommandText =
                 """
-                INSERT INTO Events (Id, Type, Text, OccurredAt, Relevance, VisibleOnWebsite, XProcessed, ThreadsProcessed, FacebookProcessed)
-                VALUES (@id, @type, @text, @occ, @rel, @visibleOnWebsite, @xProcessed, @threadsProcessed, @facebookProcessed);
+                INSERT INTO Events (Id, Type, Text, OccurredAt, Relevance, VisibleOnWebsite, SlackProcessed, XProcessed, ThreadsProcessed, FacebookProcessed)
+                VALUES (@id, @type, @text, @occ, @rel, @visibleOnWebsite, @slackProcessed, @xProcessed, @threadsProcessed, @facebookProcessed);
                 """;
             insertCmd.Parameters.AddWithValue("@id", eventId);
             insertCmd.Parameters.AddWithValue("@type", (int)EventType.CustomEvent);
             insertCmd.Parameters.AddWithValue("@text", combinedRaw);
             insertCmd.Parameters.AddWithValue("@occ", occurredAt);
             insertCmd.Parameters.AddWithValue("@rel", relevance);
-            insertCmd.Parameters.AddWithValue("@visibleOnWebsite", visibleOnWebsite ? 1 : 0);
-            insertCmd.Parameters.AddWithValue("@xProcessed", _xEvents.IsConfigured ? 0 : 1);
-            insertCmd.Parameters.AddWithValue("@threadsProcessed", _threadsEvents.IsConfigured ? 0 : 1);
-            insertCmd.Parameters.AddWithValue("@facebookProcessed", _facebookEvents.IsConfigured ? 0 : 1);
+            insertCmd.Parameters.AddWithValue("@visibleOnWebsite", storageFlags.VisibleOnWebsite);
+            insertCmd.Parameters.AddWithValue("@slackProcessed", storageFlags.SlackProcessed);
+            insertCmd.Parameters.AddWithValue("@xProcessed", storageFlags.XProcessed);
+            insertCmd.Parameters.AddWithValue("@threadsProcessed", storageFlags.ThreadsProcessed);
+            insertCmd.Parameters.AddWithValue("@facebookProcessed", storageFlags.FacebookProcessed);
 
             insertCmd.ExecuteNonQuery();
             created = 1;
@@ -1276,8 +1323,14 @@ public sealed class EventDataService : IDisposable
         if (created > 0)
         {
             ReloadIntoCache();
-            ProcessPendingImmediateCustomEvents();
+            if (_enableEventDispatch)
+            {
+                ProcessPendingSlackEvents();
+                ProcessPendingImmediateCustomEvents();
+            }
         }
+
+        return eventId;
     }
     
     public IReadOnlyList<EventItem> GetEvents(

--- a/LongevityWorldCup.Website/Config.cs
+++ b/LongevityWorldCup.Website/Config.cs
@@ -43,6 +43,7 @@ namespace LongevityWorldCup.Website
         public string? FacebookPageId { get; set; }
         public string? FacebookUserAccessToken { get; set; }
         public string? FacebookPageAccessToken { get; set; }
+        public string? CustomEventDesignerSecretHash { get; set; }
 
         // Load configuration from the file
         public static async Task<Config> LoadAsync()

--- a/LongevityWorldCup.Website/Controllers/CustomEventsController.cs
+++ b/LongevityWorldCup.Website/Controllers/CustomEventsController.cs
@@ -1,0 +1,104 @@
+using LongevityWorldCup.Website.Business;
+using LongevityWorldCup.Website.Tools;
+using Microsoft.AspNetCore.Mvc;
+
+namespace LongevityWorldCup.Website.Controllers;
+
+[ApiController]
+[Route("api/custom-events")]
+public sealed class CustomEventsController(EventDataService events, Config config, ILogger<CustomEventsController> log) : ControllerBase
+{
+    private const int MaxRequestBytes = 16 * 1024;
+    private const int MaxSecretLength = 1024;
+    private const int MaxTitleLength = 500;
+    private const int MaxContentLength = 10_000;
+
+    private readonly EventDataService _events = events;
+    private readonly Config _config = config;
+    private readonly ILogger<CustomEventsController> _log = log;
+
+    public sealed record CreateCustomEventRequest(
+        string? Secret,
+        string? Title,
+        string? Content,
+        bool SendToWebpage,
+        bool SendToSlack,
+        bool SendToX,
+        bool SendToThreads,
+        bool SendToFacebook);
+
+    [HttpPost]
+    [RequestSizeLimit(MaxRequestBytes)]
+    public IActionResult Create([FromBody] CreateCustomEventRequest? request)
+    {
+        if (request is null)
+            return BadRequest("Request body is required.");
+
+        if (string.IsNullOrEmpty(request.Secret) || request.Secret.Length > MaxSecretLength)
+        {
+            _log.LogWarning("Custom Event Designer direct post rejected because the secret was missing or too long.");
+            return Unauthorized("Invalid secret.");
+        }
+
+        var verification = SecretHashVerifier.Verify(request.Secret, _config.CustomEventDesignerSecretHash);
+        if (verification == SecretVerificationResult.NotConfigured)
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, "Custom Event Designer direct posting is not configured.");
+        if (verification == SecretVerificationResult.InvalidHash)
+        {
+            _log.LogError("Custom Event Designer direct posting is disabled because CustomEventDesignerSecretHash is invalid.");
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, "Custom Event Designer direct posting is not configured.");
+        }
+        if (verification != SecretVerificationResult.Verified)
+        {
+            _log.LogWarning("Custom Event Designer direct post rejected because the secret did not match.");
+            return Unauthorized("Invalid secret.");
+        }
+
+        var title = request.Title?.Trim() ?? "";
+        var content = request.Content?.Trim() ?? "";
+        if (string.IsNullOrWhiteSpace(title))
+            return BadRequest("Title is required.");
+        if (title.Length > MaxTitleLength)
+            return BadRequest($"Title must be {MaxTitleLength} characters or fewer.");
+        if (content.Length > MaxContentLength)
+            return BadRequest($"Content must be {MaxContentLength} characters or fewer.");
+
+        var targets = new CustomEventDeliveryTargets(
+            request.SendToWebpage,
+            request.SendToSlack,
+            request.SendToX,
+            request.SendToThreads,
+            request.SendToFacebook);
+        var selectedTargets = GetSelectedTargets(targets);
+        if (selectedTargets.Count == 0)
+            return BadRequest("Select at least one destination.");
+
+        var eventId = _events.CreateCustomEvent(
+            titleRaw: title,
+            contentRaw: content,
+            deliveryTargets: targets);
+
+        _log.LogInformation(
+            "Custom Event Designer direct post created event {EventId} for targets {Targets}.",
+            eventId,
+            string.Join(",", selectedTargets));
+
+        return Ok(new
+        {
+            success = true,
+            eventId,
+            selectedTargets
+        });
+    }
+
+    private static List<string> GetSelectedTargets(CustomEventDeliveryTargets targets)
+    {
+        var selected = new List<string>();
+        if (targets.SendToWebpage) selected.Add("webpage");
+        if (targets.SendToSlack) selected.Add("slack");
+        if (targets.SendToX) selected.Add("x");
+        if (targets.SendToThreads) selected.Add("threads");
+        if (targets.SendToFacebook) selected.Add("facebook");
+        return selected;
+    }
+}

--- a/LongevityWorldCup.Website/Program.cs
+++ b/LongevityWorldCup.Website/Program.cs
@@ -307,7 +307,8 @@ namespace LongevityWorldCup.Website
                 FacebookAppSecret = "",
                 FacebookPageId = "",
                 FacebookUserAccessToken = "",
-                FacebookPageAccessToken = ""
+                FacebookPageAccessToken = "",
+                CustomEventDesignerSecretHash = ""
             };
 
             // Serialize to JSON and save to file

--- a/LongevityWorldCup.Website/Tools/SecretHashVerifier.cs
+++ b/LongevityWorldCup.Website/Tools/SecretHashVerifier.cs
@@ -1,0 +1,77 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace LongevityWorldCup.Website.Tools;
+
+public enum SecretVerificationResult
+{
+    Verified,
+    Mismatch,
+    NotConfigured,
+    InvalidHash
+}
+
+public static class SecretHashVerifier
+{
+    public const string Algorithm = "pbkdf2-sha256";
+    public const int DefaultIterations = 210_000;
+    private const int SaltByteCount = 16;
+    private const int HashByteCount = 32;
+    private const int MaxHashByteCount = 128;
+
+    public static string CreateHash(string secret)
+    {
+        if (string.IsNullOrEmpty(secret))
+            throw new ArgumentException("Secret is required.", nameof(secret));
+
+        var salt = RandomNumberGenerator.GetBytes(SaltByteCount);
+        var hash = DeriveHash(secret, salt, DefaultIterations, HashByteCount);
+        return $"{Algorithm}:{DefaultIterations}:{Convert.ToBase64String(salt)}:{Convert.ToBase64String(hash)}";
+    }
+
+    public static SecretVerificationResult Verify(string? secret, string? storedHash)
+    {
+        if (string.IsNullOrWhiteSpace(storedHash))
+            return SecretVerificationResult.NotConfigured;
+
+        if (string.IsNullOrEmpty(secret))
+            return SecretVerificationResult.Mismatch;
+
+        var parts = storedHash.Split(':');
+        if (parts.Length != 4 || !string.Equals(parts[0], Algorithm, StringComparison.Ordinal))
+            return SecretVerificationResult.InvalidHash;
+
+        if (!int.TryParse(parts[1], out var iterations) || iterations < DefaultIterations)
+            return SecretVerificationResult.InvalidHash;
+
+        byte[] salt;
+        byte[] expectedHash;
+        try
+        {
+            salt = Convert.FromBase64String(parts[2]);
+            expectedHash = Convert.FromBase64String(parts[3]);
+        }
+        catch (FormatException)
+        {
+            return SecretVerificationResult.InvalidHash;
+        }
+
+        if (salt.Length < SaltByteCount || expectedHash.Length < HashByteCount || expectedHash.Length > MaxHashByteCount)
+            return SecretVerificationResult.InvalidHash;
+
+        var actualHash = DeriveHash(secret, salt, iterations, expectedHash.Length);
+        return CryptographicOperations.FixedTimeEquals(actualHash, expectedHash)
+            ? SecretVerificationResult.Verified
+            : SecretVerificationResult.Mismatch;
+    }
+
+    private static byte[] DeriveHash(string secret, byte[] salt, int iterations, int hashByteCount)
+    {
+        return Rfc2898DeriveBytes.Pbkdf2(
+            Encoding.UTF8.GetBytes(secret),
+            salt,
+            iterations,
+            HashAlgorithmName.SHA256,
+            hashByteCount);
+    }
+}

--- a/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
+++ b/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
@@ -75,7 +75,7 @@
             font-size: 13px;
         }
 
-        input[type="text"], textarea {
+        input[type="text"], input[type="password"], textarea {
             width: 100%;
             border: 1px solid rgba(255,255,255,0.1);
             border-radius: 14px;
@@ -218,6 +218,21 @@
             line-height: 1.4;
         }
 
+        .post-status {
+            min-height: 18px;
+            font-size: 12px;
+            line-height: 1.4;
+            color: var(--muted);
+        }
+
+        .post-status.is-success {
+            color: var(--ok);
+        }
+
+        .post-status.is-error {
+            color: #ffb7c9;
+        }
+
         button {
             border: 0;
             border-radius: 10px;
@@ -234,10 +249,33 @@
             background: rgba(255,255,255,0.1);
         }
 
+        button:disabled {
+            cursor: not-allowed;
+            opacity: 0.48;
+        }
+
         .token {
             width: 100%;
             min-height: 110px;
             resize: vertical;
+        }
+
+        details.payload-box summary {
+            cursor: pointer;
+            font-size: 13px;
+            font-weight: 700;
+        }
+
+        .live-checklist {
+            margin: 12px 0 0;
+            padding-left: 20px;
+            color: var(--muted);
+            font-size: 12px;
+            line-height: 1.55;
+        }
+
+        .live-checklist code {
+            color: var(--text);
         }
 
         .preview-stack {
@@ -831,14 +869,46 @@
             </div>
 
             <div class="payload-box">
-                <h2>Server Command</h2>
+                <h2>Direct Post</h2>
+                <label>
+                    <span>Secret</span>
+                    <input id="designerSecretInput" type="password" autocomplete="off" />
+                </label>
+                <div class="payload-actions">
+                    <button id="generateSecretHashBtn" class="secondary" type="button">Generate Config Hash</button>
+                    <button id="copySecretHashBtn" class="secondary" type="button" disabled>Copy Hash</button>
+                    <div id="secretHashState" class="post-status" aria-live="polite"></div>
+                </div>
+                <textarea id="secretHashOutput" class="token" readonly hidden></textarea>
+                <div class="payload-actions">
+                    <button id="postEventBtn" type="button">Post Event</button>
+                    <button id="copyCleanupCommandBtn" class="secondary" type="button" disabled hidden>Copy Cleanup SQL</button>
+                    <div id="directPostStatus" class="post-status" aria-live="polite"></div>
+                </div>
+                <textarea id="cleanupCommandOutput" class="token" readonly hidden></textarea>
+                <div id="postValidationHint" class="validation-hint" hidden>Title and at least one destination are required before posting.</div>
+            </div>
+
+            <details class="payload-box">
+                <summary>Live test checklist</summary>
+                <ol class="live-checklist">
+                    <li>Generate a config hash from a temporary secret and set <code>CustomEventDesignerSecretHash</code> in the published Linux config.</li>
+                    <li>Restart <code>longevityworldcup.service</code> so the config is reloaded.</li>
+                    <li>Use a harmless title, select only Webpage, and post once.</li>
+                    <li>Confirm the event appears on the website, then copy the cleanup SQL if the test row should be removed.</li>
+                    <li>Rollback by clearing the config hash or restoring the previous config value, then restart.</li>
+                </ol>
+            </details>
+
+            <details class="payload-box">
+                <summary>Manual server command fallback</summary>
                 <textarea id="commandOutput" class="token" readonly></textarea>
                 <div class="payload-actions">
-                    <button id="copyCommandBtn" type="button">Copy Command</button>
+                    <button id="copyCommandBtn" class="secondary" type="button">Copy Command</button>
                     <div id="copyState" style="font-size:12px;color:var(--muted);"></div>
                 </div>
                 <div id="commandValidationHint" class="validation-hint" hidden>Title is required before the command can be generated or copied.</div>
-            </div>
+            </details>
         </div>
 
         <div class="preview-stack">
@@ -871,6 +941,10 @@
     <script src="{{ASSET_CUSTOM_EVENT_MARKUP_JS}}"></script>
     <script>
         const LIMITS = { x: 280, threads: 500 };
+        const SECRET_HASH_ALGORITHM = "pbkdf2-sha256";
+        const SECRET_HASH_ITERATIONS = 210000;
+        const SECRET_HASH_SALT_BYTES = 16;
+        const SECRET_HASH_BYTES = 32;
         const SEND_TO_STORAGE_KEY = "customEventDesigner.sendTo";
         const titleInput = document.getElementById("titleInput");
         const contentInput = document.getElementById("contentInput");
@@ -879,6 +953,16 @@
         const sendX = document.getElementById("sendX");
         const sendThreads = document.getElementById("sendThreads");
         const sendFacebook = document.getElementById("sendFacebook");
+        const designerSecretInput = document.getElementById("designerSecretInput");
+        const generateSecretHashBtn = document.getElementById("generateSecretHashBtn");
+        const copySecretHashBtn = document.getElementById("copySecretHashBtn");
+        const secretHashOutput = document.getElementById("secretHashOutput");
+        const secretHashState = document.getElementById("secretHashState");
+        const postEventBtn = document.getElementById("postEventBtn");
+        const copyCleanupCommandBtn = document.getElementById("copyCleanupCommandBtn");
+        const cleanupCommandOutput = document.getElementById("cleanupCommandOutput");
+        const directPostStatus = document.getElementById("directPostStatus");
+        const postValidationHint = document.getElementById("postValidationHint");
         const webpagePreviewBlock = document.getElementById("webpagePreviewBlock");
         const webpagePreviewSurface = document.getElementById("webpagePreviewSurface");
         const commandOutput = document.getElementById("commandOutput");
@@ -1729,8 +1813,145 @@
             return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
         }
 
+        function bytesToBase64(bytes) {
+            let binary = "";
+            const chunkSize = 0x8000;
+            for (let i = 0; i < bytes.length; i += chunkSize) {
+                binary += String.fromCharCode(...bytes.slice(i, i + chunkSize));
+            }
+            return btoa(binary);
+        }
+
         function buildServerCommand(payload) {
             return `sudo bash -lc 'cd /var/www/.longevityworldcup && bash /home/user/LongevityWorldCup/LongevityWorldCup.Website/Scripts/custom_event.sh "LongevityWorldCup.db" --payload "${payload}"'`;
+        }
+
+        function buildCleanupCommand(eventId) {
+            return `sudo sqlite3 /var/www/.longevityworldcup/LongevityWorldCup.db "DELETE FROM Events WHERE Id = '${eventId}';"`;
+        }
+
+        async function buildDesignerSecretHash(secret) {
+            if (!window.crypto || !window.crypto.subtle) {
+                throw new Error("Secure browser crypto is not available.");
+            }
+
+            const salt = window.crypto.getRandomValues(new Uint8Array(SECRET_HASH_SALT_BYTES));
+            const key = await window.crypto.subtle.importKey(
+                "raw",
+                new TextEncoder().encode(secret),
+                "PBKDF2",
+                false,
+                ["deriveBits"]
+            );
+            const derivedBits = await window.crypto.subtle.deriveBits(
+                {
+                    name: "PBKDF2",
+                    hash: "SHA-256",
+                    salt,
+                    iterations: SECRET_HASH_ITERATIONS
+                },
+                key,
+                SECRET_HASH_BYTES * 8
+            );
+            const hash = new Uint8Array(derivedBits);
+            return `${SECRET_HASH_ALGORITHM}:${SECRET_HASH_ITERATIONS}:${bytesToBase64(salt)}:${bytesToBase64(hash)}`;
+        }
+
+        function setSecretHashStatus(message, kind) {
+            secretHashState.textContent = message || "";
+            secretHashState.classList.toggle("is-success", kind === "success");
+            secretHashState.classList.toggle("is-error", kind === "error");
+        }
+
+        function updateSecretHashControls() {
+            generateSecretHashBtn.disabled = !designerSecretInput.value;
+            copySecretHashBtn.disabled = !secretHashOutput.value;
+        }
+
+        function clearGeneratedSecretHash() {
+            secretHashOutput.value = "";
+            secretHashOutput.hidden = true;
+            setSecretHashStatus("", "");
+            updateSecretHashControls();
+        }
+
+        async function generateSecretHash() {
+            if (!designerSecretInput.value) {
+                clearGeneratedSecretHash();
+                setSecretHashStatus("Enter a secret first.", "error");
+                return;
+            }
+
+            generateSecretHashBtn.disabled = true;
+            setSecretHashStatus("Generating...", "");
+
+            try {
+                secretHashOutput.value = await buildDesignerSecretHash(designerSecretInput.value);
+                secretHashOutput.hidden = false;
+                setSecretHashStatus("Hash generated.", "success");
+            } catch (error) {
+                secretHashOutput.value = "";
+                secretHashOutput.hidden = true;
+                setSecretHashStatus(error && error.message ? error.message : "Could not generate hash.", "error");
+            } finally {
+                updateSecretHashControls();
+            }
+        }
+
+        async function copySecretHash() {
+            if (!secretHashOutput.value) {
+                return;
+            }
+
+            await navigator.clipboard.writeText(secretHashOutput.value);
+            setSecretHashStatus("Hash copied.", "success");
+        }
+
+        function buildEventPayload() {
+            return {
+                title: titleInput.value.trim(),
+                content: contentInput.value.trim(),
+                sendToWebpage: sendWebpage.checked,
+                sendToSlack: sendSlack.checked,
+                sendToX: sendX.checked,
+                sendToThreads: sendThreads.checked,
+                sendToFacebook: sendFacebook.checked
+            };
+        }
+
+        function hasSelectedDestination(payload) {
+            return !!(
+                payload.sendToWebpage ||
+                payload.sendToSlack ||
+                payload.sendToX ||
+                payload.sendToThreads ||
+                payload.sendToFacebook
+            );
+        }
+
+        function setDirectPostStatus(message, kind) {
+            directPostStatus.textContent = message || "";
+            directPostStatus.classList.toggle("is-success", kind === "success");
+            directPostStatus.classList.toggle("is-error", kind === "error");
+        }
+
+        function clearCleanupCommand() {
+            cleanupCommandOutput.value = "";
+            cleanupCommandOutput.hidden = true;
+            copyCleanupCommandBtn.disabled = true;
+            copyCleanupCommandBtn.hidden = true;
+        }
+
+        function setCleanupCommand(eventId) {
+            if (!/^[a-f0-9]{32}$/i.test(eventId || "")) {
+                clearCleanupCommand();
+                return;
+            }
+
+            cleanupCommandOutput.value = buildCleanupCommand(eventId);
+            cleanupCommandOutput.hidden = false;
+            copyCleanupCommandBtn.disabled = false;
+            copyCleanupCommandBtn.hidden = false;
         }
 
         function loadSendToSettings() {
@@ -1989,15 +2210,8 @@
             const contentRaw = contentInput.value.trim();
             const combinedRaw = contentRaw ? `${titleRaw}\n\n${contentRaw}` : titleRaw;
             const hasTitle = !!titleRaw;
-            const payload = {
-                title: titleRaw,
-                content: contentRaw,
-                sendToWebpage: sendWebpage.checked,
-                sendToSlack: sendSlack.checked,
-                sendToX: sendX.checked,
-                sendToThreads: sendThreads.checked,
-                sendToFacebook: sendFacebook.checked
-            };
+            const payload = buildEventPayload();
+            const hasDestination = hasSelectedDestination(payload);
             previewCopyPayloads = new Map();
             previewCopyPayloads.set("webpage", buildPlatformRawText("webpage", null, titleRaw, contentRaw, sendWebpage.checked));
 
@@ -2005,6 +2219,8 @@
             webpagePreviewSurface.hidden = !sendWebpage.checked;
             commandValidationHint.hidden = hasTitle;
             copyCommandBtn.disabled = !hasTitle;
+            postEventBtn.disabled = !hasTitle || !hasDestination;
+            postValidationHint.hidden = hasTitle && hasDestination;
 
             document.getElementById("eventTitlePreview").innerHTML = renderWebpageMarkup(normalizeNewlines(titleRaw).replace(/\n+/g, " ").trim());
             document.getElementById("eventContentPreview").innerHTML = contentRaw ? renderWebpageMarkupWithBreaks(contentRaw) : "";
@@ -2046,6 +2262,56 @@
                 commandOutput.value = buildServerCommand(payloadToken);
             } else {
                 commandOutput.value = "";
+            }
+        }
+
+        async function postEvent() {
+            const payload = buildEventPayload();
+            if (!payload.title || !hasSelectedDestination(payload)) {
+                setDirectPostStatus("Title and at least one destination are required before posting.", "error");
+                update();
+                return;
+            }
+
+            postEventBtn.disabled = true;
+            setDirectPostStatus("Posting...", "");
+            clearCleanupCommand();
+
+            try {
+                const response = await fetch("/api/custom-events", {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        "Accept": "application/json"
+                    },
+                    body: JSON.stringify({
+                        secret: designerSecretInput.value,
+                        ...payload
+                    })
+                });
+
+                const contentType = response.headers.get("content-type") || "";
+                const body = contentType.includes("application/json")
+                    ? await response.json()
+                    : await response.text();
+
+                if (!response.ok) {
+                    const message = typeof body === "string"
+                        ? body
+                        : (body && body.message) || `Post failed with HTTP ${response.status}.`;
+                    clearCleanupCommand();
+                    setDirectPostStatus(message || `Post failed with HTTP ${response.status}.`, "error");
+                    return;
+                }
+
+                const targets = Array.isArray(body.selectedTargets) ? body.selectedTargets.join(", ") : "";
+                setCleanupCommand(body.eventId);
+                setDirectPostStatus(`Posted event ${body.eventId}${targets ? ` to ${targets}` : ""}.`, "success");
+            } catch {
+                clearCleanupCommand();
+                setDirectPostStatus("Post failed. Check your connection and try again.", "error");
+            } finally {
+                update();
             }
         }
 
@@ -2146,9 +2412,13 @@
                 if (event.target === titleInput || event.target === contentInput) {
                     updateMentionSuggestions(event.target);
                 }
+                clearCleanupCommand();
                 update();
             });
-            el.addEventListener("change", update);
+            el.addEventListener("change", () => {
+                clearCleanupCommand();
+                update();
+            });
         });
 
         insertBoldBtn.addEventListener("click", insertBold);
@@ -2161,6 +2431,18 @@
             }
             await copyText(commandOutput.value, "Command copied.");
         });
+        copyCleanupCommandBtn.addEventListener("click", async () => {
+            if (!cleanupCommandOutput.value) {
+                return;
+            }
+            await navigator.clipboard.writeText(cleanupCommandOutput.value);
+            setDirectPostStatus("Cleanup SQL copied.", "success");
+        });
+        generateSecretHashBtn.addEventListener("click", generateSecretHash);
+        copySecretHashBtn.addEventListener("click", copySecretHash);
+        designerSecretInput.addEventListener("input", clearGeneratedSecretHash);
+        postEventBtn.addEventListener("click", postEvent);
+        updateSecretHashControls();
         window.addEventListener("resize", update);
 
         fetch("/api/data/athletes", { headers: { accept: "application/json" } })


### PR DESCRIPTION
## Summary

Adds authenticated direct posting to the internal Custom Event Designer while preserving the existing manual command fallback.

- Adds `POST /api/custom-events` with PBKDF2-SHA256 secret-hash verification from `CustomEventDesignerSecretHash`.
- Adds browser-side config-hash generation, direct-post controls, validation, live-test guidance, and cleanup SQL after successful posts.
- Keeps existing non-designer custom event behavior intact: SeasonFinalizerService still defaults to Slack pending and configured social platforms pending.
- Documents the safe Linux live-test flow, rollback, config path, service restart, and cleanup commands.

## Validation

- `dotnet build LongevityWorldCup.sln --no-restore -p:UseAppHost=false -p:OutDir=tmp\verify-full-build\`
- `dotnet test LongevityWorldCup.Tests/LongevityWorldCup.Tests.csproj --no-restore -p:UseAppHost=false -p:OutDir=tmp\verify-full-tests\` (33/33 passed)
- Designer inline JS syntax check with Node VM
- `bash -n LongevityWorldCup.Website/Scripts/custom_event.sh`
- `dotnet publish LongevityWorldCup.Website/LongevityWorldCup.Website.csproj --configuration Release --no-restore -p:UseAppHost=false --output tmp\verify-linux-publish`
- Targeted endpoint/database checks for destination flags, hash auth, validation, webpage-only post, cleanup, and rollback disabled state
- `git diff --check`

## Notes

`git diff --check` only reported Git CRLF conversion notices on touched non-shell files. No functional warnings remain.
