### PR TITLE
[codex] autonomous maintenance

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,6 +16,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
     - uses: actions/checkout@v5

--- a/LongevityWorldCup.Tests/ConfigPersistenceTests.cs
+++ b/LongevityWorldCup.Tests/ConfigPersistenceTests.cs
@@ -7,6 +7,25 @@ namespace LongevityWorldCup.Tests;
 public sealed class ConfigPersistenceTests
 {
     [Fact]
+    public async Task InitializeDefaultConfig_CanRunConcurrentlyForSameMissingFile()
+    {
+        using var temp = new TempDirectory();
+        var configPath = Path.Combine(temp.Path, "config.json");
+
+        var tasks = Enumerable.Range(0, 32)
+            .Select(_ => Task.Run(() => Program.InitializeDefaultConfig(configPath)))
+            .ToArray();
+
+        await Task.WhenAll(tasks);
+
+        var config = await Config.LoadAsync(configPath, Path.Combine(temp.Path, "runtime-config.json"));
+        Assert.Equal("hi@longevityworldcup.com", config.EmailFrom);
+        Assert.Equal("smtp.gmail.com", config.SmtpServer);
+        Assert.NotNull(config.LongevitymaxxingChallenge);
+        Assert.Empty(Directory.EnumerateFiles(temp.Path, "*.tmp"));
+    }
+
+    [Fact]
     public async Task LoadAsync_AppliesRuntimeTokenConfig_WhenRuntimeConfigIsCurrent()
     {
         using var temp = new TempDirectory();

--- a/LongevityWorldCup.Website/Program.cs
+++ b/LongevityWorldCup.Website/Program.cs
@@ -516,9 +516,28 @@ namespace LongevityWorldCup.Website
                 LongevitymaxxingChallenge = new LongevitymaxxingChallengeConfig()
             };
 
-            // Serialize to JSON and save to file
+            // Serialize to JSON and atomically publish it so parallel test hosts do not see a partial file.
             string json = JsonSerializer.Serialize(defaultConfig, JsonOptions); // Use cached options
-            File.WriteAllText(configFilePath, json);
+            string configDirectory = Path.GetDirectoryName(Path.GetFullPath(configFilePath))
+                ?? Directory.GetCurrentDirectory();
+            string tempConfigFilePath = Path.Combine(
+                configDirectory,
+                $"config.{Guid.NewGuid():N}.tmp");
+
+            try
+            {
+                File.WriteAllText(tempConfigFilePath, json);
+                File.Move(tempConfigFilePath, configFilePath);
+            }
+            catch (IOException) when (File.Exists(configFilePath))
+            {
+                // Another startup path created the config first.
+            }
+            finally
+            {
+                if (File.Exists(tempConfigFilePath))
+                    File.Delete(tempConfigFilePath);
+            }
         }
     }
 }

--- a/LongevityWorldCup.Website/Program.cs
+++ b/LongevityWorldCup.Website/Program.cs
@@ -479,10 +479,8 @@ namespace LongevityWorldCup.Website
             return JsonSerializer.SerializeAsync(context.Response.Body, response, HealthCheckJsonOptions);
         }
 
-        private static void InitializeDefaultConfig()
+        internal static void InitializeDefaultConfig(string configFilePath = "config.json")
         {
-            string configFilePath = "config.json";
-
             // Check if the config file already exists
             if (File.Exists(configFilePath))
                 return;


### PR DESCRIPTION
## Summary
- Rebases cleanly onto latest `origin/master` (`3dc05cf1`, "Bump NuGet patch dependencies").
- Fixed a startup race where parallel ASP.NET test hosts could both try to create `config.json` in the same output directory.
- Default config creation now writes a complete temporary file and publishes it atomically; if another startup path wins the race, the later path leaves the completed config in place.
- Added focused regression coverage that runs default config initialization concurrently against the same missing file and verifies the created config is readable with no leftover temp files.
- Added explicit timeouts to the .NET and Dependency Review CI jobs so routine checks cannot hang indefinitely.

## Why It Matters
- `dotnet test` was failing intermittently on Windows with `IOException: The process cannot access the file ... config.json` when integration tests started hosts in parallel.
- The atomic publish path prevents startup from observing a partially written default config.
- The dedicated test makes the concurrency guarantee explicit instead of relying only on incidental integration-test coverage.
- CI job timeouts make failures bounded and easier for future autonomous maintenance runs to diagnose.

## Verification
- Baseline before the config fix: `dotnet test --verbosity minimal` failed with 2 config file access failures and 296 passing tests.
- After initial config fix: `dotnet test --verbosity minimal` passed with 298 tests.
- After adding regression coverage: `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --filter ConfigPersistenceTests --verbosity minimal` passed with 4 tests.
- After rebasing onto `569208bc`: `dotnet test --verbosity minimal` passed with 319 tests.
- After rebasing onto latest `origin/master` (`3dc05cf1`): `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --filter ConfigPersistenceTests --verbosity minimal` passed with 4 tests.
- After rebasing onto latest `origin/master` (`3dc05cf1`): `dotnet test --verbosity minimal` passed with 319 tests.
- CI timeout batch: parsed `.github/workflows/dotnet.yml` and `.github/workflows/dependency-review.yml` with PyYAML.
- CI timeout batch: `git diff --check` passed, with only Git's existing line-ending warnings for touched workflow files.

## Residual Risk
- Low. The config behavioral change is limited to first-run default config creation and preserves existing config files unchanged.
- The initializer is now `internal` with a path overload for testability; production still calls it with the same default `config.json` path.
- CI timeout values may need tuning if the repository intentionally adds substantially slower checks later; current local full test time is under 30 seconds.
