### PR TITLE
[codex] Fix ultranarrow sticky title

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/partials/header.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/header.html
@@ -678,6 +678,17 @@
         }
     }
 
+    @media (max-width: 300px) {
+        .site-sticky-header-link {
+            gap: 0.35rem;
+        }
+
+        .site-sticky-header-title {
+            font-size: 1.04rem;
+            letter-spacing: 1.35px;
+        }
+    }
+
     @media (max-width: 600px) {
         .bannertext {
             font-size: 2rem;


### PR DESCRIPTION
## What changed

- Adds an ultra-narrow sticky-header breakpoint below 300px.
- Slightly tightens the sticky title gap, font size, and letter spacing so the full brand title fits.

## Why

At a 280px viewport, the sticky header title rendered as `Longevity World C...` even though the page itself had no horizontal overflow.

## Screenshot proof

| Before | After |
| --- | --- |
| <img width="265" height="663" alt="Before: sticky header clips Longevity World Cup to Longevity World C..." src="https://github.com/user-attachments/assets/2fdd7947-66f5-42ea-8acd-d8e6d8d5ffbd" /> | <img width="265" height="663" alt="After: sticky header shows Longevity World Cup fully" src="https://github.com/user-attachments/assets/87861c80-811a-4640-9bbe-cc4c57f1e97f" /> |

## Verification

- Browser screenshot at `/events`, 280x700: before sticky title clipped to `Longevity World C...`.
- Browser screenshot at `/events`, 280x700: after sticky title shows `Longevity World Cup` fully.
- Browser guard checks at 280x700, 300x700, and 320x700: title `scrollWidth` equals `clientWidth`, with no horizontal page overflow.
- `git diff --cached --check`