### PR TITLE
[codex] Advertise longevitymaxxing challenge

### DIFF
--- a/LongevityWorldCup.Tests/LongevitymaxxingChallengePageTests.cs
+++ b/LongevityWorldCup.Tests/LongevitymaxxingChallengePageTests.cs
@@ -1,5 +1,8 @@
 using LongevityWorldCup.Website;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Xunit;
 
 namespace LongevityWorldCup.Tests;
@@ -82,6 +85,48 @@ public sealed class LongevitymaxxingChallengePageTests
     }
 
     [Fact]
+    public async Task Homepage_AdvertisesLongevitymaxxingChallengeWhileSignupIsOpen()
+    {
+        using var factory = CreateFactory(new Config
+        {
+            LongevitymaxxingChallenge = new LongevitymaxxingChallengeConfig
+            {
+                StartDate = "2099-06-08",
+                SignupClosesAtUtc = "2099-06-08T00:00:00Z"
+            }
+        });
+        using var client = factory.CreateClient();
+
+        var html = await client.GetStringAsync("/");
+
+        Assert.Contains("id=\"longevitymaxxingPromo\"", html);
+        Assert.Contains("Separate Lifestyle challenge", html);
+        Assert.Contains("does not affect Ultimate League rankings", html);
+        Assert.Contains("href=\"/longevitymaxxing\"", html);
+        Assert.Contains("/api/longevitymaxxing/state", html);
+    }
+
+    [Fact]
+    public async Task Homepage_HidesLongevitymaxxingPromoAfterSignupCloses()
+    {
+        using var factory = CreateFactory(new Config
+        {
+            LongevitymaxxingChallenge = new LongevitymaxxingChallengeConfig
+            {
+                StartDate = "2000-06-08",
+                SignupClosesAtUtc = "2000-06-08T00:00:00Z"
+            }
+        });
+        using var client = factory.CreateClient();
+
+        var html = await client.GetStringAsync("/");
+
+        Assert.DoesNotContain("id=\"longevitymaxxingPromo\"", html);
+        Assert.DoesNotContain("Separate Lifestyle challenge", html);
+        Assert.DoesNotContain("does not affect Ultimate League rankings", html);
+    }
+
+    [Fact]
     public async Task LongevitymaxxingScript_KeepsSignupLeaderboardVisibleAndFocusesDueCheckIn()
     {
         using var factory = CreateFactory();
@@ -150,13 +195,21 @@ public sealed class LongevitymaxxingChallengePageTests
         Assert.Contains(".lmx-practice-note", css);
     }
 
-    private static WebApplicationFactory<Program> CreateFactory()
+    private static WebApplicationFactory<Program> CreateFactory(Config? config = null)
     {
         return new WebApplicationFactory<Program>()
             .WithWebHostBuilder(builder =>
             {
                 builder.UseSetting("EnableScheduledJobs", "false");
                 builder.UseSetting("EnableStartupBadgeRefresh", "false");
+                if (config is not null)
+                {
+                    builder.ConfigureTestServices(services =>
+                    {
+                        services.RemoveAll<Config>();
+                        services.AddSingleton(config);
+                    });
+                }
             });
     }
 }

--- a/LongevityWorldCup.Website/Middleware/HtmlInjectionMiddleware.cs
+++ b/LongevityWorldCup.Website/Middleware/HtmlInjectionMiddleware.cs
@@ -7,7 +7,7 @@ using System.Text.RegularExpressions;
 
 namespace LongevityWorldCup.Website.Middleware
 {
-    public class HtmlInjectionMiddleware(RequestDelegate next, AthleteOgImageService athleteOgImages, LeagueOgImageService leagueOgImages, AssetVersionProvider assetVersionProvider, LeaderboardFactsService leaderboardFacts, SitemapService sitemap, ILogger<HtmlInjectionMiddleware> logger, IWebHostEnvironment environment)
+    public class HtmlInjectionMiddleware(RequestDelegate next, AthleteOgImageService athleteOgImages, LeagueOgImageService leagueOgImages, AssetVersionProvider assetVersionProvider, LeaderboardFactsService leaderboardFacts, SitemapService sitemap, Config config, ILogger<HtmlInjectionMiddleware> logger, IWebHostEnvironment environment)
     {
         private readonly RequestDelegate _next = next;
         private readonly AthleteOgImageService _athleteOgImages = athleteOgImages;
@@ -15,6 +15,7 @@ namespace LongevityWorldCup.Website.Middleware
         private readonly AssetVersionProvider _assetVersionProvider = assetVersionProvider;
         private readonly LeaderboardFactsService _leaderboardFacts = leaderboardFacts;
         private readonly SitemapService _sitemap = sitemap;
+        private readonly Config _config = config;
         private readonly ILogger<HtmlInjectionMiddleware> _logger = logger;
         private readonly string _webRootPath = ResolveWebRootPath(environment);
         private const string SiteBaseUrl = "https://longevityworldcup.com";
@@ -22,6 +23,8 @@ namespace LongevityWorldCup.Website.Middleware
         private const string LongevitymaxxingOgImagePath = "/assets/longevitymaxxing-og.png";
         private const string LeaderboardRowsStartMarker = "<!--LEADERBOARD-TBODY-ROWS-START-->";
         private const string LeaderboardRowsEndMarker = "<!--LEADERBOARD-TBODY-ROWS-END-->";
+        private const string LongevitymaxxingPromoStartMarker = "<!--LONGEVITYMAXXING-PROMO-START-->";
+        private const string LongevitymaxxingPromoEndMarker = "<!--LONGEVITYMAXXING-PROMO-END-->";
         private const string LeaderboardSkeletonTbodyOpenTag = "<tbody class=\"loading-skeleton\" aria-busy=\"true\">";
         private static readonly HashSet<string> IndexableRoutes = new(StringComparer.OrdinalIgnoreCase)
         {
@@ -95,6 +98,7 @@ namespace LongevityWorldCup.Website.Middleware
                     // Replace placeholders within leaderboardContent first (since it contains nested placeholders)
                     leaderboardContent = leaderboardContent.Replace("<!--AGE-VISUALIZATION-->", ageVisualization);
                     leaderboardContent = ApplyLeaderboardRows(leaderboardContent, context);
+                    leaderboardContent = ApplyLongevitymaxxingPromo(leaderboardContent);
 
                     // Replace placeholders with header and footer content
                     bodyContent = bodyContent
@@ -207,6 +211,24 @@ namespace LongevityWorldCup.Website.Middleware
                 LeaderboardSkeletonTbodyOpenTag,
                 $"<tbody {LeaderboardHtmlRenderer.ServerRenderedTbodyAttributes}>",
                 StringComparison.Ordinal);
+        }
+
+        private static string RemoveMarkedSection(string html, string startMarker, string endMarker)
+        {
+            var start = html.IndexOf(startMarker, StringComparison.Ordinal);
+            var end = html.IndexOf(endMarker, StringComparison.Ordinal);
+            if (start < 0 || end < 0 || end <= start)
+            {
+                return html;
+            }
+
+            var sectionEnd = end + endMarker.Length;
+            while (sectionEnd < html.Length && (html[sectionEnd] == '\r' || html[sectionEnd] == '\n'))
+            {
+                sectionEnd++;
+            }
+
+            return html.Remove(start, sectionEnd - start);
         }
 
         private static bool ShouldRenderLeaderboardRows(HttpContext context)
@@ -1202,6 +1224,40 @@ $@"<script type=""module"">
                 _ when canonicalPath.StartsWith("/league/", StringComparison.OrdinalIgnoreCase) => "Leaderboard",
                 _ => "Page"
             };
+        }
+
+        private string ApplyLongevitymaxxingPromo(string html)
+        {
+            if (ShouldShowLongevitymaxxingPromo())
+            {
+                return html;
+            }
+
+            return RemoveMarkedSection(html, LongevitymaxxingPromoStartMarker, LongevitymaxxingPromoEndMarker);
+        }
+
+        private bool ShouldShowLongevitymaxxingPromo()
+        {
+            var cfg = _config.LongevitymaxxingChallenge ?? new LongevitymaxxingChallengeConfig();
+            var start = ParseDateOnly(cfg.StartDate, DateOnly.FromDateTime(DateTime.UtcNow.Date));
+            var signupCloses = ParseDateTimeOffset(cfg.SignupClosesAtUtc, new DateTimeOffset(start.ToDateTime(TimeOnly.MinValue), TimeSpan.Zero));
+            var now = DateTimeOffset.UtcNow;
+
+            return now < signupCloses.ToUniversalTime() && DateOnly.FromDateTime(now.UtcDateTime.Date) < start;
+        }
+
+        private static DateOnly ParseDateOnly(string? value, DateOnly fallback)
+        {
+            return DateOnly.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed)
+                ? parsed
+                : fallback;
+        }
+
+        private static DateTimeOffset ParseDateTimeOffset(string? value, DateTimeOffset fallback)
+        {
+            return DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var parsed)
+                ? parsed.ToUniversalTime()
+                : fallback.ToUniversalTime();
         }
 
         private sealed record SeoMeta(

--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -494,6 +494,48 @@
     }
     .ranking-explanation.is-visible{ display:block; }
     .ranking-explanation strong{ color:var(--primary-color); }
+    .longevitymaxxing-promo{
+        display:grid; grid-template-columns:minmax(0, 1fr) auto; align-items:center; gap:1rem; margin:0 0 1.25rem;
+        padding:1rem 1.1rem; border:1px solid rgba(0,188,212,.2); border-left:4px solid var(--secondary-color);
+        border-radius:8px; background:linear-gradient(135deg, rgba(255,255,255,.92), rgba(0,188,212,.07) 48%, rgba(255,64,129,.08));
+        box-shadow:0 10px 24px rgba(0,0,0,.08); box-sizing:border-box;
+    }
+    .longevitymaxxing-promo[hidden]{ display:none; }
+    .longevitymaxxing-promo-text{
+        display:grid; gap:.45rem; min-width:0;
+    }
+    .longevitymaxxing-promo-kicker{
+        display:inline-flex; align-items:center; gap:.45rem; color:var(--secondary-color);
+        font-size:.78rem; font-weight:700; line-height:1.2; text-transform:uppercase; letter-spacing:.06em;
+    }
+    .longevitymaxxing-promo-kicker i{
+        color:var(--primary-color); font-size:.95rem;
+    }
+    .longevitymaxxing-promo h2{
+        margin:0; padding:0; text-align:left; color:#1f2933; font-size:clamp(1.35rem, 2.8vw, 1.95rem);
+        line-height:1.08; letter-spacing:0; text-shadow:none;
+    }
+    .longevitymaxxing-promo p{
+        max-width:48rem; margin:0; color:#3d4b55; font-size:1rem; line-height:1.45;
+    }
+    .longevitymaxxing-promo-points{
+        display:flex; flex-wrap:wrap; gap:.45rem; margin-top:.05rem;
+    }
+    .longevitymaxxing-promo-points span{
+        display:inline-flex; align-items:center; min-height:30px; padding:.25rem .6rem; border:1px solid rgba(0,0,0,.08);
+        border-radius:999px; background:rgba(255,255,255,.72); color:#52606d; font-size:.82rem; font-weight:700; box-sizing:border-box;
+    }
+    .longevitymaxxing-promo-action{
+        display:inline-flex; align-items:center; justify-content:center; gap:.45rem; min-height:44px; white-space:nowrap;
+        padding:.72rem 1rem; border-radius:999px; background:var(--main-action-color); color:var(--light-text-color);
+        font-weight:700; text-decoration:none; box-shadow:0 7px 16px rgba(76,175,80,.26);
+        transition:transform .2s ease, box-shadow .2s ease, background .2s ease;
+    }
+    .longevitymaxxing-promo-action:hover,
+    .longevitymaxxing-promo-action:focus-visible{
+        background:var(--main-action-selected-color); transform:translateY(-1px);
+        box-shadow:0 10px 20px rgba(56,142,60,.28); outline:none;
+    }
     .search-wrapper{ display:flex; justify-content:flex-end; margin-bottom:1rem; }
     .search-container{ position:relative; max-width:250px; width:100%; min-height:44px; margin-right:.5rem; }
     #athleteSearch{
@@ -1620,6 +1662,18 @@
             margin-left:auto;
             margin-right:auto;
         }
+        .longevitymaxxing-promo{
+            grid-template-columns:1fr; gap:.9rem; margin-bottom:1rem; padding:.95rem; box-shadow:0 8px 18px rgba(0,0,0,.07);
+        }
+        .longevitymaxxing-promo h2{
+            font-size:1.42rem;
+        }
+        .longevitymaxxing-promo p{
+            font-size:.96rem;
+        }
+        .longevitymaxxing-promo-action{
+            width:100%; box-sizing:border-box;
+        }
         body.sidebar-drawer-open{
             overflow:hidden;
         }
@@ -2079,6 +2133,19 @@
             margin-bottom:.55rem;
         }
 
+        .longevitymaxxing-promo{
+            grid-template-columns:minmax(0, 1fr) auto; gap:.7rem; margin-bottom:.6rem; padding:.75rem .85rem;
+        }
+
+        .longevitymaxxing-promo h2{
+            font-size:1.18rem;
+        }
+
+        .longevitymaxxing-promo p,
+        .longevitymaxxing-promo-points{
+            display:none;
+        }
+
         .leaderboard-view-switcher{
             width:auto;
             min-width:0;
@@ -2216,6 +2283,50 @@
 <div class="main-container">
 
     <div class="content">
+        <!--LONGEVITYMAXXING-PROMO-START-->
+        <section class="longevitymaxxing-promo" id="longevitymaxxingPromo" aria-labelledby="longevitymaxxingPromoTitle">
+            <div class="longevitymaxxing-promo-text">
+                <div class="longevitymaxxing-promo-kicker"><i class="fa fa-calendar-check-o" aria-hidden="true"></i> Separate Lifestyle challenge</div>
+                <h2 id="longevitymaxxingPromoTitle">Longevitymaxxing Challenge</h2>
+                <p>Join the 14-day check-in sprint for sleep, exercise, nutrition, and vices. It has its own public visual leaderboard and does not affect Ultimate League rankings.</p>
+                <div class="longevitymaxxing-promo-points" aria-label="Challenge details">
+                    <span>14 days</span>
+                    <span>Daily check-ins</span>
+                    <span>Free signup</span>
+                </div>
+            </div>
+            <a class="longevitymaxxing-promo-action" href="/longevitymaxxing">
+                Join the challenge <i class="fa fa-arrow-right" aria-hidden="true"></i>
+            </a>
+        </section>
+        <script>
+            (function () {
+                var promo = document.getElementById('longevitymaxxingPromo');
+                if (!promo || !window.fetch) return;
+
+                fetch('/api/longevitymaxxing/state', { cache: 'no-store' })
+                    .then(function (response) { return response.ok ? response.json() : null; })
+                    .then(function (state) {
+                        if (!state) return;
+                        if (!state.signupOpen) {
+                            promo.hidden = true;
+                            return;
+                        }
+
+                        var closesAt = Date.parse(state.signupClosesAtUtc);
+                        if (Number.isFinite(closesAt)) {
+                            var delay = closesAt - Date.now();
+                            if (delay <= 0) {
+                                promo.hidden = true;
+                            } else if (delay < 2147483647) {
+                                window.setTimeout(function () { promo.hidden = true; }, delay);
+                            }
+                        }
+                    })
+                    .catch(function () { });
+            }());
+        </script>
+        <!--LONGEVITYMAXXING-PROMO-END-->
         <div class="podium" aria-busy="true" style="display:none;">
             <div class="podium-item podium-skeleton-item second" aria-hidden="true">
                 <div class="podium-skeleton-portrait skeleton-shimmer"></div>


### PR DESCRIPTION
## What changed

- Added a compact homepage promo band for the Longevitymaxxing Challenge above the main leaderboard.
- Positioned it as a separate Lifestyle challenge so it does not imply any Ultimate League ranking, placement, or badge impact.
- Added middleware logic to remove the promo after challenge signup closes.
- Added a small client-side guard so already-open pages hide the promo at the signup cutoff.

## Screenshot

Captured locally at `.artifacts/longevitymaxxing-homepage-promo.png`.

## Validation

- `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --filter LongevitymaxxingChallengePageTests`
- `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj`
- Browser smoke check on `http://localhost:5123/`
