### PR TITLE
[codex] Fix unsubscribe mobile heading

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/unsubscribe.html
+++ b/LongevityWorldCup.Website/wwwroot/unsubscribe.html
@@ -24,7 +24,7 @@
             margin-bottom: 0.8rem;
             font-size: 2.5rem;
             line-height: 1.12;
-            overflow-wrap: anywhere;
+            overflow-wrap: normal;
         }
 
         .unsubscribe-panel h1[data-aos]:not(.aos-animate) {
@@ -116,7 +116,7 @@
             }
 
             .unsubscribe-panel h1 {
-                font-size: 2rem;
+                font-size: clamp(1.8rem, 9vw, 2rem);
             }
 
             .unsubscribe-button {


### PR DESCRIPTION
## What changed

- Keeps the Unsubscribe page heading from breaking in the middle of the word on narrow mobile screens.
- Uses a mobile font-size clamp for the fixed page title while preserving the panel and form layout.

## Why

At a 320px mobile viewport, the one-word `Unsubscribe` title wrapped as `Unsubscri` / `be`, which looked like an accidental text break.

## Screenshot proof

| Before | After |
| --- | --- |
| <img width="305" height="667" alt="Before: Unsubscribe heading splits mid-word on mobile" src="https://github.com/user-attachments/assets/e5b20441-8fa6-463d-903c-c3299332ff1b" /> | <img width="305" height="667" alt="After: Unsubscribe heading fits on one line on mobile" src="https://github.com/user-attachments/assets/cb3f3bc8-dbc3-40e2-9948-b047c159a30a" /> |

## Verification

- Browser screenshot at `/unsubscribe`, 320x700: before title rendered across 2 line boxes.
- Browser screenshot at `/unsubscribe`, 320x700: after title renders on 1 line.
- Browser guard checks at 280x700, 320x700, and 360x700: page has no horizontal overflow.
- `git diff --cached --check`