### PR TITLE
[codex] autonomous maintenance

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,7 @@ permissions:
   security-events: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,6 +13,10 @@ permissions:
   contents: read
   security-events: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze-csharp:
     name: Analyze C#

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   dependency-review:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,7 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
       - name: Checkout code

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -37,5 +38,78 @@ jobs:
         -p:WarningsAsErrors=NU1900%3BNU1901%3BNU1902%3BNU1903%3BNU1904%3BNU1905
     - name: Build
       run: dotnet build --no-restore
-    - name: Test
-      run: dotnet test --no-build --verbosity normal
+    - name: Test with coverage
+      run: >
+        dotnet test
+        --no-build
+        --verbosity normal
+        -p:CollectCoverage=true
+        -p:CoverletOutput=TestResults/Coverage/
+        -p:CoverletOutputFormat=cobertura
+    - name: Summarize .NET coverage
+      id: coverage
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        coverage_file="$(find . -name coverage.cobertura.xml -print | head -n 1)"
+        if [[ -z "$coverage_file" ]]; then
+          echo "coverage.cobertura.xml was not produced." >&2
+          exit 1
+        fi
+
+        python3 - "$coverage_file" <<'PY' | tee coverage-summary.md
+        import sys
+        import xml.etree.ElementTree as ET
+
+        root = ET.parse(sys.argv[1]).getroot()
+        line_coverage = float(root.attrib.get("line-rate", "0")) * 100
+        branch_coverage = float(root.attrib.get("branch-rate", "0")) * 100
+
+        print("## .NET test coverage")
+        print()
+        print(f"- Line coverage: {line_coverage:.1f}%")
+        print(f"- Branch coverage: {branch_coverage:.1f}%")
+        PY
+
+        cat coverage-summary.md >> "$GITHUB_STEP_SUMMARY"
+        {
+          echo "markdown<<DOTNET_COVERAGE_SUMMARY"
+          cat coverage-summary.md
+          echo "DOTNET_COVERAGE_SUMMARY"
+        } >> "$GITHUB_OUTPUT"
+    - name: Comment .NET coverage on PR
+      if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+      uses: actions/github-script@v9
+      env:
+        COVERAGE_MARKDOWN: ${{ steps.coverage.outputs.markdown }}
+      with:
+        script: |
+          const marker = '<!-- dotnet-coverage-summary -->';
+          const body = [marker, process.env.COVERAGE_MARKDOWN].join('\n');
+          const { owner, repo } = context.repo;
+          const issue_number = context.issue.number;
+          const { data: comments } = await github.rest.issues.listComments({
+            owner,
+            repo,
+            issue_number,
+            per_page: 100
+          });
+          const existing = comments.find(comment =>
+            comment.user?.type === 'Bot' && comment.body?.includes(marker));
+
+          if (existing) {
+            await github.rest.issues.updateComment({
+              owner,
+              repo,
+              comment_id: existing.id,
+              body
+            });
+          } else {
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number,
+              body
+            });
+          }

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,6 +12,7 @@ on:
 permissions:
   contents: read
   issues: write
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
@@ -89,27 +90,35 @@ jobs:
           const body = [marker, process.env.COVERAGE_MARKDOWN].join('\n');
           const { owner, repo } = context.repo;
           const issue_number = context.issue.number;
-          const { data: comments } = await github.rest.issues.listComments({
-            owner,
-            repo,
-            issue_number,
-            per_page: 100
-          });
-          const existing = comments.find(comment =>
-            comment.user?.type === 'Bot' && comment.body?.includes(marker));
-
-          if (existing) {
-            await github.rest.issues.updateComment({
-              owner,
-              repo,
-              comment_id: existing.id,
-              body
-            });
-          } else {
-            await github.rest.issues.createComment({
+          try {
+            const { data: comments } = await github.rest.issues.listComments({
               owner,
               repo,
               issue_number,
-              body
+              per_page: 100
             });
+            const existing = comments.find(comment =>
+              comment.user?.type === 'Bot' && comment.body?.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body
+              });
+            }
+          } catch (error) {
+            if (error.status === 403) {
+              core.warning('Could not update the PR coverage comment with GITHUB_TOKEN; the coverage report is still available in the job summary.');
+            } else {
+              throw error;
+            }
           }

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -14,7 +14,7 @@ permissions:
   issues: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/LongevityWorldCup.Tests/AssetVersionProviderTests.cs
+++ b/LongevityWorldCup.Tests/AssetVersionProviderTests.cs
@@ -1,0 +1,120 @@
+using System.Security.Cryptography;
+using System.Text;
+using LongevityWorldCup.Website.Tools;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class AssetVersionProviderTests
+{
+    [Fact]
+    public void AppendVersion_AddsHashForExistingRootedAsset()
+    {
+        using var temp = new TempDirectory();
+        var assetPath = WriteAsset(temp.Path, "wwwroot/css/site.css", "body { color: black; }");
+        var provider = CreateProvider(webRootPath: Path.Combine(temp.Path, "wwwroot"));
+
+        var versionedPath = provider.AppendVersion("/css/site.css");
+
+        Assert.Equal($"/css/site.css?v={ExpectedVersion(File.ReadAllText(assetPath))}", versionedPath);
+    }
+
+    [Fact]
+    public void AppendVersion_PreservesExistingQueryString()
+    {
+        using var temp = new TempDirectory();
+        var assetPath = WriteAsset(temp.Path, "wwwroot/js/app.js", "console.log('ok');");
+        var provider = CreateProvider(webRootPath: Path.Combine(temp.Path, "wwwroot"));
+
+        var versionedPath = provider.AppendVersion("/js/app.js?module=true");
+
+        Assert.Equal($"/js/app.js?module=true&v={ExpectedVersion(File.ReadAllText(assetPath))}", versionedPath);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("css/site.css")]
+    [InlineData("/css/missing.css")]
+    public void AppendVersion_ReturnsOriginalPath_WhenPathCannotBeVersioned(string assetPath)
+    {
+        using var temp = new TempDirectory();
+        var provider = CreateProvider(webRootPath: Path.Combine(temp.Path, "wwwroot"));
+
+        Assert.Equal(assetPath, provider.AppendVersion(assetPath));
+    }
+
+    [Fact]
+    public void AppendVersion_UsesContentRootWwwroot_WhenWebRootPathIsUnavailable()
+    {
+        using var temp = new TempDirectory();
+        var assetPath = WriteAsset(temp.Path, "wwwroot/assets/logo.png", "fake image bytes");
+        var provider = CreateProvider(contentRootPath: temp.Path, webRootPath: Path.Combine(temp.Path, "missing-wwwroot"));
+
+        var versionedPath = provider.AppendVersion("/assets/logo.png");
+
+        Assert.Equal($"/assets/logo.png?v={ExpectedVersion(File.ReadAllText(assetPath))}", versionedPath);
+    }
+
+    [Fact]
+    public void AppendVersion_DoesNotHashFilesOutsideWebRoot()
+    {
+        using var temp = new TempDirectory();
+        Directory.CreateDirectory(Path.Combine(temp.Path, "wwwroot"));
+        File.WriteAllText(Path.Combine(temp.Path, "secret.txt"), "not a public asset");
+        var provider = CreateProvider(webRootPath: Path.Combine(temp.Path, "wwwroot"));
+
+        Assert.Equal("/../secret.txt", provider.AppendVersion("/../secret.txt"));
+    }
+
+    private static AssetVersionProvider CreateProvider(string webRootPath, string? contentRootPath = null)
+    {
+        return new AssetVersionProvider(new TestWebHostEnvironment
+        {
+            ContentRootPath = contentRootPath ?? Directory.GetParent(webRootPath)?.FullName ?? webRootPath,
+            WebRootPath = webRootPath
+        });
+    }
+
+    private static string WriteAsset(string root, string relativePath, string content)
+    {
+        var path = Path.Combine(root, relativePath.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    private static string ExpectedVersion(string content)
+    {
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(content));
+        return Convert.ToHexString(hash[..8]).ToLowerInvariant();
+    }
+
+    private sealed class TestWebHostEnvironment : IWebHostEnvironment
+    {
+        public string ApplicationName { get; set; } = "LongevityWorldCup.Tests";
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+        public string ContentRootPath { get; set; } = string.Empty;
+        public string EnvironmentName { get; set; } = Environments.Development;
+        public IFileProvider WebRootFileProvider { get; set; } = new NullFileProvider();
+        public string WebRootPath { get; set; } = string.Empty;
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public string Path { get; } = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"lwc-assets-{Guid.NewGuid():N}");
+
+        public TempDirectory()
+        {
+            Directory.CreateDirectory(Path);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+                Directory.Delete(Path, recursive: true);
+        }
+    }
+}

--- a/LongevityWorldCup.Tests/AssetVersionProviderTests.cs
+++ b/LongevityWorldCup.Tests/AssetVersionProviderTests.cs
@@ -69,6 +69,21 @@ public sealed class AssetVersionProviderTests
         Assert.Equal("/../secret.txt", provider.AppendVersion("/../secret.txt"));
     }
 
+    [Fact]
+    public void AppendVersion_DoesNotHashCaseVariantSiblingOnCaseSensitiveFileSystems()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        using var temp = new TempDirectory();
+        Directory.CreateDirectory(Path.Combine(temp.Path, "wwwroot"));
+        Directory.CreateDirectory(Path.Combine(temp.Path, "WWWROOT"));
+        File.WriteAllText(Path.Combine(temp.Path, "WWWROOT", "secret.txt"), "not a public asset");
+        var provider = CreateProvider(webRootPath: Path.Combine(temp.Path, "wwwroot"));
+
+        Assert.Equal("/../WWWROOT/secret.txt", provider.AppendVersion("/../WWWROOT/secret.txt"));
+    }
+
     private static AssetVersionProvider CreateProvider(string webRootPath, string? contentRootPath = null)
     {
         return new AssetVersionProvider(new TestWebHostEnvironment

--- a/LongevityWorldCup.Tests/BitcoinDataServiceTests.cs
+++ b/LongevityWorldCup.Tests/BitcoinDataServiceTests.cs
@@ -1,0 +1,143 @@
+using System.Net;
+using LongevityWorldCup.Website.Business;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class BitcoinDataServiceTests
+{
+    [Fact]
+    public async Task GetBtcUsdAsync_UsesPrimaryPriceApiAndCachesResult()
+    {
+        var handler = new RecordingHandler(request => request.RequestUri?.Host switch
+        {
+            "api.coingecko.com" => JsonResponse("""{"bitcoin":{"usd":65432.10}}"""),
+            _ => throw new InvalidOperationException($"Unexpected request: {request.RequestUri}")
+        });
+        var service = CreateService(handler);
+
+        var first = await service.GetBtcUsdAsync();
+        var second = await service.GetBtcUsdAsync();
+
+        Assert.Equal(65432.10m, first);
+        Assert.Equal(first, second);
+        var request = Assert.Single(handler.Requests);
+        Assert.Equal("https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd", request);
+    }
+
+    [Fact]
+    public async Task GetBtcUsdAsync_FallsBackToBlockchainTickerWhenPrimaryFails()
+    {
+        var handler = new RecordingHandler(request => request.RequestUri?.Host switch
+        {
+            "api.coingecko.com" => new HttpResponseMessage(HttpStatusCode.BadGateway),
+            "blockchain.info" => JsonResponse("""{"USD":{"last":54321.98}}"""),
+            _ => throw new InvalidOperationException($"Unexpected request: {request.RequestUri}")
+        });
+        var service = CreateService(handler);
+
+        var result = await service.GetBtcUsdAsync();
+
+        Assert.Equal(54321.98m, result);
+        Assert.Equal(
+            [
+                "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd",
+                "https://blockchain.info/ticker"
+            ],
+            handler.Requests);
+    }
+
+    [Fact]
+    public async Task GetBtcUsdAsync_ThrowsWhenPrimaryAndFallbackFail()
+    {
+        var handler = new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+        var service = CreateService(handler);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => service.GetBtcUsdAsync());
+
+        Assert.Equal("Both primary and fallback APIs failed for BTC to USD rate.", ex.Message);
+        Assert.Equal(2, handler.Requests.Count);
+    }
+
+    [Fact]
+    public async Task GetTotalReceivedSatoshisAsync_UsesPrimaryBalanceApiAndCachesResult()
+    {
+        var handler = new RecordingHandler(request => request.RequestUri?.Host switch
+        {
+            "blockchain.info" => TextResponse("123456789"),
+            _ => throw new InvalidOperationException($"Unexpected request: {request.RequestUri}")
+        });
+        var service = CreateService(handler);
+
+        var first = await service.GetTotalReceivedSatoshisAsync();
+        var second = await service.GetTotalReceivedSatoshisAsync();
+
+        Assert.Equal(123456789L, first);
+        Assert.Equal(first, second);
+        var request = Assert.Single(handler.Requests);
+        Assert.StartsWith("https://blockchain.info/q/addressbalance/", request, StringComparison.Ordinal);
+        Assert.EndsWith("?confirmations=3", request, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetTotalReceivedSatoshisAsync_FallsBackToBlockCypherBalance()
+    {
+        var handler = new RecordingHandler(request => request.RequestUri?.Host switch
+        {
+            "blockchain.info" => new HttpResponseMessage(HttpStatusCode.TooManyRequests),
+            "api.blockcypher.com" => JsonResponse("""{"balance":987654321}"""),
+            _ => throw new InvalidOperationException($"Unexpected request: {request.RequestUri}")
+        });
+        var service = CreateService(handler);
+
+        var result = await service.GetTotalReceivedSatoshisAsync();
+
+        Assert.Equal(987654321L, result);
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.StartsWith(
+            "https://api.blockcypher.com/v1/btc/main/addrs/",
+            handler.Requests[1],
+            StringComparison.Ordinal);
+        Assert.EndsWith("/balance?confirmations=3", handler.Requests[1], StringComparison.Ordinal);
+    }
+
+    private static BitcoinDataService CreateService(RecordingHandler handler)
+    {
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        return new BitcoinDataService(
+            new StaticHttpClientFactory(new HttpClient(handler)),
+            cache,
+            events: null!,
+            NullLogger<BitcoinDataService>.Instance);
+    }
+
+    private static HttpResponseMessage JsonResponse(string json)
+        => new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json)
+        };
+
+    private static HttpResponseMessage TextResponse(string text)
+        => new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(text)
+        };
+
+    private sealed class StaticHttpClientFactory(HttpClient client) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => client;
+    }
+
+    private sealed class RecordingHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory) : HttpMessageHandler
+    {
+        public List<string> Requests { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add(request.RequestUri?.AbsoluteUri ?? string.Empty);
+            return Task.FromResult(responseFactory(request));
+        }
+    }
+}

--- a/LongevityWorldCup.Tests/BtcpayInvoiceClientTests.cs
+++ b/LongevityWorldCup.Tests/BtcpayInvoiceClientTests.cs
@@ -136,6 +136,55 @@ public sealed class BtcpayInvoiceClientTests
         Assert.DoesNotContain("user@example.test", lookup.Error);
     }
 
+    [Fact]
+    public void ParseInvoiceJson_TreatsSettledInvoiceAsPaidWithoutPaidAmount()
+    {
+        var result = BtcpayInvoiceClient.ParseInvoiceJson(
+            """
+            {
+              "status": "Settled",
+              "additionalStatus": "None",
+              "amount": "25.50",
+              "currency": "USD",
+              "checkoutLink": "https://btcpay.example.test/i/invoice-1"
+            }
+            """);
+
+        Assert.True(result.Success);
+        Assert.True(result.IsPaid);
+        Assert.Equal("Settled", result.Status);
+        Assert.Null(result.PaidAmount);
+    }
+
+    [Fact]
+    public void ParseInvoiceJson_ParsesNumericAndCaseInsensitiveProviderFields()
+    {
+        var result = BtcpayInvoiceClient.ParseInvoiceJson(
+            """
+            {
+              "STATUS": "Processing",
+              "ADDITIONALSTATUS": "PaidPartial",
+              "AMOUNT": 25.50,
+              "CURRENCY": "usd",
+              "PAIDAMOUNT": 1.25,
+              "CHECKOUTLINK": "https://btcpay.example.test/i/invoice-1",
+              "BUYER": { "EMAIL": "buyer@example.test" },
+              "METADATA": { "ATHLETENAME": "Alice Athlete" }
+            }
+            """);
+
+        Assert.True(result.Success);
+        Assert.True(result.IsPaid);
+        Assert.Equal("Processing", result.Status);
+        Assert.Equal("PaidPartial", result.AdditionalStatus);
+        Assert.Equal(25.50m, result.Amount);
+        Assert.Equal(1.25m, result.PaidAmount);
+        Assert.Equal("usd", result.Currency);
+        Assert.Equal("https://btcpay.example.test/i/invoice-1", result.CheckoutLink);
+        Assert.Equal("buyer@example.test", result.BuyerEmail);
+        Assert.Equal("Alice Athlete", result.AthleteNameFromMetadata);
+    }
+
     private sealed class StaticHttpClientFactory(HttpStatusCode statusCode, string body) : IHttpClientFactory
     {
         public HttpClient CreateClient(string name)

--- a/LongevityWorldCup.Tests/BtcpayInvoiceClientTests.cs
+++ b/LongevityWorldCup.Tests/BtcpayInvoiceClientTests.cs
@@ -1,4 +1,6 @@
 using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
 using LongevityWorldCup.Website;
 using LongevityWorldCup.Website.Business;
 using Xunit;
@@ -7,6 +9,107 @@ namespace LongevityWorldCup.Tests;
 
 public sealed class BtcpayInvoiceClientTests
 {
+    [Fact]
+    public async Task CreateInvoiceAsync_SendsCanonicalPayloadAndAuthorizationHeader()
+    {
+        var handler = new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                """
+                {
+                  "id": "invoice-123",
+                  "checkoutLink": "https://btcpay.example.test/i/invoice-123"
+                }
+                """)
+        });
+        var client = new BtcpayInvoiceClient(new RecordingHttpClientFactory(handler));
+        var config = new Config
+        {
+            BTCPayBaseUrl = "https://btcpay.example.test/",
+            BTCPayStoreId = "store id",
+            BTCPayGreenfieldApiKey = "secret-token"
+        };
+
+        var result = await client.CreateInvoiceAsync(
+            config,
+            new BtcpayInvoiceCreateRequest(
+                25.5m,
+                " usd ",
+                "order-1",
+                "buyer@example.test",
+                "Buyer Name",
+                new Dictionary<string, object?> { ["athleteSlug"] = "alice" }));
+
+        Assert.True(result.Success);
+        Assert.Equal("invoice-123", result.InvoiceId);
+        Assert.Equal("https://btcpay.example.test/i/invoice-123", result.CheckoutLink);
+
+        var request = Assert.Single(handler.Requests);
+        Assert.Equal(HttpMethod.Post, request.Method);
+        Assert.Equal("https://btcpay.example.test/api/v1/stores/store%20id/invoices", request.RequestUri?.AbsoluteUri);
+        Assert.Equal("token", request.Authorization?.Scheme);
+        Assert.Equal("secret-token", request.Authorization?.Parameter);
+
+        using var payload = JsonDocument.Parse(request.Body);
+        var root = payload.RootElement;
+        Assert.Equal(25.5m, root.GetProperty("amount").GetDecimal());
+        Assert.Equal("USD", root.GetProperty("currency").GetString());
+        Assert.Equal("BTC", root.GetProperty("checkout").GetProperty("paymentMethods")[0].GetString());
+        Assert.Equal("HighSpeed", root.GetProperty("checkout").GetProperty("speedPolicy").GetString());
+        Assert.Equal("buyer@example.test", root.GetProperty("buyer").GetProperty("email").GetString());
+
+        var metadata = root.GetProperty("metadata");
+        Assert.Equal("alice", metadata.GetProperty("athleteSlug").GetString());
+        Assert.Equal("order-1", metadata.GetProperty("orderId").GetString());
+        Assert.Equal("Buyer Name", metadata.GetProperty("buyerName").GetString());
+        Assert.Equal("buyer@example.test", metadata.GetProperty("buyerEmail").GetString());
+    }
+
+    [Fact]
+    public async Task GetInvoiceAsync_UsesEscapedTrimmedInvoiceIdAndParsesResult()
+    {
+        var handler = new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                """
+                {
+                  "status": "Processing",
+                  "additionalStatus": "PaidPartial",
+                  "amount": "25.50",
+                  "currency": "USD",
+                  "paidAmount": "1.25",
+                  "checkoutLink": "https://btcpay.example.test/i/invoice-1",
+                  "buyer": { "email": "buyer@example.test" },
+                  "metadata": { "athleteName": "Alice Athlete" }
+                }
+                """)
+        });
+        var client = new BtcpayInvoiceClient(new RecordingHttpClientFactory(handler));
+        var config = new Config
+        {
+            BTCPayBaseUrl = "https://btcpay.example.test/",
+            BTCPayStoreId = "store",
+            BTCPayGreenfieldApiKey = "secret-token"
+        };
+
+        var result = await client.GetInvoiceAsync(config, " invoice/1 ");
+
+        Assert.True(result.Success);
+        Assert.True(result.IsPaid);
+        Assert.Equal("Processing", result.Status);
+        Assert.Equal("PaidPartial", result.AdditionalStatus);
+        Assert.Equal(25.50m, result.Amount);
+        Assert.Equal(1.25m, result.PaidAmount);
+        Assert.Equal("buyer@example.test", result.BuyerEmail);
+        Assert.Equal("Alice Athlete", result.AthleteNameFromMetadata);
+
+        var request = Assert.Single(handler.Requests);
+        Assert.Equal(HttpMethod.Get, request.Method);
+        Assert.Equal("https://btcpay.example.test/api/v1/stores/store/invoices/invoice%2F1", request.RequestUri?.AbsoluteUri);
+        Assert.Equal("token", request.Authorization?.Scheme);
+        Assert.Equal("secret-token", request.Authorization?.Parameter);
+    }
+
     [Fact]
     public async Task BtcpayFailuresDoNotExposeRawResponseBodies()
     {
@@ -47,4 +150,34 @@ public sealed class BtcpayInvoiceClientTests
                 Content = new StringContent(body)
             });
     }
+
+    private sealed class RecordingHttpClientFactory(RecordingHandler handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name)
+            => new(handler);
+    }
+
+    private sealed class RecordingHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory) : HttpMessageHandler
+    {
+        public List<RecordedRequest> Requests { get; } = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var body = request.Content is null
+                ? string.Empty
+                : await request.Content.ReadAsStringAsync(cancellationToken);
+            Requests.Add(new RecordedRequest(
+                request.Method,
+                request.RequestUri,
+                request.Headers.Authorization,
+                body));
+            return responseFactory(request);
+        }
+    }
+
+    private sealed record RecordedRequest(
+        HttpMethod Method,
+        Uri? RequestUri,
+        AuthenticationHeaderValue? Authorization,
+        string Body);
 }

--- a/LongevityWorldCup.Tests/CanonicalRouteTests.cs
+++ b/LongevityWorldCup.Tests/CanonicalRouteTests.cs
@@ -1,0 +1,37 @@
+using System.Net;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class CanonicalRouteTests
+{
+    [Theory]
+    [InlineData("/index.html?ref=test", "/?ref=test")]
+    [InlineData("/event-board/event-board.html?view=latest", "/events?view=latest")]
+    [InlineData("/leaderboard/leaderboard/", "/leaderboard")]
+    [InlineData("/misc-pages/ruleset.html", "/ruleset")]
+    [InlineData("/onboarding/convergence.html", "/apply")]
+    public async Task LegacyAliases_RedirectToCanonicalPath(string path, string expectedLocation)
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+
+        using var response = await client.GetAsync(path);
+
+        Assert.Equal(HttpStatusCode.MovedPermanently, response.StatusCode);
+        Assert.Equal(expectedLocation, response.Headers.Location?.ToString());
+    }
+
+    [Fact]
+    public async Task CanonicalCleanPath_ServesPageWithoutRedirect()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+
+        using var response = await client.GetAsync("/about");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Null(response.Headers.Location);
+    }
+}

--- a/LongevityWorldCup.Tests/CanonicalRouteTests.cs
+++ b/LongevityWorldCup.Tests/CanonicalRouteTests.cs
@@ -12,6 +12,7 @@ public sealed class CanonicalRouteTests
     [InlineData("/leaderboard/leaderboard/", "/leaderboard")]
     [InlineData("/misc-pages/ruleset.html", "/ruleset")]
     [InlineData("/onboarding/convergence.html", "/apply")]
+    [InlineData("/RULES/?ref=docs", "/ruleset?ref=docs")]
     public async Task LegacyAliases_RedirectToCanonicalPath(string path, string expectedLocation)
     {
         using var factory = new TestWebApplicationFactory();
@@ -21,6 +22,20 @@ public sealed class CanonicalRouteTests
 
         Assert.Equal(HttpStatusCode.MovedPermanently, response.StatusCode);
         Assert.Equal(expectedLocation, response.Headers.Location?.ToString());
+    }
+
+    [Theory]
+    [InlineData("/Leaderboard?sort=rank")]
+    [InlineData("/about/?ref=footer")]
+    public async Task CleanRouteVariants_ServeWithoutRedirect(string path)
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+
+        using var response = await client.GetAsync(path);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Null(response.Headers.Location);
     }
 
     [Fact]

--- a/LongevityWorldCup.Tests/ClientIdentifierTests.cs
+++ b/LongevityWorldCup.Tests/ClientIdentifierTests.cs
@@ -7,11 +7,17 @@ namespace LongevityWorldCup.Tests;
 
 public sealed class ClientIdentifierTests
 {
-    [Fact]
-    public void FromUsesCloudflareHeaderWhenRemoteAddressIsTrustedProxy()
+    [Theory]
+    [InlineData("127.0.0.1")]
+    [InlineData("10.1.2.3")]
+    [InlineData("172.16.0.1")]
+    [InlineData("172.31.255.255")]
+    [InlineData("192.168.1.5")]
+    [InlineData("::ffff:10.1.2.3")]
+    public void FromUsesCloudflareHeaderWhenRemoteAddressIsTrustedProxy(string proxyAddress)
     {
         var context = new DefaultHttpContext();
-        context.Connection.RemoteIpAddress = IPAddress.Loopback;
+        context.Connection.RemoteIpAddress = IPAddress.Parse(proxyAddress);
         context.Request.Headers["CF-Connecting-IP"] = "203.0.113.10";
 
         Assert.Equal("203.0.113.10", ClientIdentifier.From(context));
@@ -25,5 +31,47 @@ public sealed class ClientIdentifierTests
         context.Request.Headers["X-Forwarded-For"] = "203.0.113.10";
 
         Assert.Equal("198.51.100.5", ClientIdentifier.From(context));
+    }
+
+    [Fact]
+    public void FromPrefersCloudflareHeaderOverForwardedFor()
+    {
+        var context = new DefaultHttpContext();
+        context.Connection.RemoteIpAddress = IPAddress.Loopback;
+        context.Request.Headers["CF-Connecting-IP"] = "203.0.113.10";
+        context.Request.Headers["X-Forwarded-For"] = "198.51.100.7";
+
+        Assert.Equal("203.0.113.10", ClientIdentifier.From(context));
+    }
+
+    [Fact]
+    public void FromUsesFirstForwardedForHopFromTrustedProxy()
+    {
+        var context = new DefaultHttpContext();
+        context.Connection.RemoteIpAddress = IPAddress.Parse("10.0.0.5");
+        context.Request.Headers["X-Forwarded-For"] = "203.0.113.10, 198.51.100.7";
+
+        Assert.Equal("203.0.113.10", ClientIdentifier.From(context));
+    }
+
+    [Fact]
+    public void FromFallsBackToProxyAddressWhenForwardedHeadersAreInvalid()
+    {
+        var context = new DefaultHttpContext();
+        context.Connection.RemoteIpAddress = IPAddress.Parse("10.0.0.5");
+        context.Request.Headers["CF-Connecting-IP"] = "not-an-ip";
+        context.Request.Headers["X-Forwarded-For"] = "also-not-an-ip";
+
+        Assert.Equal("10.0.0.5", ClientIdentifier.From(context));
+    }
+
+    [Fact]
+    public void FromReturnsUnknownWhenRemoteAddressIsMissing()
+    {
+        var context = new DefaultHttpContext();
+        context.Connection.RemoteIpAddress = null;
+        context.Request.Headers["CF-Connecting-IP"] = "203.0.113.10";
+
+        Assert.Equal(ClientIdentifier.Unknown, ClientIdentifier.From(context));
     }
 }

--- a/LongevityWorldCup.Tests/ConfigPersistenceTests.cs
+++ b/LongevityWorldCup.Tests/ConfigPersistenceTests.cs
@@ -100,6 +100,29 @@ public sealed class ConfigPersistenceTests
     }
 
     [Fact]
+    public async Task LoadAsync_IgnoresMalformedRuntimeTokenConfig_WhenPrimaryConfigIsValid()
+    {
+        using var temp = new TempDirectory();
+        var configPath = Path.Combine(temp.Path, "config.json");
+        var runtimeConfigPath = Path.Combine(temp.Path, "runtime-config.json");
+
+        await WriteConfigAsync(configPath, new Config
+        {
+            XAccessToken = "primary-x-access",
+            ThreadsAccessToken = "primary-threads"
+        });
+        await File.WriteAllTextAsync(runtimeConfigPath, "{ malformed");
+
+        File.SetLastWriteTimeUtc(configPath, DateTime.UtcNow.AddMinutes(-10));
+        File.SetLastWriteTimeUtc(runtimeConfigPath, DateTime.UtcNow);
+
+        var config = await Config.LoadAsync(configPath, runtimeConfigPath);
+
+        Assert.Equal("primary-x-access", config.XAccessToken);
+        Assert.Equal("primary-threads", config.ThreadsAccessToken);
+    }
+
+    [Fact]
     public async Task SaveAsync_FallsBackToRuntimeTokenConfig_WhenPrimaryConfigIsReadOnly()
     {
         using var temp = new TempDirectory();

--- a/LongevityWorldCup.Tests/CustomEventMarkupTests.cs
+++ b/LongevityWorldCup.Tests/CustomEventMarkupTests.cs
@@ -1,0 +1,76 @@
+using LongevityWorldCup.Website.Tools;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class CustomEventMarkupTests
+{
+    [Fact]
+    public void SplitTitleAndContent_NormalizesNewlinesAndTrimsOnlyTitleEnd()
+    {
+        var (title, content) = CustomEventMarkup.SplitTitleAndContent("Title  \r\n\r\n Body line  \r\nNext ");
+
+        Assert.Equal("Title", title);
+        Assert.Equal(" Body line  \nNext", content);
+    }
+
+    [Fact]
+    public void HyperlinkDetection_RecognizesSafeLinksInsideStyledMarkup()
+    {
+        const string text = "Read [bold]([guide](https://example.test/path(a))) now";
+
+        Assert.True(CustomEventMarkup.ContainsHyperlink(text));
+        Assert.Equal("https://example.test/path(a)", CustomEventMarkup.GetSingleHyperlink(text));
+    }
+
+    [Theory]
+    [InlineData("[x](javascript:alert(1))")]
+    [InlineData("[x](mailto:hello@example.test)")]
+    [InlineData("[x](https://example.test")]
+    [InlineData("[bold]([x](javascript:alert(1)))")]
+    public void HyperlinkDetection_RejectsUnsafeOrMalformedLinks(string text)
+    {
+        Assert.False(CustomEventMarkup.ContainsHyperlink(text));
+        Assert.Null(CustomEventMarkup.GetSingleHyperlink(text));
+    }
+
+    [Fact]
+    public void GetSingleHyperlink_ReturnsNullWhenMultipleSafeLinksExist()
+    {
+        const string text = "[one](https://one.example.test) and [two](https://two.example.test)";
+
+        Assert.True(CustomEventMarkup.ContainsHyperlink(text));
+        Assert.Null(CustomEventMarkup.GetSingleHyperlink(text));
+    }
+
+    [Fact]
+    public void ToPlainText_ResolvesMentionsAndCanDropHyperlinkLabels()
+    {
+        static string Resolve(string slug) => slug == "siim_land" ? "Siim Land" : "";
+
+        var plain = CustomEventMarkup.ToPlainText(
+            "Welcome [mention](siim_land). Read [guide](https://example.test). Meet [mention](unknown_slug).",
+            keepHyperlinkLabels: false,
+            Resolve);
+
+        Assert.Equal("Welcome Siim Land. Read . Meet Unknown Slug.", plain);
+    }
+
+    [Fact]
+    public void ParseSegments_PreservesStylesAndMergesAdjacentRuns()
+    {
+        var segments = CustomEventMarkup.ParseSegments(
+            "A [bold](B [link](https://example.test)) [strong](C) D",
+            keepHyperlinkLabels: true);
+
+        Assert.Equal(
+            [
+                new CustomEventSegment("A ", CustomEventTextStyle.Regular),
+                new CustomEventSegment("B link", CustomEventTextStyle.Bold),
+                new CustomEventSegment(" ", CustomEventTextStyle.Regular),
+                new CustomEventSegment("C", CustomEventTextStyle.Strong),
+                new CustomEventSegment(" D", CustomEventTextStyle.Regular)
+            ],
+            segments);
+    }
+}

--- a/LongevityWorldCup.Tests/DailyFileLoggerProviderTests.cs
+++ b/LongevityWorldCup.Tests/DailyFileLoggerProviderTests.cs
@@ -1,0 +1,57 @@
+using LongevityWorldCup.Website.Business;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class DailyFileLoggerProviderTests
+{
+    [Fact]
+    public void Constructor_CleansOnlyExpiredDateNamedLogs()
+    {
+        using var temp = new TempDirectory();
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var expiredLog = Path.Combine(temp.Path, $"{today.AddDays(-2):yyyy-MM-dd}.log");
+        var retainedLog = Path.Combine(temp.Path, $"{today.AddDays(-1):yyyy-MM-dd}.log");
+        var invalidNameLog = Path.Combine(temp.Path, "manual-note.log");
+        File.WriteAllText(expiredLog, "expired");
+        File.WriteAllText(retainedLog, "retained");
+        File.WriteAllText(invalidNameLog, "manual");
+
+        using var provider = new DailyFileLoggerProvider(temp.Path, retentionDays: 2);
+
+        Assert.False(File.Exists(expiredLog));
+        Assert.True(File.Exists(retainedLog));
+        Assert.True(File.Exists(invalidNameLog));
+    }
+
+    [Fact]
+    public void Logger_WritesCurrentUtcDayLog()
+    {
+        using var temp = new TempDirectory();
+        using var provider = new DailyFileLoggerProvider(temp.Path);
+        var logger = provider.CreateLogger("Tests.Category");
+
+        logger.LogInformation("Hello {Name}", "Alice");
+
+        var todayLog = Path.Combine(temp.Path, $"{DateOnly.FromDateTime(DateTime.UtcNow):yyyy-MM-dd}.log");
+        var text = File.ReadAllText(todayLog);
+        Assert.Contains("[Information] Tests.Category - Hello Alice", text, StringComparison.Ordinal);
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public string Path { get; } = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"lwc-daily-log-{Guid.NewGuid():N}");
+
+        public TempDirectory()
+        {
+            Directory.CreateDirectory(Path);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+                Directory.Delete(Path, recursive: true);
+        }
+    }
+}

--- a/LongevityWorldCup.Tests/DatabaseManagerBackupTests.cs
+++ b/LongevityWorldCup.Tests/DatabaseManagerBackupTests.cs
@@ -1,0 +1,47 @@
+using LongevityWorldCup.Website.Business;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class DatabaseManagerBackupTests
+{
+    [Fact]
+    public void BackupDatabase_CreatesDistinctFilesForRepeatedBackups()
+    {
+        using var temp = new TempDirectory();
+        using var database = new DatabaseManager(dbPath: Path.Combine(temp.Path, "test.db"));
+
+        database.Run(sqlite =>
+        {
+            using var command = sqlite.CreateCommand();
+            command.CommandText = "CREATE TABLE Sample (Id INTEGER PRIMARY KEY, Name TEXT NOT NULL); INSERT INTO Sample (Name) VALUES ('Alice');";
+            command.ExecuteNonQuery();
+        });
+
+        var backupDir = Path.Combine(temp.Path, "backups");
+
+        var firstBackup = database.BackupDatabase(backupDir);
+        var secondBackup = database.BackupDatabase(backupDir);
+
+        Assert.NotEqual(firstBackup, secondBackup);
+        Assert.True(File.Exists(firstBackup));
+        Assert.True(File.Exists(secondBackup));
+        Assert.Equal(2, Directory.GetFiles(backupDir, "*.db", SearchOption.TopDirectoryOnly).Length);
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public string Path { get; } = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"lwc-db-backup-{Guid.NewGuid():N}");
+
+        public TempDirectory()
+        {
+            Directory.CreateDirectory(Path);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+                Directory.Delete(Path, recursive: true);
+        }
+    }
+}

--- a/LongevityWorldCup.Tests/DatabaseManagerBackupTests.cs
+++ b/LongevityWorldCup.Tests/DatabaseManagerBackupTests.cs
@@ -29,6 +29,23 @@ public sealed class DatabaseManagerBackupTests
         Assert.Equal(2, Directory.GetFiles(backupDir, "*.db", SearchOption.TopDirectoryOnly).Length);
     }
 
+    [Fact]
+    public void BackupDatabase_RetentionOnlyDeletesManagedBackupFiles()
+    {
+        using var temp = new TempDirectory();
+        using var database = new DatabaseManager(dbPath: Path.Combine(temp.Path, "test.db"));
+        var backupDir = Path.Combine(temp.Path, "backups");
+        Directory.CreateDirectory(backupDir);
+        var unrelatedDatabase = Path.Combine(backupDir, "manual-snapshot.db");
+        File.WriteAllText(unrelatedDatabase, "not managed by DatabaseManager");
+
+        database.BackupDatabase(backupDir, maxBackupFiles: 1);
+        database.BackupDatabase(backupDir, maxBackupFiles: 1);
+
+        Assert.True(File.Exists(unrelatedDatabase));
+        Assert.Single(Directory.GetFiles(backupDir, "LongevityWC_*.db", SearchOption.TopDirectoryOnly));
+    }
+
     private sealed class TempDirectory : IDisposable
     {
         public string Path { get; } = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"lwc-db-backup-{Guid.NewGuid():N}");

--- a/LongevityWorldCup.Tests/EnvironmentHelpersTests.cs
+++ b/LongevityWorldCup.Tests/EnvironmentHelpersTests.cs
@@ -1,0 +1,17 @@
+using LongevityWorldCup.Website.Tools;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class EnvironmentHelpersTests
+{
+    [Theory]
+    [InlineData(@"C:\Source\Process.cs", "Process")]
+    [InlineData("/source/Status.cs", "Status")]
+    [InlineData("Class.CS", "Class")]
+    [InlineData("Metrics", "Metrics")]
+    public void ExtractFileName_RemovesOnlyCsExtension(string path, string expected)
+    {
+        Assert.Equal(expected, EnvironmentHelpers.ExtractFileName(path));
+    }
+}

--- a/LongevityWorldCup.Tests/EventBoardRedirectMiddlewareTests.cs
+++ b/LongevityWorldCup.Tests/EventBoardRedirectMiddlewareTests.cs
@@ -1,0 +1,52 @@
+using System.Net;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class EventBoardRedirectMiddlewareTests
+{
+    [Fact]
+    public async Task EventBoardEmbedWithoutAthlete_RedirectsToErrorPage()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+
+        using var response = await client.GetAsync("/event-board-embed.html?embed=1");
+
+        Assert.Equal(HttpStatusCode.Found, response.StatusCode);
+        Assert.Equal("/error/404.html", response.Headers.Location?.ToString());
+    }
+
+    [Fact]
+    public async Task EventBoardEmbedWithoutEmbedFlag_RedirectsToCanonicalAthlete()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+
+        using var response = await client.GetAsync("/event-board-embed.html?athlete=ron-lugbill&rows=all");
+
+        Assert.Equal(HttpStatusCode.MovedPermanently, response.StatusCode);
+        Assert.Equal("/athlete/ron-lugbill", response.Headers.Location?.ToString());
+        Assert.False(response.Headers.Contains("X-Robots-Tag"));
+    }
+
+    [Fact]
+    public async Task EventBoardEmbedWithEmbedFlag_ServesNoIndexHtml()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+
+        using var response = await client.GetAsync("/event-board-embed.html?athlete=ron-lugbill&embed=1");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("noindex, nofollow", GetHeader(response, "X-Robots-Tag"));
+        Assert.Null(response.Headers.Location);
+    }
+
+    private static string GetHeader(HttpResponseMessage response, string name)
+    {
+        Assert.True(response.Headers.TryGetValues(name, out var values), $"Missing response header '{name}'.");
+        return Assert.Single(values);
+    }
+}

--- a/LongevityWorldCup.Tests/EventBoardRedirectMiddlewareTests.cs
+++ b/LongevityWorldCup.Tests/EventBoardRedirectMiddlewareTests.cs
@@ -38,10 +38,13 @@ public sealed class EventBoardRedirectMiddlewareTests
         using var client = factory.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
 
         using var response = await client.GetAsync("/event-board-embed.html?athlete=ron-lugbill&embed=1");
+        var html = await response.Content.ReadAsStringAsync();
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.Equal("noindex, nofollow", GetHeader(response, "X-Robots-Tag"));
         Assert.Null(response.Headers.Location);
+        Assert.Contains("<meta name=\"robots\" content=\"noindex, nofollow, noarchive, nosnippet\">", html);
+        Assert.Contains("<meta name=\"googlebot\" content=\"noindex, nofollow, noarchive, nosnippet\">", html);
     }
 
     private static string GetHeader(HttpResponseMessage response, string name)

--- a/LongevityWorldCup.Tests/EventHelpersTests.cs
+++ b/LongevityWorldCup.Tests/EventHelpersTests.cs
@@ -1,0 +1,124 @@
+using LongevityWorldCup.Website.Tools;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class EventHelpersTests
+{
+    [Theory]
+    [InlineData("slug[alice] clock[pheno] from[44.2] to[41.8]", "pheno", 44.2, 41.8)]
+    [InlineData("slug[alice] clock[Pheno Age] from[44.2] to[41.8]", "pheno", 44.2, 41.8)]
+    [InlineData("slug[alice] clock[bortz age] from[50.5] to[49.1]", "bortz", 50.5, 49.1)]
+    public void TryExtractBiologicalAgeImprovement_NormalizesSupportedClockPayloads(
+        string raw,
+        string expectedClock,
+        double expectedFromAge,
+        double expectedToAge)
+    {
+        var parsed = EventHelpers.TryExtractBiologicalAgeImprovement(raw, out var clock, out var fromAge, out var toAge);
+
+        Assert.True(parsed);
+        Assert.Equal(expectedClock, clock);
+        Assert.Equal(expectedFromAge, fromAge);
+        Assert.Equal(expectedToAge, toAge);
+    }
+
+    [Theory]
+    [InlineData("clock[pheno] from[41.8] to[44.2]")]
+    [InlineData("clock[unknown] from[44.2] to[41.8]")]
+    [InlineData("clock[pheno] from[NaN] to[41.8]")]
+    [InlineData("clock[pheno] from[44.2] to[Infinity]")]
+    public void TryExtractBiologicalAgeImprovement_RejectsInvalidPayloads(string raw)
+    {
+        Assert.False(EventHelpers.TryExtractBiologicalAgeImprovement(raw, out _, out _, out _));
+    }
+
+    [Theory]
+    [InlineData("place[3] prevPlace[8] crowdAge[35.25] crowdCount[123]", 3, 8, 35.25, 123)]
+    [InlineData("place[7] crowdAge[35.25] crowdCount[123]", 7, null, 35.25, 123)]
+    public void TryExtractCrowdAgeTop10Change_ParsesValidTop10Payloads(
+        string raw,
+        int expectedPlace,
+        int? expectedPreviousPlace,
+        double expectedCrowdAge,
+        int expectedCrowdCount)
+    {
+        var parsed = EventHelpers.TryExtractCrowdAgeTop10Change(
+            raw,
+            out var place,
+            out var previousPlace,
+            out var crowdAge,
+            out var crowdCount);
+
+        Assert.True(parsed);
+        Assert.Equal(expectedPlace, place);
+        Assert.Equal(expectedPreviousPlace, previousPlace);
+        Assert.Equal(expectedCrowdAge, crowdAge);
+        Assert.Equal(expectedCrowdCount, crowdCount);
+    }
+
+    [Theory]
+    [InlineData("place[11] crowdAge[35.25] crowdCount[123]")]
+    [InlineData("place[3] prevPlace[11] crowdAge[35.25] crowdCount[123]")]
+    [InlineData("place[3] crowdAge[NaN] crowdCount[123]")]
+    [InlineData("place[3] crowdAge[35.25] crowdCount[0]")]
+    public void TryExtractCrowdAgeTop10Change_RejectsInvalidTop10Payloads(string raw)
+    {
+        Assert.False(EventHelpers.TryExtractCrowdAgeTop10Change(raw, out _, out _, out _, out _));
+    }
+
+    [Fact]
+    public void TryExtractAgeImprovementTop10Change_ParsesValidPayload()
+    {
+        var parsed = EventHelpers.TryExtractAgeImprovementTop10Change(
+            "clock[bortz age] place[4] prevPlace[9] improvement[-6.75] ageReduction[-20.4]",
+            out var clock,
+            out var place,
+            out var previousPlace,
+            out var improvement,
+            out var ageReduction);
+
+        Assert.True(parsed);
+        Assert.Equal("bortz", clock);
+        Assert.Equal(4, place);
+        Assert.Equal(9, previousPlace);
+        Assert.Equal(-6.75, improvement);
+        Assert.Equal(-20.4, ageReduction);
+    }
+
+    [Theory]
+    [InlineData("clock[pheno] place[0] improvement[-6.75] ageReduction[-20.4]")]
+    [InlineData("clock[pheno] place[4] prevPlace[0] improvement[-6.75] ageReduction[-20.4]")]
+    [InlineData("clock[clock] place[4] improvement[-6.75] ageReduction[-20.4]")]
+    [InlineData("clock[pheno] place[4] improvement[Infinity] ageReduction[-20.4]")]
+    [InlineData("clock[pheno] place[4] improvement[-6.75] ageReduction[NaN]")]
+    public void TryExtractAgeImprovementTop10Change_RejectsInvalidPayloads(string raw)
+    {
+        Assert.False(EventHelpers.TryExtractAgeImprovementTop10Change(raw, out _, out _, out _, out _, out _));
+    }
+
+    [Theory]
+    [InlineData("slug[alice] solo[] prevs[bob, carol]", true, new[] { "bob", "carol" })]
+    [InlineData("slug[alice] solo[1] prevs[bob]", true, new[] { "bob" })]
+    [InlineData("slug[alice] solo[false] prevs[]", false, new string[0])]
+    public void FieldExtractors_ParseFlagsAndCsvLists(string raw, bool expectedSolo, string[] expectedPrevs)
+    {
+        Assert.True(EventHelpers.TryExtractSolo(raw, out var solo));
+        Assert.Equal(expectedSolo, solo);
+
+        var hasPrevs = EventHelpers.TryExtractPrevs(raw, out var prevs);
+
+        Assert.Equal(expectedPrevs.Length > 0, hasPrevs);
+        Assert.Equal(expectedPrevs, prevs);
+    }
+
+    [Theory]
+    [InlineData("First line\nSecond line", "First line")]
+    [InlineData("First line\r\nSecond line", "First line")]
+    [InlineData("  First line  ", "First line")]
+    public void TryExtractCustomEventTitle_ReturnsTrimmedFirstLine(string raw, string expectedTitle)
+    {
+        Assert.True(EventHelpers.TryExtractCustomEventTitle(raw, out var title));
+        Assert.Equal(expectedTitle, title);
+    }
+}

--- a/LongevityWorldCup.Tests/FillerPostLogScheduleTests.cs
+++ b/LongevityWorldCup.Tests/FillerPostLogScheduleTests.cs
@@ -1,0 +1,164 @@
+using LongevityWorldCup.Website.Business;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class FillerPostLogScheduleTests
+{
+    [Fact]
+    public void IsOnRandomizedCooldownForType_ReturnsFalseWhenTypeHasNoRows()
+    {
+        using var fixture = TempDatabaseFixture.Create();
+        fixture.CreateLogTable("FillerLog");
+
+        var result = FillerPostLogSchedule.IsOnRandomizedCooldownForType(
+            fixture.Database,
+            "FillerLog",
+            FillerType.Donation,
+            minDays: 30,
+            maxDays: 30,
+            nowUtc: new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsOnRandomizedCooldownForType_UsesLatestRowForRequestedType()
+    {
+        using var fixture = TempDatabaseFixture.Create();
+        fixture.CreateLogTable("FillerLog");
+        fixture.InsertLogRow("FillerLog", FillerType.Donation, new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        fixture.InsertLogRow("FillerLog", FillerType.Donation, new DateTime(2026, 1, 20, 0, 0, 0, DateTimeKind.Utc));
+        fixture.InsertLogRow("FillerLog", FillerType.Ruleset, new DateTime(2026, 2, 20, 0, 0, 0, DateTimeKind.Utc));
+
+        var result = FillerPostLogSchedule.IsOnRandomizedCooldownForType(
+            fixture.Database,
+            "FillerLog",
+            FillerType.Donation,
+            minDays: 30,
+            maxDays: 30,
+            nowUtc: new DateTime(2026, 2, 10, 0, 0, 0, DateTimeKind.Utc));
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsOnRandomizedCooldownForType_ExpiresAtFixedCooldownBoundary()
+    {
+        using var fixture = TempDatabaseFixture.Create();
+        fixture.CreateLogTable("FillerLog");
+        var postedAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        fixture.InsertLogRow("FillerLog", FillerType.Donation, postedAt);
+
+        Assert.True(FillerPostLogSchedule.IsOnRandomizedCooldownForType(
+            fixture.Database,
+            "FillerLog",
+            FillerType.Donation,
+            minDays: 30,
+            maxDays: 30,
+            nowUtc: postedAt.AddDays(29).AddHours(23)));
+        Assert.False(FillerPostLogSchedule.IsOnRandomizedCooldownForType(
+            fixture.Database,
+            "FillerLog",
+            FillerType.Donation,
+            minDays: 30,
+            maxDays: 30,
+            nowUtc: postedAt.AddDays(30)));
+    }
+
+    [Fact]
+    public void IsOnRandomizedCooldownForType_IgnoresMalformedTimestamps()
+    {
+        using var fixture = TempDatabaseFixture.Create();
+        fixture.CreateLogTable("FillerLog");
+        fixture.InsertRawLogRow("FillerLog", FillerType.Donation, "not-a-date");
+
+        var result = FillerPostLogSchedule.IsOnRandomizedCooldownForType(
+            fixture.Database,
+            "FillerLog",
+            FillerType.Donation,
+            minDays: 30,
+            maxDays: 30,
+            nowUtc: new DateTime(2026, 2, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsOnRandomizedCooldownForType_NormalizesNegativeAndInvertedBounds()
+    {
+        using var fixture = TempDatabaseFixture.Create();
+        fixture.CreateLogTable("FillerLog");
+        var postedAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        fixture.InsertLogRow("FillerLog", FillerType.Donation, postedAt);
+
+        var result = FillerPostLogSchedule.IsOnRandomizedCooldownForType(
+            fixture.Database,
+            "FillerLog",
+            FillerType.Donation,
+            minDays: -10,
+            maxDays: -20,
+            nowUtc: postedAt);
+
+        Assert.False(result);
+    }
+
+    private sealed class TempDatabaseFixture : IDisposable
+    {
+        private readonly string _root;
+
+        private TempDatabaseFixture(string root, DatabaseManager database)
+        {
+            _root = root;
+            Database = database;
+        }
+
+        public DatabaseManager Database { get; }
+
+        public static TempDatabaseFixture Create()
+        {
+            var root = Path.Combine(Path.GetTempPath(), "lwc-filler-schedule-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(root);
+            return new TempDatabaseFixture(root, new DatabaseManager(dbPath: Path.Combine(root, "test.db")));
+        }
+
+        public void CreateLogTable(string tableName)
+        {
+            Database.Run(sqlite =>
+            {
+                using var command = sqlite.CreateCommand();
+                command.CommandText = $"""
+                    CREATE TABLE {tableName} (
+                        PostedAtUtc TEXT NOT NULL,
+                        Type INTEGER NOT NULL
+                    );
+                    """;
+                command.ExecuteNonQuery();
+            });
+        }
+
+        public void InsertLogRow(string tableName, FillerType type, DateTime postedAtUtc)
+        {
+            InsertRawLogRow(tableName, type, postedAtUtc.ToString("o"));
+        }
+
+        public void InsertRawLogRow(string tableName, FillerType type, string postedAtUtc)
+        {
+            Database.Run(sqlite =>
+            {
+                using var command = sqlite.CreateCommand();
+                command.CommandText = $"INSERT INTO {tableName} (PostedAtUtc, Type) VALUES (@postedAtUtc, @type);";
+                command.Parameters.AddWithValue("@postedAtUtc", postedAtUtc);
+                command.Parameters.AddWithValue("@type", (int)type);
+                command.ExecuteNonQuery();
+            });
+        }
+
+        public void Dispose()
+        {
+            Database.Dispose();
+            if (Directory.Exists(_root))
+                Directory.Delete(_root, recursive: true);
+        }
+    }
+}

--- a/LongevityWorldCup.Tests/GenerationResolverTests.cs
+++ b/LongevityWorldCup.Tests/GenerationResolverTests.cs
@@ -1,0 +1,75 @@
+using System.Text.Json.Nodes;
+using LongevityWorldCup.Website.Tools;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class GenerationResolverTests
+{
+    [Theory]
+    [InlineData(1927, null)]
+    [InlineData(1928, "Silent Generation")]
+    [InlineData(1945, "Silent Generation")]
+    [InlineData(1946, "Baby Boomers")]
+    [InlineData(1964, "Baby Boomers")]
+    [InlineData(1965, "Gen X")]
+    [InlineData(1980, "Gen X")]
+    [InlineData(1981, "Millennials")]
+    [InlineData(1996, "Millennials")]
+    [InlineData(1997, "Gen Z")]
+    [InlineData(2012, "Gen Z")]
+    [InlineData(2013, "Gen Alpha")]
+    public void Resolve_MapsBirthYearToGenerationBoundaries(int birthYear, string? expectedGeneration)
+    {
+        Assert.Equal(expectedGeneration, GenerationResolver.Resolve(generation: null, birthYear));
+    }
+
+    [Fact]
+    public void Resolve_PrefersExplicitGeneration()
+    {
+        Assert.Equal("Custom Generation", GenerationResolver.Resolve("Custom Generation", birthYear: 1990));
+    }
+
+    [Fact]
+    public void Resolve_ReturnsNullWhenGenerationAndBirthYearAreMissing()
+    {
+        Assert.Null(GenerationResolver.Resolve(generation: null, birthYear: null));
+    }
+
+    [Fact]
+    public void ResolveFromAthleteJson_UsesExplicitGeneration()
+    {
+        var athlete = new JsonObject
+        {
+            ["Generation"] = "Legacy League",
+            ["DateOfBirth"] = new JsonObject { ["Year"] = 1990 }
+        };
+
+        Assert.Equal("Legacy League", GenerationResolver.ResolveFromAthleteJson(athlete));
+    }
+
+    [Fact]
+    public void ResolveFromAthleteJson_UsesBirthYearWhenGenerationIsMissing()
+    {
+        var athlete = new JsonObject
+        {
+            ["DateOfBirth"] = new JsonObject { ["Year"] = 1990 }
+        };
+
+        Assert.Equal("Millennials", GenerationResolver.ResolveFromAthleteJson(athlete));
+    }
+
+    [Theory]
+    [MemberData(nameof(AthletesWithoutResolvableGeneration))]
+    public void ResolveFromAthleteJson_ReturnsNullWhenBirthYearIsUnavailable(JsonObject athlete)
+    {
+        Assert.Null(GenerationResolver.ResolveFromAthleteJson(athlete));
+    }
+
+    public static IEnumerable<object[]> AthletesWithoutResolvableGeneration()
+    {
+        yield return [new JsonObject()];
+        yield return [new JsonObject { ["DateOfBirth"] = new JsonObject() }];
+        yield return [new JsonObject { ["DateOfBirth"] = new JsonObject { ["Year"] = "1990" } }];
+    }
+}

--- a/LongevityWorldCup.Tests/HealthCheckEndpointTests.cs
+++ b/LongevityWorldCup.Tests/HealthCheckEndpointTests.cs
@@ -16,6 +16,7 @@ public sealed class HealthCheckEndpointTests
         using var response = await client.GetAsync("/health");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.True(response.Headers.CacheControl?.NoStore);
         Assert.Equal("application/json; charset=utf-8", response.Content.Headers.ContentType?.ToString());
 
         using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());

--- a/LongevityWorldCup.Tests/LeagueOgImageServiceTests.cs
+++ b/LongevityWorldCup.Tests/LeagueOgImageServiceTests.cs
@@ -1,0 +1,51 @@
+using LongevityWorldCup.Website.Business;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class LeagueOgImageServiceTests
+{
+    [Theory]
+    [InlineData("Ultimate", "ultimate")]
+    [InlineData("Ultimate League", "ultimate")]
+    [InlineData("women's", "womens")]
+    [InlineData("womens league", "womens")]
+    [InlineData("silent generation", "silent-generation")]
+    [InlineData("baby boomers league", "baby-boomers")]
+    [InlineData("gen x", "gen-x")]
+    [InlineData("gen-z", "gen-z")]
+    [InlineData("Gen Alpha League", "gen-alpha")]
+    public void TryNormalizeLeagueSlug_AcceptsRouteAndDisplayAliases(string raw, string expectedSlug)
+    {
+        var normalized = LeagueOgImageService.TryNormalizeLeagueSlug(raw, out var slug);
+
+        Assert.True(normalized);
+        Assert.Equal(expectedSlug, slug);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("unknown")]
+    [InlineData("crowd")]
+    [InlineData("pheno")]
+    public void TryNormalizeLeagueSlug_RejectsUnsupportedShareCardLeagues(string? raw)
+    {
+        var normalized = LeagueOgImageService.TryNormalizeLeagueSlug(raw, out var slug);
+
+        Assert.False(normalized);
+        Assert.Equal("", slug);
+    }
+
+    [Theory]
+    [InlineData("mens", "Men's League")]
+    [InlineData("baby boomers", "Baby Boomers League")]
+    [InlineData("prosperan", "Prosperan League")]
+    public void TryGetLeagueDisplayName_ReturnsCanonicalDisplayName(string raw, string expectedDisplayName)
+    {
+        var found = LeagueOgImageService.TryGetLeagueDisplayName(raw, out var displayName);
+
+        Assert.True(found);
+        Assert.Equal(expectedDisplayName, displayName);
+    }
+}

--- a/LongevityWorldCup.Tests/LongevityWorldCup.Tests.csproj
+++ b/LongevityWorldCup.Tests/LongevityWorldCup.Tests.csproj
@@ -11,6 +11,9 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Microsoft.Playwright" Version="1.60.0" />
+    <PackageReference Include="coverlet.msbuild" Version="10.0.1">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/LongevityWorldCup.Tests/NewsletterServiceTests.cs
+++ b/LongevityWorldCup.Tests/NewsletterServiceTests.cs
@@ -1,0 +1,105 @@
+using LongevityWorldCup.Website.Business;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class NewsletterServiceTests
+{
+    [Fact]
+    public async Task SubscribeAsync_CreatesSubscriptionFileAndRejectsDuplicateCaseInsensitive()
+    {
+        using var root = TempContentRoot.Create();
+        var environment = new TestWebHostEnvironment(root.Path);
+
+        var firstResult = await NewsletterService.SubscribeAsync(
+            "Reader@example.com",
+            NullLogger.Instance,
+            environment,
+            CancellationToken.None);
+        var duplicateResult = await NewsletterService.SubscribeAsync(
+            "reader@example.com",
+            NullLogger.Instance,
+            environment,
+            CancellationToken.None);
+
+        Assert.Null(firstResult);
+        Assert.Equal("This email is already subscribed.", duplicateResult);
+        Assert.Equal(["Reader@example.com"], File.ReadAllLines(root.SubscriptionsPath));
+    }
+
+    [Fact]
+    public async Task UnsubscribeAsync_RemovesMatchingEmailCaseInsensitiveAndTrimsRemainingLines()
+    {
+        using var root = TempContentRoot.Create();
+        Directory.CreateDirectory(root.AppDataPath);
+        File.WriteAllLines(root.SubscriptionsPath, [" Keep@example.com ", "", "Remove@example.com"]);
+        var environment = new TestWebHostEnvironment(root.Path);
+
+        var result = await NewsletterService.UnsubscribeAsync(
+            "remove@example.com",
+            NullLogger.Instance,
+            environment,
+            CancellationToken.None);
+
+        Assert.Null(result);
+        Assert.Equal(["Keep@example.com"], File.ReadAllLines(root.SubscriptionsPath));
+    }
+
+    [Fact]
+    public async Task UnsubscribeAsync_SucceedsWhenSubscriptionFileDoesNotExist()
+    {
+        using var root = TempContentRoot.Create();
+        var environment = new TestWebHostEnvironment(root.Path);
+
+        var result = await NewsletterService.UnsubscribeAsync(
+            "missing@example.com",
+            NullLogger.Instance,
+            environment,
+            CancellationToken.None);
+
+        Assert.Null(result);
+        Assert.False(File.Exists(root.SubscriptionsPath));
+    }
+
+    private sealed class TempContentRoot : IDisposable
+    {
+        private TempContentRoot(string path)
+        {
+            Path = path;
+            AppDataPath = System.IO.Path.Combine(path, "AppData");
+            SubscriptionsPath = System.IO.Path.Combine(AppDataPath, "subscriptions.txt");
+        }
+
+        public string Path { get; }
+        public string AppDataPath { get; }
+        public string SubscriptionsPath { get; }
+
+        public static TempContentRoot Create()
+        {
+            var path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "lwc-newsletter-tests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(path);
+            return new TempContentRoot(path);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+        }
+    }
+
+    private sealed class TestWebHostEnvironment(string rootPath) : IWebHostEnvironment
+    {
+        public string ApplicationName { get; set; } = "LongevityWorldCup.Tests";
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+        public string ContentRootPath { get; set; } = rootPath;
+        public string EnvironmentName { get; set; } = "Test";
+        public string WebRootPath { get; set; } = rootPath;
+        public IFileProvider WebRootFileProvider { get; set; } = new NullFileProvider();
+    }
+}

--- a/LongevityWorldCup.Tests/PageOgImageServiceTests.cs
+++ b/LongevityWorldCup.Tests/PageOgImageServiceTests.cs
@@ -1,0 +1,48 @@
+using LongevityWorldCup.Website;
+using LongevityWorldCup.Website.Business;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class PageOgImageServiceTests
+{
+    [Fact]
+    public void TryGetCurrentPayload_NormalizesSlugAndBuildsVersionedUrl()
+    {
+        using var factory = CreateFactory();
+        var pages = factory.Services.GetRequiredService<PageOgImageService>();
+
+        var found = pages.TryGetCurrentPayload(" VIEW-CROWD ", out var payload);
+        var url = pages.BuildVersionedImageUrl("https://longevityworldcup.com", payload);
+
+        Assert.True(found);
+        Assert.Equal("view-crowd", payload.Slug);
+        Assert.Equal("Community view", payload.Kicker);
+        Assert.Equal("Crowd Age leaderboard", payload.Title);
+        Assert.Contains("Crowd Age", payload.Stats);
+        Assert.Matches("^[0-9a-f]{12}$", payload.Signature);
+        Assert.Equal($"https://longevityworldcup.com/og/page/view-crowd.png?v={payload.Signature}", url);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("missing")]
+    [InlineData("view-unknown")]
+    public void TryGetCurrentPayload_RejectsUnknownPageSlug(string rawSlug)
+    {
+        using var factory = CreateFactory();
+        var pages = factory.Services.GetRequiredService<PageOgImageService>();
+
+        var found = pages.TryGetCurrentPayload(rawSlug, out var payload);
+
+        Assert.False(found);
+        Assert.Null(payload);
+    }
+
+    private static WebApplicationFactory<Program> CreateFactory()
+    {
+        return new TestWebApplicationFactory();
+    }
+}

--- a/LongevityWorldCup.Tests/PublicCalculationApiTests.cs
+++ b/LongevityWorldCup.Tests/PublicCalculationApiTests.cs
@@ -96,8 +96,79 @@ public sealed class PublicCalculationApiTests
         Assert.IsType<BadRequestObjectResult>(response);
     }
 
+    [Theory]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity)]
+    public void PhenoAgeEndpoint_ReturnsBadRequestForNonFiniteInput(double invalidValue)
+    {
+        var controller = CreateController();
+
+        var response = controller.CalculatePhenoAge(new PhenoAgeCalculationRequest
+        {
+            ChronologicalAge = 45.5,
+            AlbGL = 46,
+            CreatUmolL = invalidValue,
+            GluMmolL = 5.05,
+            CrpMgL = 0.8,
+            Wbc1000cellsuL = 6.3,
+            LymPc = 25.5,
+            McvFL = 96.7,
+            RdwPc = 12.5,
+            AlpUL = 51
+        });
+
+        var badRequest = Assert.IsType<BadRequestObjectResult>(response);
+        Assert.Equal("All Pheno Age inputs must be finite numbers.", GetMessage(badRequest.Value));
+    }
+
+    [Theory]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity)]
+    public void BortzAgeEndpoint_ReturnsBadRequestForNonFiniteInput(double invalidValue)
+    {
+        var controller = CreateController();
+
+        var response = controller.CalculateBortzAge(new BortzAgeCalculationRequest
+        {
+            ChronologicalAge = 45.5,
+            AlbGL = 46,
+            AlpUL = 51,
+            UreaMmolL = 5.4,
+            CholesterolMmolL = 4.8,
+            CreatUmolL = 88.4,
+            CystatinCMgL = 0.85,
+            Hba1cMmolMol = 34,
+            CrpMgL = 0.8,
+            GgtUL = 22,
+            Rbc10e12L = 4.7,
+            McvFL = 96.7,
+            RdwPc = 12.5,
+            Wbc1000cellsuL = 6.3,
+            MonocytePc = 7.2,
+            NeutrophilPc = 58.1,
+            LymPc = 25.5,
+            AltUL = 24,
+            ShbgNmolL = invalidValue,
+            VitaminDNmolL = 85,
+            GluMmolL = 5.05,
+            MchPg = 31.5,
+            ApoA1GL = 1.55
+        });
+
+        var badRequest = Assert.IsType<BadRequestObjectResult>(response);
+        Assert.Equal("All Bortz Age inputs must be finite numbers.", GetMessage(badRequest.Value));
+    }
+
     private static DataController CreateController()
     {
         return new DataController(null!);
+    }
+
+    private static string? GetMessage(object? value)
+    {
+        Assert.NotNull(value);
+        return value!.GetType().GetProperty("message")?.GetValue(value) as string;
     }
 }

--- a/LongevityWorldCup.Tests/PublicGetCacheHeadersTests.cs
+++ b/LongevityWorldCup.Tests/PublicGetCacheHeadersTests.cs
@@ -1,0 +1,70 @@
+using LongevityWorldCup.Website.Tools;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Net.Http.Headers;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class PublicGetCacheHeadersTests
+{
+    [Fact]
+    public void BuildWeakContentETag_ReturnsStableSha256WeakValidator()
+    {
+        var eTag = PublicGetCacheHeaders.BuildWeakContentETag("hello");
+
+        Assert.Equal("W/\"sha256-2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824\"", eTag);
+    }
+
+    [Theory]
+    [InlineData("\"sha256-test\"", "W/\"sha256-test\"")]
+    [InlineData("W/\"sha256-test\"", "\"sha256-test\"")]
+    [InlineData("\"other\", W/\"sha256-test\"", "\"sha256-test\"")]
+    [InlineData("*", "\"sha256-test\"")]
+    public void RequestHasMatchingETag_MatchesWildcardAndWeakOrStrongTags(string ifNoneMatch, string eTag)
+    {
+        var headers = new HeaderDictionary
+        {
+            [HeaderNames.IfNoneMatch] = ifNoneMatch
+        };
+
+        Assert.True(PublicGetCacheHeaders.RequestHasMatchingETag(headers, eTag));
+    }
+
+    [Theory]
+    [InlineData("\"sha256-other\"", "\"sha256-test\"")]
+    [InlineData("W/\"sha256-other\"", "\"sha256-test\"")]
+    public void RequestHasMatchingETag_RejectsDifferentTags(string ifNoneMatch, string eTag)
+    {
+        var headers = new HeaderDictionary
+        {
+            [HeaderNames.IfNoneMatch] = ifNoneMatch
+        };
+
+        Assert.False(PublicGetCacheHeaders.RequestHasMatchingETag(headers, eTag));
+    }
+
+    [Fact]
+    public void RequestHasMatchingETag_ReturnsFalseWhenHeaderIsMissing()
+    {
+        Assert.False(PublicGetCacheHeaders.RequestHasMatchingETag(new HeaderDictionary(), "\"sha256-test\""));
+    }
+
+    [Fact]
+    public void Apply_SetsCacheHeadersAndValidators()
+    {
+        var context = new DefaultHttpContext();
+        var lastModified = new DateTimeOffset(2026, 6, 20, 10, 30, 0, TimeSpan.Zero);
+
+        PublicGetCacheHeaders.Apply(
+            context.Response,
+            PublicGetCacheHeaders.AiFactsCacheControl,
+            PublicGetCacheHeaders.AiFactsMaxAgeSeconds,
+            "W/\"sha256-test\"",
+            lastModified);
+
+        Assert.Equal(PublicGetCacheHeaders.AiFactsCacheControl, context.Response.Headers.CacheControl);
+        Assert.Equal("W/\"sha256-test\"", context.Response.Headers.ETag);
+        Assert.Equal("Sat, 20 Jun 2026 10:30:00 GMT", context.Response.Headers.LastModified);
+        Assert.False(string.IsNullOrWhiteSpace(context.Response.Headers.Expires));
+    }
+}

--- a/LongevityWorldCup.Tests/PublicGetCachingTests.cs
+++ b/LongevityWorldCup.Tests/PublicGetCachingTests.cs
@@ -58,9 +58,12 @@ public sealed class PublicGetCachingTests
         Assert.True(firstResponse.Headers.CacheControl?.Public);
         Assert.Equal(TimeSpan.FromMinutes(5), firstResponse.Headers.CacheControl?.MaxAge);
         Assert.True(firstResponse.Headers.CacheControl?.MustRevalidate);
+        Assert.Equal("index, follow", firstResponse.Headers.GetValues("X-Robots-Tag").Single());
         Assert.NotNull(firstResponse.Headers.ETag);
         Assert.True(firstResponse.Headers.ETag!.IsWeak);
         Assert.NotNull(firstResponse.Content.Headers.LastModified);
+        Assert.Equal("text/markdown", firstResponse.Content.Headers.ContentType?.MediaType);
+        Assert.Equal("utf-8", firstResponse.Content.Headers.ContentType?.CharSet);
 
         var firstBody = await firstResponse.Content.ReadAsStringAsync();
         Assert.NotEmpty(firstBody);
@@ -74,10 +77,23 @@ public sealed class PublicGetCachingTests
         Assert.True(secondResponse.Headers.CacheControl?.Public);
         Assert.Equal(TimeSpan.FromMinutes(5), secondResponse.Headers.CacheControl?.MaxAge);
         Assert.True(secondResponse.Headers.CacheControl?.MustRevalidate);
+        Assert.Equal("index, follow", secondResponse.Headers.GetValues("X-Robots-Tag").Single());
         Assert.NotNull(secondResponse.Headers.ETag);
         Assert.Equal(firstResponse.Headers.ETag.Tag, secondResponse.Headers.ETag!.Tag);
         Assert.Equal(firstResponse.Headers.ETag.IsWeak, secondResponse.Headers.ETag.IsWeak);
         Assert.Equal("", await secondResponse.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task LegacyAiAthletesEndpoint_RedirectsPermanentlyToLeaderboardFacts()
+    {
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+
+        using var response = await client.GetAsync("/ai/athletes.md");
+
+        Assert.Equal(HttpStatusCode.MovedPermanently, response.StatusCode);
+        Assert.Equal("/ai/leaderboard.md", response.Headers.Location?.ToString());
     }
 
     private static void AssertCacheControlExtension(CacheControlHeaderValue? cacheControl, string name, string value)

--- a/LongevityWorldCup.Tests/PublicPostRateLimitingTests.cs
+++ b/LongevityWorldCup.Tests/PublicPostRateLimitingTests.cs
@@ -21,6 +21,7 @@ public sealed class PublicPostRateLimitingTests
 
         using var limitedResponse = await PostEmptyPhenoAgeRequest(client);
         Assert.Equal(HttpStatusCode.TooManyRequests, limitedResponse.StatusCode);
+        Assert.True(limitedResponse.Headers.RetryAfter?.Delta > TimeSpan.Zero);
     }
 
     [Fact]

--- a/LongevityWorldCup.Tests/RouteCanonicalizationTests.cs
+++ b/LongevityWorldCup.Tests/RouteCanonicalizationTests.cs
@@ -1,0 +1,33 @@
+using LongevityWorldCup.Website.Middleware;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class RouteCanonicalizationTests
+{
+    [Theory]
+    [InlineData(null, "/")]
+    [InlineData("", "/")]
+    [InlineData("leaderboard/", "/leaderboard")]
+    [InlineData("/about?ref=footer", "/about")]
+    [InlineData("rules#details", "/rules")]
+    [InlineData("/longevitymaxxing/", "/longevitymaxxing")]
+    public void NormalizePath_StripsQueryFragmentsAndTrailingSlashes(string? rawPath, string expected)
+    {
+        var normalized = RouteCanonicalization.NormalizePath(rawPath);
+
+        Assert.Equal(expected, normalized);
+    }
+
+    [Theory]
+    [InlineData("/RULES/?ref=docs", "/ruleset")]
+    [InlineData("misc-pages/media.html", "/media")]
+    [InlineData("/onboarding/BORTZ-AGE.html#form", "/bortz-age")]
+    [InlineData("/Some/New/Page/", "/some/new/page")]
+    public void GetCanonicalPath_UsesAliasesAndLowercasesUnknownPaths(string rawPath, string expected)
+    {
+        var canonical = RouteCanonicalization.GetCanonicalPath(rawPath);
+
+        Assert.Equal(expected, canonical);
+    }
+}

--- a/LongevityWorldCup.Tests/ScheduledJobConfigurationTests.cs
+++ b/LongevityWorldCup.Tests/ScheduledJobConfigurationTests.cs
@@ -1,0 +1,26 @@
+using LongevityWorldCup.Website.Jobs;
+using Quartz;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class ScheduledJobConfigurationTests
+{
+    [Fact]
+    public void QuartzJobs_DisallowConcurrentExecution()
+    {
+        var jobTypes = typeof(DailyJob).Assembly
+            .GetTypes()
+            .Where(type => typeof(IJob).IsAssignableFrom(type) && type is { IsAbstract: false, IsInterface: false })
+            .OrderBy(type => type.FullName, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.NotEmpty(jobTypes);
+        foreach (var jobType in jobTypes)
+        {
+            Assert.True(
+                Attribute.IsDefined(jobType, typeof(DisallowConcurrentExecutionAttribute)),
+                $"{jobType.FullName} should prevent overlapping Quartz executions.");
+        }
+    }
+}

--- a/LongevityWorldCup.Tests/SecretHashVerifierTests.cs
+++ b/LongevityWorldCup.Tests/SecretHashVerifierTests.cs
@@ -6,6 +6,12 @@ namespace LongevityWorldCup.Tests;
 public class SecretHashVerifierTests
 {
     [Fact]
+    public void CreateHash_RejectsEmptySecret()
+    {
+        Assert.Throws<ArgumentException>(() => SecretHashVerifier.CreateHash(""));
+    }
+
+    [Fact]
     public void CreateHash_VerifiesMatchingSecret()
     {
         var hash = SecretHashVerifier.CreateHash("correct horse battery staple");
@@ -50,5 +56,46 @@ public class SecretHashVerifierTests
         var result = SecretHashVerifier.Verify("secret", weak);
 
         Assert.Equal(SecretVerificationResult.InvalidHash, result);
+    }
+
+    [Fact]
+    public void Verify_RejectsInvalidBase64Payloads()
+    {
+        var validSalt = Convert.ToBase64String(new byte[16]);
+        var validHash = Convert.ToBase64String(new byte[32]);
+
+        Assert.Equal(
+            SecretVerificationResult.InvalidHash,
+            SecretHashVerifier.Verify("secret", $"{SecretHashVerifier.Algorithm}:{SecretHashVerifier.DefaultIterations}:not-base64:{validHash}"));
+        Assert.Equal(
+            SecretVerificationResult.InvalidHash,
+            SecretHashVerifier.Verify("secret", $"{SecretHashVerifier.Algorithm}:{SecretHashVerifier.DefaultIterations}:{validSalt}:not-base64"));
+    }
+
+    [Fact]
+    public void Verify_RejectsShortSaltOrHashPayloads()
+    {
+        var validSalt = new byte[16];
+        var validHash = new byte[32];
+
+        Assert.Equal(
+            SecretVerificationResult.InvalidHash,
+            SecretHashVerifier.Verify("secret", BuildStoredHash(new byte[15], validHash)));
+        Assert.Equal(
+            SecretVerificationResult.InvalidHash,
+            SecretHashVerifier.Verify("secret", BuildStoredHash(validSalt, new byte[31])));
+    }
+
+    [Fact]
+    public void Verify_RejectsOversizedHashPayload()
+    {
+        var result = SecretHashVerifier.Verify("secret", BuildStoredHash(new byte[16], new byte[129]));
+
+        Assert.Equal(SecretVerificationResult.InvalidHash, result);
+    }
+
+    private static string BuildStoredHash(byte[] salt, byte[] hash)
+    {
+        return $"{SecretHashVerifier.Algorithm}:{SecretHashVerifier.DefaultIterations}:{Convert.ToBase64String(salt)}:{Convert.ToBase64String(hash)}";
     }
 }

--- a/LongevityWorldCup.Tests/SitemapDiscoveryTests.cs
+++ b/LongevityWorldCup.Tests/SitemapDiscoveryTests.cs
@@ -1,6 +1,8 @@
+using System.Net;
 using System.Xml.Linq;
 using System.Runtime.CompilerServices;
 using LongevityWorldCup.Website.Business;
+using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
 
 namespace LongevityWorldCup.Tests;
@@ -93,6 +95,26 @@ public class SitemapDiscoveryTests
         Assert.Equal("2026-05-30", leaderboard.LastModified);
         var amateur = Assert.Single(urls, url => url.Loc == "https://longevityworldcup.com/league/amateur");
         Assert.Equal("2026-05-21", amateur.LastModified);
+    }
+
+    [Fact]
+    public async Task SitemapEndpoint_ReturnsXmlWithShortPublicCacheHeaders()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+
+        using var response = await client.GetAsync("/sitemap.xml");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/xml", response.Content.Headers.ContentType?.MediaType);
+        Assert.Equal("utf-8", response.Content.Headers.ContentType?.CharSet);
+        Assert.True(response.Headers.CacheControl?.Public);
+        Assert.Equal(TimeSpan.FromMinutes(5), response.Headers.CacheControl?.MaxAge);
+        Assert.True(response.Headers.CacheControl?.MustRevalidate);
+
+        var xml = await response.Content.ReadAsStringAsync();
+        Assert.Contains("<urlset", xml, StringComparison.Ordinal);
+        Assert.Contains("https://longevityworldcup.com/", xml, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/LongevityWorldCup.Tests/SitemapDiscoveryTests.cs
+++ b/LongevityWorldCup.Tests/SitemapDiscoveryTests.cs
@@ -69,6 +69,33 @@ public class SitemapDiscoveryTests
     }
 
     [Fact]
+    public void BuildXml_NormalizesAndDeduplicatesRoutesUsingNewestLastModified()
+    {
+        var xml = SitemapService.BuildXml(
+        [
+            new SitemapUrlEntry("/Leaderboard/", new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc), "weekly", 0.1m),
+            new SitemapUrlEntry("leaderboard", new DateTime(2026, 5, 30, 0, 0, 0, DateTimeKind.Utc), "daily", 0.9m),
+            new SitemapUrlEntry("/league/Amateur/", new DateTime(2026, 5, 20, 0, 0, 0, DateTimeKind.Utc), "daily", 0.8m),
+            new SitemapUrlEntry("/league/amateur", new DateTime(2026, 5, 21, 0, 0, 0, DateTimeKind.Utc), "daily", 0.8m)
+        ]);
+
+        var doc = XDocument.Parse(xml);
+        XNamespace ns = "http://www.sitemaps.org/schemas/sitemap/0.9";
+        var urls = doc.Descendants(ns + "url")
+            .Select(url => new
+            {
+                Loc = url.Element(ns + "loc")?.Value,
+                LastModified = url.Element(ns + "lastmod")?.Value
+            })
+            .ToList();
+
+        var leaderboard = Assert.Single(urls, url => url.Loc == "https://longevityworldcup.com/leaderboard");
+        Assert.Equal("2026-05-30", leaderboard.LastModified);
+        var amateur = Assert.Single(urls, url => url.Loc == "https://longevityworldcup.com/league/amateur");
+        Assert.Equal("2026-05-21", amateur.LastModified);
+    }
+
+    [Fact]
     public void Robots_AllowsPublicLeagueAndAthleteRoutes()
     {
         var robotsPath = FindRepoFile(Path.Combine("LongevityWorldCup.Website", "wwwroot", "robots.txt"));

--- a/LongevityWorldCup.Tests/SlackWebhookClientTests.cs
+++ b/LongevityWorldCup.Tests/SlackWebhookClientTests.cs
@@ -1,0 +1,108 @@
+using System.Net;
+using System.Text.Json;
+using LongevityWorldCup.Website;
+using LongevityWorldCup.Website.Business;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class SlackWebhookClientTests
+{
+    [Fact]
+    public async Task SendAsync_PostsJsonPayloadToConfiguredWebhook()
+    {
+        var handler = new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK));
+        var client = new SlackWebhookClient(
+            new HttpClient(handler),
+            new Config { SlackWebhookUrl = "https://hooks.slack.example.test/services/T000/B000/secret" },
+            NullLogger<SlackWebhookClient>.Instance);
+
+        await client.SendAsync("hello from tests");
+
+        var request = Assert.Single(handler.Requests);
+        Assert.Equal(HttpMethod.Post, request.Method);
+        Assert.Equal("https://hooks.slack.example.test/services/T000/B000/secret", request.RequestUri?.AbsoluteUri);
+        Assert.Equal("application/json", request.ContentType);
+        using var payload = JsonDocument.Parse(request.Body);
+        Assert.Equal("hello from tests", payload.RootElement.GetProperty("text").GetString());
+    }
+
+    [Fact]
+    public async Task SendAsync_SkipsHttpRequestWhenWebhookIsMissing()
+    {
+        var handler = new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK));
+        var logger = new RecordingLogger<SlackWebhookClient>();
+        var client = new SlackWebhookClient(
+            new HttpClient(handler),
+            new Config { SlackWebhookUrl = " " },
+            logger);
+
+        await client.SendAsync("do not send");
+
+        Assert.Empty(handler.Requests);
+        var error = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Error, error.Level);
+        Assert.Contains("Slack webhook URL is not configured", error.Message);
+        Assert.Contains("do not send", error.Message);
+    }
+
+    [Fact]
+    public async Task SendAsync_ThrowsWhenSlackReturnsFailure()
+    {
+        var handler = new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.BadGateway));
+        var client = new SlackWebhookClient(
+            new HttpClient(handler),
+            new Config { SlackWebhookUrl = "https://hooks.slack.example.test/services/T000/B000/secret" },
+            NullLogger<SlackWebhookClient>.Instance);
+
+        await Assert.ThrowsAsync<HttpRequestException>(() => client.SendAsync("will fail"));
+        Assert.Single(handler.Requests);
+    }
+
+    private sealed class RecordingHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory) : HttpMessageHandler
+    {
+        public List<RecordedRequest> Requests { get; } = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var body = request.Content is null
+                ? string.Empty
+                : await request.Content.ReadAsStringAsync(cancellationToken);
+            Requests.Add(new RecordedRequest(
+                request.Method,
+                request.RequestUri,
+                request.Content?.Headers.ContentType?.MediaType,
+                body));
+            return responseFactory(request);
+        }
+    }
+
+    private sealed record RecordedRequest(
+        HttpMethod Method,
+        Uri? RequestUri,
+        string? ContentType,
+        string Body);
+
+    private sealed class RecordingLogger<T> : ILogger<T>
+    {
+        public List<LogEntry> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add(new LogEntry(logLevel, formatter(state, exception)));
+        }
+    }
+
+    private sealed record LogEntry(LogLevel Level, string Message);
+}

--- a/LongevityWorldCup.Tests/SocialContactParserTests.cs
+++ b/LongevityWorldCup.Tests/SocialContactParserTests.cs
@@ -1,0 +1,51 @@
+using LongevityWorldCup.Website.Tools;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class SocialContactParserTests
+{
+    [Theory]
+    [InlineData("@alice", "@alice")]
+    [InlineData("https://x.com/alice", "@alice")]
+    [InlineData("x.com/@alice/status/123", "@alice")]
+    [InlineData("https://twitter.com/alice?lang=en", "@alice")]
+    [InlineData("https://mobile.twitter.com/alice", "@alice")]
+    public void TryBuildMention_ExtractsXHandlesFromSupportedFormats(string mediaContact, string expectedMention)
+    {
+        Assert.Equal(expectedMention, SocialContactParser.TryBuildMention(mediaContact, SocialPlatform.X));
+    }
+
+    [Theory]
+    [InlineData("https://threads.com/@alice", "@alice")]
+    [InlineData("www.threads.com/alice", "@alice")]
+    public void TryBuildMention_ExtractsThreadsHandlesFromSupportedFormats(string mediaContact, string expectedMention)
+    {
+        Assert.Equal(expectedMention, SocialContactParser.TryBuildMention(mediaContact, SocialPlatform.Threads));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("https://notx.com/alice")]
+    [InlineData("https://x.com.evil.example/alice")]
+    [InlineData("https://threads.com/alice")]
+    public void TryBuildMention_RejectsUnsupportedXContacts(string? mediaContact)
+    {
+        Assert.Null(SocialContactParser.TryBuildMention(mediaContact, SocialPlatform.X));
+    }
+
+    [Theory]
+    [InlineData("https://notthreads.com/alice")]
+    [InlineData("https://threads.com.evil.example/alice")]
+    [InlineData("https://x.com/alice")]
+    public void TryBuildMention_RejectsUnsupportedThreadsContacts(string mediaContact)
+    {
+        Assert.Null(SocialContactParser.TryBuildMention(mediaContact, SocialPlatform.Threads));
+    }
+
+    [Fact]
+    public void TryBuildMention_DoesNotBuildFacebookMentions()
+    {
+        Assert.Null(SocialContactParser.TryBuildMention("https://facebook.com/alice", SocialPlatform.Facebook));
+    }
+}

--- a/LongevityWorldCup.Tests/StringExtensionsTests.cs
+++ b/LongevityWorldCup.Tests/StringExtensionsTests.cs
@@ -1,0 +1,40 @@
+using LongevityWorldCup.Website.Tools;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class StringExtensionsTests
+{
+    [Fact]
+    public void TrimEnd_RemovesOneMatchingSuffix()
+    {
+        Assert.Equal("backup.db", "backup.db.db".TrimEnd(".db", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void TrimEnd_DoesNotTrimIndividualSuffixCharacters()
+    {
+        Assert.Equal("Process", "Process".TrimEnd(".cs", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void TrimStart_RemovesOneMatchingPrefix()
+    {
+        Assert.Equal("/static/assets/logo.png", "/static//static/assets/logo.png".TrimStart("/static/", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void IsTrimmable_ReturnsTrueOnlyForLeadingOrTrailingWhitespace()
+    {
+        Assert.True(" value".IsTrimmable());
+        Assert.True("value ".IsTrimmable());
+        Assert.False("value inside".IsTrimmable());
+        Assert.False(string.Empty.IsTrimmable());
+    }
+
+    [Fact]
+    public void WithoutWhitespace_RemovesAllWhitespaceCharacters()
+    {
+        Assert.Equal("abc", " a\tb\r\nc ".WithoutWhitespace());
+    }
+}

--- a/LongevityWorldCup.Tests/TrackingParamStripperMiddlewareTests.cs
+++ b/LongevityWorldCup.Tests/TrackingParamStripperMiddlewareTests.cs
@@ -1,0 +1,58 @@
+using System.Net;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class TrackingParamStripperMiddlewareTests
+{
+    [Fact]
+    public async Task TrackingParameters_AreRemovedAndNonTrackingParametersArePreserved()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+
+        using var response = await client.GetAsync(
+            "/css/badges.css?utm_source=newsletter&ref=keep&utm_campaign=summer&name=Alice%20Bob&empty=");
+
+        Assert.Equal(HttpStatusCode.MovedPermanently, response.StatusCode);
+        Assert.Equal("/css/badges.css?ref=keep&name=Alice%20Bob&empty=", response.Headers.Location?.ToString());
+    }
+
+    [Fact]
+    public async Task TrackingParameters_AreMatchedCaseInsensitivelyAndRepeatedValuesSurvive()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+
+        using var response = await client.GetAsync(
+            "/css/badges.css?UTM_Source=newsletter&ref=first&fbclid=abc&ref=second");
+
+        Assert.Equal(HttpStatusCode.MovedPermanently, response.StatusCode);
+        Assert.Equal("/css/badges.css?ref=first&ref=second", response.Headers.Location?.ToString());
+    }
+
+    [Fact]
+    public async Task TrackingOnlyQuery_RedirectsToCleanPathWithoutQuestionMark()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+
+        using var response = await client.GetAsync("/css/badges.css?gclid=abc&utm_medium=email");
+
+        Assert.Equal(HttpStatusCode.MovedPermanently, response.StatusCode);
+        Assert.Equal("/css/badges.css", response.Headers.Location?.ToString());
+    }
+
+    [Fact]
+    public async Task CleanQuery_DoesNotRedirect()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+
+        using var response = await client.GetAsync("/css/badges.css?ref=keep");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Null(response.Headers.Location);
+    }
+}

--- a/LongevityWorldCup.Tests/XPostPhaseDeciderTests.cs
+++ b/LongevityWorldCup.Tests/XPostPhaseDeciderTests.cs
@@ -1,0 +1,44 @@
+using LongevityWorldCup.Website.Business;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class XPostPhaseDeciderTests
+{
+    [Theory]
+    [InlineData(0, XPostPhase.Tiny)]
+    [InlineData(4, XPostPhase.Tiny)]
+    [InlineData(5, XPostPhase.Early)]
+    [InlineData(20, XPostPhase.Early)]
+    [InlineData(21, XPostPhase.Mature)]
+    public void Determine_UsesConfiguredSampleThresholds(int sampleSize, XPostPhase expected)
+    {
+        var sample = new XPostSampleSize(
+            XPostSampleBasis.Combined,
+            sampleSize,
+            PhenoCount: sampleSize,
+            BortzCount: sampleSize,
+            CombinedCount: sampleSize);
+
+        var phase = XPostPhaseDecider.Determine(sample);
+
+        Assert.Equal(expected, phase);
+    }
+
+    [Fact]
+    public void Determine_RejectsNullSample()
+    {
+        Assert.Throws<ArgumentNullException>(() => XPostPhaseDecider.Determine(null!));
+    }
+
+    [Theory]
+    [InlineData(XPostPhase.Tiny, XPostPhase.Mature, XPostPhase.Tiny)]
+    [InlineData(XPostPhase.Mature, XPostPhase.Early, XPostPhase.Early)]
+    [InlineData(XPostPhase.Early, XPostPhase.Early, XPostPhase.Early)]
+    public void Min_ReturnsTheMoreConservativePhase(XPostPhase left, XPostPhase right, XPostPhase expected)
+    {
+        var phase = XPostPhaseDecider.Min(left, right);
+
+        Assert.Equal(expected, phase);
+    }
+}

--- a/LongevityWorldCup.Website/Business/DatabaseManager.cs
+++ b/LongevityWorldCup.Website/Business/DatabaseManager.cs
@@ -161,7 +161,10 @@ public sealed class DatabaseManager : IDisposable
         {
             var files = new List<FileInfo>();
             foreach (var f in Directory.GetFiles(backupDir, "*.db"))
-                files.Add(new FileInfo(f));
+            {
+                if (Path.GetFileName(f).StartsWith(filePrefix, StringComparison.Ordinal))
+                    files.Add(new FileInfo(f));
+            }
 
             files.Sort((a, b) => b.CreationTimeUtc.CompareTo(a.CreationTimeUtc));
 

--- a/LongevityWorldCup.Website/Business/DatabaseManager.cs
+++ b/LongevityWorldCup.Website/Business/DatabaseManager.cs
@@ -47,7 +47,8 @@ public sealed class DatabaseManager : IDisposable
             DataSource = DbPath,
             Mode = SqliteOpenMode.ReadWriteCreate,
             Cache = SqliteCacheMode.Shared,
-            DefaultTimeout = defaultTimeoutSeconds
+            DefaultTimeout = defaultTimeoutSeconds,
+            Pooling = false
         };
 
         _sqlite = new SqliteConnection(csb.ToString());
@@ -135,7 +136,7 @@ public sealed class DatabaseManager : IDisposable
 
         Directory.CreateDirectory(backupDir);
 
-        var backupFile = Path.Combine(backupDir, $"{filePrefix}{DateTime.UtcNow:yyyyMMdd_HHmmss}.db");
+        var backupFile = Path.Combine(backupDir, $"{filePrefix}{DateTime.UtcNow:yyyyMMdd_HHmmss}_{Guid.NewGuid():N}.db");
 
         Run(sqlite =>
         {
@@ -145,7 +146,13 @@ public sealed class DatabaseManager : IDisposable
                 chk.ExecuteNonQuery();
             }
 
-            using var dest = new SqliteConnection($"Data Source={backupFile}");
+            var backupConnectionString = new SqliteConnectionStringBuilder
+            {
+                DataSource = backupFile,
+                Pooling = false
+            }.ToString();
+
+            using var dest = new SqliteConnection(backupConnectionString);
             dest.Open();
             sqlite.BackupDatabase(dest);
         });

--- a/LongevityWorldCup.Website/Config.cs
+++ b/LongevityWorldCup.Website/Config.cs
@@ -111,7 +111,16 @@ namespace LongevityWorldCup.Website
                 return;
 
             var json = await File.ReadAllTextAsync(RuntimeConfigFilePath);
-            var runtimeConfig = JsonSerializer.Deserialize<RuntimeConfig>(json);
+            RuntimeConfig? runtimeConfig;
+            try
+            {
+                runtimeConfig = JsonSerializer.Deserialize<RuntimeConfig>(json);
+            }
+            catch (JsonException)
+            {
+                return;
+            }
+
             if (runtimeConfig is null)
                 return;
 

--- a/LongevityWorldCup.Website/Jobs/BitcoinDonationCheckJob.cs
+++ b/LongevityWorldCup.Website/Jobs/BitcoinDonationCheckJob.cs
@@ -1,15 +1,19 @@
 using LongevityWorldCup.Website.Business;
+using Microsoft.Extensions.Logging;
 using Quartz;
 
 namespace LongevityWorldCup.Website.Jobs
 {
+    [DisallowConcurrentExecution]
     public class BitcoinDonationCheckJob : IJob
     {
         private readonly BitcoinDataService _btc;
+        private readonly ILogger<BitcoinDonationCheckJob> _logger;
 
-        public BitcoinDonationCheckJob(BitcoinDataService btc)
+        public BitcoinDonationCheckJob(BitcoinDataService btc, ILogger<BitcoinDonationCheckJob> logger)
         {
             _btc = btc;
+            _logger = logger;
         }
 
         public async Task Execute(IJobExecutionContext context)
@@ -18,7 +22,10 @@ namespace LongevityWorldCup.Website.Jobs
             {
                 await _btc.CheckDonationAddressAndCreateEventsAsync(context.CancellationToken);
             }
-            catch { }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Bitcoin donation check job failed.");
+            }
         }
     }
 }

--- a/LongevityWorldCup.Website/Jobs/DatabaseBackupJob.cs
+++ b/LongevityWorldCup.Website/Jobs/DatabaseBackupJob.cs
@@ -1,17 +1,21 @@
 using System.Threading.Tasks;
 using LongevityWorldCup.Website.Business;
 using LongevityWorldCup.Website.Tools;
+using Microsoft.Extensions.Logging;
 using Quartz;
 
 namespace LongevityWorldCup.Website.Jobs
 {
+    [DisallowConcurrentExecution]
     public class DatabaseBackupJob : IJob
     {
         private readonly DatabaseManager _db;
+        private readonly ILogger<DatabaseBackupJob> _logger;
 
-        public DatabaseBackupJob(DatabaseManager db)
+        public DatabaseBackupJob(DatabaseManager db, ILogger<DatabaseBackupJob> logger)
         {
             _db = db;
+            _logger = logger;
         }
 
         public Task Execute(IJobExecutionContext context)
@@ -19,10 +23,12 @@ namespace LongevityWorldCup.Website.Jobs
             try
             {
                 var dir = System.IO.Path.Combine(EnvironmentHelpers.GetDataDir(), "Backups");
-                _db.BackupDatabase(dir);
+                var backupPath = _db.BackupDatabase(dir);
+                _logger.LogInformation("Database backup completed at {BackupPath}", backupPath);
             }
-            catch
+            catch (Exception ex)
             {
+                _logger.LogError(ex, "Database backup job failed.");
             }
 
             return Task.CompletedTask;

--- a/LongevityWorldCup.Website/Jobs/LongevitymaxxingReminderJob.cs
+++ b/LongevityWorldCup.Website/Jobs/LongevitymaxxingReminderJob.cs
@@ -3,6 +3,7 @@ using Quartz;
 
 namespace LongevityWorldCup.Website.Jobs;
 
+[DisallowConcurrentExecution]
 public sealed class LongevitymaxxingReminderJob(
     LongevitymaxxingChallengeService challenge,
     EventDataService events,

--- a/LongevityWorldCup.Website/Jobs/SeasonFinalizerJob.cs
+++ b/LongevityWorldCup.Website/Jobs/SeasonFinalizerJob.cs
@@ -4,6 +4,7 @@ using LongevityWorldCup.Website.Business;
 
 namespace LongevityWorldCup.Website.Jobs
 {
+    [DisallowConcurrentExecution]
     public sealed class SeasonFinalizerJob : IJob
     {
         private readonly SeasonFinalizerService _seasonFinalizer;

--- a/LongevityWorldCup.Website/Tools/AssetVersionProvider.cs
+++ b/LongevityWorldCup.Website/Tools/AssetVersionProvider.cs
@@ -10,9 +10,10 @@ public sealed class AssetVersionProvider
 
     public AssetVersionProvider(IWebHostEnvironment environment)
     {
-        _webRootPath = !string.IsNullOrWhiteSpace(environment.WebRootPath) && Directory.Exists(environment.WebRootPath)
+        var webRootPath = !string.IsNullOrWhiteSpace(environment.WebRootPath) && Directory.Exists(environment.WebRootPath)
             ? environment.WebRootPath
             : Path.Combine(environment.ContentRootPath, "wwwroot");
+        _webRootPath = Path.GetFullPath(webRootPath);
     }
 
     public string AppendVersion(string assetPath)
@@ -25,9 +26,9 @@ public sealed class AssetVersionProvider
         var queryIndex = assetPath.IndexOf('?');
         var cleanPath = queryIndex >= 0 ? assetPath[..queryIndex] : assetPath;
         var relativePath = cleanPath.TrimStart('/').Replace('/', Path.DirectorySeparatorChar);
-        var fullPath = Path.Combine(_webRootPath, relativePath);
+        var fullPath = Path.GetFullPath(Path.Combine(_webRootPath, relativePath));
 
-        if (!File.Exists(fullPath))
+        if (!IsUnderWebRoot(fullPath) || !File.Exists(fullPath))
         {
             return assetPath;
         }
@@ -44,6 +45,15 @@ public sealed class AssetVersionProvider
         return queryIndex >= 0
             ? $"{assetPath}&v={version}"
             : $"{assetPath}?v={version}";
+    }
+
+    private bool IsUnderWebRoot(string fullPath)
+    {
+        var root = _webRootPath.EndsWith(Path.DirectorySeparatorChar)
+            ? _webRootPath
+            : _webRootPath + Path.DirectorySeparatorChar;
+
+        return fullPath.StartsWith(root, StringComparison.OrdinalIgnoreCase);
     }
 
     private static string ComputeHash(string fullPath)

--- a/LongevityWorldCup.Website/Tools/AssetVersionProvider.cs
+++ b/LongevityWorldCup.Website/Tools/AssetVersionProvider.cs
@@ -5,8 +5,15 @@ namespace LongevityWorldCup.Website.Tools;
 
 public sealed class AssetVersionProvider
 {
+    private static readonly StringComparison PathComparison = OperatingSystem.IsWindows()
+        ? StringComparison.OrdinalIgnoreCase
+        : StringComparison.Ordinal;
+    private static readonly StringComparer PathComparer = OperatingSystem.IsWindows()
+        ? StringComparer.OrdinalIgnoreCase
+        : StringComparer.Ordinal;
+
     private readonly string _webRootPath;
-    private readonly ConcurrentDictionary<string, CacheEntry> _cache = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, CacheEntry> _cache = new(PathComparer);
 
     public AssetVersionProvider(IWebHostEnvironment environment)
     {
@@ -53,7 +60,7 @@ public sealed class AssetVersionProvider
             ? _webRootPath
             : _webRootPath + Path.DirectorySeparatorChar;
 
-        return fullPath.StartsWith(root, StringComparison.OrdinalIgnoreCase);
+        return fullPath.StartsWith(root, PathComparison);
     }
 
     private static string ComputeHash(string fullPath)

--- a/LongevityWorldCup.Website/Tools/EnvironmentHelpers.cs
+++ b/LongevityWorldCup.Website/Tools/EnvironmentHelpers.cs
@@ -95,8 +95,9 @@ public static class EnvironmentHelpers
             fileName = callerFilePath[lastSeparatorIndex..]; // From lastSeparatorIndex until the end of the string.
         }
 
-        var fileNameWithoutExtension = fileName.TrimEnd(".cs", StringComparison.InvariantCultureIgnoreCase);
-        return fileNameWithoutExtension;
+        return fileName.EndsWith(".cs", StringComparison.InvariantCultureIgnoreCase)
+            ? fileName[..^3]
+            : fileName;
     }
 
     public static bool IsFileTypeAssociated(string fileExtension)

--- a/LongevityWorldCup.Website/Tools/SocialContactParser.cs
+++ b/LongevityWorldCup.Website/Tools/SocialContactParser.cs
@@ -27,14 +27,14 @@ public static class SocialContactParser
     public static string? TryExtractXHandle(string? mediaContact)
     {
         return TryExtractHandle(mediaContact, isSupportedHost: host =>
-            host.EndsWith("x.com", StringComparison.OrdinalIgnoreCase) ||
-            host.EndsWith("twitter.com", StringComparison.OrdinalIgnoreCase));
+            IsHostOrSubdomain(host, "x.com") ||
+            IsHostOrSubdomain(host, "twitter.com"));
     }
 
     public static string? TryExtractThreadsHandle(string? mediaContact)
     {
         return TryExtractHandle(mediaContact, isSupportedHost: host =>
-            host.EndsWith("threads.com", StringComparison.OrdinalIgnoreCase));
+            IsHostOrSubdomain(host, "threads.com"));
     }
 
     private static string? TryExtractHandle(string? mediaContact, Func<string, bool> isSupportedHost)
@@ -69,6 +69,12 @@ public static class SocialContactParser
             return true;
 
         return Uri.TryCreate("https://" + value, UriKind.Absolute, out uri!);
+    }
+
+    private static bool IsHostOrSubdomain(string host, string domain)
+    {
+        return string.Equals(host, domain, StringComparison.OrdinalIgnoreCase) ||
+               host.EndsWith("." + domain, StringComparison.OrdinalIgnoreCase);
     }
 
     private static string? NormalizeHandle(string? value)


### PR DESCRIPTION
## What changed

- Added GitHub Actions `concurrency` groups to the .NET, CodeQL, and Dependency Review workflows.
- Pull request validation runs now cancel older in-progress runs for the same PR when a newer commit is pushed.
- Master pushes and scheduled CodeQL scans keep running to completion.
- Added a 45-minute GitHub Actions job timeout to the production deploy workflow, complementing the existing 30-minute SSH command timeout.
- Hardened SQLite database backups so repeated backups cannot collide on the same timestamped filename.
- Disabled SQLite pooling for the owned database connection and backup destination connection so disposed test/backup databases release file handles promptly on Windows.
- Added focused backup coverage for repeated backup creation and cleanup.
- Scoped backup retention cleanup to `DatabaseManager`-managed backup files so manual `.db` snapshots in the backup directory are preserved.
- Added backup job logging and Quartz non-concurrent execution so startup and scheduled backup triggers cannot overlap silently.
- Added Bitcoin donation check job failure logging and Quartz non-concurrent execution so startup and scheduled donation checks cannot overlap silently.
- Added Quartz non-concurrent execution to season finalization and Longevitymaxxing Challenge reminder jobs, plus a reflection test requiring all Quartz jobs to opt out of overlapping executions.
- Added focused tests for daily file logging writes and retention cleanup.
- Fixed `EnvironmentHelpers.ExtractFileName` so it removes only an actual `.cs` extension instead of trimming any trailing `c`, `s`, or `.` characters.
- Added focused tests for shared string helper prefix/suffix trimming and whitespace behavior.
- Made malformed runtime token config sidecars non-fatal when the primary config is valid.
- Added request-level coverage for canonical route redirects, query preservation, and clean canonical page serving.
- Hardened asset versioning so normalized asset paths must stay inside `wwwroot` before a file hash is computed.
- Added focused asset versioning tests for hash query generation, existing query strings, fallback web-root resolution, unversionable paths, and path traversal rejection.
- Tightened social contact parsing so X, Twitter, and Threads handles are extracted only from the exact supported hosts or their subdomains.
- Added focused social contact parser tests for supported mention formats, lookalike domain rejection, cross-platform rejection, and the current no-Facebook-mention behavior.
- Added focused generation resolver coverage for birth-year boundaries, explicit generation overrides, JSON fallback behavior, and missing birth-year handling.
- Added focused public cache header coverage for weak SHA-256 ETag generation, conditional ETag matching, wildcard handling, mismatch rejection, and validator header application.
- Added focused event payload helper coverage for biological-age improvement parsing, Crowd Age and Pheno/Bortz Improvement top-10 payload validation, CSV/flag parsing, and Custom Event title extraction.
- Added focused filler post cooldown scheduler coverage for empty logs, latest-row selection, fixed cooldown boundaries, malformed timestamps, and normalized cooldown bounds.
- Added focused client identifier coverage for trusted proxy ranges, forwarded header precedence, invalid forwarded headers, first-hop parsing, and missing remote address fallback.
- Added focused secret hash verifier coverage for empty secrets, invalid Base64 payloads, short salts/hashes, oversized hashes, and malformed hash metadata.
- Added focused newsletter persistence coverage for subscription file creation, case-insensitive duplicate detection, unsubscribe cleanup, and missing-file idempotency.
- Added focused social post phase decider coverage for tiny/early/mature sample thresholds, null samples, and conservative phase selection.
- Added focused BTCPay invoice client coverage for create-invoice payloads, authorization headers, escaped store/invoice URLs, and lookup parsing.
- Added focused Slack webhook delivery coverage for JSON payloads, missing webhook skips, and non-success response propagation.
- Added focused sitemap XML coverage for normalized route de-duplication and newest `lastmod` selection.
- Added focused Custom Event markup coverage for title/content splitting, safe-link detection, unsafe-link rejection, mention fallback, and styled segment parsing.
- Added focused tracking-parameter redirect coverage for stripping known marketing query keys while preserving clean query values.
- Added focused Bitcoin data service coverage for BTC/USD primary and fallback APIs, donation balance fallbacks, failure reporting, and cache reuse.
- Added focused Event board embed-route coverage for missing-athlete error routing, canonical athlete redirects, noindex headers, and noindex embed metadata.
- Added .NET coverage reporting to the main CI workflow, including line/branch coverage in the job summary and a sticky PR comment.
- Expanded canonical route request coverage for uppercase legacy aliases, query preservation, and clean route variants that should serve without redirect.
- Expanded AI markdown endpoint coverage for indexable crawler headers, markdown content type, conditional GET behavior, and the legacy `/ai/athletes.md` permanent redirect.
- Added focused route canonicalization helper coverage for query/fragment stripping, trailing-slash normalization, alias lookup, and lowercase fallback behavior.
- Added public Pheno Age and Bortz Age calculator coverage for NaN and infinite biomarker inputs returning finite-number validation errors.
- Added focused league Open Graph share-card helper coverage for accepted route/display aliases, unsupported league rejection, and canonical display-name lookup.
- Expanded BTCPay invoice parser coverage for settled invoices without paid amounts and numeric, case-insensitive provider fields.
- Added focused page Open Graph share-card payload coverage for slug normalization, versioned image URLs, signatures, and unknown page rejection.
- Added focused health endpoint coverage for the no-store cache policy on operational status responses.
- Added focused public POST rate-limit coverage for retry-after hints on rejected requests.
- Added focused sitemap endpoint coverage for XML content type and short public cache headers.

## Why it matters

This keeps the long-lived autonomous maintenance branch from wasting CI time on stale commits while preserving full validation for the latest branch state and protected master activity. It also prevents a deploy workflow runner from hanging indefinitely if checkout, freshness checks, or SSH orchestration stalls outside the SSH action's own timeout. The database backup changes prevent accidental backup overwrite, avoid deleting unrelated manual snapshots, improve deterministic cleanup after SQLite work, and make backup job success/failure visible in logs. Donation polling failures are now visible in logs instead of being swallowed silently. Scheduled jobs that update durable state now consistently avoid overlapping Quartz executions. Logger coverage protects local operational logs from accidental retention regressions. The filename helper fix prevents utility callers from corrupting names such as `Process.cs` or `Status.cs`, and the string helper tests lock in the shared one-occurrence trimming contract. Config loading now tolerates a corrupt runtime sidecar instead of blocking startup when the primary config is valid. Canonical route tests protect clean URL and SEO alias behavior from middleware regressions, including uppercase legacy aliases and accepted clean-route variants. Asset versioning now has explicit safety coverage around the same cache-busting helper used by injected HTML and partial placeholders. Social post mention parsing now avoids false positives from lookalike domains while preserving accepted X, Twitter, and Threads formats. Generation resolver coverage protects the backend generation league bands used by leaderboard snapshots, badges, and profile rendering. Cache header tests protect the low-level conditional GET helper used by public data and AI document endpoints. Event payload helper tests protect the shared parsing contract used by social post builders, skip policies, and Event dispatch paths. Filler cooldown scheduler tests protect social reminder cadence behavior shared by X, Threads, and Facebook logs. Client identifier tests protect rate limiting and request attribution behavior behind trusted proxies. Secret hash verifier tests protect admin/shared-secret validation from accepting malformed or weak stored hash payloads. Newsletter persistence tests protect the local subscription file contract used by public subscribe and unsubscribe endpoints. Social post phase tests protect the sample-size thresholds shared by X and Threads wording. BTCPay invoice client tests protect the outbound payment-provider contract used by application and commitment payment flows. Slack webhook tests protect operational/social event delivery behavior around configured and missing webhooks. Sitemap tests protect SEO/discovery XML normalization when routes are supplied with duplicate path variants. Custom Event markup tests protect the shared parser used by the designer, Event board rendering, social composition, and image rendering. Tracking-parameter redirect tests protect public URL cleanup from regressing cache-friendly and canonical share paths. Bitcoin data service tests protect donation and public price endpoints from silent regressions in third-party API fallback and caching behavior. Event board embed-route tests protect the partial iframe route from accidental indexing, bad missing-athlete handling, missing noindex metadata, or canonical redirect regressions. Coverage reporting makes .NET line and branch coverage visible directly on PR validation instead of requiring log spelunking. AI markdown endpoint tests protect machine-readable public discovery routes from losing indexability headers, markdown content metadata, or the legacy redirect to current leaderboard facts. Route canonicalization helper tests make clean URL normalization failures diagnosable before they surface only as request-level redirect mismatches. Calculator finite-input tests lock down the shared guard that prevents public pheno age and Bortz Age endpoints from attempting calculations with NaN or infinite biomarker values. League share-card helper tests protect Open Graph route aliases and display-name normalization from accidental drift without invoking expensive image rendering. BTCPay parser variants protect payment status handling when the provider returns settled invoices without a separate paid amount or uses numeric/case-varied JSON fields. Page share-card payload tests protect Open Graph metadata URL generation and slug lookup behavior without invoking image rendering. Health endpoint cache-policy coverage protects monitoring and uptime probes from serving stale operational state. Rate-limit retry hint coverage protects clients from losing the `Retry-After` contract when public POST throttling rejects a request. Sitemap endpoint coverage protects crawler-facing XML metadata and cache behavior from middleware regressions.

## Verification

- `dotnet test --no-restore --filter FullyQualifiedName~DatabaseManagerBackupTests --verbosity minimal`
- `dotnet test --no-restore --filter FullyQualifiedName~ScheduledJobConfigurationTests --verbosity minimal`
- `dotnet test --no-restore --filter FullyQualifiedName~DailyFileLoggerProviderTests --verbosity minimal`
- `dotnet test --no-restore --filter FullyQualifiedName~EnvironmentHelpersTests --verbosity minimal`
- `dotnet test --no-restore --filter FullyQualifiedName~StringExtensionsTests --verbosity minimal`
- `dotnet test --no-restore --filter FullyQualifiedName~ConfigPersistenceTests --verbosity minimal`
- `dotnet test --no-restore --filter FullyQualifiedName~CanonicalRouteTests --verbosity minimal`
- `dotnet test --no-restore --filter FullyQualifiedName~AssetVersionProviderTests --verbosity minimal`
- `dotnet test --no-restore --filter FullyQualifiedName~SocialContactParserTests --verbosity minimal`
- `dotnet test --no-restore --filter FullyQualifiedName~GenerationResolverTests --verbosity minimal`
- `dotnet test --no-restore --filter FullyQualifiedName~PublicGetCacheHeadersTests --verbosity minimal`
- `dotnet test --no-restore --filter FullyQualifiedName~EventHelpersTests --verbosity minimal`
- `dotnet test --no-restore --filter FullyQualifiedName~FillerPostLogScheduleTests --verbosity minimal`
- `dotnet test --no-restore --filter FullyQualifiedName~ClientIdentifierTests --verbosity minimal`
- `dotnet test --no-restore --filter FullyQualifiedName~SecretHashVerifierTests --verbosity minimal`
- `dotnet test --no-restore --filter FullyQualifiedName~NewsletterServiceTests --verbosity minimal`
- `dotnet test --no-restore --filter FullyQualifiedName~XPostPhaseDeciderTests --verbosity minimal`
- `dotnet test --no-restore --filter FullyQualifiedName~BtcpayInvoiceClientTests --verbosity minimal`
- `dotnet test --no-restore --filter FullyQualifiedName~SlackWebhookClientTests --verbosity minimal`
- `dotnet test --no-restore --filter FullyQualifiedName~SitemapDiscoveryTests --verbosity minimal`
- `dotnet test --no-restore --filter FullyQualifiedName~CustomEventMarkupTests --verbosity minimal`
- `dotnet test --no-restore --filter FullyQualifiedName~TrackingParamStripperMiddlewareTests --verbosity minimal`
- `dotnet test --no-restore --filter FullyQualifiedName~BitcoinDataServiceTests --verbosity minimal`
- `dotnet test --no-restore --filter FullyQualifiedName~EventBoardRedirectMiddlewareTests --verbosity minimal`
- `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --filter PublicGetCachingTests --no-restore`
- `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --filter RouteCanonicalizationTests --no-restore`
- `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --filter CanonicalRouteTests --no-restore`
- `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --filter PublicCalculationApiTests --no-restore`
- `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --filter LeagueOgImageServiceTests --no-restore`
- `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --filter BtcpayInvoiceClientTests --no-restore`
- `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --filter PageOgImageServiceTests --no-restore`
- `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --filter HealthCheckEndpointTests --no-restore`
- `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --filter PublicPostRateLimitingTests --no-restore`
- `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --filter SitemapDiscoveryTests --no-restore`
- `dotnet restore`
- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity normal -p:CollectCoverage=true -p:CoverletOutput=TestResults/Coverage/ -p:CoverletOutputFormat=cobertura`
- `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --no-restore`
- `git diff --check`
- GitHub Actions passed on latest head `a8c2bf3`.

## Residual risk

- `actionlint` is not installed in this local environment, so workflow expression validation relies on GitHub Actions.
- Disabling SQLite pooling is expected to be low-risk because `DatabaseManager` owns a singleton connection rather than repeatedly opening short-lived pooled connections.
- Some repository token policies can block automatic PR comments; the workflow keeps the coverage report in the job summary and warns instead of failing in that case.
