### PR TITLE
[codex] Fix history mobile nav overflow

### DIFF
--- a/LongevityWorldCup.MarkdownPageGenerator/Program.cs
+++ b/LongevityWorldCup.MarkdownPageGenerator/Program.cs
@@ -363,9 +363,12 @@ static string RenderPage(string title, string documentHtml, string contentsHtml,
             }
 
             .documentation-nav a {
-                flex: 0 0 auto;
+                box-sizing: border-box;
+                flex: 0 1 auto;
+                max-width: 100%;
                 background: rgba(255, 255, 255, 0.58);
-                white-space: nowrap;
+                white-space: normal;
+                overflow-wrap: anywhere;
             }
 
             .documentation-nav .documentation-nav-level-3 {

--- a/LongevityWorldCup.Website/wwwroot/misc-pages/about.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/about.html
@@ -228,9 +228,12 @@
             }
 
             .documentation-nav a {
-                flex: 0 0 auto;
+                box-sizing: border-box;
+                flex: 0 1 auto;
+                max-width: 100%;
                 background: rgba(255, 255, 255, 0.58);
-                white-space: nowrap;
+                white-space: normal;
+                overflow-wrap: anywhere;
             }
 
             .documentation-nav .documentation-nav-level-3 {

--- a/LongevityWorldCup.Website/wwwroot/misc-pages/history.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/history.html
@@ -228,9 +228,12 @@
             }
 
             .documentation-nav a {
-                flex: 0 0 auto;
+                box-sizing: border-box;
+                flex: 0 1 auto;
+                max-width: 100%;
                 background: rgba(255, 255, 255, 0.58);
-                white-space: nowrap;
+                white-space: normal;
+                overflow-wrap: anywhere;
             }
 
             .documentation-nav .documentation-nav-level-3 {

--- a/LongevityWorldCup.Website/wwwroot/misc-pages/ruleset.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/ruleset.html
@@ -228,9 +228,12 @@
             }
 
             .documentation-nav a {
-                flex: 0 0 auto;
+                box-sizing: border-box;
+                flex: 0 1 auto;
+                max-width: 100%;
                 background: rgba(255, 255, 255, 0.58);
-                white-space: nowrap;
+                white-space: normal;
+                overflow-wrap: anywhere;
             }
 
             .documentation-nav .documentation-nav-level-3 {


### PR DESCRIPTION
## What changed

- Allows long mobile History page timeline navigation chips to shrink and wrap inside the viewport.

## Why

The mobile History page navigation could widen beyond the viewport, clipping long timeline entries at the right edge.

## Screenshot proof

| Before | After |
| --- | --- |
| ![Before: long History timeline nav item clipped at the mobile viewport edge](https://github.com/user-attachments/assets/d92a5902-4be6-46ea-926c-0531b4f6987d) | ![After: the long History timeline nav item wraps within the mobile nav panel](https://github.com/user-attachments/assets/c3cec063-2d00-4aad-94f8-3517a5bd4cea) |

## Verification

- Browser screenshot at mobile width confirmed the before state clipped the long timeline item.
- Browser screenshot at mobile width confirmed the after state wraps the long timeline item inside the nav.
- Browser DOM metrics after the fix: `bodyScrollWidth` 375, `scrollWidth` 375, and 0 clipped nav links.
- `git diff --cached --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS under a mobile breakpoint; no auth, data, or application logic changes.
> 
> **Overview**
> Fixes **horizontal overflow** on narrow screens for documentation pages (About, History, Ruleset) by updating the `@media (max-width: 900px)` styles for `.documentation-nav a`.
> 
> Nav chips no longer stay on one line with rigid flex sizing (`flex: 0 0 auto` + `white-space: nowrap`). They now use **`flex: 0 1 auto`**, **`max-width: 100%`**, **`white-space: normal`**, and **`overflow-wrap: anywhere`** so long labels (e.g. History timeline entries) **wrap inside the viewport** instead of clipping past the right edge.
> 
> The same CSS is applied in **`MarkdownPageGenerator/Program.cs`** (embedded page template) and the three generated **`misc-pages/*.html`** files so generator output stays in sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 919230859f84007073f746c294281e6a5bbe7faf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->