### PR TITLE
Persist runtime social tokens outside publish config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ Longevitymaxxing Challenge final results and linked-athlete completions may appe
 ## Social API Token Maintenance
 
 - Threads access token maintenance is part of the daily Threads social post job, even on days with no postable content.
-- `ThreadsAccessTokenExpiresAtUtc` and `ThreadsAccessTokenLastRefreshAttemptAtUtc` are runtime config metadata used to avoid silent token expiry; keep them in sync when manually replacing `ThreadsAccessToken`.
+- `ThreadsAccessTokenExpiresAtUtc` and `ThreadsAccessTokenLastRefreshAttemptAtUtc` are runtime config metadata used to avoid silent token expiry; keep them in sync when manually replacing `ThreadsAccessToken`. Runtime social token updates may be persisted in `/var/www/.longevityworldcup/runtime-config.json` when `publish/config.json` is not writable, so update or remove that sidecar if you need a manual config replacement to take precedence immediately.
 - Expired Threads tokens cannot be recovered in code. Generate a fresh token in Meta, then let the app refresh it proactively before future expiry.
 
 ## Keep This File Updated

--- a/LongevityWorldCup.Documentation/FacebookApiSetup.md
+++ b/LongevityWorldCup.Documentation/FacebookApiSetup.md
@@ -119,7 +119,15 @@ Use exactly the values printed by the helper.
 
 ---
 
-## 8. Publish the Meta App
+## 8. Token Refresh Persistence
+
+The Website refreshes Facebook user and page tokens automatically after an auth failure. It first saves the rotated values to `config.json`. If production `config.json` is readable but not writable by the service account, it saves the runtime token fields to `/var/www/.longevityworldcup/runtime-config.json`.
+
+On startup, `runtime-config.json` is applied only when it is newer than `config.json`. If you manually regenerate Facebook tokens, edit `config.json` and remove or update the runtime sidecar if you need the manual values to take effect immediately.
+
+---
+
+## 9. Publish the Meta App
 
 Before going live:
 

--- a/LongevityWorldCup.Documentation/ServerDeployment.md
+++ b/LongevityWorldCup.Documentation/ServerDeployment.md
@@ -78,6 +78,8 @@ The final sync preserves production-owned runtime paths:
 
 Deletion is scoped to `wwwroot/athletes/` so removed athlete proofs disappear from production without turning this deploy into a broad cleanup of old unrelated server files.
 
+Social API token refreshes first try to persist updated token state in `config.json`. If the service account can read but not write that file, the app writes the runtime token fields to `/var/www/.longevityworldcup/runtime-config.json` instead. On startup, that sidecar is applied only when it is newer than `config.json`, so a fresh manual edit to `config.json` takes precedence. Delete or update the sidecar when intentionally resetting social tokens.
+
 ## Check Website
 https://www.longevityworldcup.com/
 
@@ -225,6 +227,8 @@ After first run, config file is created:
 ```sh
 sudo nano /var/www/LongevityWorldCup/publish/config.json
 ```
+
+The app may also create `/var/www/.longevityworldcup/runtime-config.json` for rotated X, Threads, and Facebook tokens when `publish/config.json` is read-only to `www-data`.
 
 Make sure to publish the app at the unisable google website if it's a new setup. Otherwise refresh token expires in 7 days: https://console.cloud.google.com/auth/audience  
 Publish before generating refresh token!

--- a/LongevityWorldCup.Documentation/ThreadsApiSetup.md
+++ b/LongevityWorldCup.Documentation/ThreadsApiSetup.md
@@ -157,7 +157,8 @@ Behavior:
 - when Meta returns `expires_in`, the client stores `ThreadsAccessTokenExpiresAtUtc` in `config.json`
 - if the saved expiry is within 14 days, the daily Threads job refreshes the token before it expires
 - if expiry metadata is missing, the daily Threads job attempts refresh at most once every 20 hours until it can save expiry metadata
-- the refreshed token and refresh metadata are saved back into `config.json`
+- the refreshed token and refresh metadata are saved back into `config.json`; if production `config.json` is not writable by the service account, the runtime token fields are saved in `/var/www/.longevityworldcup/runtime-config.json`
+- on startup, `runtime-config.json` is applied only when it is newer than `config.json`
 
 Meta constraints:
 - short-lived tokens must be exchanged for long-lived tokens before production use
@@ -168,3 +169,4 @@ Meta constraints:
 Operational note:
 - do not manually remove `ThreadsAppSecret` or `ThreadsAppId` from config if later maintenance depends on them
 - after manually replacing `ThreadsAccessToken`, either also clear the two metadata fields or set `ThreadsAccessTokenExpiresAtUtc` to the token's known UTC expiry
+- when manually resetting Threads token state, remove or update `/var/www/.longevityworldcup/runtime-config.json` if the sidecar is newer than `config.json`

--- a/LongevityWorldCup.Documentation/XApiSetup.md
+++ b/LongevityWorldCup.Documentation/XApiSetup.md
@@ -79,6 +79,12 @@ Meaning:
 - `XConsumerKey` / `XConsumerSecret`: OAuth 1.0a app/API keys used for signing media upload requests
 - `XUserAccessToken` / `XUserAccessTokenSecret`: OAuth 1.0a user-context tokens used for media upload
 
-## 6. Billing / Credits
+## 6. Token Refresh Persistence
+
+The Website refreshes `XAccessToken` and `XRefreshToken` automatically after an auth failure. It first saves the rotated values to `config.json`. If production `config.json` is readable but not writable by the service account, it saves the runtime token fields to `/var/www/.longevityworldcup/runtime-config.json`.
+
+On startup, `runtime-config.json` is applied only when it is newer than `config.json`. If you manually regenerate X tokens, edit `config.json` and remove or update the runtime sidecar if you need the manual values to take effect immediately.
+
+## 7. Billing / Credits
 
 Posting on X consumes credits. If you receive `402 Payment Required`, check billing and credits in the X developer portal.

--- a/LongevityWorldCup.Tests/ConfigPersistenceTests.cs
+++ b/LongevityWorldCup.Tests/ConfigPersistenceTests.cs
@@ -1,0 +1,152 @@
+using System.Text.Json;
+using LongevityWorldCup.Website;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class ConfigPersistenceTests
+{
+    [Fact]
+    public async Task LoadAsync_AppliesRuntimeTokenConfig_WhenRuntimeConfigIsCurrent()
+    {
+        using var temp = new TempDirectory();
+        var configPath = Path.Combine(temp.Path, "config.json");
+        var runtimeConfigPath = Path.Combine(temp.Path, "runtime-config.json");
+
+        await WriteConfigAsync(configPath, new Config
+        {
+            EmailFrom = "hi@example.com",
+            XAccessToken = "old-x-access",
+            XRefreshToken = "old-x-refresh",
+            ThreadsAccessToken = "old-threads",
+            ThreadsAccessTokenExpiresAtUtc = "2026-06-01T00:00:00.0000000Z",
+            ThreadsAccessTokenLastRefreshAttemptAtUtc = "2026-06-01T12:00:00.0000000Z",
+            FacebookUserAccessToken = "old-facebook-user",
+            FacebookPageAccessToken = "old-facebook-page"
+        });
+        await WriteRuntimeConfigAsync(runtimeConfigPath, new
+        {
+            XAccessToken = "new-x-access",
+            XRefreshToken = "new-x-refresh",
+            ThreadsAccessToken = "new-threads",
+            ThreadsAccessTokenExpiresAtUtc = "2026-07-01T00:00:00.0000000Z",
+            ThreadsAccessTokenLastRefreshAttemptAtUtc = "2026-06-03T12:00:00.0000000Z",
+            FacebookUserAccessToken = "new-facebook-user",
+            FacebookPageAccessToken = "new-facebook-page"
+        });
+
+        File.SetLastWriteTimeUtc(configPath, DateTime.UtcNow.AddMinutes(-10));
+        File.SetLastWriteTimeUtc(runtimeConfigPath, DateTime.UtcNow);
+
+        var config = await Config.LoadAsync(configPath, runtimeConfigPath);
+
+        Assert.Equal("hi@example.com", config.EmailFrom);
+        Assert.Equal("new-x-access", config.XAccessToken);
+        Assert.Equal("new-x-refresh", config.XRefreshToken);
+        Assert.Equal("new-threads", config.ThreadsAccessToken);
+        Assert.Equal("2026-07-01T00:00:00.0000000Z", config.ThreadsAccessTokenExpiresAtUtc);
+        Assert.Equal("2026-06-03T12:00:00.0000000Z", config.ThreadsAccessTokenLastRefreshAttemptAtUtc);
+        Assert.Equal("new-facebook-user", config.FacebookUserAccessToken);
+        Assert.Equal("new-facebook-page", config.FacebookPageAccessToken);
+    }
+
+    [Fact]
+    public async Task LoadAsync_IgnoresRuntimeTokenConfig_WhenPrimaryConfigIsNewer()
+    {
+        using var temp = new TempDirectory();
+        var configPath = Path.Combine(temp.Path, "config.json");
+        var runtimeConfigPath = Path.Combine(temp.Path, "runtime-config.json");
+
+        await WriteConfigAsync(configPath, new Config
+        {
+            XAccessToken = "manual-x-access",
+            XRefreshToken = "manual-x-refresh",
+            ThreadsAccessToken = "manual-threads"
+        });
+        await WriteRuntimeConfigAsync(runtimeConfigPath, new
+        {
+            XAccessToken = "old-sidecar-x-access",
+            XRefreshToken = "old-sidecar-x-refresh",
+            ThreadsAccessToken = "old-sidecar-threads"
+        });
+
+        File.SetLastWriteTimeUtc(runtimeConfigPath, DateTime.UtcNow.AddMinutes(-10));
+        File.SetLastWriteTimeUtc(configPath, DateTime.UtcNow);
+
+        var config = await Config.LoadAsync(configPath, runtimeConfigPath);
+
+        Assert.Equal("manual-x-access", config.XAccessToken);
+        Assert.Equal("manual-x-refresh", config.XRefreshToken);
+        Assert.Equal("manual-threads", config.ThreadsAccessToken);
+    }
+
+    [Fact]
+    public async Task SaveAsync_FallsBackToRuntimeTokenConfig_WhenPrimaryConfigIsReadOnly()
+    {
+        using var temp = new TempDirectory();
+        var configPath = Path.Combine(temp.Path, "config.json");
+        var runtimeConfigPath = Path.Combine(temp.Path, "runtime-config.json");
+
+        await File.WriteAllTextAsync(configPath, "{}");
+        File.SetAttributes(configPath, File.GetAttributes(configPath) | FileAttributes.ReadOnly);
+
+        try
+        {
+            var config = new Config
+            {
+                XAccessToken = "saved-x-access",
+                XRefreshToken = "saved-x-refresh",
+                ThreadsAccessToken = "saved-threads",
+                ThreadsAccessTokenExpiresAtUtc = "2026-07-01T00:00:00.0000000Z",
+                ThreadsAccessTokenLastRefreshAttemptAtUtc = "2026-06-03T12:00:00.0000000Z",
+                FacebookUserAccessToken = "saved-facebook-user",
+                FacebookPageAccessToken = "saved-facebook-page"
+            }.UseFilePathsForTesting(configPath, runtimeConfigPath);
+
+            await config.SaveAsync();
+        }
+        finally
+        {
+            File.SetAttributes(configPath, FileAttributes.Normal);
+        }
+
+        using var doc = JsonDocument.Parse(await File.ReadAllTextAsync(runtimeConfigPath));
+        var root = doc.RootElement;
+
+        Assert.Equal("saved-x-access", root.GetProperty("XAccessToken").GetString());
+        Assert.Equal("saved-x-refresh", root.GetProperty("XRefreshToken").GetString());
+        Assert.Equal("saved-threads", root.GetProperty("ThreadsAccessToken").GetString());
+        Assert.Equal("2026-07-01T00:00:00.0000000Z", root.GetProperty("ThreadsAccessTokenExpiresAtUtc").GetString());
+        Assert.Equal("2026-06-03T12:00:00.0000000Z", root.GetProperty("ThreadsAccessTokenLastRefreshAttemptAtUtc").GetString());
+        Assert.Equal("saved-facebook-user", root.GetProperty("FacebookUserAccessToken").GetString());
+        Assert.Equal("saved-facebook-page", root.GetProperty("FacebookPageAccessToken").GetString());
+    }
+
+    private static async Task WriteConfigAsync(string path, Config config)
+    {
+        var json = JsonSerializer.Serialize(config, new JsonSerializerOptions { WriteIndented = true });
+        await File.WriteAllTextAsync(path, json);
+    }
+
+    private static async Task WriteRuntimeConfigAsync(string path, object config)
+    {
+        var json = JsonSerializer.Serialize(config, new JsonSerializerOptions { WriteIndented = true });
+        await File.WriteAllTextAsync(path, json);
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public string Path { get; } = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"lwc-config-{Guid.NewGuid():N}");
+
+        public TempDirectory()
+        {
+            Directory.CreateDirectory(Path);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+                Directory.Delete(Path, recursive: true);
+        }
+    }
+}

--- a/LongevityWorldCup.Website/Config.cs
+++ b/LongevityWorldCup.Website/Config.cs
@@ -1,12 +1,17 @@
 using System.IO;
 using System.Text.Json;
 using System.Threading.Tasks;
+using LongevityWorldCup.Website.Tools;
 
 namespace LongevityWorldCup.Website
 {
     public class Config
     {
         private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+        private const string DefaultConfigFilePath = "config.json";
+        private const string RuntimeConfigFileName = "runtime-config.json";
+        private string? _configFilePath;
+        private string? _runtimeConfigFilePath;
 
         public string? EmailFrom { get; set; }
         public string? EmailTo { get; set; }
@@ -15,7 +20,8 @@ namespace LongevityWorldCup.Website
         public string? SmtpUser { get; set; }
         public string? SmtpPassword { get; set; }
 
-        private static readonly string ConfigFilePath = "config.json";
+        private string ConfigFilePath => _configFilePath ?? DefaultConfigFilePath;
+        private string RuntimeConfigFilePath => _runtimeConfigFilePath ?? GetDefaultRuntimeConfigFilePath();
 
         public string? GmailClientId { get; set; }
         public string? GmailClientSecret { get; set; }
@@ -51,21 +57,117 @@ namespace LongevityWorldCup.Website
         // Load configuration from the file
         public static async Task<Config> LoadAsync()
         {
-            if (!File.Exists(ConfigFilePath))
+            return await LoadAsync(DefaultConfigFilePath, GetDefaultRuntimeConfigFilePath());
+        }
+
+        internal static async Task<Config> LoadAsync(string configFilePath, string runtimeConfigFilePath)
+        {
+            if (!File.Exists(configFilePath))
                 throw new FileNotFoundException("Configuration file not found.");
 
-            string json = await File.ReadAllTextAsync(ConfigFilePath);
+            string json = await File.ReadAllTextAsync(configFilePath);
 
             // Ensure deserialization doesn't return null
             var config = JsonSerializer.Deserialize<Config>(json);
-            return config ?? throw new InvalidDataException("Configuration file content is invalid.");
+            if (config is null)
+                throw new InvalidDataException("Configuration file content is invalid.");
+
+            config._configFilePath = configFilePath;
+            config._runtimeConfigFilePath = runtimeConfigFilePath;
+            await config.ApplyRuntimeConfigIfCurrentAsync();
+            return config;
         }
 
         // Save configuration to the file
         public async Task SaveAsync()
         {
             string json = JsonSerializer.Serialize(this, JsonOptions); // Use cached options
-            await File.WriteAllTextAsync(ConfigFilePath, json);
+            try
+            {
+                await File.WriteAllTextAsync(ConfigFilePath, json);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                await SaveRuntimeConfigAsync();
+            }
+        }
+
+        internal Config UseFilePathsForTesting(string configFilePath, string runtimeConfigFilePath)
+        {
+            _configFilePath = configFilePath;
+            _runtimeConfigFilePath = runtimeConfigFilePath;
+            return this;
+        }
+
+        private async Task ApplyRuntimeConfigIfCurrentAsync()
+        {
+            if (!File.Exists(RuntimeConfigFilePath))
+                return;
+
+            var configLastWriteUtc = File.GetLastWriteTimeUtc(ConfigFilePath);
+            var runtimeLastWriteUtc = File.GetLastWriteTimeUtc(RuntimeConfigFilePath);
+            if (runtimeLastWriteUtc < configLastWriteUtc)
+                return;
+
+            var json = await File.ReadAllTextAsync(RuntimeConfigFilePath);
+            var runtimeConfig = JsonSerializer.Deserialize<RuntimeConfig>(json);
+            if (runtimeConfig is null)
+                return;
+
+            ApplyRuntimeConfig(runtimeConfig);
+        }
+
+        private async Task SaveRuntimeConfigAsync()
+        {
+            var runtimePath = RuntimeConfigFilePath;
+            var runtimeDirectory = Path.GetDirectoryName(Path.GetFullPath(runtimePath));
+            if (!string.IsNullOrWhiteSpace(runtimeDirectory))
+                Directory.CreateDirectory(runtimeDirectory);
+
+            var runtimeConfig = RuntimeConfig.From(this);
+            var json = JsonSerializer.Serialize(runtimeConfig, JsonOptions);
+            await File.WriteAllTextAsync(runtimePath, json);
+        }
+
+        private void ApplyRuntimeConfig(RuntimeConfig runtimeConfig)
+        {
+            XAccessToken = runtimeConfig.XAccessToken ?? XAccessToken;
+            XRefreshToken = runtimeConfig.XRefreshToken ?? XRefreshToken;
+            ThreadsAccessToken = runtimeConfig.ThreadsAccessToken ?? ThreadsAccessToken;
+            ThreadsAccessTokenExpiresAtUtc = runtimeConfig.ThreadsAccessTokenExpiresAtUtc ?? ThreadsAccessTokenExpiresAtUtc;
+            ThreadsAccessTokenLastRefreshAttemptAtUtc = runtimeConfig.ThreadsAccessTokenLastRefreshAttemptAtUtc ?? ThreadsAccessTokenLastRefreshAttemptAtUtc;
+            FacebookUserAccessToken = runtimeConfig.FacebookUserAccessToken ?? FacebookUserAccessToken;
+            FacebookPageAccessToken = runtimeConfig.FacebookPageAccessToken ?? FacebookPageAccessToken;
+        }
+
+        private static string GetDefaultRuntimeConfigFilePath()
+        {
+            return Path.Combine(EnvironmentHelpers.GetDataDir(), RuntimeConfigFileName);
+        }
+
+        private sealed class RuntimeConfig
+        {
+            public string? XAccessToken { get; set; }
+            public string? XRefreshToken { get; set; }
+            public string? ThreadsAccessToken { get; set; }
+            public string? ThreadsAccessTokenExpiresAtUtc { get; set; }
+            public string? ThreadsAccessTokenLastRefreshAttemptAtUtc { get; set; }
+            public string? FacebookUserAccessToken { get; set; }
+            public string? FacebookPageAccessToken { get; set; }
+
+            public static RuntimeConfig From(Config config)
+            {
+                return new RuntimeConfig
+                {
+                    XAccessToken = config.XAccessToken,
+                    XRefreshToken = config.XRefreshToken,
+                    ThreadsAccessToken = config.ThreadsAccessToken,
+                    ThreadsAccessTokenExpiresAtUtc = config.ThreadsAccessTokenExpiresAtUtc,
+                    ThreadsAccessTokenLastRefreshAttemptAtUtc = config.ThreadsAccessTokenLastRefreshAttemptAtUtc,
+                    FacebookUserAccessToken = config.FacebookUserAccessToken,
+                    FacebookPageAccessToken = config.FacebookPageAccessToken
+                };
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Add a runtime social token sidecar at `/var/www/.longevityworldcup/runtime-config.json` when `publish/config.json` cannot be written by the service account.
- Load sidecar token fields only when the sidecar is newer than `config.json`, so fresh manual config edits take precedence.
- Document the operational behavior for deployment, X, Threads, Facebook, and agent notes.

## Investigation
The production error came from `XApiClient.TryRefreshTokenAsync()` successfully rotating the X OAuth tokens, then calling `Config.SaveAsync()`. On the server, `publish/config.json` is readable but not writable by the app process, so `File.WriteAllTextAsync("config.json", ...)` raises `UnauthorizedAccessException`. That also risks losing rotated refresh tokens after a service restart.

## Tests
- `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --no-restore`