### PR TITLE
[codex] Fix mobile sticky play position

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/css/mobile-roughness.css
+++ b/LongevityWorldCup.Website/wwwroot/css/mobile-roughness.css
@@ -184,6 +184,7 @@ input[type="reset"] {
 
     .leaderboard-view-switcher .view-badge,
     .join-game.scrolled-button {
+        margin-top: 0;
         min-height: 44px;
     }
 }


### PR DESCRIPTION
## What changed

- Removes the inherited mobile top margin from the fixed compact `PLAY` button.

## Why

On mobile leaderboard scroll, the fixed `PLAY` button protruded below the sticky header and overlapped the page title.

## Screenshot proof

| Before | After |
| --- | --- |
| ![Before: mobile sticky PLAY button protrudes below the header into the leaderboard title](https://github.com/user-attachments/assets/500e5f2d-3de6-4b83-b967-67cd2f15a3f4) | ![After: mobile sticky PLAY button stays inside the header above the leaderboard title](https://github.com/user-attachments/assets/57bacdc7-7746-449d-b881-81f96faf358c) |

## Verification

- Browser screenshot at mobile width confirmed the before state had the `PLAY` button hanging into the title area.
- Browser metrics before the fix: 13.6px protrusion below the sticky header and 13.2px overlap with the `Longevity leaderboard` title.
- Browser metrics after the fix: 0px protrusion below the sticky header and 0px overlap with the title.
- `git diff --cached --check`