### PR TITLE
[codex] Fix mobile compatibility label wrapping

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/css/longevitymaxxing.css
+++ b/LongevityWorldCup.Website/wwwroot/css/longevitymaxxing.css
@@ -3333,6 +3333,9 @@ body.lmx-quote-open {
     .lmx-life-strip span {
         min-height: 2.35rem;
         padding-inline: 0.55rem;
+        gap: 0.28rem;
+        font-size: clamp(0.75rem, 3.2vw, 0.82rem);
+        white-space: nowrap;
     }
 
     .lmx-question-preview {


### PR DESCRIPTION
## What changed

Fixes the mobile Longevitymaxxing compatibility strip so each compatibility tile keeps its label on one line at phone widths.

## Why

At a 390px viewport, the `Family compatible` tile wrapped onto two lines while the other tiles stayed single-line. This was a pure visual inconsistency, visible in a before/after screenshot without inspecting code.

## Visual verification

| Before | After |
| --- | --- |
| ![Before: Family compatible wraps onto two lines in the mobile compatibility strip](https://github.com/user-attachments/assets/9d94f96a-01b6-4d9e-9796-ed8e69401cad) | ![After: Family compatible stays on one line in the mobile compatibility strip](https://github.com/user-attachments/assets/d9622293-b376-496c-9ca4-36668cb58187) |

## Validation

- Browser visual check: `http://127.0.0.1:5318/longevitymaxxing` at 390x844
- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -c Debug -o .artifacts\build\website`

Note: a normal build to `bin\Debug` was blocked by an already-running local `LongevityWorldCup.Website` process holding the output DLL, so the successful build used an isolated output directory.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS in a narrow mobile breakpoint; no logic, data, or auth changes.
> 
> **Overview**
> On viewports **≤520px**, mobile styles for **`.lmx-life-strip span`** (compatibility tiles) now use **`white-space: nowrap`**, a slightly tighter **`gap`**, and **`font-size: clamp(0.75rem, 3.2vw, 0.82rem)`** so longer labels (e.g. **Family compatible**) stay on a single line like the other tiles instead of wrapping at ~390px widths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6931045b69e84d4405377117c266a132f1d57be0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


