### PR TITLE
Fix media download mobile wrap

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/misc-pages/media.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/media.html
@@ -196,13 +196,13 @@
             }
         }
 
-        @media (max-width: 340px) {
+        @media (max-width: 360px) {
             .media-kit-primary-download {
-                gap: 0.35rem;
-                padding-inline: 0.75rem;
-                font-size: 0.84rem;
+                gap: 0.3rem;
+                padding-inline: 0.55rem;
+                font-size: 0.82rem;
                 line-height: 1.2;
-                white-space: normal;
+                white-space: nowrap;
                 text-align: center;
             }
 

--- a/LongevityWorldCup.Website/wwwroot/misc-pages/media.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/media.html
@@ -202,7 +202,7 @@
                 padding-inline: 0.55rem;
                 font-size: 0.82rem;
                 line-height: 1.2;
-                white-space: nowrap;
+                white-space: normal;
                 text-align: center;
             }
 


### PR DESCRIPTION
## Summary
- Keep the Media kit primary download CTA label on one line on small mobile screens.
- Reuse the existing small-phone media query and only tighten the button spacing/font in that range.

## Visual proof
| Before | After |
| --- | --- |
| ![Before: Media kit download button wraps ZIP onto a second line](https://github.com/user-attachments/assets/d8b2877e-d505-40a2-8d9c-5fe9c03cba84) | ![After: Media kit download button stays on one line](https://github.com/user-attachments/assets/1e5a9a09-280f-4d68-bb02-8d8205d822e0) |

## Verification
- Browser check at `/media`, 320x700: CTA label line count drops from 2 to 1.
- Browser guard checks at `/media`, 341x700 and 361x700: CTA label remains one line with no horizontal page overflow.
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static page CSS only; no auth, data, or backend impact.
> 
> **Overview**
> Adjusts the **Media kit** page so the primary **Download full media kit (ZIP)** button stays on **one line** on very narrow viewports.
> 
> The small-screen breakpoint moves from **340px** to **360px**, and within that range the CTA gets slightly tighter **gap**, **horizontal padding**, and **font size** so the label no longer wraps (e.g. “ZIP” on a second line) without changing behavior elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f294f2a7051a44ed2faad42bb49bb1724143c8e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->