### PR TITLE
Fix narrow Longevitymaxxing title wrap

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/css/longevitymaxxing.css
+++ b/LongevityWorldCup.Website/wwwroot/css/longevitymaxxing.css
@@ -3392,6 +3392,10 @@ body.lmx-quote-open {
 }
 
 @media (max-width: 360px) {
+    .lmx-title-row h1 {
+        font-size: 1.85rem;
+    }
+
     .lmx-life-strip {
         grid-template-columns: 1fr;
     }


### PR DESCRIPTION
## Summary
- Keep the Longevitymaxxing page title on one line on very narrow mobile screens.
- Limit the CSS change to the existing 360px mobile breakpoint.

## Visual proof
| Before | After |
| --- | --- |
| ![Before: Longevitymaxxing title wraps final letter onto a second line](https://github.com/user-attachments/assets/7bea60c3-b148-4e51-95f8-5a56b8b247fe) | ![After: Longevitymaxxing title fits on one line](https://github.com/user-attachments/assets/76a89375-c163-44aa-a1b4-ecb7cc742933) |

## Verification
- Browser check at `/longevitymaxxing`, 320x700: title line count drops from 2 to 1.
- Browser guard check at `/longevitymaxxing`, 361x700: title remains one line with the existing 2rem size.
- `git diff --check`
