### PR TITLE
[codex] Fix ultranarrow leaderboard table

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -2110,7 +2110,7 @@
                 display: none;
             }
 
-            .leaderboard table tbody tr {
+            .leaderboard table tbody tr:not(.no-results):not(.tier-separator) {
                 display: grid;
                 grid-template-columns: 2rem minmax(0, 1fr);
                 grid-template-areas:
@@ -2164,7 +2164,7 @@
             }
 
             .leaderboard table td.age-reduction-td::before {
-                content: "Age reduction";
+                content: attr(data-label);
                 display: block;
                 margin-bottom: 0.08rem;
                 color: #64748b;

--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -2095,6 +2095,96 @@
             }
         }
 
+        @media (max-width: 300px) {
+            .leaderboard table {
+                border-spacing: 0 0.45rem;
+                table-layout: auto;
+            }
+
+            .leaderboard .portrait {
+                width: 32px;
+                height: 32px;
+            }
+
+            .leaderboard table thead {
+                display: none;
+            }
+
+            .leaderboard table tbody tr {
+                display: grid;
+                grid-template-columns: 2rem minmax(0, 1fr);
+                grid-template-areas:
+                    "rank athlete"
+                    "rank score";
+                align-items: center;
+                column-gap: 0.45rem;
+                padding: 0.45rem 0.55rem;
+            }
+
+            .leaderboard table tbody tr.tier-separator {
+                display: block;
+                padding: 0;
+            }
+
+            .leaderboard table tbody tr.tier-separator .tier-separator-cell {
+                display: block;
+            }
+
+            .leaderboard table td.rank-td {
+                grid-area: rank;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                width: auto;
+                min-width: 0;
+                padding: 0;
+            }
+
+            .leaderboard table tbody tr td.athlete-td {
+                grid-area: athlete;
+                gap: 0.35rem;
+                min-width: 0;
+                padding: 0;
+            }
+
+            .leaderboard .athlete-td .portrait-wrapper,
+            .leaderboard .athlete-td .rank-change {
+                flex: 0 0 32px;
+                width: 32px;
+                min-width: 32px;
+            }
+
+            .leaderboard table td.age-reduction-td {
+                grid-area: score;
+                display: block;
+                width: auto;
+                min-width: 0;
+                padding: 0.1rem 0 0;
+                text-align: left;
+            }
+
+            .leaderboard table td.age-reduction-td::before {
+                content: "Age reduction";
+                display: block;
+                margin-bottom: 0.08rem;
+                color: #64748b;
+                font-size: 0.58rem;
+                font-weight: 700;
+                letter-spacing: 0.04em;
+                text-transform: uppercase;
+            }
+
+            .leaderboard table td.age-reduction-td .age-reduction {
+                display: inline-block;
+                line-height: 1.2;
+            }
+
+            .athlete-name {
+                padding-left: 0.25rem;
+                padding-right: 0.25rem;
+            }
+        }
+
         @media (max-width: 420px) {
             .leaderboard table th:nth-child(2),
             .leaderboard table td.athlete-td {


### PR DESCRIPTION
## What changed

- Stacks leaderboard rows below 300px so rank, athlete, and age reduction fit inside the card.
- Uses each metric cell's `data-label` for the stacked row label so improvement views keep their active metric wording.
- Leaves no-results rows as full-width table rows instead of applying the stacked card grid to them.

## Why

At a 280px viewport, the leaderboard table stayed wider than its card, clipping the right age-reduction column.

## Screenshot proof

Gist: https://gist.github.com/nopara73/66c714c97950d0d4eaf309a8179ac3c3

| Before | After |
| --- | --- |
| ![Before: leaderboard age reduction column clipped at 280px](https://gist.githubusercontent.com/nopara73/66c714c97950d0d4eaf309a8179ac3c3/raw/7bcff93682e5cfda52f8c4a4d63b431e411e36a9/pr-710-before-leaderboard-280.svg) | ![After: leaderboard row stacks and age reduction is fully visible at 280px](https://gist.githubusercontent.com/nopara73/66c714c97950d0d4eaf309a8179ac3c3/raw/a8f8ae1c8cc54ec5dcac6e99b747a86d721956ff/pr-710-after-leaderboard-280.svg) |

## Verification

- Browser crop at `/leaderboard`, 280x700: before the age-reduction column is clipped at the right edge.
- Browser crop at `/leaderboard`, 280x700: after the row stacks inside the card with rank, athlete, and age reduction fully visible.
- Browser metric check at 280x700: `tableScrollWidth` equals `tableClientWidth` (249px), and wrapper scroll width also equals client width.
- In-app browser check at `/leaderboard?view=improvement`, 280x700: first stacked metric cell has `data-label="Improvement"` and `::before` content `"Improvement"`.
- In-app browser check after an unmatched search, 280x700: `tr.no-results` remains `display: table-row` with a 249px full-width cell.
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only responsive CSS in one partial; no backend, auth, or data changes.
> 
> **Overview**
> Adds a **`@media (max-width: 300px)`** block in `leaderboard-content.html` so the leaderboard no longer overflows its card on very narrow viewports (e.g. ~280px).
> 
> Below that breakpoint, table rows switch from a wide horizontal layout to a **CSS grid** stack: rank in a narrow column, athlete on the first row, and age reduction on a second row. The **table header is hidden**, portraits shrink to 32px, and the age-reduction cell shows a compact **“Age reduction”** label via `::before { content: attr(data-label) }` (cells already expose `data-label` from rendering). Tier separator rows keep a simple block layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f3f090f17c0dd151e153fecbe221db4d85741ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->