### PR TITLE
Add periodic social reminders

### DIFF
--- a/LongevityWorldCup.Tests/SocialFillerHistoryReminderTests.cs
+++ b/LongevityWorldCup.Tests/SocialFillerHistoryReminderTests.cs
@@ -1,0 +1,342 @@
+using LongevityWorldCup.Website.Business;
+using LongevityWorldCup.Website.Tools;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class SocialFillerHistoryReminderTests
+{
+    [Fact]
+    public void HistoryDocumentReminderBuildsSimplePlatformSafeCopy()
+    {
+        var shared = HistoryDocumentReminderPost.BuildText(new Random(2));
+
+        Assert.Contains(shared, AllowedHistoryReminderTexts());
+        Assert.Equal(
+            new[]
+            {
+                "How longevity became a sport:",
+                "For anyone new here:",
+                "A short history of longevity as a sport:",
+                "The backstory:",
+                "Longevity as a sport did not appear out of nowhere:"
+            },
+            HistoryDocumentReminderPost.LeadLines);
+        foreach (var lead in HistoryDocumentReminderPost.LeadLines)
+        {
+            var variant = $"{lead}\n{HistoryDocumentReminderPost.Url}";
+            Assert.True(variant.Length <= 280);
+            Assert.True(variant.Length <= 500);
+        }
+    }
+
+    [Fact]
+    public void RulesetReminderBuildsSimplePlatformSafeCopy()
+    {
+        var shared = RulesetReminderPost.BuildText(new Random(2));
+
+        Assert.Contains(shared, AllowedRulesetReminderTexts());
+        Assert.Equal(
+            new[]
+            {
+                "How the competition works:",
+                "The Ruleset:",
+                "For anyone wondering how rankings work:",
+                "How athletes are ranked:",
+                "The rules behind the leaderboard:",
+                "What counts, what does not:",
+                "Pro, Amateur, seasons, clocks, prizes:",
+                "The current Longevity World Cup Ruleset:",
+                "Start here if the leaderboard looks confusing:",
+                "The scoring rules are public:",
+                "The ranking rules are public:",
+                "The Longevity World Cup rulebook:",
+                "How the Ultimate League works:",
+                "What the competition measures:",
+                "The rules of longevity as a sport:",
+                "How results become rankings:",
+                "The heart of a game lies within its rules",
+                "Great play emerges from clear constraints"
+            },
+            RulesetReminderPost.LeadLines);
+        foreach (var lead in RulesetReminderPost.LeadLines)
+        {
+            var variant = $"{lead}\n{RulesetReminderPost.Url}";
+            Assert.True(variant.Length <= 280);
+            Assert.True(variant.Length <= 500);
+        }
+    }
+
+    [Fact]
+    public void GitHubRepositoryReminderBuildsSimplePlatformSafeCopy()
+    {
+        var shared = GitHubRepositoryReminderPost.BuildText(new Random(2));
+
+        Assert.Contains(shared, AllowedGitHubRepositoryReminderTexts());
+        Assert.Equal(
+            new[]
+            {
+                "The Longevity World Cup website is free and open source.",
+                "The leaderboard is public. The code is too.",
+                "Longevity World Cup is open source.",
+                "The Longevity World Cup website can be inspected, forked, and improved.",
+                "The code behind Longevity World Cup is public.",
+                "Free and open source, including the website.",
+                "The Longevity World Cup website is open for contributions.",
+                "Want to see how the site works? The code is public.",
+                "Longevity World Cup is built in the open.",
+                "The website is free software. Fork it, modify it, contribute.",
+                "The project is open source for anyone who wants to inspect or improve it.",
+                "Public competition, public rules, public code.",
+                "The Longevity World Cup website is available to read, fork, and contribute to.",
+                "The website code is open source.",
+                "You can fork the Longevity World Cup website.",
+                "The code is public because the competition should be inspectable.",
+                "Longevity World Cup is not a black box. The website code is public.",
+                "The website is open source. Contributions are welcome.",
+                "The Longevity World Cup project is free to fork and modify.",
+                "The code behind the website lives on GitHub.",
+                "Open rules. Open leaderboard. Open source website."
+            },
+            GitHubRepositoryReminderPost.LeadLines);
+        foreach (var lead in GitHubRepositoryReminderPost.LeadLines)
+        {
+            var variant = $"{lead}\n{GitHubRepositoryReminderPost.Url}";
+            Assert.True(variant.Length <= 280);
+            Assert.True(variant.Length <= 500);
+        }
+    }
+
+    [Fact]
+    public void DonationReminderBuildsSimplePlatformSafeCopy()
+    {
+        var shared = DonationReminderPost.BuildText(new Random(2));
+
+        Assert.Contains(shared, AllowedDonationReminderTexts());
+        Assert.Equal(
+            new[]
+            {
+                "Help fund the Longevity World Cup prize pool:",
+                "Bitcoin donations fund the prize pool:",
+                "Support the prize pool:",
+                "Want to support the competition?",
+                "Help keep the prize pool growing:",
+                "90% of Bitcoin donations go to the prize pool:",
+                "Contribute to the Bitcoin-funded prize pool:",
+                "Donations support prizes and operating costs:"
+            },
+            DonationReminderPost.LeadLines);
+        foreach (var lead in DonationReminderPost.LeadLines)
+        {
+            var variant = $"{lead}\n{DonationReminderPost.Url}";
+            Assert.True(variant.Length <= 280);
+            Assert.True(variant.Length <= 500);
+        }
+    }
+
+    [Fact]
+    public void HistoryDocumentReminderPlatformBuildersUseAllowedVariant()
+    {
+        var x = XMessageBuilder.ForFiller(FillerType.HistoryDocument, "", slug => slug);
+        var threads = ThreadsMessageBuilder.ForFiller(FillerType.HistoryDocument, "", slug => slug);
+
+        Assert.Contains(x, AllowedHistoryReminderTexts());
+        Assert.Contains(threads, AllowedHistoryReminderTexts());
+    }
+
+    [Fact]
+    public void RulesetReminderPlatformBuildersUseAllowedVariant()
+    {
+        var x = XMessageBuilder.ForFiller(FillerType.Ruleset, "", slug => slug);
+        var threads = ThreadsMessageBuilder.ForFiller(FillerType.Ruleset, "", slug => slug);
+
+        Assert.Contains(x, AllowedRulesetReminderTexts());
+        Assert.Contains(threads, AllowedRulesetReminderTexts());
+    }
+
+    [Fact]
+    public void GitHubRepositoryReminderPlatformBuildersUseAllowedVariant()
+    {
+        var x = XMessageBuilder.ForFiller(FillerType.GitHubRepository, "", slug => slug);
+        var threads = ThreadsMessageBuilder.ForFiller(FillerType.GitHubRepository, "", slug => slug);
+
+        Assert.Contains(x, AllowedGitHubRepositoryReminderTexts());
+        Assert.Contains(threads, AllowedGitHubRepositoryReminderTexts());
+    }
+
+    [Fact]
+    public void DonationReminderPlatformBuildersUseAllowedVariant()
+    {
+        var x = XMessageBuilder.ForFiller(FillerType.Donation, "", slug => slug);
+        var threads = ThreadsMessageBuilder.ForFiller(FillerType.Donation, "", slug => slug);
+
+        Assert.Contains(x, AllowedDonationReminderTexts());
+        Assert.Contains(threads, AllowedDonationReminderTexts());
+    }
+
+    [Fact]
+    public void PeriodicRemindersAppearInEachPlatformFillerRotation()
+    {
+        using var fixture = TempDatabaseFixture.Create();
+        var x = new XFillerPostLogService(fixture.Database);
+        var threads = new ThreadsFillerPostLogService(fixture.Database);
+        var facebook = new FacebookFillerPostLogService(fixture.Database);
+
+        Assert.Contains(x.GetSuggestedFillersOrdered(), item => item.Type == FillerType.HistoryDocument);
+        Assert.Contains(x.GetSuggestedFillersOrdered(), item => item.Type == FillerType.Ruleset);
+        Assert.Contains(x.GetSuggestedFillersOrdered(), item => item.Type == FillerType.GitHubRepository);
+        Assert.Contains(x.GetSuggestedFillersOrdered(), item => item.Type == FillerType.Donation);
+        Assert.Contains(threads.GetSuggestedFillersOrdered(), item => item.Type == FillerType.HistoryDocument);
+        Assert.Contains(threads.GetSuggestedFillersOrdered(), item => item.Type == FillerType.Ruleset);
+        Assert.Contains(threads.GetSuggestedFillersOrdered(), item => item.Type == FillerType.GitHubRepository);
+        Assert.Contains(threads.GetSuggestedFillersOrdered(), item => item.Type == FillerType.Donation);
+        Assert.Contains(facebook.GetSuggestedFillersOrdered(), item => item.Type == FillerType.HistoryDocument);
+        Assert.Contains(facebook.GetSuggestedFillersOrdered(), item => item.Type == FillerType.Ruleset);
+        Assert.Contains(facebook.GetSuggestedFillersOrdered(), item => item.Type == FillerType.GitHubRepository);
+        Assert.Contains(facebook.GetSuggestedFillersOrdered(), item => item.Type == FillerType.Donation);
+    }
+
+    [Fact]
+    public void HistoryDocumentReminderUsesTwoToFourMonthRandomizedCooldown()
+    {
+        using var fixture = TempDatabaseFixture.Create();
+        var log = new XFillerPostLogService(fixture.Database);
+        var postedAt = new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+
+        log.LogPost(postedAt, FillerType.HistoryDocument, HistoryDocumentReminderPost.InfoToken);
+
+        Assert.True(log.IsOnRandomizedCooldownForType(
+            FillerType.HistoryDocument,
+            HistoryDocumentReminderPost.MinCooldownDays,
+            HistoryDocumentReminderPost.MaxCooldownDays,
+            postedAt.AddDays(59)));
+        Assert.False(log.IsOnRandomizedCooldownForType(
+            FillerType.HistoryDocument,
+            HistoryDocumentReminderPost.MinCooldownDays,
+            HistoryDocumentReminderPost.MaxCooldownDays,
+            postedAt.AddDays(121)));
+    }
+
+    [Fact]
+    public void RulesetReminderUsesTwoToFourMonthRandomizedCooldown()
+    {
+        using var fixture = TempDatabaseFixture.Create();
+        var log = new XFillerPostLogService(fixture.Database);
+        var postedAt = new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+
+        log.LogPost(postedAt, FillerType.Ruleset, RulesetReminderPost.InfoToken);
+
+        Assert.True(log.IsOnRandomizedCooldownForType(
+            FillerType.Ruleset,
+            RulesetReminderPost.MinCooldownDays,
+            RulesetReminderPost.MaxCooldownDays,
+            postedAt.AddDays(59)));
+        Assert.False(log.IsOnRandomizedCooldownForType(
+            FillerType.Ruleset,
+            RulesetReminderPost.MinCooldownDays,
+            RulesetReminderPost.MaxCooldownDays,
+            postedAt.AddDays(121)));
+    }
+
+    [Fact]
+    public void GitHubRepositoryReminderUsesTwoToFourMonthRandomizedCooldown()
+    {
+        using var fixture = TempDatabaseFixture.Create();
+        var log = new XFillerPostLogService(fixture.Database);
+        var postedAt = new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+
+        log.LogPost(postedAt, FillerType.GitHubRepository, GitHubRepositoryReminderPost.InfoToken);
+
+        Assert.True(log.IsOnRandomizedCooldownForType(
+            FillerType.GitHubRepository,
+            GitHubRepositoryReminderPost.MinCooldownDays,
+            GitHubRepositoryReminderPost.MaxCooldownDays,
+            postedAt.AddDays(59)));
+        Assert.False(log.IsOnRandomizedCooldownForType(
+            FillerType.GitHubRepository,
+            GitHubRepositoryReminderPost.MinCooldownDays,
+            GitHubRepositoryReminderPost.MaxCooldownDays,
+            postedAt.AddDays(121)));
+    }
+
+    [Fact]
+    public void DonationReminderUsesOneToThreeMonthRandomizedCooldown()
+    {
+        using var fixture = TempDatabaseFixture.Create();
+        var log = new XFillerPostLogService(fixture.Database);
+        var postedAt = new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+
+        log.LogPost(postedAt, FillerType.Donation, DonationReminderPost.InfoToken);
+
+        Assert.True(log.IsOnRandomizedCooldownForType(
+            FillerType.Donation,
+            DonationReminderPost.MinCooldownDays,
+            DonationReminderPost.MaxCooldownDays,
+            postedAt.AddDays(29)));
+        Assert.False(log.IsOnRandomizedCooldownForType(
+            FillerType.Donation,
+            DonationReminderPost.MinCooldownDays,
+            DonationReminderPost.MaxCooldownDays,
+            postedAt.AddDays(91)));
+    }
+
+    private sealed class TempDatabaseFixture : IDisposable
+    {
+        private readonly string _root;
+
+        private TempDatabaseFixture(string root, DatabaseManager database)
+        {
+            _root = root;
+            Database = database;
+        }
+
+        public DatabaseManager Database { get; }
+
+        public static TempDatabaseFixture Create()
+        {
+            var root = Path.Combine(Path.GetTempPath(), "lwc-social-filler-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(root);
+            return new TempDatabaseFixture(root, new DatabaseManager(dbPath: Path.Combine(root, "test.db")));
+        }
+
+        public void Dispose()
+        {
+            Database.Dispose();
+            try
+            {
+                Directory.Delete(_root, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    private static IReadOnlyList<string> AllowedHistoryReminderTexts()
+    {
+        return HistoryDocumentReminderPost.LeadLines
+            .Select(lead => $"{lead}\n{HistoryDocumentReminderPost.Url}")
+            .ToArray();
+    }
+
+    private static IReadOnlyList<string> AllowedRulesetReminderTexts()
+    {
+        return RulesetReminderPost.LeadLines
+            .Select(lead => $"{lead}\n{RulesetReminderPost.Url}")
+            .ToArray();
+    }
+
+    private static IReadOnlyList<string> AllowedGitHubRepositoryReminderTexts()
+    {
+        return GitHubRepositoryReminderPost.LeadLines
+            .Select(lead => $"{lead}\n{GitHubRepositoryReminderPost.Url}")
+            .ToArray();
+    }
+
+    private static IReadOnlyList<string> AllowedDonationReminderTexts()
+    {
+        return DonationReminderPost.LeadLines
+            .Select(lead => $"{lead}\n{DonationReminderPost.Url}")
+            .ToArray();
+    }
+}

--- a/LongevityWorldCup.Website/Business/FacebookEventService.cs
+++ b/LongevityWorldCup.Website/Business/FacebookEventService.cs
@@ -175,8 +175,20 @@ public class FacebookEventService
 
     public string? TryBuildFillerMessage(FillerType fillerType, string payloadText)
     {
-        _ = fillerType;
         _ = payloadText;
+
+        if (fillerType == FillerType.HistoryDocument)
+            return HistoryDocumentReminderPost.BuildText();
+
+        if (fillerType == FillerType.Ruleset)
+            return RulesetReminderPost.BuildText();
+
+        if (fillerType == FillerType.GitHubRepository)
+            return GitHubRepositoryReminderPost.BuildText();
+
+        if (fillerType == FillerType.Donation)
+            return DonationReminderPost.BuildText();
+
         return null;
     }
 

--- a/LongevityWorldCup.Website/Business/FacebookFillerPostLogService.cs
+++ b/LongevityWorldCup.Website/Business/FacebookFillerPostLogService.cs
@@ -120,6 +120,10 @@ public class FacebookFillerPostLogService
         options.Add((FillerType.CrowdGuesses, ""));
         foreach (var dk in DomainKeys)
             options.Add((FillerType.DomainTop, $"domain[{dk}]"));
+        options.Add((FillerType.HistoryDocument, ""));
+        options.Add((FillerType.Ruleset, ""));
+        options.Add((FillerType.GitHubRepository, ""));
+        options.Add((FillerType.Donation, ""));
 
         var lastByOption = _db.Run(sqlite =>
         {
@@ -226,6 +230,11 @@ public class FacebookFillerPostLogService
         return now - lastAt.Value < cooldown;
     }
 
+    public bool IsOnRandomizedCooldownForType(FillerType type, int minDays, int maxDays, DateTime? nowUtc = null)
+    {
+        return FillerPostLogSchedule.IsOnRandomizedCooldownForType(_db, TableName, type, minDays, maxDays, nowUtc);
+    }
+
     private static bool TokenBelongsToOption(FillerType type, string payloadText, string token)
     {
         var payload = payloadText ?? "";
@@ -241,6 +250,10 @@ public class FacebookFillerPostLogService
                 && t.Contains($"domain[{domainKey.Trim().ToLowerInvariant()}]", StringComparison.Ordinal),
             FillerType.CrowdGuesses => t.StartsWith("podium[", StringComparison.Ordinal),
             FillerType.Newcomers => t.StartsWith("slugs[", StringComparison.Ordinal),
+            FillerType.HistoryDocument => t.StartsWith("history-document[", StringComparison.Ordinal),
+            FillerType.Ruleset => t.StartsWith("ruleset[", StringComparison.Ordinal),
+            FillerType.GitHubRepository => t.StartsWith("github-repository[", StringComparison.Ordinal),
+            FillerType.Donation => t.StartsWith("donation-reminder[", StringComparison.Ordinal),
             _ => false
         };
     }

--- a/LongevityWorldCup.Website/Business/FillerPostLogSchedule.cs
+++ b/LongevityWorldCup.Website/Business/FillerPostLogSchedule.cs
@@ -1,0 +1,78 @@
+using System.Globalization;
+
+namespace LongevityWorldCup.Website.Business;
+
+public static class FillerPostLogSchedule
+{
+    public static bool IsOnRandomizedCooldownForType(
+        DatabaseManager db,
+        string tableName,
+        FillerType type,
+        int minDays,
+        int maxDays,
+        DateTime? nowUtc = null)
+    {
+        if (db is null)
+            throw new ArgumentNullException(nameof(db));
+        if (string.IsNullOrWhiteSpace(tableName))
+            throw new ArgumentNullException(nameof(tableName));
+
+        minDays = Math.Max(0, minDays);
+        maxDays = Math.Max(minDays, maxDays);
+
+        var lastAt = GetLastPostedAtForType(db, tableName, type);
+        if (!lastAt.HasValue)
+            return false;
+
+        var cooldownDays = DetermineCooldownDays(tableName, type, lastAt.Value, minDays, maxDays);
+        var now = nowUtc ?? DateTime.UtcNow;
+        return now - lastAt.Value < TimeSpan.FromDays(cooldownDays);
+    }
+
+    private static DateTime? GetLastPostedAtForType(DatabaseManager db, string tableName, FillerType type)
+    {
+        return db.Run(sqlite =>
+        {
+            using var cmd = sqlite.CreateCommand();
+            cmd.CommandText = $"""
+                SELECT PostedAtUtc
+                FROM {tableName}
+                WHERE Type = @type
+                ORDER BY PostedAtUtc DESC
+                LIMIT 1
+                """;
+            cmd.Parameters.AddWithValue("@type", (int)type);
+            var raw = cmd.ExecuteScalar();
+            if (raw is string s &&
+                DateTime.TryParse(s, null, DateTimeStyles.RoundtripKind, out var dt))
+                return (DateTime?)dt;
+            return null;
+        });
+    }
+
+    private static int DetermineCooldownDays(string tableName, FillerType type, DateTime lastAtUtc, int minDays, int maxDays)
+    {
+        if (maxDays <= minDays)
+            return minDays;
+
+        var key = string.Create(
+            CultureInfo.InvariantCulture,
+            $"{tableName}|{(int)type}|{lastAtUtc.ToUniversalTime():O}");
+        var range = maxDays - minDays + 1;
+        return minDays + (int)(Fnv1A32(key) % (uint)range);
+    }
+
+    private static uint Fnv1A32(string text)
+    {
+        const uint offset = 2166136261;
+        const uint prime = 16777619;
+        var hash = offset;
+        foreach (var ch in text)
+        {
+            hash ^= ch;
+            hash *= prime;
+        }
+
+        return hash;
+    }
+}

--- a/LongevityWorldCup.Website/Business/ThreadsFillerPostLogService.cs
+++ b/LongevityWorldCup.Website/Business/ThreadsFillerPostLogService.cs
@@ -120,6 +120,10 @@ public class ThreadsFillerPostLogService
         options.Add((FillerType.CrowdGuesses, ""));
         foreach (var dk in DomainKeys)
             options.Add((FillerType.DomainTop, $"domain[{dk}]"));
+        options.Add((FillerType.HistoryDocument, ""));
+        options.Add((FillerType.Ruleset, ""));
+        options.Add((FillerType.GitHubRepository, ""));
+        options.Add((FillerType.Donation, ""));
 
         var lastByOption = _db.Run(sqlite =>
         {
@@ -225,6 +229,11 @@ public class ThreadsFillerPostLogService
         return now - lastAt.Value < cooldown;
     }
 
+    public bool IsOnRandomizedCooldownForType(FillerType type, int minDays, int maxDays, DateTime? nowUtc = null)
+    {
+        return FillerPostLogSchedule.IsOnRandomizedCooldownForType(_db, TableName, type, minDays, maxDays, nowUtc);
+    }
+
     private static bool TokenBelongsToOption(FillerType type, string payloadText, string token)
     {
         var payload = payloadText ?? "";
@@ -240,6 +249,10 @@ public class ThreadsFillerPostLogService
                 && t.Contains($"domain[{domainKey.Trim().ToLowerInvariant()}]", StringComparison.Ordinal),
             FillerType.CrowdGuesses => t.StartsWith("podium[", StringComparison.Ordinal),
             FillerType.Newcomers => t.StartsWith("slugs[", StringComparison.Ordinal),
+            FillerType.HistoryDocument => t.StartsWith("history-document[", StringComparison.Ordinal),
+            FillerType.Ruleset => t.StartsWith("ruleset[", StringComparison.Ordinal),
+            FillerType.GitHubRepository => t.StartsWith("github-repository[", StringComparison.Ordinal),
+            FillerType.Donation => t.StartsWith("donation-reminder[", StringComparison.Ordinal),
             _ => false
         };
     }

--- a/LongevityWorldCup.Website/Business/XFillerPostLogService.cs
+++ b/LongevityWorldCup.Website/Business/XFillerPostLogService.cs
@@ -7,7 +7,11 @@ public enum FillerType
     Top3Leaderboard,
     CrowdGuesses,
     Newcomers,
-    DomainTop
+    DomainTop,
+    HistoryDocument,
+    Ruleset,
+    GitHubRepository,
+    Donation
 }
 
 public class XFillerPostLogService
@@ -133,6 +137,10 @@ public class XFillerPostLogService
         options.Add((FillerType.CrowdGuesses, ""));
         foreach (var dk in DomainKeys)
             options.Add((FillerType.DomainTop, $"domain[{dk}]"));
+        options.Add((FillerType.HistoryDocument, ""));
+        options.Add((FillerType.Ruleset, ""));
+        options.Add((FillerType.GitHubRepository, ""));
+        options.Add((FillerType.Donation, ""));
 
         var lastByOption = _db.Run(sqlite =>
         {
@@ -278,6 +286,11 @@ public class XFillerPostLogService
         return now - lastAt.Value < cooldown;
     }
 
+    public bool IsOnRandomizedCooldownForType(FillerType type, int minDays, int maxDays, DateTime? nowUtc = null)
+    {
+        return FillerPostLogSchedule.IsOnRandomizedCooldownForType(_db, TableName, type, minDays, maxDays, nowUtc);
+    }
+
     private static bool TokenBelongsToOption(FillerType type, string payloadText, string tokenText)
     {
         var token = tokenText ?? "";
@@ -289,6 +302,10 @@ public class XFillerPostLogService
             FillerType.DomainTop => token.StartsWith(payload + " ", StringComparison.OrdinalIgnoreCase),
             FillerType.CrowdGuesses => token.StartsWith("podium[", StringComparison.OrdinalIgnoreCase),
             FillerType.Newcomers => token.StartsWith("slugs[", StringComparison.OrdinalIgnoreCase),
+            FillerType.HistoryDocument => token.StartsWith("history-document[", StringComparison.OrdinalIgnoreCase),
+            FillerType.Ruleset => token.StartsWith("ruleset[", StringComparison.OrdinalIgnoreCase),
+            FillerType.GitHubRepository => token.StartsWith("github-repository[", StringComparison.OrdinalIgnoreCase),
+            FillerType.Donation => token.StartsWith("donation-reminder[", StringComparison.OrdinalIgnoreCase),
             _ => false
         };
     }

--- a/LongevityWorldCup.Website/Jobs/FacebookDailyPostJob.cs
+++ b/LongevityWorldCup.Website/Jobs/FacebookDailyPostJob.cs
@@ -1,4 +1,5 @@
 using LongevityWorldCup.Website.Business;
+using LongevityWorldCup.Website.Tools;
 using Quartz;
 
 namespace LongevityWorldCup.Website.Jobs;
@@ -53,7 +54,117 @@ public class FacebookDailyPostJob : IJob
             return;
         }
 
-        _ = _fillerLog.GetSuggestedFillersOrdered();
+        var fillerCandidates = _fillerLog.GetSuggestedFillersOrdered();
+        foreach (var (fillerType, payloadText) in fillerCandidates)
+        {
+            if (!TryGetPeriodicInfoToken(fillerType, out var infoToken) ||
+                !TryGetRandomizedCooldownDays(fillerType, out var minCooldownDays, out var maxCooldownDays))
+                continue;
+
+            var payload = payloadText ?? "";
+            var nowUtc = DateTime.UtcNow;
+            if (_fillerLog.IsOnRandomizedCooldownForType(
+                    fillerType,
+                    minCooldownDays,
+                    maxCooldownDays,
+                    nowUtc))
+            {
+                _logger.LogInformation(
+                    "FacebookDailyPostJob skipped filler in cooldown {FillerType} {PayloadText} ({MinCooldownDays}-{MaxCooldownDays}d randomized)",
+                    fillerType,
+                    payloadText,
+                    minCooldownDays,
+                    maxCooldownDays);
+                continue;
+            }
+
+            var fillerMsg = _facebookEvents.TryBuildFillerMessage(fillerType, payload);
+            if (string.IsNullOrWhiteSpace(fillerMsg))
+                continue;
+
+            _logger.LogInformation(
+                "FacebookDailyPostJob selected filler {FillerType} messageLength {MessageLength} infoToken {InfoToken}",
+                fillerType,
+                fillerMsg.Length,
+                infoToken);
+
+            var fillerSent = await _facebookEvents.TrySendAsync(fillerMsg);
+            if (!fillerSent)
+            {
+                _logger.LogWarning("FacebookDailyPostJob send failed for filler {FillerType}; leaving unlogged", fillerType);
+                return;
+            }
+
+            _fillerLog.LogPost(nowUtc, fillerType, infoToken);
+            _logger.LogInformation("FacebookDailyPostJob posted filler {FillerType}", fillerType);
+            return;
+        }
+
         _logger.LogInformation("FacebookDailyPostJob no postable event found");
+    }
+
+    private static bool TryGetPeriodicInfoToken(FillerType fillerType, out string infoToken)
+    {
+        if (fillerType == FillerType.HistoryDocument)
+        {
+            infoToken = HistoryDocumentReminderPost.InfoToken;
+            return true;
+        }
+
+        if (fillerType == FillerType.Ruleset)
+        {
+            infoToken = RulesetReminderPost.InfoToken;
+            return true;
+        }
+
+        if (fillerType == FillerType.GitHubRepository)
+        {
+            infoToken = GitHubRepositoryReminderPost.InfoToken;
+            return true;
+        }
+
+        if (fillerType == FillerType.Donation)
+        {
+            infoToken = DonationReminderPost.InfoToken;
+            return true;
+        }
+
+        infoToken = "";
+        return false;
+    }
+
+    private static bool TryGetRandomizedCooldownDays(FillerType fillerType, out int minDays, out int maxDays)
+    {
+        if (fillerType == FillerType.HistoryDocument)
+        {
+            minDays = HistoryDocumentReminderPost.MinCooldownDays;
+            maxDays = HistoryDocumentReminderPost.MaxCooldownDays;
+            return true;
+        }
+
+        if (fillerType == FillerType.Ruleset)
+        {
+            minDays = RulesetReminderPost.MinCooldownDays;
+            maxDays = RulesetReminderPost.MaxCooldownDays;
+            return true;
+        }
+
+        if (fillerType == FillerType.GitHubRepository)
+        {
+            minDays = GitHubRepositoryReminderPost.MinCooldownDays;
+            maxDays = GitHubRepositoryReminderPost.MaxCooldownDays;
+            return true;
+        }
+
+        if (fillerType == FillerType.Donation)
+        {
+            minDays = DonationReminderPost.MinCooldownDays;
+            maxDays = DonationReminderPost.MaxCooldownDays;
+            return true;
+        }
+
+        minDays = 0;
+        maxDays = 0;
+        return false;
     }
 }

--- a/LongevityWorldCup.Website/Jobs/ThreadsDailyPostJob.cs
+++ b/LongevityWorldCup.Website/Jobs/ThreadsDailyPostJob.cs
@@ -99,16 +99,31 @@ public class ThreadsDailyPostJob : IJob
             return;
         }
 
+        if (await TryPostHistoryReminderAsync())
+            return;
+
+        if (await TryPostPeriodicReminderAsync(FillerType.Ruleset))
+            return;
+
+        if (await TryPostPeriodicReminderAsync(FillerType.GitHubRepository))
+            return;
+
+        if (await TryPostPeriodicReminderAsync(FillerType.Donation))
+            return;
+
         var fillerCandidates = _fillerLog.GetSuggestedFillersOrdered();
         foreach (var (fillerType, payloadText) in fillerCandidates)
         {
+            if (IsPeriodicReminder(fillerType))
+                continue;
+
             var payload = payloadText ?? "";
             var cooldown = GetCooldownForFiller(fillerType);
             var nowUtc = DateTime.UtcNow;
-            var onCooldown = _fillerLog.IsOnCooldownForType(fillerType, cooldown, nowUtc);
+            var onCooldown = IsFillerOnCooldown(fillerType, cooldown, nowUtc);
             if (onCooldown)
             {
-                _logger.LogInformation("ThreadsDailyPostJob skipped filler in cooldown {FillerType} {PayloadText} ({CooldownDays}d)", fillerType, payloadText, cooldown.TotalDays);
+                _logger.LogInformation("ThreadsDailyPostJob skipped filler in cooldown {FillerType} {PayloadText} ({Cooldown})", fillerType, payloadText, FormatCooldown(fillerType, cooldown));
                 continue;
             }
 
@@ -127,7 +142,7 @@ public class ThreadsDailyPostJob : IJob
                 continue;
             }
 
-            if (_fillerLog.IsUnchangedFromLastForOption(fillerType, payload, infoToken))
+            if (ShouldCheckUnchangedToken(fillerType) && _fillerLog.IsUnchangedFromLastForOption(fillerType, payload, infoToken))
             {
                 _logger.LogInformation("ThreadsDailyPostJob skipped unchanged filler {FillerType} {PayloadText}", fillerType, payloadText);
                 continue;
@@ -154,6 +169,50 @@ public class ThreadsDailyPostJob : IJob
         _logger.LogInformation("ThreadsDailyPostJob no postable event found");
     }
 
+    private async Task<bool> TryPostHistoryReminderAsync()
+    {
+        return await TryPostPeriodicReminderAsync(FillerType.HistoryDocument);
+    }
+
+    private async Task<bool> TryPostPeriodicReminderAsync(FillerType fillerType)
+    {
+        var nowUtc = DateTime.UtcNow;
+        var cooldown = GetCooldownForFiller(fillerType);
+        if (IsFillerOnCooldown(fillerType, cooldown, nowUtc))
+        {
+            _logger.LogInformation(
+                "ThreadsDailyPostJob skipped filler in cooldown {FillerType} ({Cooldown})",
+                fillerType,
+                FormatCooldown(fillerType, cooldown));
+            return false;
+        }
+
+        var fillerMsg = _threadsEvents.TryBuildFillerMessage(fillerType, "");
+        if (string.IsNullOrWhiteSpace(fillerMsg))
+            return false;
+
+        var infoToken = TryBuildFillerInfoToken(fillerType, "");
+        if (string.IsNullOrWhiteSpace(infoToken))
+            return false;
+
+        _logger.LogInformation(
+            "ThreadsDailyPostJob selected filler {FillerType} messageLength {MessageLength} infoToken {InfoToken}",
+            fillerType,
+            fillerMsg.Length,
+            infoToken);
+
+        var fillerSent = await _threadsEvents.TrySendAsync(fillerMsg);
+        if (!fillerSent)
+        {
+            _logger.LogWarning("ThreadsDailyPostJob send failed for filler {FillerType}; leaving unlogged", fillerType);
+            return true;
+        }
+
+        _fillerLog.LogPost(nowUtc, fillerType, infoToken);
+        _logger.LogInformation("ThreadsDailyPostJob posted filler {FillerType}", fillerType);
+        return true;
+    }
+
     private string? TryBuildFillerInfoToken(FillerType fillerType, string payloadText)
     {
         static string Norm(string? s) => string.IsNullOrWhiteSpace(s) ? "" : s.Trim().ToLowerInvariant();
@@ -166,6 +225,18 @@ public class ThreadsDailyPostJob : IJob
             if (top3.Count == 0) return null;
             return $"league[{Norm(leagueSlug)}] slugs[{string.Join(", ", top3)}]";
         }
+
+        if (fillerType == FillerType.HistoryDocument)
+            return HistoryDocumentReminderPost.InfoToken;
+
+        if (fillerType == FillerType.Ruleset)
+            return RulesetReminderPost.InfoToken;
+
+        if (fillerType == FillerType.GitHubRepository)
+            return GitHubRepositoryReminderPost.InfoToken;
+
+        if (fillerType == FillerType.Donation)
+            return DonationReminderPost.InfoToken;
 
         if (fillerType == FillerType.CrowdGuesses)
         {
@@ -212,8 +283,78 @@ public class ThreadsDailyPostJob : IJob
         return fillerType switch
         {
             FillerType.CrowdGuesses => TimeSpan.FromDays(10),
+            FillerType.HistoryDocument => TimeSpan.FromDays(HistoryDocumentReminderPost.MinCooldownDays),
+            FillerType.Ruleset => TimeSpan.FromDays(RulesetReminderPost.MinCooldownDays),
+            FillerType.GitHubRepository => TimeSpan.FromDays(GitHubRepositoryReminderPost.MinCooldownDays),
+            FillerType.Donation => TimeSpan.FromDays(DonationReminderPost.MinCooldownDays),
             _ => TimeSpan.FromDays(7)
         };
+    }
+
+    private bool IsFillerOnCooldown(FillerType fillerType, TimeSpan cooldown, DateTime nowUtc)
+    {
+        if (TryGetRandomizedCooldownDays(fillerType, out var minDays, out var maxDays))
+        {
+            return _fillerLog.IsOnRandomizedCooldownForType(
+                fillerType,
+                minDays,
+                maxDays,
+                nowUtc);
+        }
+
+        return _fillerLog.IsOnCooldownForType(fillerType, cooldown, nowUtc);
+    }
+
+    private static bool ShouldCheckUnchangedToken(FillerType fillerType)
+    {
+        return !IsPeriodicReminder(fillerType);
+    }
+
+    private static string FormatCooldown(FillerType fillerType, TimeSpan cooldown)
+    {
+        return TryGetRandomizedCooldownDays(fillerType, out var minDays, out var maxDays)
+            ? $"{minDays}-{maxDays}d randomized"
+            : $"{cooldown.TotalDays}d";
+    }
+
+    private static bool IsPeriodicReminder(FillerType fillerType)
+    {
+        return fillerType is FillerType.HistoryDocument or FillerType.Ruleset or FillerType.GitHubRepository or FillerType.Donation;
+    }
+
+    private static bool TryGetRandomizedCooldownDays(FillerType fillerType, out int minDays, out int maxDays)
+    {
+        if (fillerType == FillerType.HistoryDocument)
+        {
+            minDays = HistoryDocumentReminderPost.MinCooldownDays;
+            maxDays = HistoryDocumentReminderPost.MaxCooldownDays;
+            return true;
+        }
+
+        if (fillerType == FillerType.Ruleset)
+        {
+            minDays = RulesetReminderPost.MinCooldownDays;
+            maxDays = RulesetReminderPost.MaxCooldownDays;
+            return true;
+        }
+
+        if (fillerType == FillerType.GitHubRepository)
+        {
+            minDays = GitHubRepositoryReminderPost.MinCooldownDays;
+            maxDays = GitHubRepositoryReminderPost.MaxCooldownDays;
+            return true;
+        }
+
+        if (fillerType == FillerType.Donation)
+        {
+            minDays = DonationReminderPost.MinCooldownDays;
+            maxDays = DonationReminderPost.MaxCooldownDays;
+            return true;
+        }
+
+        minDays = 0;
+        maxDays = 0;
+        return false;
     }
 
     private static string? TryGetSubjectSlugForEvent(EventType type, string rawText)

--- a/LongevityWorldCup.Website/Jobs/XDailyPostJob.cs
+++ b/LongevityWorldCup.Website/Jobs/XDailyPostJob.cs
@@ -114,16 +114,31 @@ public class XDailyPostJob : IJob
             return;
         }
 
+        if (await TryPostHistoryReminderAsync())
+            return;
+
+        if (await TryPostPeriodicReminderAsync(FillerType.Ruleset))
+            return;
+
+        if (await TryPostPeriodicReminderAsync(FillerType.GitHubRepository))
+            return;
+
+        if (await TryPostPeriodicReminderAsync(FillerType.Donation))
+            return;
+
         var fillerCandidates = _fillerLog.GetSuggestedFillersOrdered();
         foreach (var (fillerType, payloadText) in fillerCandidates)
         {
+            if (IsPeriodicReminder(fillerType))
+                continue;
+
             var payload = payloadText ?? "";
             var cooldown = GetCooldownForFiller(fillerType);
             var nowUtc = DateTime.UtcNow;
-            var onCooldown = _fillerLog.IsOnCooldownForType(fillerType, cooldown, nowUtc);
+            var onCooldown = IsFillerOnCooldown(fillerType, cooldown, nowUtc);
             if (onCooldown)
             {
-                _logger.LogInformation("XDailyPostJob skipped filler in cooldown {FillerType} {PayloadText} ({CooldownDays}d)", fillerType, payloadText, cooldown.TotalDays);
+                _logger.LogInformation("XDailyPostJob skipped filler in cooldown {FillerType} {PayloadText} ({Cooldown})", fillerType, payloadText, FormatCooldown(fillerType, cooldown));
                 continue;
             }
 
@@ -142,7 +157,7 @@ public class XDailyPostJob : IJob
                 continue;
             }
 
-            if (_fillerLog.IsUnchangedFromLastForOption(fillerType, payload, infoToken))
+            if (ShouldCheckUnchangedToken(fillerType) && _fillerLog.IsUnchangedFromLastForOption(fillerType, payload, infoToken))
             {
                 _logger.LogInformation("XDailyPostJob skipped unchanged filler {FillerType} {PayloadText}", fillerType, payloadText);
                 continue;
@@ -167,6 +182,50 @@ public class XDailyPostJob : IJob
         }
 
         _logger.LogInformation("XDailyPostJob no postable event found");
+    }
+
+    private async Task<bool> TryPostHistoryReminderAsync()
+    {
+        return await TryPostPeriodicReminderAsync(FillerType.HistoryDocument);
+    }
+
+    private async Task<bool> TryPostPeriodicReminderAsync(FillerType fillerType)
+    {
+        var nowUtc = DateTime.UtcNow;
+        var cooldown = GetCooldownForFiller(fillerType);
+        if (IsFillerOnCooldown(fillerType, cooldown, nowUtc))
+        {
+            _logger.LogInformation(
+                "XDailyPostJob skipped filler in cooldown {FillerType} ({Cooldown})",
+                fillerType,
+                FormatCooldown(fillerType, cooldown));
+            return false;
+        }
+
+        var fillerMsg = _xEvents.TryBuildFillerMessage(fillerType, "");
+        if (string.IsNullOrWhiteSpace(fillerMsg))
+            return false;
+
+        var infoToken = TryBuildFillerInfoToken(fillerType, "");
+        if (string.IsNullOrWhiteSpace(infoToken))
+            return false;
+
+        _logger.LogInformation(
+            "XDailyPostJob selected filler {FillerType} messageLength {MessageLength} infoToken {InfoToken}",
+            fillerType,
+            fillerMsg.Length,
+            infoToken);
+
+        var fillerSent = await _xEvents.TrySendAsync(fillerMsg);
+        if (!fillerSent)
+        {
+            _logger.LogWarning("XDailyPostJob send failed for filler {FillerType}; leaving unlogged", fillerType);
+            return true;
+        }
+
+        _fillerLog.LogPost(nowUtc, fillerType, infoToken);
+        _logger.LogInformation("XDailyPostJob posted filler {FillerType}", fillerType);
+        return true;
     }
 
     private static bool ShouldPostInCurrentSlot(IJobExecutionContext context, out TimeOnly currentSlotUtc, out TimeOnly selectedSlotUtc)
@@ -198,6 +257,18 @@ public class XDailyPostJob : IJob
             if (top3.Count == 0) return null;
             return $"league[{Norm(leagueSlug)}] slugs[{string.Join(", ", top3)}]";
         }
+
+        if (fillerType == FillerType.HistoryDocument)
+            return HistoryDocumentReminderPost.InfoToken;
+
+        if (fillerType == FillerType.Ruleset)
+            return RulesetReminderPost.InfoToken;
+
+        if (fillerType == FillerType.GitHubRepository)
+            return GitHubRepositoryReminderPost.InfoToken;
+
+        if (fillerType == FillerType.Donation)
+            return DonationReminderPost.InfoToken;
 
         if (fillerType == FillerType.CrowdGuesses)
         {
@@ -244,8 +315,78 @@ public class XDailyPostJob : IJob
         return fillerType switch
         {
             FillerType.CrowdGuesses => TimeSpan.FromDays(10),
+            FillerType.HistoryDocument => TimeSpan.FromDays(HistoryDocumentReminderPost.MinCooldownDays),
+            FillerType.Ruleset => TimeSpan.FromDays(RulesetReminderPost.MinCooldownDays),
+            FillerType.GitHubRepository => TimeSpan.FromDays(GitHubRepositoryReminderPost.MinCooldownDays),
+            FillerType.Donation => TimeSpan.FromDays(DonationReminderPost.MinCooldownDays),
             _ => TimeSpan.FromDays(7)
         };
+    }
+
+    private bool IsFillerOnCooldown(FillerType fillerType, TimeSpan cooldown, DateTime nowUtc)
+    {
+        if (TryGetRandomizedCooldownDays(fillerType, out var minDays, out var maxDays))
+        {
+            return _fillerLog.IsOnRandomizedCooldownForType(
+                fillerType,
+                minDays,
+                maxDays,
+                nowUtc);
+        }
+
+        return _fillerLog.IsOnCooldownForType(fillerType, cooldown, nowUtc);
+    }
+
+    private static bool ShouldCheckUnchangedToken(FillerType fillerType)
+    {
+        return !IsPeriodicReminder(fillerType);
+    }
+
+    private static string FormatCooldown(FillerType fillerType, TimeSpan cooldown)
+    {
+        return TryGetRandomizedCooldownDays(fillerType, out var minDays, out var maxDays)
+            ? $"{minDays}-{maxDays}d randomized"
+            : $"{cooldown.TotalDays}d";
+    }
+
+    private static bool IsPeriodicReminder(FillerType fillerType)
+    {
+        return fillerType is FillerType.HistoryDocument or FillerType.Ruleset or FillerType.GitHubRepository or FillerType.Donation;
+    }
+
+    private static bool TryGetRandomizedCooldownDays(FillerType fillerType, out int minDays, out int maxDays)
+    {
+        if (fillerType == FillerType.HistoryDocument)
+        {
+            minDays = HistoryDocumentReminderPost.MinCooldownDays;
+            maxDays = HistoryDocumentReminderPost.MaxCooldownDays;
+            return true;
+        }
+
+        if (fillerType == FillerType.Ruleset)
+        {
+            minDays = RulesetReminderPost.MinCooldownDays;
+            maxDays = RulesetReminderPost.MaxCooldownDays;
+            return true;
+        }
+
+        if (fillerType == FillerType.GitHubRepository)
+        {
+            minDays = GitHubRepositoryReminderPost.MinCooldownDays;
+            maxDays = GitHubRepositoryReminderPost.MaxCooldownDays;
+            return true;
+        }
+
+        if (fillerType == FillerType.Donation)
+        {
+            minDays = DonationReminderPost.MinCooldownDays;
+            maxDays = DonationReminderPost.MaxCooldownDays;
+            return true;
+        }
+
+        minDays = 0;
+        maxDays = 0;
+        return false;
     }
 
     private static string? TryGetSubjectSlugForEvent(EventType type, string rawText)

--- a/LongevityWorldCup.Website/Tools/DonationReminderPost.cs
+++ b/LongevityWorldCup.Website/Tools/DonationReminderPost.cs
@@ -1,0 +1,35 @@
+namespace LongevityWorldCup.Website.Tools;
+
+public static class DonationReminderPost
+{
+    public const string Url = "https://longevityworldcup.com/#donation-section";
+    public const string InfoToken = "donation-reminder[v1] url[https://longevityworldcup.com/#donation-section]";
+    public const int MinCooldownDays = 30;
+    public const int MaxCooldownDays = 90;
+    private static readonly string[] LeadLineOptions =
+    [
+        "Help fund the Longevity World Cup prize pool:",
+        "Bitcoin donations fund the prize pool:",
+        "Support the prize pool:",
+        "Want to support the competition?",
+        "Help keep the prize pool growing:",
+        "90% of Bitcoin donations go to the prize pool:",
+        "Contribute to the Bitcoin-funded prize pool:",
+        "Donations support prizes and operating costs:"
+    ];
+    public static IReadOnlyList<string> LeadLines => LeadLineOptions;
+
+    public static string BuildText()
+    {
+        return BuildText(Random.Shared);
+    }
+
+    public static string BuildText(Random random)
+    {
+        if (random is null)
+            throw new ArgumentNullException(nameof(random));
+
+        var lead = LeadLineOptions[random.Next(LeadLineOptions.Length)];
+        return $"{lead}\n{Url}";
+    }
+}

--- a/LongevityWorldCup.Website/Tools/GitHubRepositoryReminderPost.cs
+++ b/LongevityWorldCup.Website/Tools/GitHubRepositoryReminderPost.cs
@@ -1,0 +1,48 @@
+namespace LongevityWorldCup.Website.Tools;
+
+public static class GitHubRepositoryReminderPost
+{
+    public const string Url = "https://github.com/nopara73/LongevityWorldCup";
+    public const string InfoToken = "github-repository[v1] url[https://github.com/nopara73/LongevityWorldCup]";
+    public const int MinCooldownDays = 60;
+    public const int MaxCooldownDays = 120;
+    private static readonly string[] LeadLineOptions =
+    [
+        "The Longevity World Cup website is free and open source.",
+        "The leaderboard is public. The code is too.",
+        "Longevity World Cup is open source.",
+        "The Longevity World Cup website can be inspected, forked, and improved.",
+        "The code behind Longevity World Cup is public.",
+        "Free and open source, including the website.",
+        "The Longevity World Cup website is open for contributions.",
+        "Want to see how the site works? The code is public.",
+        "Longevity World Cup is built in the open.",
+        "The website is free software. Fork it, modify it, contribute.",
+        "The project is open source for anyone who wants to inspect or improve it.",
+        "Public competition, public rules, public code.",
+        "The Longevity World Cup website is available to read, fork, and contribute to.",
+        "The website code is open source.",
+        "You can fork the Longevity World Cup website.",
+        "The code is public because the competition should be inspectable.",
+        "Longevity World Cup is not a black box. The website code is public.",
+        "The website is open source. Contributions are welcome.",
+        "The Longevity World Cup project is free to fork and modify.",
+        "The code behind the website lives on GitHub.",
+        "Open rules. Open leaderboard. Open source website."
+    ];
+    public static IReadOnlyList<string> LeadLines => LeadLineOptions;
+
+    public static string BuildText()
+    {
+        return BuildText(Random.Shared);
+    }
+
+    public static string BuildText(Random random)
+    {
+        if (random is null)
+            throw new ArgumentNullException(nameof(random));
+
+        var lead = LeadLineOptions[random.Next(LeadLineOptions.Length)];
+        return $"{lead}\n{Url}";
+    }
+}

--- a/LongevityWorldCup.Website/Tools/HistoryDocumentReminderPost.cs
+++ b/LongevityWorldCup.Website/Tools/HistoryDocumentReminderPost.cs
@@ -1,0 +1,32 @@
+namespace LongevityWorldCup.Website.Tools;
+
+public static class HistoryDocumentReminderPost
+{
+    public const string Url = "https://longevityworldcup.com/history";
+    public const string InfoToken = "history-document[v1] url[https://longevityworldcup.com/history]";
+    public const int MinCooldownDays = 60;
+    public const int MaxCooldownDays = 120;
+    private static readonly string[] LeadLineOptions =
+    [
+        "How longevity became a sport:",
+        "For anyone new here:",
+        "A short history of longevity as a sport:",
+        "The backstory:",
+        "Longevity as a sport did not appear out of nowhere:"
+    ];
+    public static IReadOnlyList<string> LeadLines => LeadLineOptions;
+
+    public static string BuildText()
+    {
+        return BuildText(Random.Shared);
+    }
+
+    public static string BuildText(Random random)
+    {
+        if (random is null)
+            throw new ArgumentNullException(nameof(random));
+
+        var lead = LeadLineOptions[random.Next(LeadLineOptions.Length)];
+        return $"{lead}\n{Url}";
+    }
+}

--- a/LongevityWorldCup.Website/Tools/RulesetReminderPost.cs
+++ b/LongevityWorldCup.Website/Tools/RulesetReminderPost.cs
@@ -1,0 +1,45 @@
+namespace LongevityWorldCup.Website.Tools;
+
+public static class RulesetReminderPost
+{
+    public const string Url = "https://longevityworldcup.com/ruleset";
+    public const string InfoToken = "ruleset[v1] url[https://longevityworldcup.com/ruleset]";
+    public const int MinCooldownDays = 60;
+    public const int MaxCooldownDays = 120;
+    private static readonly string[] LeadLineOptions =
+    [
+        "How the competition works:",
+        "The Ruleset:",
+        "For anyone wondering how rankings work:",
+        "How athletes are ranked:",
+        "The rules behind the leaderboard:",
+        "What counts, what does not:",
+        "Pro, Amateur, seasons, clocks, prizes:",
+        "The current Longevity World Cup Ruleset:",
+        "Start here if the leaderboard looks confusing:",
+        "The scoring rules are public:",
+        "The ranking rules are public:",
+        "The Longevity World Cup rulebook:",
+        "How the Ultimate League works:",
+        "What the competition measures:",
+        "The rules of longevity as a sport:",
+        "How results become rankings:",
+        "The heart of a game lies within its rules",
+        "Great play emerges from clear constraints"
+    ];
+    public static IReadOnlyList<string> LeadLines => LeadLineOptions;
+
+    public static string BuildText()
+    {
+        return BuildText(Random.Shared);
+    }
+
+    public static string BuildText(Random random)
+    {
+        if (random is null)
+            throw new ArgumentNullException(nameof(random));
+
+        var lead = LeadLineOptions[random.Next(LeadLineOptions.Length)];
+        return $"{lead}\n{Url}";
+    }
+}

--- a/LongevityWorldCup.Website/Tools/ThreadsMessageBuilder.cs
+++ b/LongevityWorldCup.Website/Tools/ThreadsMessageBuilder.cs
@@ -263,6 +263,18 @@ public static class ThreadsMessageBuilder
         if (ShouldSuppressFiller(fillerType, fillerPhase))
             return "";
 
+        if (fillerType == FillerType.HistoryDocument)
+            return RejectIfTooLong(HistoryDocumentReminderPost.BuildText());
+
+        if (fillerType == FillerType.Ruleset)
+            return RejectIfTooLong(RulesetReminderPost.BuildText());
+
+        if (fillerType == FillerType.GitHubRepository)
+            return RejectIfTooLong(GitHubRepositoryReminderPost.BuildText());
+
+        if (fillerType == FillerType.Donation)
+            return RejectIfTooLong(DonationReminderPost.BuildText());
+
         if (fillerType == FillerType.Top3Leaderboard)
         {
             if (!EventHelpers.TryExtractLeague(payloadText ?? "", out var leagueSlug) || string.IsNullOrWhiteSpace(leagueSlug))

--- a/LongevityWorldCup.Website/Tools/XMessageBuilder.cs
+++ b/LongevityWorldCup.Website/Tools/XMessageBuilder.cs
@@ -263,6 +263,18 @@ public static class XMessageBuilder
         if (ShouldSuppressFiller(fillerType, fillerPhase))
             return "";
 
+        if (fillerType == FillerType.HistoryDocument)
+            return RejectIfTooLong(HistoryDocumentReminderPost.BuildText());
+
+        if (fillerType == FillerType.Ruleset)
+            return RejectIfTooLong(RulesetReminderPost.BuildText());
+
+        if (fillerType == FillerType.GitHubRepository)
+            return RejectIfTooLong(GitHubRepositoryReminderPost.BuildText());
+
+        if (fillerType == FillerType.Donation)
+            return RejectIfTooLong(DonationReminderPost.BuildText());
+
         if (fillerType == FillerType.Top3Leaderboard)
         {
             if (!EventHelpers.TryExtractLeague(payloadText ?? "", out var leagueSlug) || string.IsNullOrWhiteSpace(leagueSlug))


### PR DESCRIPTION
## Summary
- Adds periodic social filler reminders for the History document, Ruleset, GitHub repository, and donation section.
- Gives History, Ruleset, and GitHub reminders randomized 60-120 day cooldowns per platform; donation reminders use a randomized 30-90 day cooldown.
- Runs reminders on X, Threads, and Facebook after real events, before ordinary filler posts, with one post emitted per job run.
- Keeps each reminder type logged with a stable info token while randomizing the user-facing copy variants.

## Review notes
- Real event posting remains first priority.
- X and Threads skip these periodic reminders in the normal filler loop because they are handled before normal filler rotation.
- Facebook now posts the same periodic reminder types; it still does not add generic leaderboard filler behavior.

## Tests
- `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --filter FullyQualifiedName~SocialFillerHistoryReminderTests`
- `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj -- xunit.parallelizeTestCollections=false`
- `git diff --check`