### PR TITLE
Refresh Threads tokens proactively

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,12 @@ The Longevitymaxxing Challenge is a standalone Lifestyle challenge and must not 
 - When changing the API of an existing external JS file, review every injected HTML/partial caller in the repo and ensure the versioned URL path still goes through the middleware replacement flow.
 - If a helper is moved from inline script to a separate JS file, verify that the file is loaded in every page, modal, iframe, or embedded context that uses that helper.
 
+## Social API Token Maintenance
+
+- Threads access token maintenance is part of the daily Threads social post job, even on days with no postable content.
+- `ThreadsAccessTokenExpiresAtUtc` and `ThreadsAccessTokenLastRefreshAttemptAtUtc` are runtime config metadata used to avoid silent token expiry; keep them in sync when manually replacing `ThreadsAccessToken`.
+- Expired Threads tokens cannot be recovered in code. Generate a fresh token in Meta, then let the app refresh it proactively before future expiry.
+
 ## Keep This File Updated
 
 - If you modify behavior in any of the areas described above, update this file as part of the same change.

--- a/LongevityWorldCup.Documentation/ThreadsApiSetup.md
+++ b/LongevityWorldCup.Documentation/ThreadsApiSetup.md
@@ -131,7 +131,9 @@ Add this to `config.json` (Website project):
 ```json
 "ThreadsAppId": "<Threads app ID>",
 "ThreadsAppSecret": "<Threads app secret>",
-"ThreadsAccessToken": "<Threads access token>"
+"ThreadsAccessToken": "<Threads access token>",
+"ThreadsAccessTokenExpiresAtUtc": "",
+"ThreadsAccessTokenLastRefreshAttemptAtUtc": ""
 ```
 
 Where to find these values in Meta:
@@ -150,8 +152,19 @@ The LWC Threads client supports token refresh.
 
 Behavior:
 - it uses the configured `ThreadsAccessToken`
-- if the Threads API returns an auth error, it attempts to refresh the token automatically
-- the refreshed token is saved back into `config.json`
+- if the Threads API returns an auth error during posting, it attempts to refresh the token automatically
+- the daily Threads job also runs token maintenance even when there is no postable Threads content
+- when Meta returns `expires_in`, the client stores `ThreadsAccessTokenExpiresAtUtc` in `config.json`
+- if the saved expiry is within 14 days, the daily Threads job refreshes the token before it expires
+- if expiry metadata is missing, the daily Threads job attempts refresh at most once every 20 hours until it can save expiry metadata
+- the refreshed token and refresh metadata are saved back into `config.json`
+
+Meta constraints:
+- short-lived tokens must be exchanged for long-lived tokens before production use
+- long-lived tokens are valid for about 60 days
+- long-lived tokens can be refreshed only while they are unexpired
+- expired tokens cannot be recovered by the app; generate a new token in Meta and update `ThreadsAccessToken`
 
 Operational note:
 - do not manually remove `ThreadsAppSecret` or `ThreadsAppId` from config if later maintenance depends on them
+- after manually replacing `ThreadsAccessToken`, either also clear the two metadata fields or set `ThreadsAccessTokenExpiresAtUtc` to the token's known UTC expiry

--- a/LongevityWorldCup.Tests/ThreadsApiClientTokenRefreshTests.cs
+++ b/LongevityWorldCup.Tests/ThreadsApiClientTokenRefreshTests.cs
@@ -1,0 +1,50 @@
+using LongevityWorldCup.Website.Business;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class ThreadsApiClientTokenRefreshTests
+{
+    [Fact]
+    public void ShouldRefreshProactively_ReturnsTrue_WhenKnownExpiryIsInsideRefreshWindow()
+    {
+        var now = new DateTimeOffset(2026, 6, 3, 12, 0, 0, TimeSpan.Zero);
+        var expiresAt = now.AddDays(13).ToString("O");
+
+        var shouldRefresh = ThreadsApiClient.ShouldRefreshProactively(now, expiresAt, lastRefreshAttemptAtUtc: null);
+
+        Assert.True(shouldRefresh);
+    }
+
+    [Fact]
+    public void ShouldRefreshProactively_ReturnsFalse_WhenKnownExpiryIsOutsideRefreshWindow()
+    {
+        var now = new DateTimeOffset(2026, 6, 3, 12, 0, 0, TimeSpan.Zero);
+        var expiresAt = now.AddDays(15).ToString("O");
+
+        var shouldRefresh = ThreadsApiClient.ShouldRefreshProactively(now, expiresAt, lastRefreshAttemptAtUtc: null);
+
+        Assert.False(shouldRefresh);
+    }
+
+    [Fact]
+    public void ShouldRefreshProactively_ReturnsTrue_WhenExpiryIsUnknownAndNoAttemptWasRecorded()
+    {
+        var now = new DateTimeOffset(2026, 6, 3, 12, 0, 0, TimeSpan.Zero);
+
+        var shouldRefresh = ThreadsApiClient.ShouldRefreshProactively(now, expiresAtUtc: null, lastRefreshAttemptAtUtc: null);
+
+        Assert.True(shouldRefresh);
+    }
+
+    [Fact]
+    public void ShouldRefreshProactively_ReturnsFalse_WhenExpiryIsUnknownAndRefreshWasRecentlyAttempted()
+    {
+        var now = new DateTimeOffset(2026, 6, 3, 12, 0, 0, TimeSpan.Zero);
+        var lastAttempt = now.AddHours(-19).ToString("O");
+
+        var shouldRefresh = ThreadsApiClient.ShouldRefreshProactively(now, expiresAtUtc: null, lastAttempt);
+
+        Assert.False(shouldRefresh);
+    }
+}

--- a/LongevityWorldCup.Website/Business/ThreadsApiClient.cs
+++ b/LongevityWorldCup.Website/Business/ThreadsApiClient.cs
@@ -10,6 +10,8 @@ public class ThreadsApiClient
     private const string RefreshAccessTokenEndpoint = "https://graph.threads.net/refresh_access_token";
     private const string ContainerFields = "id,status,error_message";
     private const int MaxTextLength = 500;
+    private static readonly TimeSpan ProactiveRefreshWindow = TimeSpan.FromDays(14);
+    private static readonly TimeSpan UnknownExpiryRefreshRetryInterval = TimeSpan.FromHours(20);
     private static readonly int[] ContainerReadyPollDelaysMs = [1000, 2000, 3000, 5000, 5000, 10000, 10000, 15000];
 
     private readonly HttpClient _http;
@@ -28,6 +30,20 @@ public class ThreadsApiClient
     }
 
     public bool IsConfigured => !string.IsNullOrWhiteSpace(GetAccessToken());
+
+    public async Task EnsureAccessTokenFreshAsync(CancellationToken ct = default)
+    {
+        var token = GetAccessToken();
+        if (string.IsNullOrWhiteSpace(token))
+            return;
+
+        if (!ShouldRefreshProactively(DateTimeOffset.UtcNow))
+            return;
+
+        var refreshed = await TryRefreshAccessTokenAsync(ct);
+        if (!refreshed)
+            _log.LogWarning("Threads proactive token refresh did not succeed. Existing token will remain configured.");
+    }
 
     public async Task SendAsync(string text)
     {
@@ -391,9 +407,9 @@ public class ThreadsApiClient
         }
     }
 
-    private async Task<bool> TryRefreshAccessTokenAsync()
+    private async Task<bool> TryRefreshAccessTokenAsync(CancellationToken ct = default)
     {
-        await _refreshLock.WaitAsync();
+        await _refreshLock.WaitAsync(ct);
         try
         {
             var currentToken = GetAccessToken();
@@ -403,34 +419,43 @@ public class ThreadsApiClient
                 return false;
             }
 
+            var attemptUtc = DateTimeOffset.UtcNow;
+            _config.ThreadsAccessTokenLastRefreshAttemptAtUtc = FormatUtc(attemptUtc);
+
             var url = $"{RefreshAccessTokenEndpoint}?grant_type=th_refresh_token&access_token={Uri.EscapeDataString(currentToken)}";
             using var req = new HttpRequestMessage(HttpMethod.Get, url);
 
-            var res = await _http.SendAsync(req);
-            var json = await res.Content.ReadAsStringAsync();
+            var res = await _http.SendAsync(req, ct);
+            var json = await res.Content.ReadAsStringAsync(ct);
 
             if (!res.IsSuccessStatusCode)
             {
                 _log.LogError("Threads token refresh failed: {StatusCode} {Body}", res.StatusCode, json);
+                await SaveConfigAsync();
                 return false;
             }
 
             string? newAccessToken = null;
+            long? expiresInSeconds = null;
             try
             {
                 using var doc = JsonDocument.Parse(json);
                 if (doc.RootElement.TryGetProperty("access_token", out var tokenEl))
                     newAccessToken = tokenEl.GetString();
+                if (doc.RootElement.TryGetProperty("expires_in", out var expiresEl) && expiresEl.TryGetInt64(out var expiresInValue))
+                    expiresInSeconds = expiresInValue;
             }
             catch (Exception ex)
             {
                 _log.LogError(ex, "Threads token refresh response parse failed: {Json}", json);
+                await SaveConfigAsync();
                 return false;
             }
 
             if (string.IsNullOrWhiteSpace(newAccessToken))
             {
                 _log.LogError("Threads token refresh did not return access_token.");
+                await SaveConfigAsync();
                 return false;
             }
 
@@ -438,16 +463,11 @@ public class ThreadsApiClient
             {
                 _accessToken = newAccessToken;
                 _config.ThreadsAccessToken = newAccessToken;
+                if (expiresInSeconds is > 0)
+                    _config.ThreadsAccessTokenExpiresAtUtc = FormatUtc(attemptUtc.AddSeconds(expiresInSeconds.Value));
             }
 
-            try
-            {
-                await _config.SaveAsync();
-            }
-            catch (Exception ex)
-            {
-                _log.LogError(ex, "Failed to save Threads access token to config.");
-            }
+            await SaveConfigAsync();
 
             _log.LogInformation("Threads access token refreshed successfully.");
             return true;
@@ -469,6 +489,52 @@ public class ThreadsApiClient
         return responseBody.Contains("Invalid OAuth access token", StringComparison.OrdinalIgnoreCase) ||
                responseBody.Contains("Error validating access token", StringComparison.OrdinalIgnoreCase) ||
                responseBody.Contains("Session has expired", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private bool ShouldRefreshProactively(DateTimeOffset nowUtc)
+    {
+        return ShouldRefreshProactively(
+            nowUtc,
+            _config.ThreadsAccessTokenExpiresAtUtc,
+            _config.ThreadsAccessTokenLastRefreshAttemptAtUtc);
+    }
+
+    internal static bool ShouldRefreshProactively(DateTimeOffset nowUtc, string? expiresAtUtc, string? lastRefreshAttemptAtUtc)
+    {
+        var expiresAt = ParseConfigUtc(expiresAtUtc);
+        if (expiresAt.HasValue)
+            return expiresAt.Value - nowUtc <= ProactiveRefreshWindow;
+
+        var lastAttempt = ParseConfigUtc(lastRefreshAttemptAtUtc);
+        return !lastAttempt.HasValue || nowUtc - lastAttempt.Value >= UnknownExpiryRefreshRetryInterval;
+    }
+
+    private async Task SaveConfigAsync()
+    {
+        try
+        {
+            await _config.SaveAsync();
+        }
+        catch (Exception ex)
+        {
+            _log.LogError(ex, "Failed to save Threads access token config.");
+        }
+    }
+
+    private static DateTimeOffset? ParseConfigUtc(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+
+        if (!DateTimeOffset.TryParse(value, out var parsed))
+            return null;
+
+        return parsed.ToUniversalTime();
+    }
+
+    private static string FormatUtc(DateTimeOffset value)
+    {
+        return value.UtcDateTime.ToString("O");
     }
 
 }

--- a/LongevityWorldCup.Website/Business/ThreadsEventService.cs
+++ b/LongevityWorldCup.Website/Business/ThreadsEventService.cs
@@ -23,6 +23,11 @@ public class ThreadsEventService
 
     public bool IsConfigured => _threads.IsConfigured;
 
+    public Task EnsureAccessTokenFreshAsync(CancellationToken ct = default)
+    {
+        return _threads.EnsureAccessTokenFreshAsync(ct);
+    }
+
     public void SetAthletesForThreads(IReadOnlyList<AthleteForX> items)
     {
         var map = new Dictionary<string, AthleteForX>(StringComparer.OrdinalIgnoreCase);

--- a/LongevityWorldCup.Website/Config.cs
+++ b/LongevityWorldCup.Website/Config.cs
@@ -38,6 +38,8 @@ namespace LongevityWorldCup.Website
         public string? ThreadsAppId { get; set; }
         public string? ThreadsAppSecret { get; set; }
         public string? ThreadsAccessToken { get; set; }
+        public string? ThreadsAccessTokenExpiresAtUtc { get; set; }
+        public string? ThreadsAccessTokenLastRefreshAttemptAtUtc { get; set; }
         public string? FacebookAppId { get; set; }
         public string? FacebookAppSecret { get; set; }
         public string? FacebookPageId { get; set; }

--- a/LongevityWorldCup.Website/Jobs/ThreadsDailyPostJob.cs
+++ b/LongevityWorldCup.Website/Jobs/ThreadsDailyPostJob.cs
@@ -27,6 +27,7 @@ public class ThreadsDailyPostJob : IJob
     public async Task Execute(IJobExecutionContext context)
     {
         _logger.LogInformation("ThreadsDailyPostJob {ts}", DateTime.UtcNow);
+        await _threadsEvents.EnsureAccessTokenFreshAsync(context.CancellationToken);
 
         _events.SetAthletesForX(_athletes.GetAthletesForX());
         var pending = _events.GetPendingThreadsEvents();

--- a/LongevityWorldCup.Website/Program.cs
+++ b/LongevityWorldCup.Website/Program.cs
@@ -392,6 +392,8 @@ namespace LongevityWorldCup.Website
                 ThreadsAppId = "",
                 ThreadsAppSecret = "",
                 ThreadsAccessToken = "",
+                ThreadsAccessTokenExpiresAtUtc = "",
+                ThreadsAccessTokenLastRefreshAttemptAtUtc = "",
                 FacebookAppId = "",
                 FacebookAppSecret = "",
                 FacebookPageId = "",

--- a/LongevityWorldCup.Website/Properties/AssemblyInfo.cs
+++ b/LongevityWorldCup.Website/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("LongevityWorldCup.Tests")]


### PR DESCRIPTION
## Summary
- add persisted Threads token refresh metadata to runtime config
- run Threads token maintenance at the start of the daily Threads job, even when no content is posted
- refresh proactively inside a 14-day expiry window and retry unknown-expiry configs at most every 20 hours
- document the Meta token constraints and operational metadata fields

## Reconciliation
The earlier production publish was built from an uncommitted dirty worktree. This PR makes the same Threads token-maintenance code traceable through Git so production can be deployed from `master` by the normal Auto Deploy workflow.

## Tests
- `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --no-restore`