### PR TITLE
[codex] Move homepage leaderboard above highlights

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/index.html
+++ b/LongevityWorldCup.Website/wwwroot/index.html
@@ -1587,6 +1587,13 @@
             Too old for your sport? Not <a href="/about">this&nbsp;one</a>. Reverse&nbsp;your&nbsp;age and <strong>rise&nbsp;on&nbsp;the&nbsp;leaderboard!</strong>
         </p>
 
+        <!--LEADERBOARD-CONTENT-->
+        <div class="full-rankings-action">
+            <button id="viewAllAthletesBtn" onclick="window.location.href = window.getFullLeaderboardUrlWithCurrentState ? window.getFullLeaderboardUrlWithCurrentState() : '/leaderboard'" class="rankings-btn" aria-label="View all athletes on the leaderboard">
+                View all athletes
+            </button>
+        </div>
+
         <div class="lwc-highlights-countdown-wrapper">
             <div id="events-root-index"><!--EVENT-BOARD-CONTENT--></div>
 
@@ -1704,13 +1711,6 @@
             </div>
         </div>
 
-
-        <!--LEADERBOARD-CONTENT-->
-        <div class="full-rankings-action">
-            <button id="viewAllAthletesBtn" onclick="window.location.href = window.getFullLeaderboardUrlWithCurrentState ? window.getFullLeaderboardUrlWithCurrentState() : '/leaderboard'" class="rankings-btn" aria-label="View all athletes on the leaderboard">
-                View all athletes
-            </button>
-        </div>
 
         <!-- 2025 Season Archive Section -->
         <div class="section-container archive-section" data-aos="fade" data-aos-duration="700" data-aos-delay="325">


### PR DESCRIPTION
## What changed

Moved the homepage leaderboard/podium block and its "View all athletes" action above the highlights and merch store section.

## Why

This lets the homepage lead with the current standings before showing recent highlights and merch.

## Impact

Only the homepage section order changes. Ranking logic, leaderboard rendering, static asset placeholders, and merch/highlights behavior are unchanged.

## Validation

- `dotnet test LongevityWorldCup.sln` passed: 57 tests.
- Started the site locally from this checkout at `http://127.0.0.1:5297`.
- Checked the served homepage HTML order: leaderboard action appears before `events-root-index`, which appears before `lwc-countdown-box`.