### PR TITLE
[codex] Add challenge habit dashboard

### DIFF
--- a/LongevityWorldCup.Tests/LongevitymaxxingChallengePageTests.cs
+++ b/LongevityWorldCup.Tests/LongevitymaxxingChallengePageTests.cs
@@ -206,7 +206,17 @@ public sealed class LongevitymaxxingChallengePageTests
         Assert.Contains("toggle(\"lmxParticipantTools\", !checkInOnly);", javascript);
         Assert.Contains("toggle(\"lmxTitlePanel\", !checkInOnly && !publicClosed);", javascript);
         Assert.Contains("toggle(\"lmxResendPanel\", !hasParticipant);", javascript);
+        Assert.Contains("toggle(\"lmxHabitHeading\", !hasParticipant);", javascript);
+        Assert.Contains("toggle(\"lmxHabitGrid\", !hasParticipant);", javascript);
         Assert.Contains("toggle(\"lmxTrack\", hasParticipant && dashboardMode && !checkInOnly);", javascript);
+        Assert.Contains("Category dashboard", javascript);
+        Assert.Contains("function normalizeDashboardCells", javascript);
+        Assert.Contains("function categoryDashboardRow", javascript);
+        Assert.Contains("function categoryDayCell", javascript);
+        Assert.Contains("function clampHabitValue", javascript);
+        Assert.Contains("Locked-in days", javascript);
+        Assert.Contains("dashboardStat(\"Points\"", javascript);
+        Assert.Contains("row.totalPoints", javascript);
         Assert.Contains("board.className = publicViewer ? \"lmx-board public\" : \"lmx-board\";", javascript);
         Assert.Contains("lmx-cell-strip", javascript);
         Assert.DoesNotContain("S/E/N/V dots show habit gaps", javascript);
@@ -229,6 +239,9 @@ public sealed class LongevitymaxxingChallengePageTests
         Assert.Contains("function checkInSwitcherHtml", javascript);
         Assert.Contains("function getPendingCheckInDays", javascript);
         Assert.Contains("formatCheckInDate(day.date)", javascript);
+        Assert.Contains(".lmx-dashboard-grid", css);
+        Assert.Contains(".lmx-category-day.partial", css);
+        Assert.Contains(".lmx-dashboard-stats", css);
         Assert.Contains("function revealSignupDetailsBeforeSubmit()", javascript);
         Assert.Contains("setStatus(\"lmxSignupStatus\", \"Check these once, then join.\", false);", javascript);
         Assert.Contains("free signup", javascript);

--- a/LongevityWorldCup.Website/wwwroot/css/longevitymaxxing.css
+++ b/LongevityWorldCup.Website/wwwroot/css/longevitymaxxing.css
@@ -299,13 +299,14 @@
 
 .lmx-track {
     margin-top: 1rem;
-    padding: 0.75rem;
+    padding: 0.85rem;
     border-radius: 8px;
     background: rgba(255, 255, 255, 0.72);
     border: 1px solid rgba(15, 23, 42, 0.10);
 }
 
-.lmx-day-strip {
+.lmx-day-strip,
+.lmx-dashboard-days {
     display: grid;
     grid-template-columns: repeat(14, minmax(0, 1fr));
     gap: 0.35rem;
@@ -341,6 +342,254 @@
     color: #64748b;
     font-size: 0.78rem;
     font-weight: 800;
+}
+
+.lmx-dashboard-head {
+    display: flex;
+    align-items: end;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+}
+
+.lmx-dashboard-head h2 {
+    margin: 0.35rem 0 0;
+    text-align: left;
+    color: #0f172a;
+    font-size: 1.15rem;
+    letter-spacing: 0;
+}
+
+.lmx-dashboard-head > strong {
+    color: #334155;
+    font-family: Orbitron, Roboto, sans-serif;
+    font-size: 0.92rem;
+}
+
+.lmx-dashboard-stats {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 0.5rem;
+    margin-bottom: 0.75rem;
+}
+
+.lmx-dashboard-stat {
+    min-height: 4.35rem;
+    display: grid;
+    grid-template-columns: 1.75rem minmax(0, 1fr);
+    grid-template-areas:
+        "icon label"
+        "icon value"
+        "icon detail";
+    gap: 0.08rem 0.5rem;
+    align-content: center;
+    padding: 0.65rem;
+    border: 1px solid rgba(15, 23, 42, 0.10);
+    border-radius: 8px;
+    background: #ffffff;
+}
+
+.lmx-dashboard-stat i {
+    grid-area: icon;
+    width: 1.75rem;
+    height: 1.75rem;
+    border-radius: 8px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: #0f172a;
+    color: #ffffff;
+}
+
+.lmx-dashboard-stat.sleep i {
+    background: #2563eb;
+}
+
+.lmx-dashboard-stat.exercise i {
+    background: #dc2626;
+}
+
+.lmx-dashboard-stat.nutrition i {
+    background: #16a34a;
+}
+
+.lmx-dashboard-stat.vices i {
+    background: #7c3aed;
+}
+
+.lmx-dashboard-stat span {
+    grid-area: label;
+    color: #64748b;
+    font-size: 0.68rem;
+    font-weight: 900;
+    line-height: 1;
+    text-transform: uppercase;
+}
+
+.lmx-dashboard-stat strong {
+    grid-area: value;
+    min-width: 0;
+    color: #0f172a;
+    font-size: 1.05rem;
+    line-height: 1.1;
+    overflow-wrap: anywhere;
+}
+
+.lmx-dashboard-stat em {
+    grid-area: detail;
+    color: #64748b;
+    font-size: 0.76rem;
+    font-style: normal;
+    font-weight: 800;
+    line-height: 1.1;
+}
+
+.lmx-dashboard-grid {
+    display: grid;
+    gap: 0.4rem;
+}
+
+.lmx-dashboard-row {
+    display: grid;
+    grid-template-columns: minmax(9rem, 11rem) minmax(0, 1fr);
+    gap: 0.55rem;
+    align-items: center;
+}
+
+.lmx-dashboard-row-head {
+    color: #64748b;
+    font-size: 0.72rem;
+    font-weight: 900;
+    text-transform: uppercase;
+}
+
+.lmx-dashboard-day,
+.lmx-category-day {
+    min-width: 0;
+    aspect-ratio: 1;
+    border-radius: 7px;
+    border: 1px solid rgba(15, 23, 42, 0.12);
+    display: grid;
+    place-items: center;
+    box-sizing: border-box;
+    font-family: Orbitron, Roboto, sans-serif;
+    font-size: 0.68rem;
+    font-weight: 800;
+}
+
+.lmx-dashboard-day {
+    background: #eef2f7;
+    color: #475569;
+}
+
+.lmx-dashboard-day.practice {
+    color: #075985;
+    background: #e0f2fe;
+}
+
+.lmx-dashboard-day.today,
+.lmx-category-day.today {
+    outline: 3px solid rgba(248, 211, 91, 0.52);
+}
+
+.lmx-dashboard-category {
+    min-width: 0;
+    min-height: 3.2rem;
+    display: grid;
+    grid-template-columns: 2rem minmax(0, 1fr) auto;
+    gap: 0.18rem 0.45rem;
+    align-items: center;
+    padding: 0.45rem 0.55rem;
+    border: 1px solid rgba(15, 23, 42, 0.10);
+    border-radius: 8px;
+    background: #ffffff;
+}
+
+.lmx-dashboard-category i {
+    grid-row: 1 / span 2;
+    width: 2rem;
+    height: 2rem;
+    border-radius: 8px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: #ffffff;
+}
+
+.lmx-dashboard-category.sleep i {
+    background: #2563eb;
+}
+
+.lmx-dashboard-category.exercise i {
+    background: #dc2626;
+}
+
+.lmx-dashboard-category.nutrition i {
+    background: #16a34a;
+}
+
+.lmx-dashboard-category.vices i {
+    background: #7c3aed;
+}
+
+.lmx-dashboard-category span {
+    min-width: 0;
+    color: #0f172a;
+    font-weight: 900;
+    overflow-wrap: anywhere;
+}
+
+.lmx-dashboard-category strong {
+    color: #334155;
+    font-family: Orbitron, Roboto, sans-serif;
+    font-size: 0.82rem;
+}
+
+.lmx-dashboard-bar {
+    grid-column: 2 / -1;
+    height: 0.36rem;
+    border-radius: 999px;
+    background: #e2e8f0;
+    overflow: hidden;
+}
+
+.lmx-dashboard-bar span {
+    display: block;
+    height: 100%;
+    border-radius: inherit;
+    background: linear-gradient(90deg, #14b8a6, #f8d35b);
+}
+
+.lmx-category-day {
+    color: #334155;
+    background: #ffffff;
+}
+
+.lmx-category-day.full {
+    background: #bbf7d0;
+    border-color: rgba(22, 163, 74, 0.35);
+    color: #14532d;
+}
+
+.lmx-category-day.partial {
+    background: #fde68a;
+    border-color: rgba(217, 119, 6, 0.28);
+    color: #92400e;
+}
+
+.lmx-category-day.missed {
+    background: #fee2e2;
+    border-color: rgba(220, 38, 38, 0.22);
+    color: #991b1b;
+}
+
+.lmx-category-day.empty {
+    background: repeating-linear-gradient(135deg, #f8fafc, #f8fafc 4px, #eef2f7 4px, #eef2f7 8px);
+    color: transparent;
+}
+
+.lmx-category-day.practice {
+    box-shadow: inset 0 0 0 2px rgba(14, 165, 233, 0.16);
 }
 
 .lmx-metrics {
@@ -1402,6 +1651,10 @@
         grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 
+    .lmx-dashboard-stats {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
     .lmx-habit-grid {
         grid-template-columns: repeat(2, minmax(0, 1fr));
     }
@@ -1494,6 +1747,24 @@
         aspect-ratio: 1;
     }
 
+    .lmx-dashboard-row {
+        grid-template-columns: 1fr;
+        gap: 0.35rem;
+        padding: 0.55rem;
+        border: 1px solid rgba(15, 23, 42, 0.08);
+        border-radius: 8px;
+        background: #ffffff;
+    }
+
+    .lmx-dashboard-row-head {
+        display: none;
+    }
+
+    .lmx-dashboard-days {
+        grid-template-columns: repeat(7, minmax(0, 1fr));
+        gap: 0.32rem;
+    }
+
     .lmx-podium {
         grid-template-columns: 1fr;
     }
@@ -1535,6 +1806,15 @@
 
     .lmx-day-strip {
         grid-template-columns: repeat(7, minmax(0, 1fr));
+    }
+
+    .lmx-dashboard-head {
+        align-items: flex-start;
+        flex-direction: column;
+    }
+
+    .lmx-dashboard-stats {
+        grid-template-columns: 1fr;
     }
 
     .lmx-segmented {

--- a/LongevityWorldCup.Website/wwwroot/js/longevitymaxxing.js
+++ b/LongevityWorldCup.Website/wwwroot/js/longevitymaxxing.js
@@ -435,23 +435,149 @@
     }
 
     function renderChallengeVisuals(state) {
-        const strip = document.getElementById("lmxDayStrip");
-        if (!strip) return;
+        const track = document.getElementById("lmxTrack");
+        if (!track) return;
 
-        const checkedDays = new Set();
-        (state.leaderboard || []).forEach(row => {
-            (row.cells || []).forEach(cell => {
-                if (cell.checkedIn) checkedDays.add(cell.challengeDay);
-            });
-        });
+        if (!participantState) {
+            track.innerHTML = "";
+            return;
+        }
 
+        const participant = participantState.participant || {};
+        const row = (state.leaderboard || []).find(item => item.participantId === participant.id);
+        const cells = normalizeDashboardCells(row, state);
+        const scoredCells = cells.filter(cell => cell.checkedIn && cell.countsForScore !== false);
+        const checkedCells = cells.filter(cell => cell.checkedIn);
+        const categories = dashboardCategories();
+        const summaries = categories.map(category => categorySummary(category, cells, scoredCells));
+        const rankedSummaries = summaries
+            .filter(item => item.max > 0)
+            .sort((a, b) => b.rate - a.rate || b.total - a.total || a.category.label.localeCompare(b.category.label));
+        const best = rankedSummaries[0];
+        const focus = [...rankedSummaries].reverse()[0];
+        const fullDays = scoredCells.filter(cell => categories.every(category => Number(cell[category.key]) >= 2)).length;
+        const totalPoints = row && typeof row.totalPoints === "number"
+            ? row.totalPoints
+            : scoredCells.reduce((sum, cell) => sum + (typeof cell.score === "number" ? cell.score : 0), 0);
         const today = new Date().toISOString().slice(0, 10);
-        strip.innerHTML = (state.days || []).map(day => {
-            const classes = ["lmx-track-day"];
-            if (checkedDays.has(day.challengeDay)) classes.push("done");
-            if (day.date === today) classes.push("today");
-            return `<span class="${classes.join(" ")}" title="Day ${day.challengeDay} · ${escAttr(formatCheckInDate(day.date))}">${day.challengeDay}</span>`;
+        const dayHeaders = cells.map(cell => {
+            const classes = ["lmx-dashboard-day"];
+            if (cell.date === today) classes.push("today");
+            if (cell.countsForScore === false) classes.push("practice");
+            return `<span class="${classes.join(" ")}" title="${escAttr(dayTitle(cell))}">${cell.challengeDay}</span>`;
         }).join("");
+        const rows = summaries.map(summary => categoryDashboardRow(summary, cells, today)).join("");
+        const emptyLabel = state.phase === "signup" || state.phase === "roster" ? "Starts soon" : "No check-ins";
+
+        track.innerHTML = `
+            <div class="lmx-dashboard-head">
+                <div>
+                    <span class="lmx-mini-label">your trend</span>
+                    <h2>Category dashboard</h2>
+                </div>
+                <strong>${checkedCells.length ? `${checkedCells.length}/${state.durationDays || cells.length} days` : emptyLabel}</strong>
+            </div>
+            <div class="lmx-dashboard-stats" aria-label="Personal challenge stats">
+                ${dashboardStat("Best", best ? best.category.label : "-", best ? `${Math.round(best.rate * 100)}%` : "-", best ? best.category.icon : "fa-arrow-trend-up", best ? best.category.tone : "")}
+                ${dashboardStat("Focus", focus ? focus.category.label : "-", focus ? `${Math.round(focus.rate * 100)}%` : "-", focus ? focus.category.icon : "fa-crosshairs", focus ? focus.category.tone : "")}
+                ${dashboardStat("Locked-in days", String(fullDays), scoredCells.length ? `${scoredCells.length} scored` : "practice only", "fa-calendar-check")}
+                ${dashboardStat("Points", scoredCells.length ? String(totalPoints) : "-", scoredCells.length ? `${scoredCells.length} scored days` : "not started", "fa-chart-line")}
+            </div>
+            <div class="lmx-dashboard-grid" role="table" aria-label="Sleep, exercise, nutrition, and vices over time">
+                <div class="lmx-dashboard-row lmx-dashboard-row-head" role="row">
+                    <div role="columnheader">Category</div>
+                    <div class="lmx-dashboard-days" role="presentation">${dayHeaders}</div>
+                </div>
+                ${rows}
+            </div>`;
+    }
+
+    function normalizeDashboardCells(row, state) {
+        const byDay = new Map(((row && row.cells) || []).map(cell => [cell.challengeDay, cell]));
+        return (state.days || []).map(day => {
+            const cell = byDay.get(day.challengeDay) || {
+                challengeDay: day.challengeDay,
+                checkedIn: false,
+                score: null,
+                countsForScore: day.challengeDay !== 1,
+                sleep: null,
+                exercise: null,
+                nutrition: null,
+                vices: null
+            };
+            return { ...cell, date: day.date };
+        });
+    }
+
+    function dashboardCategories() {
+        return [
+            { key: "sleep", label: "Sleep", icon: "fa-moon", tone: "sleep" },
+            { key: "exercise", label: "Exercise", icon: "fa-dumbbell", tone: "exercise" },
+            { key: "nutrition", label: "Nutrition", icon: "fa-bowl-food", tone: "nutrition" },
+            { key: "vices", label: "Vices", icon: "fa-shield-halved", tone: "vices" }
+        ];
+    }
+
+    function categorySummary(category, cells, scoredCells) {
+        const denominatorCells = scoredCells.length ? scoredCells : cells.filter(cell => cell.checkedIn);
+        const total = denominatorCells.reduce((sum, cell) => sum + clampHabitValue(cell[category.key]), 0);
+        const max = denominatorCells.length * 2;
+        return {
+            category,
+            total,
+            max,
+            rate: max > 0 ? total / max : 0
+        };
+    }
+
+    function categoryDashboardRow(summary, cells, today) {
+        const category = summary.category;
+        const width = summary.max > 0 ? Math.round(summary.rate * 100) : 0;
+        const dayCells = cells.map(cell => categoryDayCell(category, cell, today)).join("");
+        return `<div class="lmx-dashboard-row" role="row">
+            <div class="lmx-dashboard-category ${escAttr(category.tone)}" role="cell">
+                <i class="fas ${escAttr(category.icon)}" aria-hidden="true"></i>
+                <span>${esc(category.label)}</span>
+                <strong>${summary.max > 0 ? `${summary.total}/${summary.max}` : "-"}</strong>
+                <div class="lmx-dashboard-bar" aria-hidden="true"><span style="width:${width}%"></span></div>
+            </div>
+            <div class="lmx-dashboard-days" role="cell" aria-label="${escAttr(`${category.label} by challenge day`)}">${dayCells}</div>
+        </div>`;
+    }
+
+    function categoryDayCell(category, cell, today) {
+        const classes = ["lmx-category-day"];
+        if (cell.date === today) classes.push("today");
+        if (cell.countsForScore === false) classes.push("practice");
+        if (!cell.checkedIn) {
+            classes.push("empty");
+            return `<span class="${classes.join(" ")}" title="${escAttr(`${dayTitle(cell)}: no check-in`)}" aria-label="${escAttr(`${category.label} day ${cell.challengeDay}: no check-in`)}"></span>`;
+        }
+
+        const value = clampHabitValue(cell[category.key]);
+        classes.push(value >= 2 ? "full" : value > 0 ? "partial" : "missed");
+        return `<span class="${classes.join(" ")}" title="${escAttr(`${dayTitle(cell)}: ${category.label} ${value}/2`)}" aria-label="${escAttr(`${category.label} day ${cell.challengeDay}: ${value} of 2`)}">${value}</span>`;
+    }
+
+    function dashboardStat(label, value, detail, icon, tone) {
+        const toneClass = tone ? ` ${escAttr(tone)}` : "";
+        return `<div class="lmx-dashboard-stat${toneClass}">
+            <i class="fas ${escAttr(icon)}" aria-hidden="true"></i>
+            <span>${esc(label)}</span>
+            <strong>${esc(value)}</strong>
+            <em>${esc(detail)}</em>
+        </div>`;
+    }
+
+    function clampHabitValue(value) {
+        const number = Number(value);
+        return Number.isFinite(number) ? Math.max(0, Math.min(2, number)) : 0;
+    }
+
+    function dayTitle(cell) {
+        const date = cell.date ? ` · ${formatCheckInDate(cell.date)}` : "";
+        const practice = cell.countsForScore === false ? " · practice" : "";
+        return `Day ${cell.challengeDay}${date}${practice}`;
     }
 
     function renderPanels(state) {
@@ -474,6 +600,8 @@
         toggle("lmxNotesPanel", hasParticipant && !checkInOnly);
         toggle("lmxSignupIntro", !signupSubmitted);
         toggle("lmxSignupDonePanel", signupSubmitted);
+        toggle("lmxHabitHeading", !hasParticipant);
+        toggle("lmxHabitGrid", !hasParticipant);
         toggle("lmxTrack", hasParticipant && dashboardMode && !checkInOnly);
         toggle("lmxMetrics", hasParticipant && dashboardMode && !checkInOnly);
         toggle("lmxBoardSection", !checkInOnly);

--- a/LongevityWorldCup.Website/wwwroot/longevitymaxxing/longevitymaxxing.html
+++ b/LongevityWorldCup.Website/wwwroot/longevitymaxxing/longevitymaxxing.html
@@ -35,8 +35,8 @@
                     <span><i class="fas fa-briefcase" aria-hidden="true"></i>Work compatible</span>
                     <span><i class="fas fa-heart-pulse" aria-hidden="true"></i>Injury compatible</span>
                 </div>
-                <h2 class="lmx-habit-heading">Habits you'll track</h2>
-                <div class="lmx-habit-grid" aria-label="Daily check-in categories">
+                <h2 id="lmxHabitHeading" class="lmx-habit-heading">Habits you'll track</h2>
+                <div id="lmxHabitGrid" class="lmx-habit-grid" aria-label="Daily check-in categories">
                     <div class="lmx-habit-card sleep">
                         <i class="fas fa-moon" aria-hidden="true"></i>
                         <span>Sleep</span>
@@ -54,7 +54,7 @@
                         <span>Vices</span>
                     </div>
                 </div>
-                <div id="lmxTrack" class="lmx-track lmx-hidden" aria-label="Challenge track">
+                <div id="lmxTrack" class="lmx-track lmx-hidden" aria-label="Personal challenge dashboard">
                     <div id="lmxDayStrip" class="lmx-day-strip"></div>
                     <div class="lmx-scale">
                         <span>Days</span>


### PR DESCRIPTION
## Summary
- Replaces the logged-in Longevitymaxxing aggregate day strip with a personal category dashboard across sleep, exercise, nutrition, and vices.
- Hides the redundant static habit cards for logged-in participants.
- Uses backend total points for the dashboard points summary so the new slip allowance and weighted scoring stay server-authoritative.
- Renames perfect 4/4 scored days to `Locked-in days`.

## Validation
- `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --filter "LongevitymaxxingChallengePageTests|LongevitymaxxingChallengeServiceTests"`
- Browser smoke check against a disposable participant: hidden habit block, corrected category icons, backend points summary, no console errors.