### PR TITLE
[codex] Add bioage sticky progress gap

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/partials/main-progress-bar.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/main-progress-bar.html
@@ -175,6 +175,8 @@
 
     (function () {
         document.addEventListener('DOMContentLoaded', function () {
+            var stickyProgressContentGap = 12;
+
             setTimeout(function () {
                 // Scroll to the content under the progress bar so it sits just below the sticky header + progress bar (no overscroll)
                 var stickyHeader = document.getElementById('site-sticky-header');
@@ -184,7 +186,7 @@
                 if (contentStart) {
                     var headerHeight = (stickyHeader && stickyHeader.offsetHeight) || 52;
                     var progressHeight = 44; /* #site-sticky-progress when visible */
-                    var topOffset = headerHeight + progressHeight;
+                    var topOffset = headerHeight + progressHeight + stickyProgressContentGap;
                     var contentTop = contentStart.getBoundingClientRect().top + (window.scrollY || window.pageYOffset);
                     var targetScroll = contentTop - topOffset;
                     window.scrollTo({ top: Math.max(0, targetScroll), behavior: 'smooth' });
@@ -218,7 +220,7 @@
                     // Flush under LWC bar: no gap
                     if (stickyHeader) {
                         stickyProgress.style.top = stickyHeader.offsetHeight + 'px';
-                        document.documentElement.style.scrollPaddingTop = (stickyHeader.offsetHeight + stickyProgress.offsetHeight) + 'px';
+                        document.documentElement.style.scrollPaddingTop = (stickyHeader.offsetHeight + stickyProgress.offsetHeight + stickyProgressContentGap) + 'px';
                     }
                 } else {
                     stickyProgress.classList.remove('visible');


### PR DESCRIPTION
## What changed

- Adds a small shared visual gap below the fixed bioage progress bars when the calculator pages auto-scroll to the content.

## Why

On mobile, the calculator heading could sit directly against the sticky progress row, making the top of the heading look cropped.

## Screenshot proof

| Before | After |
| --- | --- |
| ![Before: bioage heading pressed into the sticky progress row on mobile](https://github.com/user-attachments/assets/24ea19c4-f112-4c4c-a47d-625030f26e24) | ![After: bioage heading has a clear gap below the sticky progress row on mobile](https://github.com/user-attachments/assets/bd859cff-cf92-4322-aadf-3bee8e221191) |

## Verification

- Browser screenshot at mobile width confirmed the before state pressed the heading into the sticky progress row.
- Browser metrics after the fix confirmed an 11.5px gap between the sticky progress row and heading on `/pheno-age`.
- Browser metrics after the fix confirmed the same 11.5px gap on `/bortz-age`.
- `git diff --cached --check`