### PR TITLE
[codex] Fix join prize ribbon clipping

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/onboarding/join-game.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/join-game.html
@@ -372,8 +372,8 @@
         top: 0;
         right: 0;
         overflow: hidden;
-        width: 100px;
-        height: 100px;
+        width: 128px;
+        height: 128px;
         z-index: 0;
         pointer-events: none;
       }
@@ -387,7 +387,7 @@
 
       /* Keep title clear of the prize-money ribbon */
       .track-card.pro h2 {
-        padding-right: 4rem;
+        padding-right: 5.25rem;
       }
 
       @media (max-width: 360px) {
@@ -416,9 +416,9 @@
         justify-content: center;
         gap: 0.35rem;
         position: absolute;
-        right: -38px;
-        top: 24px;
-        width: 135px;
+        right: -34px;
+        top: 30px;
+        width: 148px;
         padding: 6px 12px;
         font-size: 0.7rem;
         font-weight: 700;


### PR DESCRIPTION
## What changed

- Widens the Professional track prize-money ribbon mask and band so the label fits on desktop/tablet widths.
- Reserves a little more heading space under the ribbon without changing the onboarding flow or copy.

## Why

At a 1280px desktop viewport, the rotated `₿ PRIZE MONEY` ribbon clipped the end of the label inside its fixed 100px corner mask.

## Screenshot proof

| Before | After |
| --- | --- |
| <img width="1265" height="712" alt="Before: Professional track prize-money ribbon clips the label" src="https://github.com/user-attachments/assets/7cb0da9c-f073-4825-84cf-9e1e7b43d25d" /> | <img width="1265" height="712" alt="After: Professional track prize-money ribbon shows the full label" src="https://github.com/user-attachments/assets/0de31176-9e3b-4e6c-9957-570112194bb4" /> |

## Verification

- Browser screenshot at `/join`, 1280x720: before ribbon visibly clipped the label.
- Browser screenshot at `/join`, 1280x720: after ribbon shows the full `₿ PRIZE MONEY` label.
- Browser guard screenshots at 1100x700 and 320x700: ribbon remains legible with no horizontal page overflow.
- `git diff --cached --check`