### PR TITLE
Add social event skip reasons

### DIFF
--- a/LongevityWorldCup.Tests/CustomEventDirectQueueWordingTests.cs
+++ b/LongevityWorldCup.Tests/CustomEventDirectQueueWordingTests.cs
@@ -1,0 +1,47 @@
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class CustomEventDirectQueueWordingTests
+{
+    [Fact]
+    public void Designer_UsesQueueWordingForDirectCustomEvents()
+    {
+        var html = File.ReadAllText(FindRepoFile("LongevityWorldCup.Website", "wwwroot", "internal", "custom-event-designer.html"));
+
+        Assert.Contains("Direct Queue", html);
+        Assert.Contains("Queue Event", html);
+        Assert.Contains("Queued event", html);
+        Assert.Contains("Queue failed", html);
+        Assert.DoesNotContain("Direct Post", html);
+        Assert.DoesNotContain("Post Event", html);
+        Assert.DoesNotContain("Posted event", html);
+        Assert.DoesNotContain("Post failed", html);
+    }
+
+    [Fact]
+    public void Api_ResponseExposesQueuedTargets()
+    {
+        var source = File.ReadAllText(FindRepoFile("LongevityWorldCup.Website", "Controllers", "CustomEventsController.cs"));
+
+        Assert.Contains("queuedTargets", source);
+        Assert.Contains("direct queue", source);
+        Assert.DoesNotContain("direct post created", source);
+        Assert.DoesNotContain("direct posting is not configured", source);
+    }
+
+    private static string FindRepoFile(params string[] parts)
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            var candidate = Path.Combine(new[] { current.FullName }.Concat(parts).ToArray());
+            if (File.Exists(candidate))
+                return candidate;
+
+            current = current.Parent;
+        }
+
+        throw new FileNotFoundException($"Could not find {Path.Combine(parts)} from {AppContext.BaseDirectory}.");
+    }
+}

--- a/LongevityWorldCup.Tests/SocialEventSkipPolicyTests.cs
+++ b/LongevityWorldCup.Tests/SocialEventSkipPolicyTests.cs
@@ -5,6 +5,73 @@ namespace LongevityWorldCup.Tests;
 
 public sealed class SocialEventSkipPolicyTests
 {
+    public static IEnumerable<object[]> XOrThreadsGoldenSkipRules()
+    {
+        var now = new DateTime(2026, 6, 6, 12, 0, 0, DateTimeKind.Utc);
+        var freshCutoff = now.AddDays(-7);
+
+        yield return new object[] { EventType.CustomEvent, "Title\n\nBody", now, 99, freshCutoff, true, false, SocialEventSkipReason.None };
+        yield return new object[] { EventType.Joined, "slug[alice]", now, 99, freshCutoff, true, true, SocialEventSkipReason.UnsupportedEventType };
+        yield return new object[] { EventType.DonationReceived, "tx[abc] sats[1000]", now, 99, freshCutoff, true, true, SocialEventSkipReason.UnsupportedEventType };
+        yield return new object[] { EventType.NewRank, "slug[alice] rank[1]", now, 0, freshCutoff, true, false, SocialEventSkipReason.None };
+        yield return new object[] { EventType.NewRank, "slug[alice] rank[4]", now, 99, freshCutoff, true, true, SocialEventSkipReason.UnsupportedEventPayload };
+        yield return new object[] { EventType.NewRank, "slug[alice] rank[1]", now.AddDays(-8), 0, freshCutoff, true, true, SocialEventSkipReason.StalePrimaryEvent };
+        yield return new object[] { EventType.AthleteCountMilestone, "athletes[100]", now, 8, freshCutoff, true, false, SocialEventSkipReason.None };
+        yield return new object[] { EventType.BadgeAward, "slug[alice] badge[Podcast] cat[Global] val[] place[1]", now, 99, freshCutoff, true, true, SocialEventSkipReason.PodcastBadgeHandledImmediately };
+        yield return new object[] { EventType.BadgeAward, "slug[alice] badge[Pheno Age - lowest] cat[Global] val[] place[2]", now, 2, freshCutoff, true, true, SocialEventSkipReason.NonWinningSingleWinnerBadge };
+        yield return new object[] { EventType.BadgeAward, "slug[alice] badge[Pheno Age best improvement] cat[Global] val[] place[1]", now, 3, freshCutoff, false, true, SocialEventSkipReason.TiedBestImprovementBadge };
+        yield return new object[] { EventType.BadgeAward, "slug[alice] badge[Crowd Age - lowest] cat[Global] val[] place[1]", now, 99, freshCutoff, true, true, SocialEventSkipReason.UnsupportedBadgeAward };
+        yield return new object[] { EventType.BadgeAward, "slug[alice] badge[Age reduction] cat[Division] val[Men's] place[1]", now, 1, freshCutoff, true, false, SocialEventSkipReason.None };
+    }
+
+    public static IEnumerable<object[]> FacebookGoldenSkipRules()
+    {
+        yield return new object[] { EventType.CustomEvent, false, SocialEventSkipReason.None };
+        yield return new object[] { EventType.Joined, true, SocialEventSkipReason.FacebookSupportsCustomEventsOnly };
+        yield return new object[] { EventType.NewRank, true, SocialEventSkipReason.FacebookSupportsCustomEventsOnly };
+        yield return new object[] { EventType.BadgeAward, true, SocialEventSkipReason.FacebookSupportsCustomEventsOnly };
+        yield return new object[] { EventType.AthleteCountMilestone, true, SocialEventSkipReason.FacebookSupportsCustomEventsOnly };
+        yield return new object[] { EventType.DonationReceived, true, SocialEventSkipReason.FacebookSupportsCustomEventsOnly };
+    }
+
+    [Theory]
+    [MemberData(nameof(XOrThreadsGoldenSkipRules))]
+    public void XOrThreads_TerminalSkipRulesMatchGoldenMatrix(
+        EventType type,
+        string text,
+        DateTime occurredAtUtc,
+        int priority,
+        DateTime freshCutoffUtc,
+        bool hasSingleGlobalPlaceOneBadgeHolder,
+        bool expectedSkipped,
+        SocialEventSkipReason expectedReason)
+    {
+        var skipped = SocialEventSkipPolicy.TryGetXOrThreadsTerminalSkipReason(
+            type,
+            text,
+            occurredAtUtc,
+            priority,
+            freshCutoffUtc,
+            _ => hasSingleGlobalPlaceOneBadgeHolder,
+            out var reason);
+
+        Assert.Equal(expectedSkipped, skipped);
+        Assert.Equal(expectedReason, reason);
+    }
+
+    [Theory]
+    [MemberData(nameof(FacebookGoldenSkipRules))]
+    public void Facebook_TerminalSkipRulesMatchGoldenMatrix(
+        EventType type,
+        bool expectedSkipped,
+        SocialEventSkipReason expectedReason)
+    {
+        var skipped = SocialEventSkipPolicy.TryGetFacebookTerminalSkipReason(type, out var reason);
+
+        Assert.Equal(expectedSkipped, skipped);
+        Assert.Equal(expectedReason, reason);
+    }
+
     [Fact]
     public void Facebook_NonCustomEventsAreTerminalSkips()
     {

--- a/LongevityWorldCup.Tests/SocialEventSkipPolicyTests.cs
+++ b/LongevityWorldCup.Tests/SocialEventSkipPolicyTests.cs
@@ -1,0 +1,93 @@
+using LongevityWorldCup.Website.Business;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class SocialEventSkipPolicyTests
+{
+    [Fact]
+    public void Facebook_NonCustomEventsAreTerminalSkips()
+    {
+        var skipped = SocialEventSkipPolicy.TryGetFacebookTerminalSkipReason(
+            EventType.NewRank,
+            out var reason);
+
+        Assert.True(skipped);
+        Assert.Equal(SocialEventSkipReason.FacebookSupportsCustomEventsOnly, reason);
+    }
+
+    [Fact]
+    public void Facebook_CustomEventsAreNotTerminalSkips()
+    {
+        var skipped = SocialEventSkipPolicy.TryGetFacebookTerminalSkipReason(
+            EventType.CustomEvent,
+            out var reason);
+
+        Assert.False(skipped);
+        Assert.Equal(SocialEventSkipReason.None, reason);
+    }
+
+    [Fact]
+    public void XOrThreads_UnsupportedEventTypesAreTerminalSkips()
+    {
+        var skipped = SocialEventSkipPolicy.TryGetXOrThreadsTerminalSkipReason(
+            EventType.Joined,
+            "slug[alice]",
+            DateTime.UtcNow,
+            priority: 99,
+            freshCutoffUtc: DateTime.UtcNow.AddDays(-7),
+            hasSingleGlobalPlaceOneBadgeHolder: _ => true,
+            out var reason);
+
+        Assert.True(skipped);
+        Assert.Equal(SocialEventSkipReason.UnsupportedEventType, reason);
+    }
+
+    [Fact]
+    public void XOrThreads_StalePrimaryEventsAreTerminalSkips()
+    {
+        var skipped = SocialEventSkipPolicy.TryGetXOrThreadsTerminalSkipReason(
+            EventType.NewRank,
+            "slug[alice] rank[1]",
+            DateTime.UtcNow.AddDays(-8),
+            priority: 0,
+            freshCutoffUtc: DateTime.UtcNow.AddDays(-7),
+            hasSingleGlobalPlaceOneBadgeHolder: _ => true,
+            out var reason);
+
+        Assert.True(skipped);
+        Assert.Equal(SocialEventSkipReason.StalePrimaryEvent, reason);
+    }
+
+    [Fact]
+    public void XOrThreads_LowRankEventsAreTerminalSkips()
+    {
+        var skipped = SocialEventSkipPolicy.TryGetXOrThreadsTerminalSkipReason(
+            EventType.NewRank,
+            "slug[alice] rank[4]",
+            DateTime.UtcNow,
+            priority: 99,
+            freshCutoffUtc: DateTime.UtcNow.AddDays(-7),
+            hasSingleGlobalPlaceOneBadgeHolder: _ => true,
+            out var reason);
+
+        Assert.True(skipped);
+        Assert.Equal(SocialEventSkipReason.UnsupportedEventPayload, reason);
+    }
+
+    [Fact]
+    public void XOrThreads_TiedBestImprovementBadgesAreTerminalSkips()
+    {
+        var skipped = SocialEventSkipPolicy.TryGetXOrThreadsTerminalSkipReason(
+            EventType.BadgeAward,
+            "slug[alice] badge[Pheno Age best improvement] cat[Global] val[] place[1]",
+            DateTime.UtcNow,
+            priority: 3,
+            freshCutoffUtc: DateTime.UtcNow.AddDays(-7),
+            hasSingleGlobalPlaceOneBadgeHolder: _ => false,
+            out var reason);
+
+        Assert.True(skipped);
+        Assert.Equal(SocialEventSkipReason.TiedBestImprovementBadge, reason);
+    }
+}

--- a/LongevityWorldCup.Tests/SocialMessageBuilderTests.cs
+++ b/LongevityWorldCup.Tests/SocialMessageBuilderTests.cs
@@ -7,6 +7,67 @@ namespace LongevityWorldCup.Tests;
 public sealed class SocialMessageBuilderTests
 {
     [Fact]
+    public void RankEventBuilders_ReturnGoldenMessages()
+    {
+        const string raw = "slug[siim_land] rank[1] prev[bryan_johnson]";
+        var expectedX =
+            "New #1 in the Ultimate League \U0001F3C6\n" +
+            "Siim Land is now ahead of Bryan Johnson.\n\n" +
+            "https://longevityworldcup.com/leaderboard";
+        var expectedThreads =
+            "Siim Land just climbed to #1 in the Ultimate League \U0001F3C6\n" +
+            "Now ahead of Bryan Johnson.\n\n" +
+            "https://longevityworldcup.com/leaderboard";
+        var expectedSlack =
+            "<https://longevityworldcup.com/athlete/siim-land|Siim Land> is now 1st \U0001F947 in Ultimate League, ahead of <https://longevityworldcup.com/athlete/bryan-johnson|Bryan Johnson>";
+
+        Assert.Equal(expectedX, XMessageBuilder.ForEventText(EventType.NewRank, raw, SlugToName));
+        Assert.Equal(expectedThreads, ThreadsMessageBuilder.ForEventText(EventType.NewRank, raw, SlugToName));
+        Assert.Equal(expectedSlack, SlackMessageBuilder.ForEventText(EventType.NewRank, raw, SlugToName));
+    }
+
+    [Fact]
+    public void CustomEventBuilders_ReturnGoldenMessages()
+    {
+        const string raw = "Community update\n\nSiim [bold](wins), [strong](majorly). Welcome [mention](siim_land).";
+        const string expectedPlatform = "Community update\n\nSiim wins, majorly. Welcome Siim Land.";
+        const string expectedSlack =
+            "Community update\n\n" +
+            "Siim *wins*, *_majorly_*. Welcome <https://longevityworldcup.com/athlete/siim-land|Siim Land>.";
+
+        Assert.Equal(
+            expectedPlatform,
+            CustomEventSocialComposer.BuildPlan("event123", raw, 280, SlugToName).PostText);
+        Assert.Equal(
+            expectedPlatform,
+            CustomEventSocialComposer.BuildPlan("event123", raw, 500, SlugToName).PostText);
+        Assert.Equal(
+            expectedPlatform,
+            CustomEventSocialComposer.BuildPlan("event123", raw, 63206, SlugToName).PostText);
+        Assert.Equal(
+            expectedSlack,
+            SlackMessageBuilder.ForEventText(EventType.CustomEvent, raw, SlugToName));
+    }
+
+    [Fact]
+    public void MilestoneEventBuilders_ReturnGoldenMessages()
+    {
+        const string raw = "athletes[100]";
+        var expectedX =
+            "100 athletes are now on the leaderboard, marking the first triple digit milestone.\n\n" +
+            "https://longevityworldcup.com/leaderboard";
+        var expectedThreads =
+            "100 athletes are now on the leaderboard. First triple-digit mark.\n\n" +
+            "https://longevityworldcup.com/leaderboard";
+        const string expectedSlack =
+            "Hit <https://longevityworldcup.com/leaderboard|100> on the leaderboard, triple digits \U0001F3C1";
+
+        Assert.Equal(expectedX, XMessageBuilder.ForEventText(EventType.AthleteCountMilestone, raw, SlugToName));
+        Assert.Equal(expectedThreads, ThreadsMessageBuilder.ForEventText(EventType.AthleteCountMilestone, raw, SlugToName));
+        Assert.Equal(expectedSlack, SlackMessageBuilder.ForEventText(EventType.AthleteCountMilestone, raw, SlugToName));
+    }
+
+    [Fact]
     public void DomainTopFiller_UsesClockSpecificBortzProfileLanguage()
     {
         var xMessage = XMessageBuilder.ForFiller(
@@ -53,7 +114,12 @@ public sealed class SocialMessageBuilderTests
     }
 
     private static string SlugToName(string slug)
-        => slug == "siim_land" ? "Siim Land" : slug.Replace('_', ' ');
+        => slug switch
+        {
+            "siim_land" => "Siim Land",
+            "bryan_johnson" => "Bryan Johnson",
+            _ => slug.Replace('_', ' ')
+        };
 
     private static XPostSampleSize MatureSample(XPostSampleBasis basis)
         => new(basis, N: 21, PhenoCount: 21, BortzCount: 21, CombinedCount: 21);

--- a/LongevityWorldCup.Website/Business/EventDataService.cs
+++ b/LongevityWorldCup.Website/Business/EventDataService.cs
@@ -130,7 +130,10 @@ public sealed class EventDataService : IDisposable
                         SlackProcessed INTEGER NOT NULL DEFAULT 0,
                         XProcessed     INTEGER NOT NULL DEFAULT 0,
                         ThreadsProcessed INTEGER NOT NULL DEFAULT 0,
-                        FacebookProcessed INTEGER NOT NULL DEFAULT 0
+                        FacebookProcessed INTEGER NOT NULL DEFAULT 0,
+                        XSkipReason    TEXT,
+                        ThreadsSkipReason TEXT,
+                        FacebookSkipReason TEXT
                     );
                     """;
                 cmd.ExecuteNonQuery();
@@ -219,6 +222,18 @@ public sealed class EventDataService : IDisposable
                     cmd.CommandText = "UPDATE Events SET VisibleOnWebsite = 1;";
                     cmd.ExecuteNonQuery();
                 }
+
+                cmd.CommandText = "ALTER TABLE Events ADD COLUMN XSkipReason TEXT;";
+                try { cmd.ExecuteNonQuery(); }
+                catch { }
+
+                cmd.CommandText = "ALTER TABLE Events ADD COLUMN ThreadsSkipReason TEXT;";
+                try { cmd.ExecuteNonQuery(); }
+                catch { }
+
+                cmd.CommandText = "ALTER TABLE Events ADD COLUMN FacebookSkipReason TEXT;";
+                try { cmd.ExecuteNonQuery(); }
+                catch { }
 
                 cmd.CommandText = "CREATE INDEX IF NOT EXISTS IX_Events_OccurredAt ON Events(OccurredAt);";
                 cmd.ExecuteNonQuery();
@@ -472,7 +487,9 @@ public sealed class EventDataService : IDisposable
         _db.Run(sqlite =>
         {
             using var cmd = sqlite.CreateCommand();
-            cmd.CommandText = $"UPDATE Events SET {processedColumn} = @state WHERE Id = @id AND {processedColumn} = 2;";
+            var skipReasonColumn = GetSkipReasonColumn(processedColumn);
+            var clearSkipReason = succeeded && skipReasonColumn is not null ? $", {skipReasonColumn} = NULL" : "";
+            cmd.CommandText = $"UPDATE Events SET {processedColumn} = @state{clearSkipReason} WHERE Id = @id AND {processedColumn} = 2;";
             cmd.Parameters.AddWithValue("@state", succeeded ? 1 : 0);
             cmd.Parameters.AddWithValue("@id", id);
             cmd.ExecuteNonQuery();
@@ -485,10 +502,25 @@ public sealed class EventDataService : IDisposable
         _db.Run(sqlite =>
         {
             using var cmd = sqlite.CreateCommand();
-            cmd.CommandText = $"UPDATE Events SET {processedColumn} = 1 WHERE Type = @type AND {processedColumn} = 0;";
+            var skipReasonColumn = GetSkipReasonColumn(processedColumn);
+            var skipReasonUpdate = skipReasonColumn is null ? "" : $", {skipReasonColumn} = @skipReason";
+            cmd.CommandText = $"UPDATE Events SET {processedColumn} = 1{skipReasonUpdate} WHERE Type = @type AND {processedColumn} = 0;";
             cmd.Parameters.AddWithValue("@type", (int)EventType.CustomEvent);
+            if (skipReasonColumn is not null)
+                cmd.Parameters.AddWithValue("@skipReason", SocialEventSkipReason.PlatformNotConfigured.ToString());
             cmd.ExecuteNonQuery();
         });
+    }
+
+    private static string? GetSkipReasonColumn(string processedColumn)
+    {
+        return processedColumn switch
+        {
+            "XProcessed" => "XSkipReason",
+            "ThreadsProcessed" => "ThreadsSkipReason",
+            "FacebookProcessed" => "FacebookSkipReason",
+            _ => null
+        };
     }
 
     public const int XPriorityPrimaryMax = 8;
@@ -498,12 +530,7 @@ public sealed class EventDataService : IDisposable
         var list = _db.Run(sqlite =>
         {
             var filters = new List<string> { "XProcessed = 0" };
-            var parameters = new List<SqliteParameter>
-            {
-                new SqliteParameter("@joined", (int)EventType.Joined)
-            };
-
-            filters.Add("Type != @joined");
+            var parameters = new List<SqliteParameter>();
 
             if (fromUtc.HasValue)
             {
@@ -590,6 +617,16 @@ public sealed class EventDataService : IDisposable
 
     public void MarkEventsXProcessed(IEnumerable<string> ids)
     {
+        MarkEventsProcessed(ids, "XProcessed", "XSkipReason");
+    }
+
+    public void MarkEventsXSkipped(IEnumerable<(string Id, SocialEventSkipReason Reason)> skipped)
+    {
+        MarkEventsSkipped(skipped, "XProcessed", "XSkipReason");
+    }
+
+    private void MarkEventsProcessed(IEnumerable<string> ids, string processedColumn, string skipReasonColumn)
+    {
         var idList = ids.ToList();
         if (idList.Count == 0) return;
 
@@ -598,11 +635,36 @@ public sealed class EventDataService : IDisposable
             using var tx = sqlite.BeginTransaction();
             using var cmd = sqlite.CreateCommand();
             cmd.Transaction = tx;
-            cmd.CommandText = "UPDATE Events SET XProcessed = 1 WHERE Id = @id AND XProcessed = 0";
+            cmd.CommandText = $"UPDATE Events SET {processedColumn} = 1, {skipReasonColumn} = NULL WHERE Id = @id AND {processedColumn} = 0";
             var pId = cmd.Parameters.Add("@id", SqliteType.Text);
             foreach (var id in idList)
             {
                 pId.Value = id;
+                cmd.ExecuteNonQuery();
+            }
+            tx.Commit();
+        });
+    }
+
+    private void MarkEventsSkipped(IEnumerable<(string Id, SocialEventSkipReason Reason)> skipped, string processedColumn, string skipReasonColumn)
+    {
+        var rows = skipped
+            .Where(x => !string.IsNullOrWhiteSpace(x.Id) && x.Reason != SocialEventSkipReason.None)
+            .ToList();
+        if (rows.Count == 0) return;
+
+        _db.Run(sqlite =>
+        {
+            using var tx = sqlite.BeginTransaction();
+            using var cmd = sqlite.CreateCommand();
+            cmd.Transaction = tx;
+            cmd.CommandText = $"UPDATE Events SET {processedColumn} = 1, {skipReasonColumn} = @reason WHERE Id = @id AND {processedColumn} = 0";
+            var pId = cmd.Parameters.Add("@id", SqliteType.Text);
+            var pReason = cmd.Parameters.Add("@reason", SqliteType.Text);
+            foreach (var (id, reason) in rows)
+            {
+                pId.Value = id;
+                pReason.Value = reason.ToString();
                 cmd.ExecuteNonQuery();
             }
             tx.Commit();
@@ -614,12 +676,7 @@ public sealed class EventDataService : IDisposable
         var list = _db.Run(sqlite =>
         {
             var filters = new List<string> { "ThreadsProcessed = 0" };
-            var parameters = new List<SqliteParameter>
-            {
-                new SqliteParameter("@joined", (int)EventType.Joined)
-            };
-
-            filters.Add("Type != @joined");
+            var parameters = new List<SqliteParameter>();
 
             if (fromUtc.HasValue)
             {
@@ -667,23 +724,12 @@ public sealed class EventDataService : IDisposable
 
     public void MarkEventsThreadsProcessed(IEnumerable<string> ids)
     {
-        var idList = ids.ToList();
-        if (idList.Count == 0) return;
+        MarkEventsProcessed(ids, "ThreadsProcessed", "ThreadsSkipReason");
+    }
 
-        _db.Run(sqlite =>
-        {
-            using var tx = sqlite.BeginTransaction();
-            using var cmd = sqlite.CreateCommand();
-            cmd.Transaction = tx;
-            cmd.CommandText = "UPDATE Events SET ThreadsProcessed = 1 WHERE Id = @id AND ThreadsProcessed = 0";
-            var pId = cmd.Parameters.Add("@id", SqliteType.Text);
-            foreach (var id in idList)
-            {
-                pId.Value = id;
-                cmd.ExecuteNonQuery();
-            }
-            tx.Commit();
-        });
+    public void MarkEventsThreadsSkipped(IEnumerable<(string Id, SocialEventSkipReason Reason)> skipped)
+    {
+        MarkEventsSkipped(skipped, "ThreadsProcessed", "ThreadsSkipReason");
     }
 
     public IReadOnlyList<(string Id, EventType Type, string Text, DateTime OccurredAtUtc, double Relevance, bool VisibleOnWebsite, int XPriority)> GetPendingFacebookEvents(DateTime? fromUtc = null, DateTime? toUtc = null, int? limit = null)
@@ -691,12 +737,7 @@ public sealed class EventDataService : IDisposable
         var list = _db.Run(sqlite =>
         {
             var filters = new List<string> { "FacebookProcessed = 0" };
-            var parameters = new List<SqliteParameter>
-            {
-                new SqliteParameter("@joined", (int)EventType.Joined)
-            };
-
-            filters.Add("Type != @joined");
+            var parameters = new List<SqliteParameter>();
 
             if (fromUtc.HasValue)
             {
@@ -744,23 +785,12 @@ public sealed class EventDataService : IDisposable
 
     public void MarkEventsFacebookProcessed(IEnumerable<string> ids)
     {
-        var idList = ids.ToList();
-        if (idList.Count == 0) return;
+        MarkEventsProcessed(ids, "FacebookProcessed", "FacebookSkipReason");
+    }
 
-        _db.Run(sqlite =>
-        {
-            using var tx = sqlite.BeginTransaction();
-            using var cmd = sqlite.CreateCommand();
-            cmd.Transaction = tx;
-            cmd.CommandText = "UPDATE Events SET FacebookProcessed = 1 WHERE Id = @id AND FacebookProcessed = 0";
-            var pId = cmd.Parameters.Add("@id", SqliteType.Text);
-            foreach (var id in idList)
-            {
-                pId.Value = id;
-                cmd.ExecuteNonQuery();
-            }
-            tx.Commit();
-        });
+    public void MarkEventsFacebookSkipped(IEnumerable<(string Id, SocialEventSkipReason Reason)> skipped)
+    {
+        MarkEventsSkipped(skipped, "FacebookProcessed", "FacebookSkipReason");
     }
 
     public void SetAthletesForX(IReadOnlyList<AthleteForX> items)

--- a/LongevityWorldCup.Website/Business/SocialEventSkipPolicy.cs
+++ b/LongevityWorldCup.Website/Business/SocialEventSkipPolicy.cs
@@ -1,0 +1,128 @@
+using LongevityWorldCup.Website.Tools;
+
+namespace LongevityWorldCup.Website.Business;
+
+public enum SocialEventSkipReason
+{
+    None,
+    PlatformNotConfigured,
+    UnsupportedEventType,
+    UnsupportedEventPayload,
+    UnsupportedBadgeAward,
+    PodcastBadgeHandledImmediately,
+    NonWinningSingleWinnerBadge,
+    TiedBestImprovementBadge,
+    StalePrimaryEvent,
+    EmptyMessage,
+    FacebookSupportsCustomEventsOnly
+}
+
+public static class SocialEventSkipPolicy
+{
+    public static bool TryGetXOrThreadsTerminalSkipReason(
+        EventType type,
+        string text,
+        DateTime occurredAtUtc,
+        int priority,
+        DateTime freshCutoffUtc,
+        Func<string, bool> hasSingleGlobalPlaceOneBadgeHolder,
+        out SocialEventSkipReason reason)
+    {
+        if (type == EventType.CustomEvent)
+        {
+            reason = default;
+            return false;
+        }
+
+        if (priority <= EventDataService.XPriorityPrimaryMax && occurredAtUtc < freshCutoffUtc)
+        {
+            reason = SocialEventSkipReason.StalePrimaryEvent;
+            return true;
+        }
+
+        if (type == EventType.AthleteCountMilestone)
+        {
+            reason = default;
+            return false;
+        }
+
+        if (type == EventType.NewRank)
+        {
+            reason = EventHelpers.TryExtractRank(text, out var rank) && rank is >= 1 and <= 3
+                ? default
+                : SocialEventSkipReason.UnsupportedEventPayload;
+            return reason != default;
+        }
+
+        if (type != EventType.BadgeAward)
+        {
+            reason = SocialEventSkipReason.UnsupportedEventType;
+            return true;
+        }
+
+        if (!EventHelpers.TryExtractBadgeLabel(text, out var label))
+        {
+            reason = SocialEventSkipReason.UnsupportedEventPayload;
+            return true;
+        }
+
+        var norm = EventHelpers.NormalizeBadgeLabel(label);
+        if (string.Equals(norm, "Podcast", StringComparison.OrdinalIgnoreCase))
+        {
+            reason = SocialEventSkipReason.PodcastBadgeHandledImmediately;
+            return true;
+        }
+
+        if (IsSingleWinnerBadge(norm) &&
+            (!EventHelpers.TryExtractPlace(text, out var place) || place != 1))
+        {
+            reason = SocialEventSkipReason.NonWinningSingleWinnerBadge;
+            return true;
+        }
+
+        if (IsBestImprovementBadge(norm) && !hasSingleGlobalPlaceOneBadgeHolder(label))
+        {
+            reason = SocialEventSkipReason.TiedBestImprovementBadge;
+            return true;
+        }
+
+        if (priority > EventDataService.XPriorityPrimaryMax)
+        {
+            reason = SocialEventSkipReason.UnsupportedBadgeAward;
+            return true;
+        }
+
+        reason = default;
+        return false;
+    }
+
+    public static bool TryGetFacebookTerminalSkipReason(EventType type, out SocialEventSkipReason reason)
+    {
+        if (type == EventType.CustomEvent)
+        {
+            reason = default;
+            return false;
+        }
+
+        reason = SocialEventSkipReason.FacebookSupportsCustomEventsOnly;
+        return true;
+    }
+
+    private static bool IsSingleWinnerBadge(string norm)
+    {
+        return
+            string.Equals(norm, "Pheno Age – lowest", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(norm, "Pheno Age best improvement", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(norm, "Bortz Age – lowest", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(norm, "Bortz Age best improvement", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(norm, "Chronological age – oldest", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(norm, "Chronological age – youngest", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsBestImprovementBadge(string norm)
+    {
+        return
+            string.Equals(norm, "Pheno Age best improvement", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(norm, "Bortz Age best improvement", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/LongevityWorldCup.Website/Controllers/CustomEventsController.cs
+++ b/LongevityWorldCup.Website/Controllers/CustomEventsController.cs
@@ -36,21 +36,21 @@ public sealed class CustomEventsController(EventDataService events, Config confi
 
         if (string.IsNullOrEmpty(request.Secret) || request.Secret.Length > MaxSecretLength)
         {
-            _log.LogWarning("Custom Event Designer direct post rejected because the secret was missing or too long.");
+            _log.LogWarning("Custom Event Designer direct queue rejected because the secret was missing or too long.");
             return Unauthorized("Invalid secret.");
         }
 
         var verification = SecretHashVerifier.Verify(request.Secret, _config.CustomEventDesignerSecretHash);
         if (verification == SecretVerificationResult.NotConfigured)
-            return StatusCode(StatusCodes.Status503ServiceUnavailable, "Custom Event Designer direct posting is not configured.");
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, "Custom Event Designer direct queueing is not configured.");
         if (verification == SecretVerificationResult.InvalidHash)
         {
-            _log.LogError("Custom Event Designer direct posting is disabled because CustomEventDesignerSecretHash is invalid.");
-            return StatusCode(StatusCodes.Status503ServiceUnavailable, "Custom Event Designer direct posting is not configured.");
+            _log.LogError("Custom Event Designer direct queueing is disabled because CustomEventDesignerSecretHash is invalid.");
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, "Custom Event Designer direct queueing is not configured.");
         }
         if (verification != SecretVerificationResult.Verified)
         {
-            _log.LogWarning("Custom Event Designer direct post rejected because the secret did not match.");
+            _log.LogWarning("Custom Event Designer direct queue rejected because the secret did not match.");
             return Unauthorized("Invalid secret.");
         }
 
@@ -79,7 +79,7 @@ public sealed class CustomEventsController(EventDataService events, Config confi
             deliveryTargets: targets);
 
         _log.LogInformation(
-            "Custom Event Designer direct post created event {EventId} for targets {Targets}.",
+            "Custom Event Designer direct queue created event {EventId} for targets {Targets}.",
             eventId,
             string.Join(",", selectedTargets));
 
@@ -87,6 +87,7 @@ public sealed class CustomEventsController(EventDataService events, Config confi
         {
             success = true,
             eventId,
+            queuedTargets = selectedTargets,
             selectedTargets
         });
     }

--- a/LongevityWorldCup.Website/Jobs/FacebookDailyPostJob.cs
+++ b/LongevityWorldCup.Website/Jobs/FacebookDailyPostJob.cs
@@ -30,9 +30,20 @@ public class FacebookDailyPostJob : IJob
 
         foreach (var (id, type, text, occurredAtUtc, _, visibleOnWebsite, _) in pending)
         {
+            if (SocialEventSkipPolicy.TryGetFacebookTerminalSkipReason(type, out var skipReason))
+            {
+                _events.MarkEventsFacebookSkipped(new[] { (id, skipReason) });
+                _logger.LogInformation("FacebookDailyPostJob marked event {Id} processed with skip reason {SkipReason}", id, skipReason);
+                continue;
+            }
+
             var msg = _facebookEvents.TryBuildMessage(type, text, id, visibleOnWebsite);
             if (string.IsNullOrWhiteSpace(msg))
+            {
+                _events.MarkEventsFacebookSkipped(new[] { (id, SocialEventSkipReason.EmptyMessage) });
+                _logger.LogInformation("FacebookDailyPostJob marked event {Id} processed with skip reason {SkipReason}", id, SocialEventSkipReason.EmptyMessage);
                 continue;
+            }
 
             _logger.LogInformation(
                 "FacebookDailyPostJob selected event {Id} type {Type} occurredAt {OccurredAtUtc} visibleOnWebsite {VisibleOnWebsite} messageLength {MessageLength}",

--- a/LongevityWorldCup.Website/Jobs/ThreadsDailyPostJob.cs
+++ b/LongevityWorldCup.Website/Jobs/ThreadsDailyPostJob.cs
@@ -43,38 +43,19 @@ public class ThreadsDailyPostJob : IJob
 
         foreach (var (id, type, text, occurredAtUtc, _, visibleOnWebsite, xPriority) in pending)
         {
-            if (type == EventType.BadgeAward)
+            if (SocialEventSkipPolicy.TryGetXOrThreadsTerminalSkipReason(
+                    type,
+                    text,
+                    occurredAtUtc,
+                    xPriority,
+                    freshCutoff,
+                    _athletes.HasSingleGlobalPlaceOneBadgeHolder,
+                    out var skipReason))
             {
-                if (EventHelpers.TryExtractBadgeLabel(text, out var label))
-                {
-                    var norm = EventHelpers.NormalizeBadgeLabel(label);
-                    if (string.Equals(norm, "Podcast", StringComparison.OrdinalIgnoreCase))
-                        continue;
-
-                    var isSingleWinnerBadge =
-                        string.Equals(norm, "Pheno Age – lowest", StringComparison.OrdinalIgnoreCase) ||
-                        string.Equals(norm, "Pheno Age best improvement", StringComparison.OrdinalIgnoreCase) ||
-                        string.Equals(norm, "Bortz Age – lowest", StringComparison.OrdinalIgnoreCase) ||
-                        string.Equals(norm, "Bortz Age best improvement", StringComparison.OrdinalIgnoreCase) ||
-                        string.Equals(norm, "Chronological age – oldest", StringComparison.OrdinalIgnoreCase) ||
-                        string.Equals(norm, "Chronological age – youngest", StringComparison.OrdinalIgnoreCase);
-                    if (isSingleWinnerBadge &&
-                        (!EventHelpers.TryExtractPlace(text, out var badgePlace) || badgePlace != 1))
-                        continue;
-
-                    var isBestImprovement =
-                        string.Equals(norm, "Pheno Age best improvement", StringComparison.OrdinalIgnoreCase) ||
-                        string.Equals(norm, "Bortz Age best improvement", StringComparison.OrdinalIgnoreCase);
-                    if (isBestImprovement && !_athletes.HasSingleGlobalPlaceOneBadgeHolder(label))
-                    {
-                        _logger.LogInformation("ThreadsDailyPostJob skipped tie Best Improvement badge event {BadgeLabel}", label);
-                        continue;
-                    }
-                }
-            }
-
-            if (xPriority <= EventDataService.XPriorityPrimaryMax && occurredAtUtc < freshCutoff)
+                _events.MarkEventsThreadsSkipped(new[] { (id, skipReason) });
+                _logger.LogInformation("ThreadsDailyPostJob marked event {Id} processed with skip reason {SkipReason}", id, skipReason);
                 continue;
+            }
 
             var nowUtc = DateTime.UtcNow;
             var subjectSlug = TryGetSubjectSlugForEvent(type, text);
@@ -85,7 +66,12 @@ public class ThreadsDailyPostJob : IJob
             }
 
             var msg = _threadsEvents.TryBuildMessage(type, text, id, visibleOnWebsite);
-            if (string.IsNullOrWhiteSpace(msg)) continue;
+            if (string.IsNullOrWhiteSpace(msg))
+            {
+                _events.MarkEventsThreadsSkipped(new[] { (id, SocialEventSkipReason.EmptyMessage) });
+                _logger.LogInformation("ThreadsDailyPostJob marked event {Id} processed with skip reason {SkipReason}", id, SocialEventSkipReason.EmptyMessage);
+                continue;
+            }
 
             _logger.LogInformation(
                 "ThreadsDailyPostJob selected event {Id} type {Type} occurredAt {OccurredAtUtc} visibleOnWebsite {VisibleOnWebsite} messageLength {MessageLength}",

--- a/LongevityWorldCup.Website/Jobs/XDailyPostJob.cs
+++ b/LongevityWorldCup.Website/Jobs/XDailyPostJob.cs
@@ -64,38 +64,19 @@ public class XDailyPostJob : IJob
 
         foreach (var (id, type, text, occurredAtUtc, _, visibleOnWebsite, xPriority) in pending)
         {
-            if (type == EventType.BadgeAward)
+            if (SocialEventSkipPolicy.TryGetXOrThreadsTerminalSkipReason(
+                    type,
+                    text,
+                    occurredAtUtc,
+                    xPriority,
+                    freshCutoff,
+                    _athletes.HasSingleGlobalPlaceOneBadgeHolder,
+                    out var skipReason))
             {
-                if (EventHelpers.TryExtractBadgeLabel(text, out var label))
-                {
-                    var norm = EventHelpers.NormalizeBadgeLabel(label);
-                    if (string.Equals(norm, "Podcast", StringComparison.OrdinalIgnoreCase))
-                        continue;
-
-                    var isSingleWinnerBadge =
-                        string.Equals(norm, "Pheno Age – lowest", StringComparison.OrdinalIgnoreCase) ||
-                        string.Equals(norm, "Pheno Age best improvement", StringComparison.OrdinalIgnoreCase) ||
-                        string.Equals(norm, "Bortz Age – lowest", StringComparison.OrdinalIgnoreCase) ||
-                        string.Equals(norm, "Bortz Age best improvement", StringComparison.OrdinalIgnoreCase) ||
-                        string.Equals(norm, "Chronological age – oldest", StringComparison.OrdinalIgnoreCase) ||
-                        string.Equals(norm, "Chronological age – youngest", StringComparison.OrdinalIgnoreCase);
-                    if (isSingleWinnerBadge &&
-                        (!EventHelpers.TryExtractPlace(text, out var badgePlace) || badgePlace != 1))
-                        continue;
-
-                    var isBestImprovement =
-                        string.Equals(norm, "Pheno Age best improvement", StringComparison.OrdinalIgnoreCase) ||
-                        string.Equals(norm, "Bortz Age best improvement", StringComparison.OrdinalIgnoreCase);
-                    if (isBestImprovement && !_athletes.HasSingleGlobalPlaceOneBadgeHolder(label))
-                    {
-                        _logger.LogInformation("XDailyPostJob skipped tie Best Improvement badge event {BadgeLabel}", label);
-                        continue;
-                    }
-                }
-            }
-
-            if (xPriority <= EventDataService.XPriorityPrimaryMax && occurredAtUtc < freshCutoff)
+                _events.MarkEventsXSkipped(new[] { (id, skipReason) });
+                _logger.LogInformation("XDailyPostJob marked event {Id} processed with skip reason {SkipReason}", id, skipReason);
                 continue;
+            }
 
             var nowUtc = DateTime.UtcNow;
             var subjectSlug = TryGetSubjectSlugForEvent(type, text);
@@ -106,7 +87,12 @@ public class XDailyPostJob : IJob
             }
 
             var msg = _xEvents.TryBuildMessage(type, text, id, visibleOnWebsite);
-            if (string.IsNullOrWhiteSpace(msg)) continue;
+            if (string.IsNullOrWhiteSpace(msg))
+            {
+                _events.MarkEventsXSkipped(new[] { (id, SocialEventSkipReason.EmptyMessage) });
+                _logger.LogInformation("XDailyPostJob marked event {Id} processed with skip reason {SkipReason}", id, SocialEventSkipReason.EmptyMessage);
+                continue;
+            }
 
             _logger.LogInformation(
                 "XDailyPostJob selected event {Id} type {Type} occurredAt {OccurredAtUtc} visibleOnWebsite {VisibleOnWebsite} messageLength {MessageLength}",

--- a/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
+++ b/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
@@ -869,7 +869,7 @@
             </div>
 
             <div class="payload-box">
-                <h2>Direct Post</h2>
+                <h2>Direct Queue</h2>
                 <label>
                     <span>Secret</span>
                     <input id="designerSecretInput" type="password" autocomplete="off" />
@@ -881,12 +881,12 @@
                 </div>
                 <textarea id="secretHashOutput" class="token" readonly hidden></textarea>
                 <div class="payload-actions">
-                    <button id="postEventBtn" type="button">Post Event</button>
+                    <button id="postEventBtn" type="button">Queue Event</button>
                     <button id="copyCleanupCommandBtn" class="secondary" type="button" disabled hidden>Copy Cleanup SQL</button>
                     <div id="directPostStatus" class="post-status" aria-live="polite"></div>
                 </div>
                 <textarea id="cleanupCommandOutput" class="token" readonly hidden></textarea>
-                <div id="postValidationHint" class="validation-hint" hidden>Title and at least one destination are required before posting.</div>
+                <div id="postValidationHint" class="validation-hint" hidden>Title and at least one destination are required before queueing.</div>
             </div>
 
             <details class="payload-box">
@@ -894,7 +894,7 @@
                 <ol class="live-checklist">
                     <li>Generate a config hash from a temporary secret and set <code>CustomEventDesignerSecretHash</code> in the published Linux config.</li>
                     <li>Restart <code>longevityworldcup.service</code> so the config is reloaded.</li>
-                    <li>Use a harmless title, select only Webpage, and post once.</li>
+                    <li>Use a harmless title, select only Webpage, and queue once.</li>
                     <li>Confirm the event appears on the website, then copy the cleanup SQL if the test row should be removed.</li>
                     <li>Rollback by clearing the config hash or restoring the previous config value, then restart.</li>
                 </ol>
@@ -2268,13 +2268,13 @@
         async function postEvent() {
             const payload = buildEventPayload();
             if (!payload.title || !hasSelectedDestination(payload)) {
-                setDirectPostStatus("Title and at least one destination are required before posting.", "error");
+                setDirectPostStatus("Title and at least one destination are required before queueing.", "error");
                 update();
                 return;
             }
 
             postEventBtn.disabled = true;
-            setDirectPostStatus("Posting...", "");
+            setDirectPostStatus("Queueing...", "");
             clearCleanupCommand();
 
             try {
@@ -2298,18 +2298,21 @@
                 if (!response.ok) {
                     const message = typeof body === "string"
                         ? body
-                        : (body && body.message) || `Post failed with HTTP ${response.status}.`;
+                        : (body && body.message) || `Queue failed with HTTP ${response.status}.`;
                     clearCleanupCommand();
-                    setDirectPostStatus(message || `Post failed with HTTP ${response.status}.`, "error");
+                    setDirectPostStatus(message || `Queue failed with HTTP ${response.status}.`, "error");
                     return;
                 }
 
-                const targets = Array.isArray(body.selectedTargets) ? body.selectedTargets.join(", ") : "";
+                const targetList = Array.isArray(body.queuedTargets)
+                    ? body.queuedTargets
+                    : (Array.isArray(body.selectedTargets) ? body.selectedTargets : []);
+                const targets = targetList.join(", ");
                 setCleanupCommand(body.eventId);
-                setDirectPostStatus(`Posted event ${body.eventId}${targets ? ` to ${targets}` : ""}.`, "success");
+                setDirectPostStatus(`Queued event ${body.eventId}${targets ? ` for ${targets}` : ""}.`, "success");
             } catch {
                 clearCleanupCommand();
-                setDirectPostStatus("Post failed. Check your connection and try again.", "error");
+                setDirectPostStatus("Queue failed. Check your connection and try again.", "error");
             } finally {
                 update();
             }


### PR DESCRIPTION
## Summary
- add persisted per-platform skip reason columns for social event processing
- mark terminal X/Threads skips, stale primary events, empty messages, and Facebook non-custom rows processed with skip reasons
- add skip policy tests for Facebook-only custom support and X/Threads terminal skip cases

## Tests
- dotnet test LongevityWorldCup.Tests\\LongevityWorldCup.Tests.csproj