### PR TITLE
Add athlete highlight events

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,11 @@ Use its canonical terms when naming UI text, code concepts, issues, and docs. If
 - Ultimate League Pro/Amateur ordering is domain behavior: Pro entries must appear before Amateur entries.
 - The crowd age leaderboard view is separate from Ultimate League ranking. Only athletes with at least 100 crowd guesses are eligible. It follows the same sign convention as other age-reduction columns: `CrowdAge - chronologicalAge`, with more negative values ranking higher, then higher `CrowdCount`, then older date of birth, then name.
 - Improvement leaderboard views are separate from Ultimate League ranking. Pheno Improvement is exposed through filters/routes as `Improvement` and ranks `latest eligible pheno age - worst eligible pheno age`; Bortz Improvement is also available through filters/routes and ranks `latest eligible bortz age - worst eligible bortz age`. Lower and more negative values rank higher, then the same clock's age reduction, then older date of birth, then name.
+- Pheno/Bortz Improvement top-10 placement changes emit Events after the initial stored placement snapshot; keep these separate from biological-age improvement Events.
 - Guess My Age submissions are server-rate-limited before increasing `CrowdCount`: one accepted realistic guess per client IP and athlete during the configured short window.
+- Existing Amateur athletes emit a went Pro Event when they first gain an eligible Bortz Age result; athletes who join already Pro only emit normal join/rank Events.
+- Existing athletes emit a biological-age improvement Event when a changed result lowers their stored best pheno age or Bortz Age; this is separate from Pheno/Bortz Improvement leaderboard metrics.
+- Crowd Age top-10 placement changes emit Events after the initial stored placement snapshot; they follow the separate Crowd Age leaderboard ordering and must not affect Ultimate League ranking.
 
 ## Static Asset Loading Must Use Middleware Versioning
 
@@ -53,6 +57,7 @@ Use its canonical terms when naming UI text, code concepts, issues, and docs. If
 - Athlete profile and proof asset URLs should be versioned when emitted from the data service. Unversioned `/athletes/...` and `/generated/...` requests are intentionally cached briefly only as a fallback.
 - When changing the API of an existing external JS file, review every injected HTML/partial caller in the repo and ensure the versioned URL path still goes through the middleware replacement flow.
 - If a helper is moved from inline script to a separate JS file, verify that the file is loaded in every page, modal, iframe, or embedded context that uses that helper.
+- Homepage highlights are intentionally curated, not a raw Event feed; preserve same-athlete de-duplication and the fourth-visit highlights-before-podium layout behavior when changing `index.html` or event-board rendering.
 
 ## Social API Token Maintenance
 

--- a/LongevityWorldCup.Tests/SocialEventSkipPolicyTests.cs
+++ b/LongevityWorldCup.Tests/SocialEventSkipPolicyTests.cs
@@ -17,10 +17,10 @@ public sealed class SocialEventSkipPolicyTests
         yield return new object[] { EventType.NewRank, "slug[alice] rank[4]", now, 99, freshCutoff, true, true, SocialEventSkipReason.UnsupportedEventPayload };
         yield return new object[] { EventType.NewRank, "slug[alice] rank[1]", now.AddDays(-8), 0, freshCutoff, true, true, SocialEventSkipReason.StalePrimaryEvent };
         yield return new object[] { EventType.AthleteCountMilestone, "athletes[100]", now, 8, freshCutoff, true, false, SocialEventSkipReason.None };
-        yield return new object[] { EventType.BecamePro, "slug[alice]", now, 8, freshCutoff, true, false, SocialEventSkipReason.None };
-        yield return new object[] { EventType.BecamePro, "not-a-slug", now, 8, freshCutoff, true, true, SocialEventSkipReason.UnsupportedEventPayload };
-        yield return new object[] { EventType.BiologicalAgeImproved, "slug[alice] clock[pheno] from[44.2] to[41.8]", now, 8, freshCutoff, true, false, SocialEventSkipReason.None };
-        yield return new object[] { EventType.BiologicalAgeImproved, "slug[alice] clock[pheno] from[41.8] to[44.2]", now, 8, freshCutoff, true, true, SocialEventSkipReason.UnsupportedEventPayload };
+        yield return new object[] { EventType.BecamePro, "slug[alice]", now, 8, freshCutoff, true, true, SocialEventSkipReason.UnsupportedEventType };
+        yield return new object[] { EventType.BecamePro, "not-a-slug", now, 8, freshCutoff, true, true, SocialEventSkipReason.UnsupportedEventType };
+        yield return new object[] { EventType.BiologicalAgeImproved, "slug[alice] clock[pheno] from[44.2] to[41.8]", now, 8, freshCutoff, true, true, SocialEventSkipReason.UnsupportedEventType };
+        yield return new object[] { EventType.BiologicalAgeImproved, "slug[alice] clock[pheno] from[41.8] to[44.2]", now, 8, freshCutoff, true, true, SocialEventSkipReason.UnsupportedEventType };
         yield return new object[] { EventType.CrowdAgeTop10Change, "slug[alice] place[3] prevPlace[8] crowdAge[35.2] crowdCount[123]", now, 8, freshCutoff, true, false, SocialEventSkipReason.None };
         yield return new object[] { EventType.CrowdAgeTop10Change, "slug[alice] place[11] crowdAge[35.2] crowdCount[123]", now, 8, freshCutoff, true, true, SocialEventSkipReason.UnsupportedEventPayload };
         yield return new object[] { EventType.AgeImprovementTop10Change, "slug[alice] clock[pheno] place[3] prevPlace[8] improvement[-6.8] ageReduction[-20.4]", now, 8, freshCutoff, true, false, SocialEventSkipReason.None };
@@ -122,6 +122,14 @@ public sealed class SocialEventSkipPolicyTests
         Assert.False(EventDataService.ShouldSkipSlackNotification(
             EventType.CustomEvent,
             freshCutoffUtc.AddYears(-1),
+            freshCutoffUtc));
+        Assert.True(EventDataService.ShouldSkipSlackNotification(
+            EventType.BecamePro,
+            freshCutoffUtc,
+            freshCutoffUtc));
+        Assert.True(EventDataService.ShouldSkipSlackNotification(
+            EventType.BiologicalAgeImproved,
+            freshCutoffUtc,
             freshCutoffUtc));
     }
 

--- a/LongevityWorldCup.Tests/SocialEventSkipPolicyTests.cs
+++ b/LongevityWorldCup.Tests/SocialEventSkipPolicyTests.cs
@@ -17,6 +17,14 @@ public sealed class SocialEventSkipPolicyTests
         yield return new object[] { EventType.NewRank, "slug[alice] rank[4]", now, 99, freshCutoff, true, true, SocialEventSkipReason.UnsupportedEventPayload };
         yield return new object[] { EventType.NewRank, "slug[alice] rank[1]", now.AddDays(-8), 0, freshCutoff, true, true, SocialEventSkipReason.StalePrimaryEvent };
         yield return new object[] { EventType.AthleteCountMilestone, "athletes[100]", now, 8, freshCutoff, true, false, SocialEventSkipReason.None };
+        yield return new object[] { EventType.BecamePro, "slug[alice]", now, 8, freshCutoff, true, false, SocialEventSkipReason.None };
+        yield return new object[] { EventType.BecamePro, "not-a-slug", now, 8, freshCutoff, true, true, SocialEventSkipReason.UnsupportedEventPayload };
+        yield return new object[] { EventType.BiologicalAgeImproved, "slug[alice] clock[pheno] from[44.2] to[41.8]", now, 8, freshCutoff, true, false, SocialEventSkipReason.None };
+        yield return new object[] { EventType.BiologicalAgeImproved, "slug[alice] clock[pheno] from[41.8] to[44.2]", now, 8, freshCutoff, true, true, SocialEventSkipReason.UnsupportedEventPayload };
+        yield return new object[] { EventType.CrowdAgeTop10Change, "slug[alice] place[3] prevPlace[8] crowdAge[35.2] crowdCount[123]", now, 8, freshCutoff, true, false, SocialEventSkipReason.None };
+        yield return new object[] { EventType.CrowdAgeTop10Change, "slug[alice] place[11] crowdAge[35.2] crowdCount[123]", now, 8, freshCutoff, true, true, SocialEventSkipReason.UnsupportedEventPayload };
+        yield return new object[] { EventType.AgeImprovementTop10Change, "slug[alice] clock[pheno] place[3] prevPlace[8] improvement[-6.8] ageReduction[-20.4]", now, 8, freshCutoff, true, false, SocialEventSkipReason.None };
+        yield return new object[] { EventType.AgeImprovementTop10Change, "slug[alice] clock[pheno] place[11] improvement[-6.8] ageReduction[-20.4]", now, 8, freshCutoff, true, true, SocialEventSkipReason.UnsupportedEventPayload };
         yield return new object[] { EventType.BadgeAward, "slug[alice] badge[Podcast] cat[Global] val[] place[1]", now, 99, freshCutoff, true, true, SocialEventSkipReason.PodcastBadgeHandledImmediately };
         yield return new object[] { EventType.BadgeAward, "slug[alice] badge[Pheno Age - lowest] cat[Global] val[] place[2]", now, 2, freshCutoff, true, true, SocialEventSkipReason.NonWinningSingleWinnerBadge };
         yield return new object[] { EventType.BadgeAward, "slug[alice] badge[Pheno Age best improvement] cat[Global] val[] place[1]", now, 3, freshCutoff, false, true, SocialEventSkipReason.TiedBestImprovementBadge };
@@ -31,6 +39,10 @@ public sealed class SocialEventSkipPolicyTests
         yield return new object[] { EventType.NewRank, true, SocialEventSkipReason.FacebookSupportsCustomEventsOnly };
         yield return new object[] { EventType.BadgeAward, true, SocialEventSkipReason.FacebookSupportsCustomEventsOnly };
         yield return new object[] { EventType.AthleteCountMilestone, true, SocialEventSkipReason.FacebookSupportsCustomEventsOnly };
+        yield return new object[] { EventType.BecamePro, true, SocialEventSkipReason.FacebookSupportsCustomEventsOnly };
+        yield return new object[] { EventType.BiologicalAgeImproved, true, SocialEventSkipReason.FacebookSupportsCustomEventsOnly };
+        yield return new object[] { EventType.CrowdAgeTop10Change, true, SocialEventSkipReason.FacebookSupportsCustomEventsOnly };
+        yield return new object[] { EventType.AgeImprovementTop10Change, true, SocialEventSkipReason.FacebookSupportsCustomEventsOnly };
         yield return new object[] { EventType.DonationReceived, true, SocialEventSkipReason.FacebookSupportsCustomEventsOnly };
     }
 

--- a/LongevityWorldCup.Tests/SocialJobIntegrationTests.cs
+++ b/LongevityWorldCup.Tests/SocialJobIntegrationTests.cs
@@ -15,6 +15,66 @@ namespace LongevityWorldCup.Tests;
 public sealed class SocialJobIntegrationTests
 {
     [Fact]
+    public void BecameProAndBiologicalAgeImprovedEvents_AreWebsiteOnly()
+    {
+        using var fixture = SocialJobFixture.Create();
+        var occurredAtUtc = new DateTime(2026, 6, 7, 12, 0, 0, DateTimeKind.Utc);
+
+        fixture.Events.CreateBecameProEvents(new[] { ("alice", occurredAtUtc) });
+        fixture.Events.CreateBiologicalAgeImprovementEvents(new[] { ("bob", occurredAtUtc, "pheno", 44.2, 41.8) });
+
+        var rows = fixture.Database.Run(sqlite =>
+        {
+            using var cmd = sqlite.CreateCommand();
+            cmd.CommandText =
+                """
+                SELECT Type, VisibleOnWebsite, SlackProcessed, XProcessed, ThreadsProcessed, FacebookProcessed
+                FROM Events
+                WHERE Type IN (@becamePro, @bioImproved)
+                ORDER BY Type;
+                """;
+            cmd.Parameters.AddWithValue("@becamePro", (int)EventType.BecamePro);
+            cmd.Parameters.AddWithValue("@bioImproved", (int)EventType.BiologicalAgeImproved);
+
+            var result = new List<(EventType Type, int VisibleOnWebsite, int SlackProcessed, int XProcessed, int ThreadsProcessed, int FacebookProcessed)>();
+            using var reader = cmd.ExecuteReader();
+            while (reader.Read())
+            {
+                result.Add((
+                    (EventType)reader.GetInt32(0),
+                    reader.GetInt32(1),
+                    reader.GetInt32(2),
+                    reader.GetInt32(3),
+                    reader.GetInt32(4),
+                    reader.GetInt32(5)));
+            }
+
+            return result;
+        });
+
+        Assert.Collection(
+            rows,
+            row =>
+            {
+                Assert.Equal(EventType.BecamePro, row.Type);
+                Assert.Equal(1, row.VisibleOnWebsite);
+                Assert.Equal(1, row.SlackProcessed);
+                Assert.Equal(1, row.XProcessed);
+                Assert.Equal(1, row.ThreadsProcessed);
+                Assert.Equal(1, row.FacebookProcessed);
+            },
+            row =>
+            {
+                Assert.Equal(EventType.BiologicalAgeImproved, row.Type);
+                Assert.Equal(1, row.VisibleOnWebsite);
+                Assert.Equal(1, row.SlackProcessed);
+                Assert.Equal(1, row.XProcessed);
+                Assert.Equal(1, row.ThreadsProcessed);
+                Assert.Equal(1, row.FacebookProcessed);
+            });
+    }
+
+    [Fact]
     public async Task FacebookJob_MarksNonCustomRowsSkippedBeforePostingCustomEvent()
     {
         using var fixture = SocialJobFixture.Create(facebookSendSucceeds: true);

--- a/LongevityWorldCup.Tests/SocialMessageBuilderTests.cs
+++ b/LongevityWorldCup.Tests/SocialMessageBuilderTests.cs
@@ -32,6 +32,87 @@ public sealed class SocialMessageBuilderTests
     }
 
     [Fact]
+    public void BecameProEventBuilders_ReturnGoldenMessages()
+    {
+        const string raw = "slug[siim_land]";
+        var expectedX =
+            "Siim Land went Pro.\n\n" +
+            "Bortz Age results now place them in the Pro track.\n\n" +
+            "https://longevityworldcup.com/athlete/siim-land";
+        const string expectedSlack =
+            "<https://longevityworldcup.com/athlete/siim-land|Siim Land> went Pro";
+
+        Assert.Equal(expectedX, XMessageBuilder.ForEventText(EventType.BecamePro, raw, SlugToName));
+        Assert.Equal(expectedX, ThreadsMessageBuilder.ForEventText(EventType.BecamePro, raw, SlugToName));
+        Assert.Equal(expectedSlack, SlackMessageBuilder.ForEventText(EventType.BecamePro, raw, SlugToName));
+    }
+
+    [Fact]
+    public void MergedSlackRankAndBecameProEvent_ReturnsWentProMessage()
+    {
+        var items = new[]
+        {
+            (EventType.NewRank, "slug[siim_land] rank[2] prev[bryan_johnson]"),
+            (EventType.BecamePro, "slug[siim_land]")
+        };
+        const string expected =
+            "In the Ultimate League, <https://longevityworldcup.com/athlete/siim-land|Siim Land> is now #2 🥈, ahead of <https://longevityworldcup.com/athlete/bryan-johnson|Bryan Johnson>, and went Pro";
+
+        Assert.Equal(expected, SlackMessageBuilder.ForMergedGroup(items, SlugToName));
+    }
+
+    [Theory]
+    [InlineData("pheno", "pheno age")]
+    [InlineData("bortz", "Bortz Age")]
+    public void BiologicalAgeImprovementEventBuilders_ReturnGoldenMessages(string clock, string expectedClockLabel)
+    {
+        var raw = $"slug[siim_land] clock[{clock}] from[44.21] to[41.8]";
+        var expectedX =
+            $"Siim Land improved their {expectedClockLabel} from 44.21 to 41.8 years.\n\n" +
+            "https://longevityworldcup.com/athlete/siim-land";
+        var expectedSlack =
+            $"<https://longevityworldcup.com/athlete/siim-land|Siim Land> improved their {expectedClockLabel} from 44.21 to 41.8 years";
+
+        Assert.Equal(expectedX, XMessageBuilder.ForEventText(EventType.BiologicalAgeImproved, raw, SlugToName));
+        Assert.Equal(expectedX, ThreadsMessageBuilder.ForEventText(EventType.BiologicalAgeImproved, raw, SlugToName));
+        Assert.Equal(expectedSlack, SlackMessageBuilder.ForEventText(EventType.BiologicalAgeImproved, raw, SlugToName));
+    }
+
+    [Fact]
+    public void CrowdAgeTop10ChangeEventBuilders_ReturnGoldenMessages()
+    {
+        const string raw = "slug[siim_land] place[3] prevPlace[8] prev[bryan_johnson] crowdAge[35.25] crowdCount[123]";
+        var expectedX =
+            "Siim Land climbed from 8th to 3rd in the Crowd Age leaderboard, ahead of Bryan Johnson.\n\n" +
+            "Crowd Age: 35.3 years from 123 guesses.\n\n" +
+            "https://longevityworldcup.com/athlete/siim-land?ctx=crowd";
+        var expectedSlack =
+            "<https://longevityworldcup.com/athlete/siim-land|Siim Land> climbed from 8th to 3rd in Crowd Age, ahead of <https://longevityworldcup.com/athlete/bryan-johnson|Bryan Johnson> (35.3 years, 123 guesses)";
+
+        Assert.Equal(expectedX, XMessageBuilder.ForEventText(EventType.CrowdAgeTop10Change, raw, SlugToName));
+        Assert.Equal(expectedX, ThreadsMessageBuilder.ForEventText(EventType.CrowdAgeTop10Change, raw, SlugToName));
+        Assert.Equal(expectedSlack, SlackMessageBuilder.ForEventText(EventType.CrowdAgeTop10Change, raw, SlugToName));
+    }
+
+    [Theory]
+    [InlineData("pheno", "Pheno Improvement", "improvement")]
+    [InlineData("bortz", "Bortz Improvement", "bortz-improvement")]
+    public void AgeImprovementTop10ChangeEventBuilders_ReturnGoldenMessages(string clock, string leaderboardName, string ctx)
+    {
+        var raw = $"slug[siim_land] clock[{clock}] place[3] prevPlace[8] prev[bryan_johnson] improvement[-6.75] ageReduction[-20.4]";
+        var expectedX =
+            $"Siim Land climbed from 8th to 3rd in the {leaderboardName} leaderboard, ahead of Bryan Johnson.\n\n" +
+            "Improvement: -6.8 years from worst to latest eligible result.\n\n" +
+            $"https://longevityworldcup.com/athlete/siim-land?ctx={ctx}";
+        var expectedSlack =
+            $"<https://longevityworldcup.com/athlete/siim-land|Siim Land> climbed from 8th to 3rd in {leaderboardName}, ahead of <https://longevityworldcup.com/athlete/bryan-johnson|Bryan Johnson> (-6.8 years)";
+
+        Assert.Equal(expectedX, XMessageBuilder.ForEventText(EventType.AgeImprovementTop10Change, raw, SlugToName));
+        Assert.Equal(expectedX, ThreadsMessageBuilder.ForEventText(EventType.AgeImprovementTop10Change, raw, SlugToName));
+        Assert.Equal(expectedSlack, SlackMessageBuilder.ForEventText(EventType.AgeImprovementTop10Change, raw, SlugToName));
+    }
+
+    [Fact]
     public void CustomEventBuilders_ReturnGoldenMessages()
     {
         const string raw = "Community update\n\nSiim [bold](wins), [strong](majorly). Welcome [mention](siim_land).";

--- a/LongevityWorldCup.Website/Business/AthleteDataService.cs
+++ b/LongevityWorldCup.Website/Business/AthleteDataService.cs
@@ -63,6 +63,12 @@ public class AthleteDataService : IDisposable
 
     // single-column biomarker/test signature to detect new/changed test submissions
     private const string TestSigColumn = "TestSig";
+    private const string HadBortzColumn = "HadBortz";
+    private const string LastLowestPhenoAgeColumn = "LastLowestPhenoAge";
+    private const string LastLowestBortzAgeColumn = "LastLowestBortzAge";
+    private const string CrowdAgeTop10PlacementColumn = "CrowdAgeTop10Placement";
+    private const string PhenoImprovementTop10PlacementColumn = "PhenoImprovementTop10Placement";
+    private const string BortzImprovementTop10PlacementColumn = "BortzImprovementTop10Placement";
 
     // NEW: notify listeners (e.g., BadgeDataService) after reloads
     public event Action? AthletesChanged;
@@ -99,6 +105,12 @@ public class AthleteDataService : IDisposable
                 var hasCurrentPlacement = false;
                 var hasLastAgeDiff = false;
                 var hasTestSig = false; // track if our signature column exists
+                var hasHadBortz = false;
+                var hasLastLowestPhenoAge = false;
+                var hasLastLowestBortzAge = false;
+                var hasCrowdAgeTop10Placement = false;
+                var hasPhenoImprovementTop10Placement = false;
+                var hasBortzImprovementTop10Placement = false;
                 using (var r = cmd.ExecuteReader())
                 {
                     while (r.Read())
@@ -112,6 +124,18 @@ public class AthleteDataService : IDisposable
                             hasLastAgeDiff = true;
                         if (string.Equals(colName, TestSigColumn, StringComparison.OrdinalIgnoreCase))
                             hasTestSig = true;
+                        if (string.Equals(colName, HadBortzColumn, StringComparison.OrdinalIgnoreCase))
+                            hasHadBortz = true;
+                        if (string.Equals(colName, LastLowestPhenoAgeColumn, StringComparison.OrdinalIgnoreCase))
+                            hasLastLowestPhenoAge = true;
+                        if (string.Equals(colName, LastLowestBortzAgeColumn, StringComparison.OrdinalIgnoreCase))
+                            hasLastLowestBortzAge = true;
+                        if (string.Equals(colName, CrowdAgeTop10PlacementColumn, StringComparison.OrdinalIgnoreCase))
+                            hasCrowdAgeTop10Placement = true;
+                        if (string.Equals(colName, PhenoImprovementTop10PlacementColumn, StringComparison.OrdinalIgnoreCase))
+                            hasPhenoImprovementTop10Placement = true;
+                        if (string.Equals(colName, BortzImprovementTop10PlacementColumn, StringComparison.OrdinalIgnoreCase))
+                            hasBortzImprovementTop10Placement = true;
                     }
                 }
 
@@ -139,6 +163,36 @@ public class AthleteDataService : IDisposable
                 {
                     TryAddAthletesColumn(sqlite, $"{TestSigColumn} TEXT NULL");
                 }
+
+                if (!hasHadBortz)
+                {
+                    TryAddAthletesColumn(sqlite, $"{HadBortzColumn} INTEGER NULL");
+                }
+
+                if (!hasLastLowestPhenoAge)
+                {
+                    TryAddAthletesColumn(sqlite, $"{LastLowestPhenoAgeColumn} REAL NULL");
+                }
+
+                if (!hasLastLowestBortzAge)
+                {
+                    TryAddAthletesColumn(sqlite, $"{LastLowestBortzAgeColumn} REAL NULL");
+                }
+
+                if (!hasCrowdAgeTop10Placement)
+                {
+                    TryAddAthletesColumn(sqlite, $"{CrowdAgeTop10PlacementColumn} INTEGER NULL");
+                }
+
+                if (!hasPhenoImprovementTop10Placement)
+                {
+                    TryAddAthletesColumn(sqlite, $"{PhenoImprovementTop10PlacementColumn} INTEGER NULL");
+                }
+
+                if (!hasBortzImprovementTop10Placement)
+                {
+                    TryAddAthletesColumn(sqlite, $"{BortzImprovementTop10PlacementColumn} INTEGER NULL");
+                }
             }
         });
 
@@ -164,7 +218,9 @@ public class AthleteDataService : IDisposable
 
         // Hydrate persisted age‐guess stats from SQLite
         ReloadCrowdStats();
+        SyncCrowdAgeTop10Placements(emitEvents: false);
         HydrateAgeImprovementIntoAthletesJson();
+        SyncAgeImprovementTop10Placements(emitEvents: false);
         HydratePlacementsIntoAthletesJson();
         HydrateNewFlagsIntoAthletesJson();
         HydrateCurrentPlacementIntoAthletesJson(); // NOTE: no DB persist here
@@ -172,6 +228,10 @@ public class AthleteDataService : IDisposable
 
         // persist biomarker/test signature for all athletes (so we can detect new/changed tests later)
         var changedSigsAtStartup = SyncBiomarkerSignatures(); // returns slugs whose signatures changed
+        var becameProAtStartup = SyncProTrackStates(newlyJoined.Select(x => x.Athlete["AthleteSlug"]!.GetValue<string>()));
+        var bioAgeImprovementsAtStartup = SyncBestBioAgeStates(
+            changedSigsAtStartup,
+            newlyJoined.Select(x => x.Athlete["AthleteSlug"]!.GetValue<string>()));
 
         // Watch the per-athlete folders recursively
         var athletesDir = Path.Combine(env.WebRootPath, "athletes");
@@ -194,6 +254,16 @@ public class AthleteDataService : IDisposable
         {
             var payload = BuildJoinedPayloadWithReplaced(newlyJoined);
             eventDataService.CreateJoinedEventsForAthletes(payload, skipIfExists: true);
+        }
+
+        if (becameProAtStartup.Count > 0)
+        {
+            eventDataService.CreateBecameProEvents(becameProAtStartup, skipIfExists: true);
+        }
+
+        if (bioAgeImprovementsAtStartup.Count > 0)
+        {
+            eventDataService.CreateBiologicalAgeImprovementEvents(bioAgeImprovementsAtStartup, skipIfExists: true);
         }
 
         DetectAndEmitRankUpsForSlugs(
@@ -234,6 +304,7 @@ public class AthleteDataService : IDisposable
         try
         {
             ReloadCrowdStats();
+            SyncCrowdAgeTop10Placements(emitEvents: true);
             HydrateAgeImprovementIntoAthletesJson();
             HydratePlacementsIntoAthletesJson();
             HydrateNewFlagsIntoAthletesJson();
@@ -246,6 +317,7 @@ public class AthleteDataService : IDisposable
         }
 
         PushAthleteDirectoryToEvents();
+        SyncCrowdAgeTop10Placements(emitEvents: true);
         AthletesChanged?.Invoke();
     }
 
@@ -505,6 +577,7 @@ public class AthleteDataService : IDisposable
 
             ReloadCrowdStats();
             HydrateAgeImprovementIntoAthletesJson();
+            SyncAgeImprovementTop10Placements(emitEvents: true);
             HydratePlacementsIntoAthletesJson();
             HydrateNewFlagsIntoAthletesJson();
             HydrateCurrentPlacementIntoAthletesJson(); // NOTE: no DB persist here
@@ -512,11 +585,25 @@ public class AthleteDataService : IDisposable
 
             // recompute and persist biomarker/test signatures after reload
             var changedSigs = SyncBiomarkerSignatures();
+            var becamePro = SyncProTrackStates(newlyJoined.Select(x => x.Athlete["AthleteSlug"]!.GetValue<string>()));
+            var bioAgeImprovements = SyncBestBioAgeStates(
+                changedSigs,
+                newlyJoined.Select(x => x.Athlete["AthleteSlug"]!.GetValue<string>()));
 
             if (newlyJoined.Count > 0)
             {
                 var payload = BuildJoinedPayloadWithReplaced(newlyJoined);
                 _eventDataService.CreateJoinedEventsForAthletes(payload, skipIfExists: true);
+            }
+
+            if (becamePro.Count > 0)
+            {
+                _eventDataService.CreateBecameProEvents(becamePro, skipIfExists: true);
+            }
+
+            if (bioAgeImprovements.Count > 0)
+            {
+                _eventDataService.CreateBiologicalAgeImprovementEvents(bioAgeImprovements, skipIfExists: true);
             }
 
             DetectAndEmitRankUpsForSlugs(
@@ -930,6 +1017,92 @@ public class AthleteDataService : IDisposable
         return list;
     }
 
+    private IReadOnlyList<(string Slug, int Place, double CrowdAge, int CrowdCount)> GetCrowdAgeTop10Snapshot()
+    {
+        return CompetitionRanking.SortByCrowdAgeRules(GetCrowdAgeRankCandidates())
+            .Take(10)
+            .Select((candidate, index) => (
+                candidate.Slug,
+                Place: index + 1,
+                candidate.CrowdAge,
+                candidate.CrowdCount))
+            .ToList();
+    }
+
+    private void SyncCrowdAgeTop10Placements(bool emitEvents)
+    {
+        var currentTop10 = GetCrowdAgeTop10Snapshot();
+        var currentBySlug = currentTop10.ToDictionary(x => x.Slug, x => x, StringComparer.OrdinalIgnoreCase);
+        var changed = new List<(string AthleteSlug, DateTime OccurredAtUtc, int Place, int? PreviousPlace, string? PreviousSlug, double CrowdAge, int CrowdCount)>();
+        var nowUtc = DateTime.UtcNow;
+
+        _db.Run(sqlite =>
+        {
+            using var tx = sqlite.BeginTransaction();
+
+            using var select = sqlite.CreateCommand();
+            select.Transaction = tx;
+            select.CommandText = $"SELECT Key, {CrowdAgeTop10PlacementColumn} FROM Athletes";
+
+            var stored = new List<(string Slug, int? Place)>();
+            using (var r = select.ExecuteReader())
+            {
+                while (r.Read())
+                {
+                    var slug = r.GetString(0);
+                    var place = r.IsDBNull(1) ? (int?)null : r.GetInt32(1);
+                    stored.Add((slug, place));
+                }
+            }
+
+            var previousSlugByPlace = stored
+                .Where(x => x.Place is >= 1 and <= 10)
+                .GroupBy(x => x.Place!.Value)
+                .ToDictionary(g => g.Key, g => g.First().Slug);
+
+            using var update = sqlite.CreateCommand();
+            update.Transaction = tx;
+            update.CommandText = $"UPDATE Athletes SET {CrowdAgeTop10PlacementColumn}=@place WHERE Key=@slug";
+            var pPlace = update.Parameters.Add("@place", SqliteType.Integer);
+            var pSlug = update.Parameters.Add("@slug", SqliteType.Text);
+
+            foreach (var (slug, previousPlace) in stored)
+            {
+                currentBySlug.TryGetValue(slug, out var current);
+                int? currentPlace = current.Place is >= 1 and <= 10 ? current.Place : null;
+
+                if (emitEvents &&
+                    currentPlace.HasValue &&
+                    previousPlace != currentPlace)
+                {
+                    previousSlugByPlace.TryGetValue(currentPlace.Value, out var previousSlug);
+                    if (string.Equals(previousSlug, slug, StringComparison.OrdinalIgnoreCase))
+                        previousSlug = null;
+
+                    changed.Add((
+                        slug,
+                        nowUtc,
+                        currentPlace.Value,
+                        previousPlace,
+                        previousSlug,
+                        current.CrowdAge,
+                        current.CrowdCount));
+                }
+
+                if (previousPlace == currentPlace) continue;
+
+                pPlace.Value = currentPlace.HasValue ? currentPlace.Value : DBNull.Value;
+                pSlug.Value = slug;
+                update.ExecuteNonQuery();
+            }
+
+            tx.Commit();
+        });
+
+        if (changed.Count > 0)
+            _eventDataService.CreateCrowdAgeTop10ChangeEvents(changed, skipIfExists: true);
+    }
+
     private IReadOnlyList<PhenoAgeImprovementRankCandidate> GetPhenoAgeImprovementRankCandidates()
     {
         var snapshot = GetAthletesSnapshot();
@@ -984,6 +1157,130 @@ public class AthleteDataService : IDisposable
         }
 
         return list;
+    }
+
+    private IReadOnlyList<(string Slug, int Place, string Clock, double Improvement, double AgeReduction)> GetAgeImprovementTop10Snapshot(string clock)
+    {
+        if (string.Equals(clock, "pheno", StringComparison.OrdinalIgnoreCase))
+        {
+            return CompetitionRanking.SortByPhenoAgeImprovementRules(GetPhenoAgeImprovementRankCandidates())
+                .Take(10)
+                .Select((candidate, index) => (
+                    candidate.Slug,
+                    Place: index + 1,
+                    Clock: "pheno",
+                    Improvement: candidate.PhenoAgeImprovement,
+                    AgeReduction: candidate.PhenoAgeReduction))
+                .ToList();
+        }
+
+        if (string.Equals(clock, "bortz", StringComparison.OrdinalIgnoreCase))
+        {
+            return CompetitionRanking.SortByBortzAgeImprovementRules(GetBortzAgeImprovementRankCandidates())
+                .Take(10)
+                .Select((candidate, index) => (
+                    candidate.Slug,
+                    Place: index + 1,
+                    Clock: "bortz",
+                    Improvement: candidate.BortzAgeImprovement,
+                    AgeReduction: candidate.BortzAgeReduction))
+                .ToList();
+        }
+
+        return [];
+    }
+
+    private void SyncAgeImprovementTop10Placements(bool emitEvents)
+    {
+        SyncAgeImprovementTop10Placements(
+            clock: "pheno",
+            placementColumn: PhenoImprovementTop10PlacementColumn,
+            currentTop10: GetAgeImprovementTop10Snapshot("pheno"),
+            emitEvents: emitEvents);
+
+        SyncAgeImprovementTop10Placements(
+            clock: "bortz",
+            placementColumn: BortzImprovementTop10PlacementColumn,
+            currentTop10: GetAgeImprovementTop10Snapshot("bortz"),
+            emitEvents: emitEvents);
+    }
+
+    private void SyncAgeImprovementTop10Placements(
+        string clock,
+        string placementColumn,
+        IReadOnlyList<(string Slug, int Place, string Clock, double Improvement, double AgeReduction)> currentTop10,
+        bool emitEvents)
+    {
+        var currentBySlug = currentTop10.ToDictionary(x => x.Slug, x => x, StringComparer.OrdinalIgnoreCase);
+        var changed = new List<(string AthleteSlug, DateTime OccurredAtUtc, string Clock, int Place, int? PreviousPlace, string? PreviousSlug, double Improvement, double AgeReduction)>();
+        var nowUtc = DateTime.UtcNow;
+
+        _db.Run(sqlite =>
+        {
+            using var tx = sqlite.BeginTransaction();
+
+            using var select = sqlite.CreateCommand();
+            select.Transaction = tx;
+            select.CommandText = $"SELECT Key, {placementColumn} FROM Athletes";
+
+            var stored = new List<(string Slug, int? Place)>();
+            using (var r = select.ExecuteReader())
+            {
+                while (r.Read())
+                {
+                    var slug = r.GetString(0);
+                    var place = r.IsDBNull(1) ? (int?)null : r.GetInt32(1);
+                    stored.Add((slug, place));
+                }
+            }
+
+            var previousSlugByPlace = stored
+                .Where(x => x.Place is >= 1 and <= 10)
+                .GroupBy(x => x.Place!.Value)
+                .ToDictionary(g => g.Key, g => g.First().Slug);
+
+            using var update = sqlite.CreateCommand();
+            update.Transaction = tx;
+            update.CommandText = $"UPDATE Athletes SET {placementColumn}=@place WHERE Key=@slug";
+            var pPlace = update.Parameters.Add("@place", SqliteType.Integer);
+            var pSlug = update.Parameters.Add("@slug", SqliteType.Text);
+
+            foreach (var (slug, previousPlace) in stored)
+            {
+                currentBySlug.TryGetValue(slug, out var current);
+                int? currentPlace = current.Place is >= 1 and <= 10 ? current.Place : null;
+
+                if (emitEvents &&
+                    currentPlace.HasValue &&
+                    previousPlace != currentPlace)
+                {
+                    previousSlugByPlace.TryGetValue(currentPlace.Value, out var previousSlug);
+                    if (string.Equals(previousSlug, slug, StringComparison.OrdinalIgnoreCase))
+                        previousSlug = null;
+
+                    changed.Add((
+                        slug,
+                        nowUtc,
+                        clock,
+                        currentPlace.Value,
+                        previousPlace,
+                        previousSlug,
+                        current.Improvement,
+                        current.AgeReduction));
+                }
+
+                if (previousPlace == currentPlace) continue;
+
+                pPlace.Value = currentPlace.HasValue ? currentPlace.Value : DBNull.Value;
+                pSlug.Value = slug;
+                update.ExecuteNonQuery();
+            }
+
+            tx.Commit();
+        });
+
+        if (changed.Count > 0)
+            _eventDataService.CreateAgeImprovementTop10ChangeEvents(changed, skipIfExists: true);
     }
 
     private static double CalculateAgeAtDate(DateTime birthDateUtc, DateTime atDateUtc)
@@ -1836,6 +2133,183 @@ public class AthleteDataService : IDisposable
         }
 
         return map;
+    }
+
+    private List<(string AthleteSlug, DateTime OccurredAtUtc)> SyncProTrackStates(IEnumerable<string>? newcomerSlugs)
+    {
+        var newcomers = newcomerSlugs?.ToHashSet(StringComparer.OrdinalIgnoreCase)
+                        ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var current = BuildProTrackMap();
+        var nowUtc = DateTime.UtcNow;
+        var becamePro = new List<(string AthleteSlug, DateTime OccurredAtUtc)>();
+
+        _db.Run(sqlite =>
+        {
+            using var tx = sqlite.BeginTransaction();
+
+            using var select = sqlite.CreateCommand();
+            select.Transaction = tx;
+            select.CommandText = $"SELECT Key, {HadBortzColumn} FROM Athletes";
+
+            var stored = new List<(string Slug, int? HadBortz)>();
+            using (var r = select.ExecuteReader())
+            {
+                while (r.Read())
+                {
+                    var slug = r.GetString(0);
+                    int? hadBortz = r.IsDBNull(1) ? null : r.GetInt32(1);
+                    stored.Add((slug, hadBortz));
+                }
+            }
+
+            using var update = sqlite.CreateCommand();
+            update.Transaction = tx;
+            update.CommandText = $"UPDATE Athletes SET {HadBortzColumn}=@hadBortz WHERE Key=@slug";
+            var pHadBortz = update.Parameters.Add("@hadBortz", SqliteType.Integer);
+            var pSlug = update.Parameters.Add("@slug", SqliteType.Text);
+
+            foreach (var (slug, hadBortz) in stored)
+            {
+                var hasBortzNow = current.TryGetValue(slug, out var isPro) && isPro;
+                if (hadBortz == 0 && hasBortzNow && !newcomers.Contains(slug))
+                {
+                    becamePro.Add((slug, nowUtc));
+                }
+
+                var currentValue = hasBortzNow ? 1 : 0;
+                if (hadBortz == currentValue) continue;
+
+                pHadBortz.Value = currentValue;
+                pSlug.Value = slug;
+                update.ExecuteNonQuery();
+            }
+
+            tx.Commit();
+        });
+
+        return becamePro;
+    }
+
+    private Dictionary<string, bool> BuildProTrackMap()
+    {
+        var map = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+        var rankings = GetRankingsOrder();
+        foreach (var o in rankings.OfType<JsonObject>())
+        {
+            var slug = o["AthleteSlug"]?.GetValue<string>();
+            if (string.IsNullOrWhiteSpace(slug)) continue;
+
+            map[slug] = o["LowestBortzAge"] is JsonValue bortzVal &&
+                        bortzVal.TryGetValue<double>(out var bortzAge) &&
+                        double.IsFinite(bortzAge);
+        }
+
+        return map;
+    }
+
+    private List<(string AthleteSlug, DateTime OccurredAtUtc, string Clock, double PreviousAge, double NewAge)> SyncBestBioAgeStates(
+        IEnumerable<string>? changedSlugs,
+        IEnumerable<string>? newcomerSlugs)
+    {
+        var changed = changedSlugs?.ToHashSet(StringComparer.OrdinalIgnoreCase)
+                      ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var newcomers = newcomerSlugs?.ToHashSet(StringComparer.OrdinalIgnoreCase)
+                        ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var current = BuildBestBioAgeMap();
+        var nowUtc = DateTime.UtcNow;
+        var improvements = new List<(string AthleteSlug, DateTime OccurredAtUtc, string Clock, double PreviousAge, double NewAge)>();
+
+        _db.Run(sqlite =>
+        {
+            using var tx = sqlite.BeginTransaction();
+
+            using var select = sqlite.CreateCommand();
+            select.Transaction = tx;
+            select.CommandText = $"SELECT Key, {LastLowestPhenoAgeColumn}, {LastLowestBortzAgeColumn} FROM Athletes";
+
+            var stored = new List<(string Slug, double? LastPheno, double? LastBortz)>();
+            using (var r = select.ExecuteReader())
+            {
+                while (r.Read())
+                {
+                    var slug = r.GetString(0);
+                    var lastPheno = r.IsDBNull(1) ? (double?)null : r.GetDouble(1);
+                    var lastBortz = r.IsDBNull(2) ? (double?)null : r.GetDouble(2);
+                    stored.Add((slug, lastPheno, lastBortz));
+                }
+            }
+
+            using var update = sqlite.CreateCommand();
+            update.Transaction = tx;
+            update.CommandText =
+                $"UPDATE Athletes SET {LastLowestPhenoAgeColumn}=@pheno, {LastLowestBortzAgeColumn}=@bortz WHERE Key=@slug";
+            var pPheno = update.Parameters.Add("@pheno", SqliteType.Real);
+            var pBortz = update.Parameters.Add("@bortz", SqliteType.Real);
+            var pSlug = update.Parameters.Add("@slug", SqliteType.Text);
+
+            foreach (var (slug, lastPheno, lastBortz) in stored)
+            {
+                current.TryGetValue(slug, out var currentAges);
+                var currentPheno = currentAges.Pheno;
+                var currentBortz = currentAges.Bortz;
+                var canEmit = changed.Contains(slug) && !newcomers.Contains(slug);
+
+                if (canEmit && IsImproved(lastPheno, currentPheno))
+                    improvements.Add((slug, nowUtc, "pheno", lastPheno!.Value, currentPheno!.Value));
+
+                if (canEmit && IsImproved(lastBortz, currentBortz))
+                    improvements.Add((slug, nowUtc, "bortz", lastBortz!.Value, currentBortz!.Value));
+
+                if (SameNullableDouble(lastPheno, currentPheno) && SameNullableDouble(lastBortz, currentBortz))
+                    continue;
+
+                pPheno.Value = currentPheno.HasValue ? currentPheno.Value : DBNull.Value;
+                pBortz.Value = currentBortz.HasValue ? currentBortz.Value : DBNull.Value;
+                pSlug.Value = slug;
+                update.ExecuteNonQuery();
+            }
+
+            tx.Commit();
+        });
+
+        return improvements;
+    }
+
+    private Dictionary<string, (double? Pheno, double? Bortz)> BuildBestBioAgeMap()
+    {
+        var snapshot = GetAthletesSnapshot();
+        var statsMap = PhenoStatsCalculator.BuildAll(snapshot, DateTime.UtcNow.Date);
+        var map = new Dictionary<string, (double? Pheno, double? Bortz)>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var result in statsMap.Values)
+        {
+            var pheno = result.SubmissionCount > 0 && result.LowestPhenoAge.HasValue && double.IsFinite(result.LowestPhenoAge.Value)
+                ? result.LowestPhenoAge
+                : null;
+            var bortz = result.BortzSubmissionCount > 0 && result.LowestBortzAge.HasValue && double.IsFinite(result.LowestBortzAge.Value)
+                ? result.LowestBortzAge
+                : null;
+            map[result.Slug] = (pheno, bortz);
+        }
+
+        return map;
+    }
+
+    private static bool IsImproved(double? previous, double? current)
+    {
+        return previous.HasValue &&
+               current.HasValue &&
+               double.IsFinite(previous.Value) &&
+               double.IsFinite(current.Value) &&
+               current.Value < previous.Value;
+    }
+
+    private static bool SameNullableDouble(double? left, double? right)
+    {
+        if (!left.HasValue || !right.HasValue)
+            return !left.HasValue && !right.HasValue;
+
+        return Math.Abs(left.Value - right.Value) < 0.0000001;
     }
 
     private void PersistCurrentPlacementsSnapshot(Dictionary<string, int> current, Dictionary<string, double> currentAgeDiffs)

--- a/LongevityWorldCup.Website/Business/EventDataService.cs
+++ b/LongevityWorldCup.Website/Business/EventDataService.cs
@@ -28,7 +28,11 @@ public enum EventType
     BadgeAward = 5,
     CustomEvent = 6,
     SeasonFinalResult = 7,
-    LongevitymaxxingChallengeResult = 8
+    LongevitymaxxingChallengeResult = 8,
+    BecamePro = 9,
+    BiologicalAgeImproved = 10,
+    CrowdAgeTop10Change = 11,
+    AgeImprovementTop10Change = 12
 }
 
 public sealed record CustomEventDeliveryTargets(
@@ -84,6 +88,10 @@ public sealed class EventDataService : IDisposable
     private const double DefaultRelevanceAthleteMilestone = 8d;
     private const double DefaultRelevanceBadgeAward = 8d;
     private const double DefaultRelevanceLongevitymaxxingChallengeResult = 9d;
+    private const double DefaultRelevanceBecamePro = 9d;
+    private const double DefaultRelevanceBiologicalAgeImproved = 9d;
+    private const double DefaultRelevanceCrowdAgeTop10Change = 8d;
+    private const double DefaultRelevanceAgeImprovementTop10Change = 8d;
     private const int MaxCustomEventRetries = 3;
 
     private readonly DatabaseManager _db;
@@ -676,6 +684,26 @@ public sealed class EventDataService : IDisposable
             return 8;
         }
 
+        if (type == EventType.BecamePro)
+        {
+            return 8;
+        }
+
+        if (type == EventType.BiologicalAgeImproved)
+        {
+            return 8;
+        }
+
+        if (type == EventType.CrowdAgeTop10Change)
+        {
+            return 8;
+        }
+
+        if (type == EventType.AgeImprovementTop10Change)
+        {
+            return 8;
+        }
+
         return 99;
     }
 
@@ -925,6 +953,302 @@ public sealed class EventDataService : IDisposable
                 pType.Value = (int)EventType.NewRank;
                 pText.Value = text;
                 pOcc.Value = occurredAt;
+                pRel.Value = defaultRelevance;
+                insertCmd.ExecuteNonQuery();
+                created++;
+            }
+
+            tx.Commit();
+        });
+
+        if (created > 0)
+        {
+            ReloadIntoCache();
+        }
+    }
+
+    public void CreateBecameProEvents(
+        IEnumerable<(string AthleteSlug, DateTime OccurredAtUtc)> items,
+        bool skipIfExists = true,
+        double defaultRelevance = DefaultRelevanceBecamePro)
+    {
+        if (items is null) throw new ArgumentNullException(nameof(items));
+
+        int created = 0;
+
+        _db.Run(sqlite =>
+        {
+            using var tx = sqlite.BeginTransaction();
+
+            using var existsCmd = sqlite.CreateCommand();
+            existsCmd.Transaction = tx;
+            existsCmd.CommandText = "SELECT 1 FROM Events WHERE Type=@t AND Text=@txt LIMIT 1;";
+            var exType = existsCmd.Parameters.Add("@t", SqliteType.Integer);
+            var exText = existsCmd.Parameters.Add("@txt", SqliteType.Text);
+
+            using var insertCmd = sqlite.CreateCommand();
+            insertCmd.Transaction = tx;
+            insertCmd.CommandText =
+                "INSERT INTO Events (Id, Type, Text, OccurredAt, Relevance) VALUES (@id, @type, @text, @occ, @rel);";
+            var pId = insertCmd.Parameters.Add("@id", SqliteType.Text);
+            var pType = insertCmd.Parameters.Add("@type", SqliteType.Integer);
+            var pText = insertCmd.Parameters.Add("@text", SqliteType.Text);
+            var pOcc = insertCmd.Parameters.Add("@occ", SqliteType.Text);
+            var pRel = insertCmd.Parameters.Add("@rel", SqliteType.Real);
+
+            foreach (var (slug, occurredAtUtc) in items)
+            {
+                if (string.IsNullOrWhiteSpace(slug)) continue;
+
+                var text = $"slug[{slug}]";
+                var shouldInsert = true;
+                if (skipIfExists)
+                {
+                    exType.Value = (int)EventType.BecamePro;
+                    exText.Value = text;
+                    shouldInsert = existsCmd.ExecuteScalar() == null;
+                }
+
+                if (!shouldInsert) continue;
+
+                pId.Value = Guid.NewGuid().ToString("N");
+                pType.Value = (int)EventType.BecamePro;
+                pText.Value = text;
+                pOcc.Value = EnsureUtc(occurredAtUtc).ToString("o");
+                pRel.Value = defaultRelevance;
+                insertCmd.ExecuteNonQuery();
+                created++;
+            }
+
+            tx.Commit();
+        });
+
+        if (created > 0)
+        {
+            ReloadIntoCache();
+        }
+    }
+
+    public void CreateBiologicalAgeImprovementEvents(
+        IEnumerable<(string AthleteSlug, DateTime OccurredAtUtc, string Clock, double PreviousAge, double NewAge)> items,
+        bool skipIfExists = true,
+        double defaultRelevance = DefaultRelevanceBiologicalAgeImproved)
+    {
+        if (items is null) throw new ArgumentNullException(nameof(items));
+
+        int created = 0;
+
+        _db.Run(sqlite =>
+        {
+            using var tx = sqlite.BeginTransaction();
+
+            using var existsCmd = sqlite.CreateCommand();
+            existsCmd.Transaction = tx;
+            existsCmd.CommandText = "SELECT 1 FROM Events WHERE Type=@t AND Text=@txt LIMIT 1;";
+            var exType = existsCmd.Parameters.Add("@t", SqliteType.Integer);
+            var exText = existsCmd.Parameters.Add("@txt", SqliteType.Text);
+
+            using var insertCmd = sqlite.CreateCommand();
+            insertCmd.Transaction = tx;
+            insertCmd.CommandText =
+                "INSERT INTO Events (Id, Type, Text, OccurredAt, Relevance) VALUES (@id, @type, @text, @occ, @rel);";
+            var pId = insertCmd.Parameters.Add("@id", SqliteType.Text);
+            var pType = insertCmd.Parameters.Add("@type", SqliteType.Integer);
+            var pText = insertCmd.Parameters.Add("@text", SqliteType.Text);
+            var pOcc = insertCmd.Parameters.Add("@occ", SqliteType.Text);
+            var pRel = insertCmd.Parameters.Add("@rel", SqliteType.Real);
+
+            foreach (var (slug, occurredAtUtc, clock, previousAge, newAge) in items)
+            {
+                if (string.IsNullOrWhiteSpace(slug)) continue;
+                var normalizedClock = NormalizeImprovementClock(clock);
+                if (normalizedClock is null) continue;
+                if (!double.IsFinite(previousAge) || !double.IsFinite(newAge)) continue;
+                if (newAge >= previousAge) continue;
+
+                var previousText = previousAge.ToString("0.##", CultureInfo.InvariantCulture);
+                var newText = newAge.ToString("0.##", CultureInfo.InvariantCulture);
+                var text = $"slug[{slug}] clock[{normalizedClock}] from[{previousText}] to[{newText}]";
+
+                var shouldInsert = true;
+                if (skipIfExists)
+                {
+                    exType.Value = (int)EventType.BiologicalAgeImproved;
+                    exText.Value = text;
+                    shouldInsert = existsCmd.ExecuteScalar() == null;
+                }
+
+                if (!shouldInsert) continue;
+
+                pId.Value = Guid.NewGuid().ToString("N");
+                pType.Value = (int)EventType.BiologicalAgeImproved;
+                pText.Value = text;
+                pOcc.Value = EnsureUtc(occurredAtUtc).ToString("o");
+                pRel.Value = defaultRelevance;
+                insertCmd.ExecuteNonQuery();
+                created++;
+            }
+
+            tx.Commit();
+        });
+
+        if (created > 0)
+        {
+            ReloadIntoCache();
+        }
+    }
+
+    public void CreateCrowdAgeTop10ChangeEvents(
+        IEnumerable<(string AthleteSlug, DateTime OccurredAtUtc, int Place, int? PreviousPlace, string? PreviousSlug, double CrowdAge, int CrowdCount)> items,
+        bool skipIfExists = true,
+        double defaultRelevance = DefaultRelevanceCrowdAgeTop10Change)
+    {
+        if (items is null) throw new ArgumentNullException(nameof(items));
+
+        int created = 0;
+
+        _db.Run(sqlite =>
+        {
+            using var tx = sqlite.BeginTransaction();
+
+            using var existsCmd = sqlite.CreateCommand();
+            existsCmd.Transaction = tx;
+            existsCmd.CommandText = "SELECT 1 FROM Events WHERE Type=@t AND Text=@txt LIMIT 1;";
+            var exType = existsCmd.Parameters.Add("@t", SqliteType.Integer);
+            var exText = existsCmd.Parameters.Add("@txt", SqliteType.Text);
+
+            using var insertCmd = sqlite.CreateCommand();
+            insertCmd.Transaction = tx;
+            insertCmd.CommandText =
+                "INSERT INTO Events (Id, Type, Text, OccurredAt, Relevance) VALUES (@id, @type, @text, @occ, @rel);";
+            var pId = insertCmd.Parameters.Add("@id", SqliteType.Text);
+            var pType = insertCmd.Parameters.Add("@type", SqliteType.Integer);
+            var pText = insertCmd.Parameters.Add("@text", SqliteType.Text);
+            var pOcc = insertCmd.Parameters.Add("@occ", SqliteType.Text);
+            var pRel = insertCmd.Parameters.Add("@rel", SqliteType.Real);
+
+            foreach (var (slug, occurredAtUtc, place, previousPlace, previousSlug, crowdAge, crowdCount) in items)
+            {
+                if (string.IsNullOrWhiteSpace(slug)) continue;
+                if (place is < 1 or > 10) continue;
+                if (previousPlace is < 1 or > 10) continue;
+                if (!double.IsFinite(crowdAge)) continue;
+                if (crowdCount < 1) continue;
+
+                var parts = new List<string>
+                {
+                    $"slug[{NormalizeEventToken(slug)}]",
+                    $"place[{place.ToString(CultureInfo.InvariantCulture)}]"
+                };
+
+                if (previousPlace.HasValue)
+                    parts.Add($"prevPlace[{previousPlace.Value.ToString(CultureInfo.InvariantCulture)}]");
+                if (!string.IsNullOrWhiteSpace(previousSlug))
+                    parts.Add($"prev[{NormalizeEventToken(previousSlug)}]");
+
+                parts.Add($"crowdAge[{crowdAge.ToString("0.##", CultureInfo.InvariantCulture)}]");
+                parts.Add($"crowdCount[{crowdCount.ToString(CultureInfo.InvariantCulture)}]");
+
+                var text = string.Join(" ", parts);
+
+                var shouldInsert = true;
+                if (skipIfExists)
+                {
+                    exType.Value = (int)EventType.CrowdAgeTop10Change;
+                    exText.Value = text;
+                    shouldInsert = existsCmd.ExecuteScalar() == null;
+                }
+
+                if (!shouldInsert) continue;
+
+                pId.Value = Guid.NewGuid().ToString("N");
+                pType.Value = (int)EventType.CrowdAgeTop10Change;
+                pText.Value = text;
+                pOcc.Value = EnsureUtc(occurredAtUtc).ToString("o");
+                pRel.Value = defaultRelevance;
+                insertCmd.ExecuteNonQuery();
+                created++;
+            }
+
+            tx.Commit();
+        });
+
+        if (created > 0)
+        {
+            ReloadIntoCache();
+        }
+    }
+
+    public void CreateAgeImprovementTop10ChangeEvents(
+        IEnumerable<(string AthleteSlug, DateTime OccurredAtUtc, string Clock, int Place, int? PreviousPlace, string? PreviousSlug, double Improvement, double AgeReduction)> items,
+        bool skipIfExists = true,
+        double defaultRelevance = DefaultRelevanceAgeImprovementTop10Change)
+    {
+        if (items is null) throw new ArgumentNullException(nameof(items));
+
+        int created = 0;
+
+        _db.Run(sqlite =>
+        {
+            using var tx = sqlite.BeginTransaction();
+
+            using var existsCmd = sqlite.CreateCommand();
+            existsCmd.Transaction = tx;
+            existsCmd.CommandText = "SELECT 1 FROM Events WHERE Type=@t AND Text=@txt LIMIT 1;";
+            var exType = existsCmd.Parameters.Add("@t", SqliteType.Integer);
+            var exText = existsCmd.Parameters.Add("@txt", SqliteType.Text);
+
+            using var insertCmd = sqlite.CreateCommand();
+            insertCmd.Transaction = tx;
+            insertCmd.CommandText =
+                "INSERT INTO Events (Id, Type, Text, OccurredAt, Relevance) VALUES (@id, @type, @text, @occ, @rel);";
+            var pId = insertCmd.Parameters.Add("@id", SqliteType.Text);
+            var pType = insertCmd.Parameters.Add("@type", SqliteType.Integer);
+            var pText = insertCmd.Parameters.Add("@text", SqliteType.Text);
+            var pOcc = insertCmd.Parameters.Add("@occ", SqliteType.Text);
+            var pRel = insertCmd.Parameters.Add("@rel", SqliteType.Real);
+
+            foreach (var (slug, occurredAtUtc, rawClock, place, previousPlace, previousSlug, improvement, ageReduction) in items)
+            {
+                if (string.IsNullOrWhiteSpace(slug)) continue;
+                var clock = NormalizeImprovementClock(rawClock);
+                if (clock is null) continue;
+                if (place is < 1 or > 10) continue;
+                if (previousPlace is < 1 or > 10) continue;
+                if (!double.IsFinite(improvement)) continue;
+                if (!double.IsFinite(ageReduction)) continue;
+
+                var parts = new List<string>
+                {
+                    $"slug[{NormalizeEventToken(slug)}]",
+                    $"clock[{clock}]",
+                    $"place[{place.ToString(CultureInfo.InvariantCulture)}]"
+                };
+
+                if (previousPlace.HasValue)
+                    parts.Add($"prevPlace[{previousPlace.Value.ToString(CultureInfo.InvariantCulture)}]");
+                if (!string.IsNullOrWhiteSpace(previousSlug))
+                    parts.Add($"prev[{NormalizeEventToken(previousSlug)}]");
+
+                parts.Add($"improvement[{improvement.ToString("0.##", CultureInfo.InvariantCulture)}]");
+                parts.Add($"ageReduction[{ageReduction.ToString("0.##", CultureInfo.InvariantCulture)}]");
+
+                var text = string.Join(" ", parts);
+
+                var shouldInsert = true;
+                if (skipIfExists)
+                {
+                    exType.Value = (int)EventType.AgeImprovementTop10Change;
+                    exText.Value = text;
+                    shouldInsert = existsCmd.ExecuteScalar() == null;
+                }
+
+                if (!shouldInsert) continue;
+
+                pId.Value = Guid.NewGuid().ToString("N");
+                pType.Value = (int)EventType.AgeImprovementTop10Change;
+                pText.Value = text;
+                pOcc.Value = EnsureUtc(occurredAtUtc).ToString("o");
                 pRel.Value = defaultRelevance;
                 insertCmd.ExecuteNonQuery();
                 created++;
@@ -1540,11 +1864,15 @@ public sealed class EventDataService : IDisposable
             (filters.Count > 0 ? " WHERE " + string.Join(" AND ", filters) : "") +
             $" ORDER BY OccurredAt {(newestFirst ? "DESC" : "ASC")}, CASE " +
             $"WHEN Type = {(int)EventType.Joined} THEN 0 " +
-            $"WHEN Type = {(int)EventType.NewRank} THEN 1 " +
-            $"WHEN Type = {(int)EventType.SeasonFinalResult} THEN 2 " +
-            $"WHEN Type = {(int)EventType.LongevitymaxxingChallengeResult} THEN 3 " +
-            $"WHEN Type = {(int)EventType.BadgeAward} THEN 4 " +
-            $"ELSE 5 END ASC" +
+            $"WHEN Type = {(int)EventType.BecamePro} THEN 1 " +
+            $"WHEN Type = {(int)EventType.BiologicalAgeImproved} THEN 2 " +
+            $"WHEN Type = {(int)EventType.CrowdAgeTop10Change} THEN 3 " +
+            $"WHEN Type = {(int)EventType.AgeImprovementTop10Change} THEN 4 " +
+            $"WHEN Type = {(int)EventType.NewRank} THEN 5 " +
+            $"WHEN Type = {(int)EventType.SeasonFinalResult} THEN 6 " +
+            $"WHEN Type = {(int)EventType.LongevitymaxxingChallengeResult} THEN 7 " +
+            $"WHEN Type = {(int)EventType.BadgeAward} THEN 8 " +
+            $"ELSE 9 END ASC" +
             (limit.HasValue ? " LIMIT @limit OFFSET @offset" : "");
 
         return _db.Run(sqlite =>
@@ -1626,6 +1954,21 @@ public sealed class EventDataService : IDisposable
     private static DateTime EnsureUtc(DateTime dt) =>
         dt.Kind == DateTimeKind.Utc ? dt : DateTime.SpecifyKind(dt, DateTimeKind.Utc);
 
+    private static string? NormalizeImprovementClock(string? clock)
+    {
+        if (string.Equals(clock, "pheno", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(clock, "phenoage", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(clock, "pheno age", StringComparison.OrdinalIgnoreCase))
+            return "pheno";
+
+        if (string.Equals(clock, "bortz", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(clock, "bortzage", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(clock, "bortz age", StringComparison.OrdinalIgnoreCase))
+            return "bortz";
+
+        return null;
+    }
+
     private void FireAndForgetSlack(EventType type, string rawText)
     {
         if (type == EventType.NewRank)
@@ -1650,6 +1993,30 @@ public sealed class EventDataService : IDisposable
         if (type == EventType.DonationReceived || type == EventType.AthleteCountMilestone)
         {
             _ = _slackEvents.SendImmediateAsync(type, rawText);
+            return;
+        }
+
+        if (type == EventType.BecamePro)
+        {
+            _ = _slackEvents.BufferAsync(type, rawText);
+            return;
+        }
+
+        if (type == EventType.BiologicalAgeImproved)
+        {
+            _ = _slackEvents.BufferAsync(type, rawText);
+            return;
+        }
+
+        if (type == EventType.CrowdAgeTop10Change)
+        {
+            _ = _slackEvents.BufferAsync(type, rawText);
+            return;
+        }
+
+        if (type == EventType.AgeImprovementTop10Change)
+        {
+            _ = _slackEvents.BufferAsync(type, rawText);
             return;
         }
 

--- a/LongevityWorldCup.Website/Business/EventDataService.cs
+++ b/LongevityWorldCup.Website/Business/EventDataService.cs
@@ -334,6 +334,9 @@ public sealed class EventDataService : IDisposable
 
     internal static bool ShouldSkipSlackNotification(EventType type, DateTime occurredAtUtc, DateTime freshCutoffUtc)
     {
+        if (type is EventType.BecamePro or EventType.BiologicalAgeImproved)
+            return true;
+
         return type == EventType.AthleteCountMilestone && EnsureUtc(occurredAtUtc) < freshCutoffUtc;
     }
 
@@ -684,16 +687,6 @@ public sealed class EventDataService : IDisposable
             return 8;
         }
 
-        if (type == EventType.BecamePro)
-        {
-            return 8;
-        }
-
-        if (type == EventType.BiologicalAgeImproved)
-        {
-            return 8;
-        }
-
         if (type == EventType.CrowdAgeTop10Change)
         {
             return 8;
@@ -989,7 +982,8 @@ public sealed class EventDataService : IDisposable
             using var insertCmd = sqlite.CreateCommand();
             insertCmd.Transaction = tx;
             insertCmd.CommandText =
-                "INSERT INTO Events (Id, Type, Text, OccurredAt, Relevance) VALUES (@id, @type, @text, @occ, @rel);";
+                "INSERT INTO Events (Id, Type, Text, OccurredAt, Relevance, SlackProcessed, XProcessed, ThreadsProcessed, FacebookProcessed) " +
+                "VALUES (@id, @type, @text, @occ, @rel, 1, 1, 1, 1);";
             var pId = insertCmd.Parameters.Add("@id", SqliteType.Text);
             var pType = insertCmd.Parameters.Add("@type", SqliteType.Integer);
             var pText = insertCmd.Parameters.Add("@text", SqliteType.Text);
@@ -1051,7 +1045,8 @@ public sealed class EventDataService : IDisposable
             using var insertCmd = sqlite.CreateCommand();
             insertCmd.Transaction = tx;
             insertCmd.CommandText =
-                "INSERT INTO Events (Id, Type, Text, OccurredAt, Relevance) VALUES (@id, @type, @text, @occ, @rel);";
+                "INSERT INTO Events (Id, Type, Text, OccurredAt, Relevance, SlackProcessed, XProcessed, ThreadsProcessed, FacebookProcessed) " +
+                "VALUES (@id, @type, @text, @occ, @rel, 1, 1, 1, 1);";
             var pId = insertCmd.Parameters.Add("@id", SqliteType.Text);
             var pType = insertCmd.Parameters.Add("@type", SqliteType.Integer);
             var pText = insertCmd.Parameters.Add("@text", SqliteType.Text);
@@ -1993,18 +1988,6 @@ public sealed class EventDataService : IDisposable
         if (type == EventType.DonationReceived || type == EventType.AthleteCountMilestone)
         {
             _ = _slackEvents.SendImmediateAsync(type, rawText);
-            return;
-        }
-
-        if (type == EventType.BecamePro)
-        {
-            _ = _slackEvents.BufferAsync(type, rawText);
-            return;
-        }
-
-        if (type == EventType.BiologicalAgeImproved)
-        {
-            _ = _slackEvents.BufferAsync(type, rawText);
             return;
         }
 

--- a/LongevityWorldCup.Website/Business/SocialEventSkipPolicy.cs
+++ b/LongevityWorldCup.Website/Business/SocialEventSkipPolicy.cs
@@ -46,22 +46,10 @@ public static class SocialEventSkipPolicy
             return false;
         }
 
-        if (type == EventType.BecamePro)
+        if (type is EventType.BecamePro or EventType.BiologicalAgeImproved)
         {
-            reason = EventHelpers.TryExtractSlug(text, out var slug) && !string.IsNullOrWhiteSpace(slug)
-                ? default
-                : SocialEventSkipReason.UnsupportedEventPayload;
-            return reason != default;
-        }
-
-        if (type == EventType.BiologicalAgeImproved)
-        {
-            reason = EventHelpers.TryExtractSlug(text, out var slug) &&
-                     !string.IsNullOrWhiteSpace(slug) &&
-                     EventHelpers.TryExtractBiologicalAgeImprovement(text, out _, out _, out _)
-                ? default
-                : SocialEventSkipReason.UnsupportedEventPayload;
-            return reason != default;
+            reason = SocialEventSkipReason.UnsupportedEventType;
+            return true;
         }
 
         if (type == EventType.CrowdAgeTop10Change)

--- a/LongevityWorldCup.Website/Business/SocialEventSkipPolicy.cs
+++ b/LongevityWorldCup.Website/Business/SocialEventSkipPolicy.cs
@@ -46,6 +46,44 @@ public static class SocialEventSkipPolicy
             return false;
         }
 
+        if (type == EventType.BecamePro)
+        {
+            reason = EventHelpers.TryExtractSlug(text, out var slug) && !string.IsNullOrWhiteSpace(slug)
+                ? default
+                : SocialEventSkipReason.UnsupportedEventPayload;
+            return reason != default;
+        }
+
+        if (type == EventType.BiologicalAgeImproved)
+        {
+            reason = EventHelpers.TryExtractSlug(text, out var slug) &&
+                     !string.IsNullOrWhiteSpace(slug) &&
+                     EventHelpers.TryExtractBiologicalAgeImprovement(text, out _, out _, out _)
+                ? default
+                : SocialEventSkipReason.UnsupportedEventPayload;
+            return reason != default;
+        }
+
+        if (type == EventType.CrowdAgeTop10Change)
+        {
+            reason = EventHelpers.TryExtractSlug(text, out var slug) &&
+                     !string.IsNullOrWhiteSpace(slug) &&
+                     EventHelpers.TryExtractCrowdAgeTop10Change(text, out _, out _, out _, out _)
+                ? default
+                : SocialEventSkipReason.UnsupportedEventPayload;
+            return reason != default;
+        }
+
+        if (type == EventType.AgeImprovementTop10Change)
+        {
+            reason = EventHelpers.TryExtractSlug(text, out var slug) &&
+                     !string.IsNullOrWhiteSpace(slug) &&
+                     EventHelpers.TryExtractAgeImprovementTop10Change(text, out _, out _, out _, out _, out _)
+                ? default
+                : SocialEventSkipReason.UnsupportedEventPayload;
+            return reason != default;
+        }
+
         if (type == EventType.NewRank)
         {
             reason = EventHelpers.TryExtractRank(text, out var rank) && rank is >= 1 and <= 3

--- a/LongevityWorldCup.Website/Jobs/ThreadsDailyPostJob.cs
+++ b/LongevityWorldCup.Website/Jobs/ThreadsDailyPostJob.cs
@@ -412,7 +412,12 @@ public class ThreadsDailyPostJob : IJob
 
     private static string? TryGetSubjectSlugForEvent(EventType type, string rawText)
     {
-        if (type == EventType.NewRank || type == EventType.BadgeAward)
+        if (type == EventType.NewRank ||
+            type == EventType.BadgeAward ||
+            type == EventType.BecamePro ||
+            type == EventType.BiologicalAgeImproved ||
+            type == EventType.CrowdAgeTop10Change ||
+            type == EventType.AgeImprovementTop10Change)
         {
             if (EventHelpers.TryExtractSlug(rawText, out var slug) && !string.IsNullOrWhiteSpace(slug))
                 return slug.Trim();

--- a/LongevityWorldCup.Website/Jobs/XDailyPostJob.cs
+++ b/LongevityWorldCup.Website/Jobs/XDailyPostJob.cs
@@ -456,7 +456,12 @@ public class XDailyPostJob : IJob
 
     private static string? TryGetSubjectSlugForEvent(EventType type, string rawText)
     {
-        if (type == EventType.NewRank || type == EventType.BadgeAward)
+        if (type == EventType.NewRank ||
+            type == EventType.BadgeAward ||
+            type == EventType.BecamePro ||
+            type == EventType.BiologicalAgeImproved ||
+            type == EventType.CrowdAgeTop10Change ||
+            type == EventType.AgeImprovementTop10Change)
         {
             if (EventHelpers.TryExtractSlug(rawText, out var slug) && !string.IsNullOrWhiteSpace(slug))
                 return slug.Trim();

--- a/LongevityWorldCup.Website/Tools/EventHelpers.cs
+++ b/LongevityWorldCup.Website/Tools/EventHelpers.cs
@@ -41,6 +41,13 @@ public static class EventHelpers
         return int.TryParse(s, NumberStyles.None, CultureInfo.InvariantCulture, out place);
     }
 
+    public static bool TryExtractPreviousPlace(string raw, out int previousPlace)
+    {
+        previousPlace = 0;
+        if (!TryExtractField(raw, "prevPlace", out var s)) return false;
+        return int.TryParse(s, NumberStyles.None, CultureInfo.InvariantCulture, out previousPlace);
+    }
+
     public static bool TryExtractPrev(string raw, out string prev) => TryExtractField(raw, "prev", out prev);
 
     public static bool TryExtractPrevs(string raw, out string[] prevs) => TryExtractCsvList(raw, "prevs", out prevs);
@@ -52,6 +59,25 @@ public static class EventHelpers
     public static bool TryExtractValue(string raw, out string value) => TryExtractField(raw, "val", out value);
 
     public static bool TryExtractLeague(string raw, out string league) => TryExtractField(raw, "league", out league);
+
+    public static bool TryExtractClock(string raw, out string clock) => TryExtractField(raw, "clock", out clock);
+
+    public static bool TryExtractFromAge(string raw, out double age) => TryExtractDoubleField(raw, "from", out age);
+
+    public static bool TryExtractToAge(string raw, out double age) => TryExtractDoubleField(raw, "to", out age);
+
+    public static bool TryExtractCrowdAge(string raw, out double crowdAge) => TryExtractDoubleField(raw, "crowdAge", out crowdAge);
+
+    public static bool TryExtractImprovement(string raw, out double improvement) => TryExtractDoubleField(raw, "improvement", out improvement);
+
+    public static bool TryExtractAgeReduction(string raw, out double ageReduction) => TryExtractDoubleField(raw, "ageReduction", out ageReduction);
+
+    public static bool TryExtractCrowdCount(string raw, out int crowdCount)
+    {
+        crowdCount = 0;
+        if (!TryExtractField(raw, "crowdCount", out var s)) return false;
+        return int.TryParse(s, NumberStyles.None, CultureInfo.InvariantCulture, out crowdCount);
+    }
 
     public static bool TryExtractTx(string raw, out string tx) => TryExtractField(raw, "tx", out tx);
 
@@ -70,6 +96,86 @@ public static class EventHelpers
     }
 
     public static bool TryExtractDomain(string raw, out string domain) => TryExtractField(raw, "domain", out domain);
+
+    public static bool TryExtractBiologicalAgeImprovement(
+        string raw,
+        out string clock,
+        out double fromAge,
+        out double toAge)
+    {
+        clock = string.Empty;
+        fromAge = 0;
+        toAge = 0;
+
+        if (!TryExtractClock(raw, out var rawClock)) return false;
+        var normalizedClock = NormalizeClock(rawClock);
+        if (normalizedClock is null) return false;
+        if (!TryExtractFromAge(raw, out fromAge)) return false;
+        if (!TryExtractToAge(raw, out toAge)) return false;
+        if (!double.IsFinite(fromAge) || !double.IsFinite(toAge)) return false;
+        if (toAge >= fromAge) return false;
+
+        clock = normalizedClock;
+        return true;
+    }
+
+    public static bool TryExtractCrowdAgeTop10Change(
+        string raw,
+        out int place,
+        out int? previousPlace,
+        out double crowdAge,
+        out int crowdCount)
+    {
+        place = 0;
+        previousPlace = null;
+        crowdAge = 0;
+        crowdCount = 0;
+
+        if (!TryExtractPlace(raw, out place) || place is < 1 or > 10) return false;
+
+        if (TryExtractPreviousPlace(raw, out var parsedPreviousPlace))
+        {
+            if (parsedPreviousPlace is < 1 or > 10) return false;
+            previousPlace = parsedPreviousPlace;
+        }
+
+        if (!TryExtractCrowdAge(raw, out crowdAge) || !double.IsFinite(crowdAge)) return false;
+        if (!TryExtractCrowdCount(raw, out crowdCount) || crowdCount < 1) return false;
+
+        return true;
+    }
+
+    public static bool TryExtractAgeImprovementTop10Change(
+        string raw,
+        out string clock,
+        out int place,
+        out int? previousPlace,
+        out double improvement,
+        out double ageReduction)
+    {
+        clock = string.Empty;
+        place = 0;
+        previousPlace = null;
+        improvement = 0;
+        ageReduction = 0;
+
+        if (!TryExtractClock(raw, out var rawClock)) return false;
+        var normalizedClock = NormalizeClock(rawClock);
+        if (normalizedClock is null) return false;
+        if (!TryExtractPlace(raw, out place) || place is < 1 or > 10) return false;
+
+        if (TryExtractPreviousPlace(raw, out var parsedPreviousPlace))
+        {
+            if (parsedPreviousPlace is < 1 or > 10) return false;
+            previousPlace = parsedPreviousPlace;
+        }
+
+        if (!TryExtractImprovement(raw, out improvement) || !double.IsFinite(improvement)) return false;
+        if (!TryExtractAgeReduction(raw, out ageReduction) || !double.IsFinite(ageReduction)) return false;
+
+        clock = normalizedClock;
+        return true;
+    }
 
     public static string NormalizeBadgeLabel(string? label)
     {
@@ -134,6 +240,28 @@ public static class EventHelpers
         var m = Regex.Match(raw ?? string.Empty, $@"\b{Regex.Escape(field)}\[(.*?)\]", RegexOptions.CultureInvariant);
         value = m.Success ? m.Groups[1].Value : string.Empty;
         return m.Success;
+    }
+
+    static bool TryExtractDoubleField(string raw, string field, out double value)
+    {
+        value = 0;
+        if (!TryExtractField(raw, field, out var s)) return false;
+        return double.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out value);
+    }
+
+    static string? NormalizeClock(string? clock)
+    {
+        if (string.Equals(clock, "pheno", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(clock, "phenoage", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(clock, "pheno age", StringComparison.OrdinalIgnoreCase))
+            return "pheno";
+
+        if (string.Equals(clock, "bortz", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(clock, "bortzage", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(clock, "bortz age", StringComparison.OrdinalIgnoreCase))
+            return "bortz";
+
+        return null;
     }
 
     static bool TryExtractFlag(string raw, string field, out bool flag)

--- a/LongevityWorldCup.Website/Tools/SlackMessageBuilder.cs
+++ b/LongevityWorldCup.Website/Tools/SlackMessageBuilder.cs
@@ -18,6 +18,10 @@ public static class SlackMessageBuilder
         {
             EventType.NewRank => BuildNewRank(slug, rank, prev, slugToName),
             EventType.Joined => BuildJoined(slug, slugToName),
+            EventType.BecamePro => BuildBecamePro(slug, slugToName),
+            EventType.BiologicalAgeImproved => BuildBiologicalAgeImprovement(slug, rawText, slugToName),
+            EventType.CrowdAgeTop10Change => BuildCrowdAgeTop10Change(slug, rawText, slugToName),
+            EventType.AgeImprovementTop10Change => BuildAgeImprovementTop10Change(slug, rawText, slugToName),
             EventType.DonationReceived => BuildDonation(rawText),
             EventType.AthleteCountMilestone => BuildAthleteCountMilestone(rawText),
             EventType.BadgeAward => BuildBadgeAward(rawText, getPodcastLinkForSlug),
@@ -54,6 +58,7 @@ public static class SlackMessageBuilder
 
         int? newRank = null;
         string? prevSlug = null;
+        var hasBecamePro = false;
 
         bool hasPodcast = false;
 
@@ -69,6 +74,12 @@ public static class SlackMessageBuilder
 
         foreach (var it in list)
         {
+            if (it.Type == EventType.BecamePro)
+            {
+                hasBecamePro = true;
+                continue;
+            }
+
             if (it.Type == EventType.NewRank)
             {
                 if (EventHelpers.TryExtractRank(it.Raw, out var r)) newRank = r;
@@ -148,7 +159,8 @@ public static class SlackMessageBuilder
             }
         }
 
-        if (!newRank.HasValue || newRank.Value <= 0) return "";
+        if (!newRank.HasValue || newRank.Value <= 0)
+            return hasBecamePro ? BuildBecamePro(slug, slugToName) : "";
 
         static string F2(double v) => v.ToString("0.00", CultureInfo.InvariantCulture);
 
@@ -228,7 +240,7 @@ public static class SlackMessageBuilder
         var hasAwardExtras = !string.IsNullOrWhiteSpace(awardText);
         var hasPodcastExtra = hasPodcast;
 
-        if (!hasLeagueExtras && !hasAwardExtras && !hasPodcastExtra)
+        if (!hasBecamePro && !hasLeagueExtras && !hasAwardExtras && !hasPodcastExtra)
         {
             return BuildNewRank(slug, newRank.Value, prevSlug, slugToName);
         }
@@ -248,12 +260,17 @@ public static class SlackMessageBuilder
             sb.Append(prevLink);
         }
 
+        if (hasBecamePro)
+        {
+            sb.Append(", and went Pro");
+        }
+
         // If the athlete is already #1 in the Ultimate League, listing additional
         // #1 positions in sub-leagues/divisions is redundant noise for Slack.
         // In that case we intentionally skip the "also #1 in ..." wording.
         if (hasLeagueExtras)
         {
-            sb.Append(", and also #1 in ");
+            sb.Append(hasBecamePro ? ", also #1 in " : ", and also #1 in ");
             sb.Append(JoinList(leagueParts));
         }
         else if (!string.IsNullOrWhiteSpace(awardText))
@@ -321,6 +338,81 @@ public static class SlackMessageBuilder
         var prevNameLink = Link(AthleteUrl(prev), prevName);
 
         return $"{currNameLink} is now {rankWithMedal} in Ultimate League, ahead of {prevNameLink}";
+    }
+
+    private static string BuildBecamePro(string? slug, Func<string, string> slugToName)
+    {
+        if (slug is null) return "An athlete went Pro";
+
+        var name = slugToName(slug);
+        var nameLink = Link(AthleteUrl(slug), name);
+        return $"{nameLink} went Pro";
+    }
+
+    private static string BuildBiologicalAgeImprovement(string? slug, string rawText, Func<string, string> slugToName)
+    {
+        if (slug is null ||
+            !EventHelpers.TryExtractBiologicalAgeImprovement(rawText, out var clock, out var fromAge, out var toAge))
+        {
+            return Escape(rawText);
+        }
+
+        var name = slugToName(slug);
+        var nameLink = Link(AthleteUrl(slug), name);
+        var clockLabel = string.Equals(clock, "bortz", StringComparison.OrdinalIgnoreCase)
+            ? "Bortz Age"
+            : "pheno age";
+        var fromText = fromAge.ToString("0.##", CultureInfo.InvariantCulture);
+        var toText = toAge.ToString("0.##", CultureInfo.InvariantCulture);
+        return $"{nameLink} improved their {clockLabel} from {fromText} to {toText} years";
+    }
+
+    private static string BuildCrowdAgeTop10Change(string? slug, string rawText, Func<string, string> slugToName)
+    {
+        if (slug is null ||
+            !EventHelpers.TryExtractCrowdAgeTop10Change(rawText, out var place, out var previousPlace, out var crowdAge, out var crowdCount))
+        {
+            return Escape(rawText);
+        }
+
+        var name = slugToName(slug);
+        var nameLink = Link(AthleteUrl(slug), name);
+        EventHelpers.TryExtractPrev(rawText, out var prevSlug);
+        var prevText = !string.IsNullOrWhiteSpace(prevSlug)
+            ? $", ahead of {Link(AthleteUrl(prevSlug), slugToName(prevSlug))}"
+            : "";
+        var crowdAgeText = crowdAge.ToString("0.#", CultureInfo.InvariantCulture);
+        var countText = crowdCount.ToString("N0", CultureInfo.InvariantCulture);
+        var movement = previousPlace.HasValue
+            ? previousPlace.Value > place ? $"climbed from {Ordinal(previousPlace.Value)} to {Ordinal(place)}" : $"moved from {Ordinal(previousPlace.Value)} to {Ordinal(place)}"
+            : $"entered the top 10 at {Ordinal(place)}";
+
+        return $"{nameLink} {movement} in Crowd Age{prevText} ({crowdAgeText} years, {countText} guesses)";
+    }
+
+    private static string BuildAgeImprovementTop10Change(string? slug, string rawText, Func<string, string> slugToName)
+    {
+        if (slug is null ||
+            !EventHelpers.TryExtractAgeImprovementTop10Change(rawText, out var clock, out var place, out var previousPlace, out var improvement, out _))
+        {
+            return Escape(rawText);
+        }
+
+        var name = slugToName(slug);
+        var nameLink = Link(AthleteUrl(slug), name);
+        EventHelpers.TryExtractPrev(rawText, out var prevSlug);
+        var prevText = !string.IsNullOrWhiteSpace(prevSlug)
+            ? $", ahead of {Link(AthleteUrl(prevSlug), slugToName(prevSlug))}"
+            : "";
+        var movement = previousPlace.HasValue
+            ? previousPlace.Value > place ? $"climbed from {Ordinal(previousPlace.Value)} to {Ordinal(place)}" : $"moved from {Ordinal(previousPlace.Value)} to {Ordinal(place)}"
+            : $"entered the top 10 at {Ordinal(place)}";
+        var leaderboardName = string.Equals(clock, "bortz", StringComparison.OrdinalIgnoreCase)
+            ? "Bortz Improvement"
+            : "Pheno Improvement";
+        var improvementText = FormatSignedYears(improvement);
+
+        return $"{nameLink} {movement} in {leaderboardName}{prevText} ({improvementText} years)";
     }
 
     private static string BuildDonation(string rawText)
@@ -454,6 +546,12 @@ public static class SlackMessageBuilder
     private static string Link(string url, string text) => $"<{url}|{Escape(text)}>";
 
     private static string Escape(string s) => s.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;");
+
+    private static string FormatSignedYears(double years)
+    {
+        var text = years.ToString("0.#", CultureInfo.InvariantCulture);
+        return years > 0 ? $"+{text}" : text;
+    }
 
     private static string Ordinal(int n)
     {

--- a/LongevityWorldCup.Website/Tools/ThreadsMessageBuilder.cs
+++ b/LongevityWorldCup.Website/Tools/ThreadsMessageBuilder.cs
@@ -111,6 +111,42 @@ public static class ThreadsMessageBuilder
             return RejectIfTooLong(newRankMsg);
         }
 
+        if (type == EventType.BecamePro)
+        {
+            if (!EventHelpers.TryExtractSlug(rawText, out var proSlug)) return "";
+            var athlete = slugToName(proSlug);
+            return RejectIfTooLong(BuildBecameProLine(athlete, AthleteUrl(proSlug)));
+        }
+
+        if (type == EventType.BiologicalAgeImproved)
+        {
+            if (!EventHelpers.TryExtractSlug(rawText, out var improvementSlug)) return "";
+            if (!EventHelpers.TryExtractBiologicalAgeImprovement(rawText, out var clock, out var fromAge, out var toAge)) return "";
+            var athlete = slugToName(improvementSlug);
+            return RejectIfTooLong(BuildBiologicalAgeImprovementLine(athlete, clock, fromAge, toAge, AthleteUrl(improvementSlug)));
+        }
+
+        if (type == EventType.CrowdAgeTop10Change)
+        {
+            if (!EventHelpers.TryExtractSlug(rawText, out var crowdSlug)) return "";
+            if (!EventHelpers.TryExtractCrowdAgeTop10Change(rawText, out var crowdPlace, out var previousPlace, out var crowdAge, out var crowdCount)) return "";
+            EventHelpers.TryExtractPrev(rawText, out var prevSlug);
+            var athlete = slugToName(crowdSlug);
+            var prev = !string.IsNullOrWhiteSpace(prevSlug) ? slugToName(prevSlug) : null;
+            return RejectIfTooLong(BuildCrowdAgeTop10Line(athlete, crowdPlace, previousPlace, prev, crowdAge, crowdCount, AthleteUrl(crowdSlug, "crowd")));
+        }
+
+        if (type == EventType.AgeImprovementTop10Change)
+        {
+            if (!EventHelpers.TryExtractSlug(rawText, out var improvementLeaderboardSlug)) return "";
+            if (!EventHelpers.TryExtractAgeImprovementTop10Change(rawText, out var improvementClock, out var improvementPlace, out var previousPlace, out var improvement, out _)) return "";
+            EventHelpers.TryExtractPrev(rawText, out var prevSlug);
+            var athlete = slugToName(improvementLeaderboardSlug);
+            var prev = !string.IsNullOrWhiteSpace(prevSlug) ? slugToName(prevSlug) : null;
+            var leagueCtxSlug = string.Equals(improvementClock, "bortz", StringComparison.OrdinalIgnoreCase) ? "bortz-improvement" : "improvement";
+            return RejectIfTooLong(BuildAgeImprovementTop10Line(athlete, improvementClock, improvementPlace, previousPlace, prev, improvement, AthleteUrl(improvementLeaderboardSlug, leagueCtxSlug)));
+        }
+
         if (type != EventType.BadgeAward) return "";
 
         if (!EventHelpers.TryExtractBadgeLabel(rawText, out var label)) return "";
@@ -441,6 +477,19 @@ public static class ThreadsMessageBuilder
         if (type == EventType.NewRank)
             return XPostSampleBasis.Combined;
 
+        if (type == EventType.BecamePro)
+            return XPostSampleBasis.Bortz;
+
+        if (type == EventType.BiologicalAgeImproved)
+        {
+            if (!EventHelpers.TryExtractClock(rawText, out var clock))
+                return null;
+
+            return string.Equals(clock, "bortz", StringComparison.OrdinalIgnoreCase)
+                ? XPostSampleBasis.Bortz
+                : XPostSampleBasis.PhenoAge;
+        }
+
         if (type != EventType.BadgeAward)
             return null;
 
@@ -716,6 +765,94 @@ public static class ThreadsMessageBuilder
             XPostPhase.Early => $"{lead}\n\n{LeaderboardUrl}",
             _ => $"{lead}\n\n{LeaderboardUrl}"
         };
+    }
+
+    private static string BuildBecameProLine(string athleteName, string athleteUrl)
+    {
+        return $"{athleteName} went Pro.\n\nBortz Age results now place them in the Pro track.\n\n{athleteUrl}";
+    }
+
+    private static string BuildBiologicalAgeImprovementLine(
+        string athleteName,
+        string clock,
+        double fromAge,
+        double toAge,
+        string athleteUrl)
+    {
+        var clockLabel = string.Equals(clock, "bortz", StringComparison.OrdinalIgnoreCase)
+            ? "Bortz Age"
+            : "pheno age";
+        var fromText = fromAge.ToString("0.##", CultureInfo.InvariantCulture);
+        var toText = toAge.ToString("0.##", CultureInfo.InvariantCulture);
+        return $"{athleteName} improved their {clockLabel} from {fromText} to {toText} years.\n\n{athleteUrl}";
+    }
+
+    private static string FormatSignedYears(double years)
+    {
+        var text = years.ToString("0.#", CultureInfo.InvariantCulture);
+        return years > 0 ? $"+{text}" : text;
+    }
+
+    private static string BuildCrowdAgeTop10Line(
+        string athleteName,
+        int place,
+        int? previousPlace,
+        string? previousAthlete,
+        double crowdAge,
+        int crowdCount,
+        string athleteUrl)
+    {
+        var placeText = CrowdOrdinal(place);
+        var crowdAgeText = crowdAge.ToString("0.#", CultureInfo.InvariantCulture);
+        var countText = crowdCount.ToString("N0", CultureInfo.InvariantCulture);
+        var movement = previousPlace.HasValue
+            ? previousPlace.Value > place ? $"climbed from {CrowdOrdinal(previousPlace.Value)} to {placeText}" : $"moved from {CrowdOrdinal(previousPlace.Value)} to {placeText}"
+            : $"entered the top 10 at {placeText}";
+
+        var lead = !string.IsNullOrWhiteSpace(previousAthlete)
+            ? $"{athleteName} {movement} in the Crowd Age leaderboard, ahead of {previousAthlete}."
+            : $"{athleteName} {movement} in the Crowd Age leaderboard.";
+
+        return $"{lead}\n\nCrowd Age: {crowdAgeText} years from {countText} guesses.\n\n{athleteUrl}";
+    }
+
+    private static string BuildAgeImprovementTop10Line(
+        string athleteName,
+        string clock,
+        int place,
+        int? previousPlace,
+        string? previousAthlete,
+        double improvement,
+        string athleteUrl)
+    {
+        var placeText = CrowdOrdinal(place);
+        var movement = previousPlace.HasValue
+            ? previousPlace.Value > place ? $"climbed from {CrowdOrdinal(previousPlace.Value)} to {placeText}" : $"moved from {CrowdOrdinal(previousPlace.Value)} to {placeText}"
+            : $"entered the top 10 at {placeText}";
+        var leaderboardName = string.Equals(clock, "bortz", StringComparison.OrdinalIgnoreCase)
+            ? "Bortz Improvement"
+            : "Pheno Improvement";
+        var improvementText = FormatSignedYears(improvement);
+
+        var lead = !string.IsNullOrWhiteSpace(previousAthlete)
+            ? $"{athleteName} {movement} in the {leaderboardName} leaderboard, ahead of {previousAthlete}."
+            : $"{athleteName} {movement} in the {leaderboardName} leaderboard.";
+
+        return $"{lead}\n\nImprovement: {improvementText} years from worst to latest eligible result.\n\n{athleteUrl}";
+    }
+
+    private static string CrowdOrdinal(int n)
+    {
+        var suffix = (n % 100) is 11 or 12 or 13
+            ? "th"
+            : (n % 10) switch
+            {
+                1 => "st",
+                2 => "nd",
+                3 => "rd",
+                _ => "th"
+            };
+        return $"{n}{suffix}";
     }
 
     private static string BuildTop3LeaderboardIntro(XPostPhase? phase, string leagueDisplayName)

--- a/LongevityWorldCup.Website/Tools/XMessageBuilder.cs
+++ b/LongevityWorldCup.Website/Tools/XMessageBuilder.cs
@@ -111,6 +111,42 @@ public static class XMessageBuilder
             return RejectIfTooLong(newRankMsg);
         }
 
+        if (type == EventType.BecamePro)
+        {
+            if (!EventHelpers.TryExtractSlug(rawText, out var proSlug)) return "";
+            var athlete = slugToName(proSlug);
+            return RejectIfTooLong(BuildBecameProLine(athlete, AthleteUrl(proSlug)));
+        }
+
+        if (type == EventType.BiologicalAgeImproved)
+        {
+            if (!EventHelpers.TryExtractSlug(rawText, out var improvementSlug)) return "";
+            if (!EventHelpers.TryExtractBiologicalAgeImprovement(rawText, out var clock, out var fromAge, out var toAge)) return "";
+            var athlete = slugToName(improvementSlug);
+            return RejectIfTooLong(BuildBiologicalAgeImprovementLine(athlete, clock, fromAge, toAge, AthleteUrl(improvementSlug)));
+        }
+
+        if (type == EventType.CrowdAgeTop10Change)
+        {
+            if (!EventHelpers.TryExtractSlug(rawText, out var crowdSlug)) return "";
+            if (!EventHelpers.TryExtractCrowdAgeTop10Change(rawText, out var crowdPlace, out var previousPlace, out var crowdAge, out var crowdCount)) return "";
+            EventHelpers.TryExtractPrev(rawText, out var prevSlug);
+            var athlete = slugToName(crowdSlug);
+            var prev = !string.IsNullOrWhiteSpace(prevSlug) ? slugToName(prevSlug) : null;
+            return RejectIfTooLong(BuildCrowdAgeTop10Line(athlete, crowdPlace, previousPlace, prev, crowdAge, crowdCount, AthleteUrl(crowdSlug, "crowd")));
+        }
+
+        if (type == EventType.AgeImprovementTop10Change)
+        {
+            if (!EventHelpers.TryExtractSlug(rawText, out var improvementLeaderboardSlug)) return "";
+            if (!EventHelpers.TryExtractAgeImprovementTop10Change(rawText, out var improvementClock, out var improvementPlace, out var previousPlace, out var improvement, out _)) return "";
+            EventHelpers.TryExtractPrev(rawText, out var prevSlug);
+            var athlete = slugToName(improvementLeaderboardSlug);
+            var prev = !string.IsNullOrWhiteSpace(prevSlug) ? slugToName(prevSlug) : null;
+            var leagueCtxSlug = string.Equals(improvementClock, "bortz", StringComparison.OrdinalIgnoreCase) ? "bortz-improvement" : "improvement";
+            return RejectIfTooLong(BuildAgeImprovementTop10Line(athlete, improvementClock, improvementPlace, previousPlace, prev, improvement, AthleteUrl(improvementLeaderboardSlug, leagueCtxSlug)));
+        }
+
         if (type != EventType.BadgeAward) return "";
 
         if (!EventHelpers.TryExtractBadgeLabel(rawText, out var label)) return "";
@@ -441,6 +477,19 @@ public static class XMessageBuilder
         if (type == EventType.NewRank)
             return XPostSampleBasis.Combined;
 
+        if (type == EventType.BecamePro)
+            return XPostSampleBasis.Bortz;
+
+        if (type == EventType.BiologicalAgeImproved)
+        {
+            if (!EventHelpers.TryExtractClock(rawText, out var clock))
+                return null;
+
+            return string.Equals(clock, "bortz", StringComparison.OrdinalIgnoreCase)
+                ? XPostSampleBasis.Bortz
+                : XPostSampleBasis.PhenoAge;
+        }
+
         if (type != EventType.BadgeAward)
             return null;
 
@@ -716,6 +765,94 @@ public static class XMessageBuilder
             XPostPhase.Early => $"{lead}\n\n{LeaderboardUrl}",
             _ => $"{lead}\n\n{LeaderboardUrl}"
         };
+    }
+
+    private static string BuildBecameProLine(string athleteName, string athleteUrl)
+    {
+        return $"{athleteName} went Pro.\n\nBortz Age results now place them in the Pro track.\n\n{athleteUrl}";
+    }
+
+    private static string BuildBiologicalAgeImprovementLine(
+        string athleteName,
+        string clock,
+        double fromAge,
+        double toAge,
+        string athleteUrl)
+    {
+        var clockLabel = string.Equals(clock, "bortz", StringComparison.OrdinalIgnoreCase)
+            ? "Bortz Age"
+            : "pheno age";
+        var fromText = fromAge.ToString("0.##", CultureInfo.InvariantCulture);
+        var toText = toAge.ToString("0.##", CultureInfo.InvariantCulture);
+        return $"{athleteName} improved their {clockLabel} from {fromText} to {toText} years.\n\n{athleteUrl}";
+    }
+
+    private static string FormatSignedYears(double years)
+    {
+        var text = years.ToString("0.#", CultureInfo.InvariantCulture);
+        return years > 0 ? $"+{text}" : text;
+    }
+
+    private static string BuildCrowdAgeTop10Line(
+        string athleteName,
+        int place,
+        int? previousPlace,
+        string? previousAthlete,
+        double crowdAge,
+        int crowdCount,
+        string athleteUrl)
+    {
+        var placeText = CrowdOrdinal(place);
+        var crowdAgeText = crowdAge.ToString("0.#", CultureInfo.InvariantCulture);
+        var countText = crowdCount.ToString("N0", CultureInfo.InvariantCulture);
+        var movement = previousPlace.HasValue
+            ? previousPlace.Value > place ? $"climbed from {CrowdOrdinal(previousPlace.Value)} to {placeText}" : $"moved from {CrowdOrdinal(previousPlace.Value)} to {placeText}"
+            : $"entered the top 10 at {placeText}";
+
+        var lead = !string.IsNullOrWhiteSpace(previousAthlete)
+            ? $"{athleteName} {movement} in the Crowd Age leaderboard, ahead of {previousAthlete}."
+            : $"{athleteName} {movement} in the Crowd Age leaderboard.";
+
+        return $"{lead}\n\nCrowd Age: {crowdAgeText} years from {countText} guesses.\n\n{athleteUrl}";
+    }
+
+    private static string BuildAgeImprovementTop10Line(
+        string athleteName,
+        string clock,
+        int place,
+        int? previousPlace,
+        string? previousAthlete,
+        double improvement,
+        string athleteUrl)
+    {
+        var placeText = CrowdOrdinal(place);
+        var movement = previousPlace.HasValue
+            ? previousPlace.Value > place ? $"climbed from {CrowdOrdinal(previousPlace.Value)} to {placeText}" : $"moved from {CrowdOrdinal(previousPlace.Value)} to {placeText}"
+            : $"entered the top 10 at {placeText}";
+        var leaderboardName = string.Equals(clock, "bortz", StringComparison.OrdinalIgnoreCase)
+            ? "Bortz Improvement"
+            : "Pheno Improvement";
+        var improvementText = FormatSignedYears(improvement);
+
+        var lead = !string.IsNullOrWhiteSpace(previousAthlete)
+            ? $"{athleteName} {movement} in the {leaderboardName} leaderboard, ahead of {previousAthlete}."
+            : $"{athleteName} {movement} in the {leaderboardName} leaderboard.";
+
+        return $"{lead}\n\nImprovement: {improvementText} years from worst to latest eligible result.\n\n{athleteUrl}";
+    }
+
+    private static string CrowdOrdinal(int n)
+    {
+        var suffix = (n % 100) is 11 or 12 or 13
+            ? "th"
+            : (n % 10) switch
+            {
+                1 => "st",
+                2 => "nd",
+                3 => "rd",
+                _ => "th"
+            };
+        return $"{n}{suffix}";
     }
 
     private static string BuildTop3LeaderboardIntro(XPostPhase? phase, string leagueDisplayName)

--- a/LongevityWorldCup.Website/wwwroot/index.html
+++ b/LongevityWorldCup.Website/wwwroot/index.html
@@ -1999,10 +1999,43 @@
 
         const homepageHighlightsBaseRows = 5;
         const homepageHighlightsMaxRows = 12;
+        const homepageVisitCounterKey = 'lwcHomepageVisitCount:v1';
+        const homepageHighlightsBeforePodiumVisit = 4;
         let homepageHighlightsRows = homepageHighlightsBaseRows;
         let homepageHighlightsMeasureTimer = null;
         let homepageHighlightsResizeTimer = null;
         let homepageHighlightsWaitAttempts = 0;
+
+        function incrementHomepageVisitCount() {
+            try {
+                const raw = window.localStorage ? window.localStorage.getItem(homepageVisitCounterKey) : null;
+                const current = Number.parseInt(raw || '0', 10);
+                const next = Math.min((Number.isFinite(current) && current >= 0 ? current : 0) + 1, 1000000);
+                window.localStorage.setItem(homepageVisitCounterKey, String(next));
+                return next;
+            } catch (_) {
+                return 1;
+            }
+        }
+
+        function placeHomepageHighlightsForVisit() {
+            const visitCount = incrementHomepageVisitCount();
+            const main = document.querySelector('main');
+            if (visitCount < homepageHighlightsBeforePodiumVisit) {
+                if (main) main.dataset.homepageVisitLayout = 'default';
+                return;
+            }
+
+            const highlights = document.querySelector('.lwc-highlights-countdown-wrapper');
+            const leaderboard = document.querySelector('.main-container');
+            if (!highlights || !leaderboard || !leaderboard.parentNode) {
+                if (main) main.dataset.homepageVisitLayout = 'default';
+                return;
+            }
+
+            leaderboard.parentNode.insertBefore(highlights, leaderboard);
+            if (main) main.dataset.homepageVisitLayout = 'repeat';
+        }
 
         function loadHomepageHighlights(rowCount, reason = 'unknown') {
             homepageHighlightsRows = rowCount;
@@ -2068,6 +2101,7 @@
         }
 
         document.addEventListener('DOMContentLoaded', function () {
+            placeHomepageHighlightsForVisit();
             fitHomepageHighlights();
             LoadLeaderboard(true, 10);
 

--- a/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
@@ -838,7 +838,15 @@
             return window.__sharedAthletesRequest;
         };
 
-        const EVENT_TYPE = { General: 0, Joined: 1, NewRank: 2, DonationReceived: 3, AthleteCountMilestone: 4, BadgeAward: 5, CustomEvent: 6, SeasonFinalResult: 7, LongevitymaxxingChallengeResult: 8 };
+        const EVENT_TYPE = { General: 0, Joined: 1, NewRank: 2, DonationReceived: 3, AthleteCountMilestone: 4, BadgeAward: 5, CustomEvent: 6, SeasonFinalResult: 7, LongevitymaxxingChallengeResult: 8, BecamePro: 9, BiologicalAgeImproved: 10, CrowdAgeTop10Change: 11, AgeImprovementTop10Change: 12 };
+        const EVENT_TYPE_NAME_BY_ID = {};
+        Object.keys(EVENT_TYPE).forEach(name => {
+            EVENT_TYPE_NAME_BY_ID[String(EVENT_TYPE[name])] = name;
+        });
+
+        function eventTypeName(type){
+            return EVENT_TYPE_NAME_BY_ID[String(Number(type))] || "Unknown";
+        }
 
         function buildEventSkeletonRows(count=5){
             return Array.from({ length: count }, () => `
@@ -1121,6 +1129,12 @@
             const n = parseInt(raw, 10);
             return Number.isFinite(n) ? n : null;
         }
+        function extractFloatToken(text, key){
+            const raw = extractToken(text, key);
+            if(raw===null) return null;
+            const n = parseFloat(raw);
+            return Number.isFinite(n) ? n : null;
+        }
 
         function renderTextWithSlugLinks(text, linkNames, athletesIndex, afterSlug){
             const s=String(text);
@@ -1310,6 +1324,7 @@
                 const type=Number(e[map["type"]]??0);
                 const text=String(e[map["text"]]??"");
                 const occurredAt=e[map["occurredat"]]??e[map["occurredAt"]]??e["OccurredAt"]??null;
+                const relevance=Number(e[map["relevance"]]??e["Relevance"]??0);
 
                 const slugTokens=extractSlugs(text).map(s=>slugifyLocal(normalizeLinkId(s)));
                 const primarySlug=slugTokens[0]||null;
@@ -1349,8 +1364,15 @@
                 const totalPoints = extractIntToken(text, "points");
                 const challengeDays = extractIntToken(text, "days");
                 const challengeCompleted = /completed\[1\]/.test(text);
+                const bioAgeFrom = extractFloatToken(text, "from");
+                const bioAgeTo = extractFloatToken(text, "to");
+                const previousPlace = extractIntToken(text, "prevPlace");
+                const eventCrowdAge = extractFloatToken(text, "crowdAge");
+                const eventCrowdCount = extractIntToken(text, "crowdCount");
+                const eventImprovement = extractFloatToken(text, "improvement");
+                const eventAgeReduction = extractFloatToken(text, "ageReduction");
 
-                return { id, type, text, occurredAt, slugs: slugTokens, primarySlug, prevSlug, prevSlugs, isSolo, badgeBurstKey, rank, sats, milestoneCount, badgeLabel, leagueCategory, leagueValue, place, seasonId, clockId, ageDiff, challengeKey, challengeDisplayName, checkedInDays, totalPoints, challengeDays, challengeCompleted };
+                return { id, type, text, occurredAt, relevance, slugs: slugTokens, primarySlug, prevSlug, prevSlugs, isSolo, badgeBurstKey, rank, sats, milestoneCount, badgeLabel, leagueCategory, leagueValue, place, seasonId, clockId, ageDiff, challengeKey, challengeDisplayName, checkedInDays, totalPoints, challengeDays, challengeCompleted, bioAgeFrom, bioAgeTo, previousPlace, eventCrowdAge, eventCrowdCount, eventImprovement, eventAgeReduction };
             });
         }
 
@@ -1493,7 +1515,7 @@
         }
 
         function groupAthleteBursts(rows, windowMs=60000){
-            const eligibleTypes=new Set([EVENT_TYPE.Joined, EVENT_TYPE.NewRank, EVENT_TYPE.DonationReceived, EVENT_TYPE.BadgeAward, EVENT_TYPE.LongevitymaxxingChallengeResult]);
+            const eligibleTypes=new Set([EVENT_TYPE.Joined, EVENT_TYPE.NewRank, EVENT_TYPE.DonationReceived, EVENT_TYPE.BadgeAward, EVENT_TYPE.LongevitymaxxingChallengeResult, EVENT_TYPE.BecamePro, EVENT_TYPE.BiologicalAgeImproved, EVENT_TYPE.CrowdAgeTop10Change, EVENT_TYPE.AgeImprovementTop10Change]);
 
             const timeOf=r=>{
                 const t=+new Date(r && r.occurredAt ? r.occurredAt : 0);
@@ -1604,7 +1626,7 @@
                 const isSelfRow = athletePageTargetSlug && primaryKey===athletePageTargetSlug;
 
                 let avatarHtml = "";
-                const canLinkAvatar = (r.type === EVENT_TYPE.Joined || r.type === EVENT_TYPE.NewRank || r.type === EVENT_TYPE.BadgeAward || r.type === EVENT_TYPE.SeasonFinalResult || r.type === EVENT_TYPE.LongevitymaxxingChallengeResult)
+                const canLinkAvatar = (r.type === EVENT_TYPE.Joined || r.type === EVENT_TYPE.NewRank || r.type === EVENT_TYPE.BadgeAward || r.type === EVENT_TYPE.SeasonFinalResult || r.type === EVENT_TYPE.LongevitymaxxingChallengeResult || r.type === EVENT_TYPE.BecamePro || r.type === EVENT_TYPE.BiologicalAgeImproved || r.type === EVENT_TYPE.CrowdAgeTop10Change || r.type === EVENT_TYPE.AgeImprovementTop10Change)
                     && r.primarySlug
                     && url
                     && !isSelfRow
@@ -1618,7 +1640,7 @@
                     ? ` data-athlete-slug="${esc(primaryKey)}"`
                     : ``;
 
-                if (r.type === EVENT_TYPE.Joined || r.type === EVENT_TYPE.NewRank || r.type === EVENT_TYPE.BadgeAward || r.type === EVENT_TYPE.SeasonFinalResult || (r.type === EVENT_TYPE.LongevitymaxxingChallengeResult && r.primarySlug)) {
+                if (r.type === EVENT_TYPE.Joined || r.type === EVENT_TYPE.NewRank || r.type === EVENT_TYPE.BadgeAward || r.type === EVENT_TYPE.SeasonFinalResult || r.type === EVENT_TYPE.BecamePro || r.type === EVENT_TYPE.BiologicalAgeImproved || r.type === EVENT_TYPE.CrowdAgeTop10Change || r.type === EVENT_TYPE.AgeImprovementTop10Change || (r.type === EVENT_TYPE.LongevitymaxxingChallengeResult && r.primarySlug)) {
                     if (img) {
                         avatarHtml = canLinkAvatar
                             ? `<a href="${url}" class="avatar-link event-athlete-link" title="${esc(name)}" aria-label="${esc(name)}"${avatarModalAttrs}${avatarTargetAttrs}><img class="avatar" src="${esc(img)}" alt="${esc(name)}" ${avatarLoadingAttrs} decoding="async" referrerpolicy="no-referrer"></a>`
@@ -1731,6 +1753,95 @@
                                 msgHtml = `${nameWithRank} adds ${bubble} to the collection`;
                             }
                         }
+                    }
+                } else if (r.type === EVENT_TYPE.BecamePro && r.primarySlug) {
+                    const nameWithRank = renderTextWithSlugLinks(
+                        `slug[${r.primarySlug}]`,
+                        linkNames,
+                        athletesIndex,
+                        afterNameWithCurrentRankFor()
+                    );
+                    msgHtml = `${nameWithRank} went Pro`;
+                } else if (r.type === EVENT_TYPE.BiologicalAgeImproved && r.primarySlug) {
+                    const nameWithRank = renderTextWithSlugLinks(
+                        `slug[${r.primarySlug}]`,
+                        linkNames,
+                        athletesIndex,
+                        afterNameWithCurrentRankFor()
+                    );
+                    const clockNorm = String(r.clockId || "").toLowerCase().replace(/\s+/g,"");
+                    const clockText = clockNorm === "bortz" || clockNorm === "bortzage" ? "Bortz Age" : "pheno age";
+                    const fromText = Number.isFinite(r.bioAgeFrom)
+                        ? new Intl.NumberFormat(undefined, { maximumFractionDigits: 2 }).format(r.bioAgeFrom)
+                        : "?";
+                    const toText = Number.isFinite(r.bioAgeTo)
+                        ? new Intl.NumberFormat(undefined, { maximumFractionDigits: 2 }).format(r.bioAgeTo)
+                        : "?";
+                    msgHtml = `${nameWithRank} improved their ${esc(clockText)} from <strong class="age-years-accent">${esc(fromText)}</strong> to <strong class="age-years-accent">${esc(toText)}</strong> years`;
+                } else if (r.type === EVENT_TYPE.CrowdAgeTop10Change && r.primarySlug) {
+                    const nameWithRank = renderTextWithSlugLinks(
+                        `slug[${r.primarySlug}]`,
+                        linkNames,
+                        athletesIndex,
+                        afterNameWithCurrentRankFor()
+                    );
+                    const placeN = Number.isFinite(r.place) ? r.place : null;
+                    const previousPlaceN = Number.isFinite(r.previousPlace) ? r.previousPlace : null;
+                    const placeText = placeN ? ordinal(placeN) : "?";
+                    const movementText = previousPlaceN
+                        ? (previousPlaceN > placeN ? `climbed from ${ordinal(previousPlaceN)} to ${placeText}` : `moved from ${ordinal(previousPlaceN)} to ${placeText}`)
+                        : `entered the top 10 at ${placeText}`;
+                    const prevHtml = r.prevSlug
+                        ? renderTextWithSlugLinks(`slug[${r.prevSlug}]`, linkNames, athletesIndex, afterNameWithCurrentRankFor())
+                        : "";
+                    const crowdAgeText = Number.isFinite(r.eventCrowdAge)
+                        ? new Intl.NumberFormat(undefined, { maximumFractionDigits: 1 }).format(r.eventCrowdAge)
+                        : "?";
+                    const crowdCountText = Number.isFinite(r.eventCrowdCount)
+                        ? new Intl.NumberFormat().format(r.eventCrowdCount)
+                        : "?";
+                    if (r.crowdAgeDirection === "lost") {
+                        const toHtml = r.otherSlug
+                            ? renderTextWithSlugLinks(`slug[${r.otherSlug}]`, linkNames, athletesIndex, afterNameWithCurrentRankFor())
+                            : "";
+                        msgHtml = toHtml
+                            ? `${nameWithRank} lost the ${esc(placeText)} Crowd Age position to ${toHtml}`
+                            : `${nameWithRank} lost the ${esc(placeText)} Crowd Age position`;
+                    } else {
+                        const prevText = prevHtml ? `, ahead of ${prevHtml}` : "";
+                        msgHtml = `${nameWithRank} ${esc(movementText)} in Crowd Age${prevText} <span class="event-inline-text">(<strong class="age-years-accent">${esc(crowdAgeText)}</strong> years, ${esc(crowdCountText)} guesses)</span>`;
+                    }
+                } else if (r.type === EVENT_TYPE.AgeImprovementTop10Change && r.primarySlug) {
+                    const nameWithRank = renderTextWithSlugLinks(
+                        `slug[${r.primarySlug}]`,
+                        linkNames,
+                        athletesIndex,
+                        afterNameWithCurrentRankFor()
+                    );
+                    const placeN = Number.isFinite(r.place) ? r.place : null;
+                    const previousPlaceN = Number.isFinite(r.previousPlace) ? r.previousPlace : null;
+                    const placeText = placeN ? ordinal(placeN) : "?";
+                    const movementText = previousPlaceN
+                        ? (previousPlaceN > placeN ? `climbed from ${ordinal(previousPlaceN)} to ${placeText}` : `moved from ${ordinal(previousPlaceN)} to ${placeText}`)
+                        : `entered the top 10 at ${placeText}`;
+                    const clockNorm = String(r.clockId || "").toLowerCase().replace(/\s+/g,"");
+                    const leaderboardName = clockNorm === "bortz" || clockNorm === "bortzage" ? "Bortz Improvement" : "Pheno Improvement";
+                    const improvementText = Number.isFinite(r.eventImprovement)
+                        ? new Intl.NumberFormat(undefined, { maximumFractionDigits: 1, signDisplay: "exceptZero" }).format(r.eventImprovement)
+                        : "?";
+                    if (r.improvementDirection === "lost") {
+                        const toHtml = r.otherSlug
+                            ? renderTextWithSlugLinks(`slug[${r.otherSlug}]`, linkNames, athletesIndex, afterNameWithCurrentRankFor())
+                            : "";
+                        msgHtml = toHtml
+                            ? `${nameWithRank} lost the ${esc(placeText)} ${esc(leaderboardName)} position to ${toHtml}`
+                            : `${nameWithRank} lost the ${esc(placeText)} ${esc(leaderboardName)} position`;
+                    } else {
+                        const prevHtml = r.prevSlug
+                            ? renderTextWithSlugLinks(`slug[${r.prevSlug}]`, linkNames, athletesIndex, afterNameWithCurrentRankFor())
+                            : "";
+                        const prevText = prevHtml ? `, ahead of ${prevHtml}` : "";
+                        msgHtml = `${nameWithRank} ${esc(movementText)} in ${esc(leaderboardName)}${prevText} <span class="event-inline-text">(<strong class="age-years-accent">${esc(improvementText)}</strong> years)</span>`;
                     }
                 } else if (r.type === EVENT_TYPE.NewRank && r.primarySlug) {
                     const taken = Number.isFinite(r.rank) ? r.rank : getCurrentPlacement(a);
@@ -1867,6 +1978,9 @@
                 tr.className = "row-appear main-row";
                 tr.dataset.rowIndex = String(idx);
                 tr.dataset.groupId = `g_${idx}`;
+                tr.dataset.eventTypeName = eventTypeName(r.type);
+                if (r.primarySlug) tr.dataset.primarySlug = String(r.primarySlug);
+                if (r.homepageHighlightSelection) tr.dataset.highlightSelection = String(r.homepageHighlightSelection);
                 if (r.id) tr.dataset.eventId = String(r.id);
                 tr.innerHTML =
                     `<td class="col-avatar"><div class="athlete-td">${avatarHtml}</div></td>
@@ -2085,6 +2199,150 @@
             return out;
         }
 
+        const HOMEPAGE_ATHLETE_HIGHLIGHT_TYPES = new Set([
+            EVENT_TYPE.Joined,
+            EVENT_TYPE.NewRank,
+            EVENT_TYPE.BadgeAward,
+            EVENT_TYPE.LongevitymaxxingChallengeResult,
+            EVENT_TYPE.BecamePro,
+            EVENT_TYPE.BiologicalAgeImproved,
+            EVENT_TYPE.CrowdAgeTop10Change,
+            EVENT_TYPE.AgeImprovementTop10Change
+        ]);
+
+        function rowTimeMs(row){
+            const t=+new Date(row && row.occurredAt ? row.occurredAt : 0);
+            return Number.isFinite(t) ? t : 0;
+        }
+
+        function topPlaceBonus(place, maxPlace=10){
+            if(!Number.isFinite(place) || place<1 || place>maxPlace) return 0;
+            return maxPlace + 1 - place;
+        }
+
+        function homepageAthleteHighlightKey(row){
+            if(!(row && row.primarySlug && HOMEPAGE_ATHLETE_HIGHLIGHT_TYPES.has(row.type))) return null;
+            return String(row.primarySlug);
+        }
+
+        function badgeHighlightScore(row){
+            const key=normalizeBadgeKey(row && row.badgeLabel);
+            const placeBonus=topPlaceBonus(row && row.place, 3);
+            let score=placeBonus*35;
+
+            if(row && row.isGroup){
+                const count=Number.isFinite(row.badgeCount) ? row.badgeCount : (Array.isArray(row.items) ? row.items.length : 1);
+                score += Math.min(count, 6)*12;
+            }
+
+            if(key==="age reduction") score += 120;
+            else if(key==="pheno age - lowest" || key==="bortz age - lowest" || key==="crowd age - lowest") score += 110;
+            else if(key==="pheno age best improvement" || key==="bortz age best improvement") score += 100;
+            else if(key.startsWith("best domain -")) score += 85;
+            else score += 55;
+
+            const cat=normalizeBadgeKey(row && row.leagueCategory);
+            if(!cat || cat==="global") score += 12;
+            return score;
+        }
+
+        function homepageHighlightImportance(row){
+            if(!row) return 0;
+
+            const relevance=Number.isFinite(row.relevance) ? row.relevance*20 : 0;
+            switch(row.type){
+                case EVENT_TYPE.NewRank:
+                    return 10000 + relevance + topPlaceBonus(row.rank, 10)*120;
+                case EVENT_TYPE.BecamePro:
+                    return 9400 + relevance;
+                case EVENT_TYPE.BiologicalAgeImproved: {
+                    const delta = Number.isFinite(row.bioAgeFrom) && Number.isFinite(row.bioAgeTo)
+                        ? Math.max(0, row.bioAgeFrom - row.bioAgeTo)
+                        : 0;
+                    return 9300 + relevance + Math.min(delta, 20)*20;
+                }
+                case EVENT_TYPE.BadgeAward:
+                    return 9000 + relevance + badgeHighlightScore(row);
+                case EVENT_TYPE.LongevitymaxxingChallengeResult:
+                    return 8800 + relevance + topPlaceBonus(row.place, 10)*50 + (row.challengeCompleted ? 25 : 0);
+                case EVENT_TYPE.CrowdAgeTop10Change: {
+                    const movement = Number.isFinite(row.previousPlace) && Number.isFinite(row.place)
+                        ? Math.max(0, row.previousPlace - row.place)
+                        : 0;
+                    return 8700 + relevance + topPlaceBonus(row.place, 10)*45 + movement*10;
+                }
+                case EVENT_TYPE.AgeImprovementTop10Change: {
+                    const magnitude = Number.isFinite(row.eventImprovement) ? Math.min(Math.abs(row.eventImprovement), 25) : 0;
+                    const movement = Number.isFinite(row.previousPlace) && Number.isFinite(row.place)
+                        ? Math.max(0, row.previousPlace - row.place)
+                        : 0;
+                    return 8650 + relevance + topPlaceBonus(row.place, 10)*45 + movement*10 + magnitude*5;
+                }
+                case EVENT_TYPE.Joined:
+                    return 5000 + relevance;
+                default:
+                    return relevance;
+            }
+        }
+
+        function compareHomepageHighlightPreference(a,b){
+            const sa=homepageHighlightImportance(a);
+            const sb=homepageHighlightImportance(b);
+            if(sa!==sb) return sa-sb;
+
+            const ta=rowTimeMs(a);
+            const tb=rowTimeMs(b);
+            if(ta!==tb) return ta-tb;
+
+            const ia=String(a && a.id || "");
+            const ib=String(b && b.id || "");
+            return ia.localeCompare(ib);
+        }
+
+        function selectHomepageHighlightRows(rows, maxRows){
+            if(!Number.isFinite(maxRows) || maxRows<=0) return rows;
+
+            const nonAthlete=[];
+            const bestByAthlete=new Map();
+            const repeats=[];
+
+            for(const row of rows){
+                const key=homepageAthleteHighlightKey(row);
+                if(!key){
+                    row.homepageHighlightSelection = "global";
+                    nonAthlete.push(row);
+                    continue;
+                }
+
+                const existing=bestByAthlete.get(key);
+                if(!existing){
+                    row.homepageHighlightSelection = "primary";
+                    bestByAthlete.set(key,row);
+                    continue;
+                }
+
+                if(compareHomepageHighlightPreference(row,existing)>0){
+                    existing.homepageHighlightSelection = "repeat";
+                    repeats.push(existing);
+                    row.homepageHighlightSelection = "primary";
+                    bestByAthlete.set(key,row);
+                }else{
+                    row.homepageHighlightSelection = "repeat";
+                    repeats.push(row);
+                }
+            }
+
+            const uniqueRows=nonAthlete.concat([...bestByAthlete.values()]);
+            if(uniqueRows.length>=maxRows) return uniqueRows;
+
+            repeats.sort((a,b)=>compareHomepageHighlightPreference(b,a));
+            const backfill = repeats.slice(0,maxRows-uniqueRows.length);
+            backfill.forEach(row => {
+                row.homepageHighlightSelection = "backfill-repeat";
+            });
+            return uniqueRows.concat(backfill);
+        }
+
         function normalizeIncomingAthleteId(id){
             if(id==null) return '';
             let s=String(id).trim();
@@ -2221,6 +2479,32 @@
                                 return;
                             }
                         }
+
+                        if(r.type===EVENT_TYPE.CrowdAgeTop10Change){
+                            if(r.prevSlug===target){
+                                const winner = r.primarySlug;
+
+                                r.crowdAgeDirection = "lost";
+                                r.otherSlug = winner || null;
+
+                                r.primarySlug = target;
+                                r.prevSlug = null;
+                                return;
+                            }
+                        }
+
+                        if(r.type===EVENT_TYPE.AgeImprovementTop10Change){
+                            if(r.prevSlug===target){
+                                const winner = r.primarySlug;
+
+                                r.improvementDirection = "lost";
+                                r.otherSlug = winner || null;
+
+                                r.primarySlug = target;
+                                r.prevSlug = null;
+                                return;
+                            }
+                        }
                     });
                 }else{
                     rows=rows.filter(r=>
@@ -2234,6 +2518,10 @@
 
                 if(!target){
                     rows = filterBadgeRowsForMainFeed(rows, mode);
+                }
+
+                if(mode==="highlights"){
+                    rows = selectHomepageHighlightRows(rows, n);
                 }
 
                 rows.sort((a,b)=>{

--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -28,9 +28,14 @@ Use this as a compact guardrail for terms agents often misuse.
 ## Rules To Preserve
 
 - **Ultimate League** ranks Pro before Amateur, then applies **Effective Age Reduction** and tie breakers.
+- Existing **Amateur** athletes emit a **went Pro Event** when they first gain an eligible **Bortz Age** result. New athletes who join already eligible for **Pro** only emit normal join/rank Events.
+- Existing athletes emit a biological-age improvement **Event** when a changed result lowers their stored best **pheno age** or **Bortz Age**. This is an Event only; it is separate from the Pheno/Bortz Improvement leaderboard metrics.
+- Homepage highlights are a curated subset of **Events**, not the raw Event feed; they may suppress repeated athlete-centric Events and keep only the most important Event per athlete when enough unique highlights exist.
+- **Crowd Age** top-10 placement changes emit **Events** after the initial stored placement snapshot. These follow the separate **Crowd Age leaderboard** ordering and do not affect **Ultimate League** ranking.
 - **Crowd Age leaderboard** requires 100 accepted guesses and orders by **Crowd Age Difference**, **Crowd Count**, date of birth, and name.
 - **Guess My Age** increments **Crowd Count** only after server-side rate limiting accepts one realistic guess per client IP and athlete during the configured short window.
 - Improvement leaderboards require at least two eligible submissions and are separate from the **Ultimate League**. Pheno orders by `latest eligible pheno age - worst eligible pheno age`, then pheno age reduction, date of birth, and name. Bortz uses Bortz equivalents and is route/filter-only.
+- Pheno/Bortz Improvement top-10 placement changes emit **Events** after the initial stored placement snapshot. These are placement Events for the improvement leaderboards, not biological-age improvement Events.
 - **Best Improvement** is a baseline-to-latest badge metric, not the worst-to-latest improvement leaderboard metric.
 - **Longevitymaxxing Challenge** results may appear as **Events**, but never affect **Ultimate League** ranking, biological age placements, or athlete **Badges**.
 - **Longevitymaxxing Challenge** Day 1 counts for check-ins, streak, completion, and consistency signals, but not habit points, category leader badges, or point tie-breaks.


### PR DESCRIPTION
## Summary
- add a BecamePro event emitted when an existing Amateur athlete first gains eligible Bortz Age data
- add biological-age improvement events when changed results lower an existing athlete's stored best Pheno Age or Bortz Age
- add Crowd Age top-10 placement change events after the initial placement snapshot
- add Pheno/Bortz Improvement top-10 placement change events after the initial placement snapshots
- render these highlights on the event board and support Slack/X/Threads copy
- de-duplicate homepage highlights by athlete, keeping the most important athlete event and only backfilling repeats when unique highlights are scarce
- move the homepage highlights/merch wrapper before the podium/leaderboard from the fourth homepage visit onward using a versioned index-page localStorage counter
- add non-visual row/layout attributes so highlight selection, event type, and repeat-visitor layout behavior are easy to verify
- preserve went-Pro wording in merged Slack batches when BecamePro is buffered with NewRank
- document the domain rules and homepage highlight curation behavior

## Tests
- dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --filter SocialMessageBuilderTests
- dotnet test LongevityWorldCup.sln
- browser smoke check on http://127.0.0.1:5087/ homepage highlights
- browser smoke check on fresh local origin: first visit keeps highlights after leaderboard; fourth visit moves highlights before podium/leaderboard
- browser smoke check for data-event-type-name, data-highlight-selection, and data-homepage-visit-layout attributes