### PR TITLE
Fix mobile sticky title truncation

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/partials/header.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/header.html
@@ -663,6 +663,11 @@
             padding-right: calc(max(0.5rem, env(safe-area-inset-right, 0px)) + 5.25rem);
         }
 
+        header:not(:has(.join-game.scrolled-button)) + .site-sticky-header,
+        header:has(.join-game.scrolled-button[style*="display: none"]) + .site-sticky-header {
+            padding-right: max(0.75rem, env(safe-area-inset-right, 0px));
+        }
+
         .site-sticky-header-link {
             max-width: 100%;
         }


### PR DESCRIPTION
## Summary
- Keep the mobile sticky header title full-width when no compact PLAY button is present.
- Preserve the reserved right-side space on pages where the compact PLAY button appears.

## Visual proof
| Before | After |
| --- | --- |
| ![Before: sticky title truncates to Longevity Wor ellipsis](https://github.com/user-attachments/assets/0b0b8f43-a4da-4968-8774-6a816c90969b) | ![After: sticky title shows full Longevity World Cup](https://github.com/user-attachments/assets/c04ae41f-a8e0-45f2-8fc9-43a31258438d) |

## Verification
- Browser check at `/play`, 320x700: sticky title no longer clips (`clientWidth == scrollWidth == 201`).
- Browser guard check at `/`, 320x700: compact PLAY button remains present and sticky right padding stays reserved.
- `git diff --check`
