### PR TITLE
[codex] Keep challenge leaderboard visible

### DIFF
--- a/LongevityWorldCup.Tests/LongevitymaxxingChallengePageTests.cs
+++ b/LongevityWorldCup.Tests/LongevitymaxxingChallengePageTests.cs
@@ -506,7 +506,7 @@ public sealed class LongevitymaxxingChallengePageTests
     }
 
     [Fact]
-    public async Task LongevitymaxxingScript_KeepsSignupLeaderboardVisibleAndFocusesDueCheckIn()
+    public async Task LongevitymaxxingScript_KeepsCommitmentBlockedLeaderboardVisibleAndFocusesDueCheckIn()
     {
         using var factory = CreateFactory();
         using var client = factory.CreateClient();
@@ -534,7 +534,9 @@ public sealed class LongevitymaxxingChallengePageTests
         Assert.DoesNotContain("publicClosed", javascript);
         Assert.DoesNotContain("public-board-only", javascript);
         Assert.Contains("const participantGateOnly = commitmentBlocked || checkInOnly;", javascript);
-        Assert.Contains("toggle(\"lmxBoardSection\", !participantGateOnly);", javascript);
+        Assert.Contains("const publicContentHidden = checkInOnly;", javascript);
+        Assert.Contains("hero.classList.toggle(\"checkin-only\", publicContentHidden);", javascript);
+        Assert.Contains("toggle(\"lmxBoardSection\", !publicContentHidden);", javascript);
         Assert.Contains("toggle(\"lmxCommitmentPanel\", hasParticipant && commitmentBlocked);", javascript);
         Assert.Contains("toggle(\"lmxParticipantTools\", hasParticipant && !commitmentBlocked && activeParticipantTab === \"home\");", javascript);
         Assert.Contains("toggle(\"lmxParticipantCalls\", hasParticipant && !commitmentBlocked && activeParticipantTab === \"home\");", javascript);
@@ -559,14 +561,14 @@ public sealed class LongevitymaxxingChallengePageTests
         Assert.Contains(".lmx-call-when small", css);
         Assert.Contains("const leaderboardRows = splitLeaderboardRows(state);", javascript);
         Assert.Contains("const leaderboard = participant.challengeInactive ? (state.leaderboard || []) : leaderboardRows.active;", javascript);
-        Assert.Contains("toggle(\"lmxTitlePanel\", !participantGateOnly);", javascript);
+        Assert.Contains("toggle(\"lmxTitlePanel\", !publicContentHidden);", javascript);
         Assert.Contains("toggle(\"lmxAccessTabs\", !hasParticipant && !isAccessLoading);", javascript);
         Assert.Contains("toggle(\"lmxResendPanel\", !hasParticipant && !isAccessLoading && accessTab === \"signin\");", javascript);
         Assert.Contains("toggle(\"lmxHabitHeading\", !hasParticipant);", javascript);
         Assert.Contains("toggle(\"lmxHabitGrid\", !hasParticipant);", javascript);
         Assert.Contains("toggle(\"lmxQuestionPreview\", !commitmentBlocked && (!hasParticipant || pendingCheckInDays.length > 0));", javascript);
         Assert.Contains("toggle(\"lmxTrack\", hasParticipant && dashboardMode && !participantGateOnly);", javascript);
-        Assert.Contains("toggle(\"lmxNotesPanel\", dashboardMode && !participantGateOnly);", javascript);
+        Assert.Contains("toggle(\"lmxNotesPanel\", dashboardMode && !publicContentHidden);", javascript);
         Assert.Contains("renderNotes(state.notes || [], false);", javascript);
         Assert.Contains("renderNotes(state.notes || state.public.notes || [], true);", javascript);
         Assert.Contains("No public notes yet.", javascript);

--- a/LongevityWorldCup.Website/wwwroot/js/longevitymaxxing.js
+++ b/LongevityWorldCup.Website/wwwroot/js/longevitymaxxing.js
@@ -873,19 +873,20 @@
         const activeParticipantTab = hasParticipant ? ensureParticipantTab(participantState) : null;
         const checkInOnly = !commitmentBlocked && pendingCheckInDays.length > 0 && activeParticipantTab === "checkin";
         const participantGateOnly = commitmentBlocked || checkInOnly;
+        const publicContentHidden = checkInOnly;
         const dashboardMode = hasParticipant || !isPreStartSignup(state);
         const hero = document.getElementById("lmxHeroLayout");
         if (hero) {
-            hero.classList.toggle("checkin-only", participantGateOnly);
+            hero.classList.toggle("checkin-only", publicContentHidden);
         }
 
-        toggle("lmxTitlePanel", !participantGateOnly);
+        toggle("lmxTitlePanel", !publicContentHidden);
         toggle("lmxAccessTabs", !hasParticipant && !isAccessLoading);
         toggle("lmxSignupPanel", !hasParticipant && !isAccessLoading && accessTab === "signup");
         toggle("lmxAccessLoadingPanel", isAccessLoading);
         toggle("lmxParticipantPanel", hasParticipant);
         toggle("lmxResendPanel", !hasParticipant && !isAccessLoading && accessTab === "signin");
-        toggle("lmxNotesPanel", dashboardMode && !participantGateOnly);
+        toggle("lmxNotesPanel", dashboardMode && !publicContentHidden);
         toggle("lmxSignupIntro", !signupSubmitted);
         toggle("lmxSignupDonePanel", signupSubmitted);
         toggle("lmxHabitHeading", !hasParticipant);
@@ -893,7 +894,7 @@
         toggle("lmxQuestionPreview", !commitmentBlocked && (!hasParticipant || pendingCheckInDays.length > 0));
         toggle("lmxTrack", hasParticipant && dashboardMode && !participantGateOnly);
         toggle("lmxMetrics", hasParticipant && dashboardMode && !participantGateOnly);
-        toggle("lmxBoardSection", !participantGateOnly);
+        toggle("lmxBoardSection", !publicContentHidden);
         toggle("lmxParticipantTabs", hasParticipant && !commitmentBlocked);
         toggle("lmxCommitmentPanel", hasParticipant && commitmentBlocked);
         toggle("lmxCheckinPanel", hasParticipant && !commitmentBlocked && activeParticipantTab === "checkin");


### PR DESCRIPTION
## Summary

- Keeps the Longevitymaxxing public leaderboard visible for participants with a commitment payment block.
- Leaves the participant actions locked until the commitment is paid or cleared by an eligible edit.
- Updates the page regression test so commitment-blocked users keep public Challenge context while due check-ins can still focus the check-in flow.

## Root Cause

The frontend used one `participantGateOnly` state for both due check-ins and commitment payment blocks. That state hid the public title, notes, and leaderboard. For a commitment block, the private participant panel should be locked, but the public leaderboard should remain visible.

## Validation

- `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --filter "FullyQualifiedName~LongevitymaxxingChallengePageTests"`
- `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --filter "FullyQualifiedName~LongevitymaxxingChallengeServiceTests"`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small frontend visibility split in `renderPanels` with matching regression tests; no auth, API, or payment logic changes.
> 
> **Overview**
> **Commitment-blocked participants** no longer lose the public challenge chrome (title, notes, leaderboard). Only the **due check-in** flow still collapses that public content via a new `publicContentHidden` flag (`checkInOnly`), while `participantGateOnly` continues to gate private dashboard pieces like track/metrics.
> 
> Regression test renamed and updated to assert `publicContentHidden` drives `lmxBoardSection`, hero `checkin-only`, title, and notes visibility instead of `participantGateOnly`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc18777219084b4f365466927b4bedfaa75b294a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->