### PR TITLE
[codex] Fix history mobile table fit

### DIFF
--- a/LongevityWorldCup.MarkdownPageGenerator/Program.cs
+++ b/LongevityWorldCup.MarkdownPageGenerator/Program.cs
@@ -402,6 +402,37 @@ static string RenderPage(string title, string documentHtml, string contentsHtml,
                 margin: 1.15rem auto 1.45rem;
             }
         }
+
+        @media (max-width: 360px) {
+            .documentation-document table {
+                display: table;
+                table-layout: fixed;
+                overflow: visible;
+            }
+
+            .documentation-document th,
+            .documentation-document td {
+                padding: 0.52rem 0.45rem;
+                white-space: normal;
+                overflow-wrap: break-word;
+            }
+
+            .documentation-document th {
+                font-size: 0.82rem;
+                line-height: 1.25;
+                overflow-wrap: normal;
+            }
+
+            .documentation-document th:first-child,
+            .documentation-document td:first-child {
+                width: 2.55rem;
+            }
+
+            .documentation-document th:last-child,
+            .documentation-document td:last-child {
+                width: 4.65rem;
+            }
+        }
     </style>
 </head>
 <body>

--- a/LongevityWorldCup.MarkdownPageGenerator/Program.cs
+++ b/LongevityWorldCup.MarkdownPageGenerator/Program.cs
@@ -39,7 +39,7 @@ foreach (var page in pages)
 {
     var markdown = await File.ReadAllTextAsync(page.Source);
     var title = ExtractTitle(markdown);
-    var documentHtml = OpenAbsoluteLinksInNewTabs(RewriteWebsiteAssetImageSources(Markdown.ToHtml(markdown, pipeline)));
+    var documentHtml = AddTableCellLabels(OpenAbsoluteLinksInNewTabs(RewriteWebsiteAssetImageSources(Markdown.ToHtml(markdown, pipeline))));
     var contentsHtml = BuildContentsNav(documentHtml, page.SourceUrl);
     var pageHtml = NormalizeGeneratedHtml(RenderPage(title, documentHtml, contentsHtml, page));
 
@@ -101,6 +101,57 @@ static string BuildContentsNav(string documentHtml, string sourceUrl)
 static string StripTags(string value)
 {
     return Regex.Replace(value, "<.*?>", string.Empty).Trim();
+}
+
+static string AddTableCellLabels(string html)
+{
+    return Regex.Replace(
+        html,
+        "<table>\\s*<thead>\\s*<tr>(?<header>.*?)</tr>\\s*</thead>\\s*<tbody>(?<body>.*?)</tbody>\\s*</table>",
+        match =>
+        {
+            var headers = Regex.Matches(
+                    match.Groups["header"].Value,
+                    "<th>(?<text>.*?)</th>",
+                    RegexOptions.IgnoreCase | RegexOptions.Singleline)
+                .Select(header => StripTags(WebUtility.HtmlDecode(header.Groups["text"].Value)))
+                .ToArray();
+
+            if (headers.Length == 0)
+            {
+                return match.Value;
+            }
+
+            var body = Regex.Replace(
+                match.Groups["body"].Value,
+                "<tr>(?<row>.*?)</tr>",
+                rowMatch =>
+                {
+                    var index = 0;
+                    var rowHtml = Regex.Replace(
+                        rowMatch.Groups["row"].Value,
+                        "<td(?<attrs>[^>]*)>",
+                        cellMatch =>
+                        {
+                            var attrs = cellMatch.Groups["attrs"].Value;
+                            if (Regex.IsMatch(attrs, "\\sdata-label=", RegexOptions.IgnoreCase) || index >= headers.Length)
+                            {
+                                index++;
+                                return cellMatch.Value;
+                            }
+
+                            var label = WebUtility.HtmlEncode(headers[index++]);
+                            return $"<td{attrs} data-label=\"{label}\">";
+                        },
+                        RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+                    return $"<tr>{rowHtml}</tr>";
+                },
+                RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+            return $"<table>{Environment.NewLine}<thead>{Environment.NewLine}<tr>{match.Groups["header"].Value}</tr>{Environment.NewLine}</thead>{Environment.NewLine}<tbody>{body}</tbody>{Environment.NewLine}</table>";
+        },
+        RegexOptions.IgnoreCase | RegexOptions.Singleline);
 }
 
 static string OpenAbsoluteLinksInNewTabs(string html)
@@ -405,32 +456,88 @@ static string RenderPage(string title, string documentHtml, string contentsHtml,
 
         @media (max-width: 360px) {
             .documentation-document table {
-                display: table;
-                table-layout: fixed;
+                display: block;
+                border-collapse: separate;
+                background: transparent;
+                border-radius: 0;
                 overflow: visible;
             }
 
-            .documentation-document th,
-            .documentation-document td {
-                padding: 0.52rem 0.45rem;
+            .documentation-document thead {
+                display: none;
+            }
+
+            .documentation-document tbody {
+                display: grid;
+                gap: 0.55rem;
+            }
+
+            .documentation-document tbody tr {
+                display: grid;
+                grid-template-columns: auto minmax(0, 1fr);
+                gap: 0.35rem 0.7rem;
+                padding: 0.62rem 0.7rem;
+                border: 1px solid rgba(148, 163, 184, 0.28);
+                border-radius: 8px;
+                background: rgba(248, 250, 252, 0.78);
+            }
+
+            .documentation-document tbody td {
+                padding: 0;
+                border-bottom: 0;
                 white-space: normal;
-                overflow-wrap: break-word;
-            }
-
-            .documentation-document th {
-                font-size: 0.82rem;
-                line-height: 1.25;
                 overflow-wrap: normal;
+                word-break: normal;
             }
 
-            .documentation-document th:first-child,
-            .documentation-document td:first-child {
-                width: 2.55rem;
+            .documentation-document tbody td {
+                display: grid;
+                grid-template-columns: auto minmax(0, 1fr);
+                gap: 0.35rem;
+                align-items: baseline;
+                color: #334155;
+                font-size: 0.86rem;
+                line-height: 1.28;
             }
 
-            .documentation-document th:last-child,
-            .documentation-document td:last-child {
-                width: 4.65rem;
+            .documentation-document tbody td::before {
+                content: attr(data-label);
+                color: #64748b;
+                font-size: 0.68rem;
+                font-weight: 800;
+                text-transform: uppercase;
+                letter-spacing: 0;
+            }
+
+            .documentation-document tbody td:first-child {
+                grid-column: 1;
+                grid-template-columns: auto auto;
+            }
+
+            .documentation-document tbody td:nth-child(2) {
+                grid-column: 1 / -1;
+                grid-row: 2;
+                font-size: 0.96rem;
+                font-weight: 700;
+                white-space: nowrap;
+            }
+
+            .documentation-document tbody td:nth-child(2)::before {
+                display: none;
+            }
+
+            .documentation-document tbody td:last-child {
+                grid-column: 2;
+                justify-self: end;
+                width: 6.25rem;
+                grid-template-columns: 1fr;
+                justify-items: end;
+                gap: 0.12rem;
+                text-align: right;
+            }
+
+            .documentation-document tbody td:last-child::before {
+                white-space: nowrap;
             }
         }
     </style>

--- a/LongevityWorldCup.Website/wwwroot/misc-pages/about.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/about.html
@@ -270,32 +270,88 @@
 
         @media (max-width: 360px) {
             .documentation-document table {
-                display: table;
-                table-layout: fixed;
+                display: block;
+                border-collapse: separate;
+                background: transparent;
+                border-radius: 0;
                 overflow: visible;
             }
 
-            .documentation-document th,
-            .documentation-document td {
-                padding: 0.52rem 0.45rem;
+            .documentation-document thead {
+                display: none;
+            }
+
+            .documentation-document tbody {
+                display: grid;
+                gap: 0.55rem;
+            }
+
+            .documentation-document tbody tr {
+                display: grid;
+                grid-template-columns: auto minmax(0, 1fr);
+                gap: 0.35rem 0.7rem;
+                padding: 0.62rem 0.7rem;
+                border: 1px solid rgba(148, 163, 184, 0.28);
+                border-radius: 8px;
+                background: rgba(248, 250, 252, 0.78);
+            }
+
+            .documentation-document tbody td {
+                padding: 0;
+                border-bottom: 0;
                 white-space: normal;
-                overflow-wrap: break-word;
-            }
-
-            .documentation-document th {
-                font-size: 0.82rem;
-                line-height: 1.25;
                 overflow-wrap: normal;
+                word-break: normal;
             }
 
-            .documentation-document th:first-child,
-            .documentation-document td:first-child {
-                width: 2.55rem;
+            .documentation-document tbody td {
+                display: grid;
+                grid-template-columns: auto minmax(0, 1fr);
+                gap: 0.35rem;
+                align-items: baseline;
+                color: #334155;
+                font-size: 0.86rem;
+                line-height: 1.28;
             }
 
-            .documentation-document th:last-child,
-            .documentation-document td:last-child {
-                width: 4.65rem;
+            .documentation-document tbody td::before {
+                content: attr(data-label);
+                color: #64748b;
+                font-size: 0.68rem;
+                font-weight: 800;
+                text-transform: uppercase;
+                letter-spacing: 0;
+            }
+
+            .documentation-document tbody td:first-child {
+                grid-column: 1;
+                grid-template-columns: auto auto;
+            }
+
+            .documentation-document tbody td:nth-child(2) {
+                grid-column: 1 / -1;
+                grid-row: 2;
+                font-size: 0.96rem;
+                font-weight: 700;
+                white-space: nowrap;
+            }
+
+            .documentation-document tbody td:nth-child(2)::before {
+                display: none;
+            }
+
+            .documentation-document tbody td:last-child {
+                grid-column: 2;
+                justify-self: end;
+                width: 6.25rem;
+                grid-template-columns: 1fr;
+                justify-items: end;
+                gap: 0.12rem;
+                text-align: right;
+            }
+
+            .documentation-document tbody td:last-child::before {
+                white-space: nowrap;
             }
         }
     </style>

--- a/LongevityWorldCup.Website/wwwroot/misc-pages/about.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/about.html
@@ -267,6 +267,37 @@
                 margin: 1.15rem auto 1.45rem;
             }
         }
+
+        @media (max-width: 360px) {
+            .documentation-document table {
+                display: table;
+                table-layout: fixed;
+                overflow: visible;
+            }
+
+            .documentation-document th,
+            .documentation-document td {
+                padding: 0.52rem 0.45rem;
+                white-space: normal;
+                overflow-wrap: break-word;
+            }
+
+            .documentation-document th {
+                font-size: 0.82rem;
+                line-height: 1.25;
+                overflow-wrap: normal;
+            }
+
+            .documentation-document th:first-child,
+            .documentation-document td:first-child {
+                width: 2.55rem;
+            }
+
+            .documentation-document th:last-child,
+            .documentation-document td:last-child {
+                width: 4.65rem;
+            }
+        }
     </style>
 </head>
 <body>

--- a/LongevityWorldCup.Website/wwwroot/misc-pages/history.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/history.html
@@ -267,6 +267,37 @@
                 margin: 1.15rem auto 1.45rem;
             }
         }
+
+        @media (max-width: 360px) {
+            .documentation-document table {
+                display: table;
+                table-layout: fixed;
+                overflow: visible;
+            }
+
+            .documentation-document th,
+            .documentation-document td {
+                padding: 0.52rem 0.45rem;
+                white-space: normal;
+                overflow-wrap: break-word;
+            }
+
+            .documentation-document th {
+                font-size: 0.82rem;
+                line-height: 1.25;
+                overflow-wrap: normal;
+            }
+
+            .documentation-document th:first-child,
+            .documentation-document td:first-child {
+                width: 2.55rem;
+            }
+
+            .documentation-document th:last-child,
+            .documentation-document td:last-child {
+                width: 4.65rem;
+            }
+        }
     </style>
 </head>
 <body>

--- a/LongevityWorldCup.Website/wwwroot/misc-pages/history.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/history.html
@@ -270,32 +270,88 @@
 
         @media (max-width: 360px) {
             .documentation-document table {
-                display: table;
-                table-layout: fixed;
+                display: block;
+                border-collapse: separate;
+                background: transparent;
+                border-radius: 0;
                 overflow: visible;
             }
 
-            .documentation-document th,
-            .documentation-document td {
-                padding: 0.52rem 0.45rem;
+            .documentation-document thead {
+                display: none;
+            }
+
+            .documentation-document tbody {
+                display: grid;
+                gap: 0.55rem;
+            }
+
+            .documentation-document tbody tr {
+                display: grid;
+                grid-template-columns: auto minmax(0, 1fr);
+                gap: 0.35rem 0.7rem;
+                padding: 0.62rem 0.7rem;
+                border: 1px solid rgba(148, 163, 184, 0.28);
+                border-radius: 8px;
+                background: rgba(248, 250, 252, 0.78);
+            }
+
+            .documentation-document tbody td {
+                padding: 0;
+                border-bottom: 0;
                 white-space: normal;
-                overflow-wrap: break-word;
-            }
-
-            .documentation-document th {
-                font-size: 0.82rem;
-                line-height: 1.25;
                 overflow-wrap: normal;
+                word-break: normal;
             }
 
-            .documentation-document th:first-child,
-            .documentation-document td:first-child {
-                width: 2.55rem;
+            .documentation-document tbody td {
+                display: grid;
+                grid-template-columns: auto minmax(0, 1fr);
+                gap: 0.35rem;
+                align-items: baseline;
+                color: #334155;
+                font-size: 0.86rem;
+                line-height: 1.28;
             }
 
-            .documentation-document th:last-child,
-            .documentation-document td:last-child {
-                width: 4.65rem;
+            .documentation-document tbody td::before {
+                content: attr(data-label);
+                color: #64748b;
+                font-size: 0.68rem;
+                font-weight: 800;
+                text-transform: uppercase;
+                letter-spacing: 0;
+            }
+
+            .documentation-document tbody td:first-child {
+                grid-column: 1;
+                grid-template-columns: auto auto;
+            }
+
+            .documentation-document tbody td:nth-child(2) {
+                grid-column: 1 / -1;
+                grid-row: 2;
+                font-size: 0.96rem;
+                font-weight: 700;
+                white-space: nowrap;
+            }
+
+            .documentation-document tbody td:nth-child(2)::before {
+                display: none;
+            }
+
+            .documentation-document tbody td:last-child {
+                grid-column: 2;
+                justify-self: end;
+                width: 6.25rem;
+                grid-template-columns: 1fr;
+                justify-items: end;
+                gap: 0.12rem;
+                text-align: right;
+            }
+
+            .documentation-document tbody td:last-child::before {
+                white-space: nowrap;
             }
         }
     </style>
@@ -360,104 +416,104 @@
 </thead>
 <tbody>
 <tr>
-<td>1</td>
-<td><a href="https://www.longevityworldcup.com/athlete/michael-lustgarten" target="_blank" rel="noopener noreferrer">Michael Lustgarten, PhD</a></td>
-<td>-22.1 years</td>
+<td data-label="Rank">1</td>
+<td data-label="Athlete"><a href="https://www.longevityworldcup.com/athlete/michael-lustgarten" target="_blank" rel="noopener noreferrer">Michael Lustgarten, PhD</a></td>
+<td data-label="Age reduction">-22.1 years</td>
 </tr>
 <tr>
-<td>2</td>
-<td><a href="https://www.longevityworldcup.com/athlete/zdenek-sipek" target="_blank" rel="noopener noreferrer">Zdenek Sipek</a></td>
-<td>-20.6 years</td>
+<td data-label="Rank">2</td>
+<td data-label="Athlete"><a href="https://www.longevityworldcup.com/athlete/zdenek-sipek" target="_blank" rel="noopener noreferrer">Zdenek Sipek</a></td>
+<td data-label="Age reduction">-20.6 years</td>
 </tr>
 <tr>
-<td>3</td>
-<td><a href="https://www.longevityworldcup.com/athlete/wen-z" target="_blank" rel="noopener noreferrer">Wen Z</a></td>
-<td>-20.1 years</td>
+<td data-label="Rank">3</td>
+<td data-label="Athlete"><a href="https://www.longevityworldcup.com/athlete/wen-z" target="_blank" rel="noopener noreferrer">Wen Z</a></td>
+<td data-label="Age reduction">-20.1 years</td>
 </tr>
 <tr>
-<td>4</td>
-<td><a href="https://www.longevityworldcup.com/athlete/philipp-schmeing" target="_blank" rel="noopener noreferrer">Philipp Schmeing</a></td>
-<td>-19.6 years</td>
+<td data-label="Rank">4</td>
+<td data-label="Athlete"><a href="https://www.longevityworldcup.com/athlete/philipp-schmeing" target="_blank" rel="noopener noreferrer">Philipp Schmeing</a></td>
+<td data-label="Age reduction">-19.6 years</td>
 </tr>
 <tr>
-<td>5</td>
-<td><a href="https://www.longevityworldcup.com/athlete/angela-buzzeo" target="_blank" rel="noopener noreferrer">Angela Buzzeo</a></td>
-<td>-19.5 years</td>
+<td data-label="Rank">5</td>
+<td data-label="Athlete"><a href="https://www.longevityworldcup.com/athlete/angela-buzzeo" target="_blank" rel="noopener noreferrer">Angela Buzzeo</a></td>
+<td data-label="Age reduction">-19.5 years</td>
 </tr>
 <tr>
-<td>6</td>
-<td><a href="https://www.longevityworldcup.com/athlete/deelicious" target="_blank" rel="noopener noreferrer">deelicious</a></td>
-<td>-18.9 years</td>
+<td data-label="Rank">6</td>
+<td data-label="Athlete"><a href="https://www.longevityworldcup.com/athlete/deelicious" target="_blank" rel="noopener noreferrer">deelicious</a></td>
+<td data-label="Age reduction">-18.9 years</td>
 </tr>
 <tr>
-<td>7</td>
-<td><a href="https://www.longevityworldcup.com/athlete/juan-robalino" target="_blank" rel="noopener noreferrer">Juan Robalino</a></td>
-<td>-18.3 years</td>
+<td data-label="Rank">7</td>
+<td data-label="Athlete"><a href="https://www.longevityworldcup.com/athlete/juan-robalino" target="_blank" rel="noopener noreferrer">Juan Robalino</a></td>
+<td data-label="Age reduction">-18.3 years</td>
 </tr>
 <tr>
-<td>8</td>
-<td><a href="https://www.longevityworldcup.com/athlete/max" target="_blank" rel="noopener noreferrer">Max</a></td>
-<td>-18.3 years</td>
+<td data-label="Rank">8</td>
+<td data-label="Athlete"><a href="https://www.longevityworldcup.com/athlete/max" target="_blank" rel="noopener noreferrer">Max</a></td>
+<td data-label="Age reduction">-18.3 years</td>
 </tr>
 <tr>
-<td>9</td>
-<td><a href="https://www.longevityworldcup.com/athlete/anicca" target="_blank" rel="noopener noreferrer">anicca</a></td>
-<td>-17.8 years</td>
+<td data-label="Rank">9</td>
+<td data-label="Athlete"><a href="https://www.longevityworldcup.com/athlete/anicca" target="_blank" rel="noopener noreferrer">anicca</a></td>
+<td data-label="Age reduction">-17.8 years</td>
 </tr>
 <tr>
-<td>10</td>
-<td><a href="https://www.longevityworldcup.com/athlete/ilhui" target="_blank" rel="noopener noreferrer">Ilhui</a></td>
-<td>-17.7 years</td>
+<td data-label="Rank">10</td>
+<td data-label="Athlete"><a href="https://www.longevityworldcup.com/athlete/ilhui" target="_blank" rel="noopener noreferrer">Ilhui</a></td>
+<td data-label="Age reduction">-17.7 years</td>
 </tr>
 <tr>
-<td>11</td>
-<td><a href="https://www.longevityworldcup.com/athlete/larsemann" target="_blank" rel="noopener noreferrer">Larsemann</a></td>
-<td>-17.4 years</td>
+<td data-label="Rank">11</td>
+<td data-label="Athlete"><a href="https://www.longevityworldcup.com/athlete/larsemann" target="_blank" rel="noopener noreferrer">Larsemann</a></td>
+<td data-label="Age reduction">-17.4 years</td>
 </tr>
 <tr>
-<td>12</td>
-<td><a href="https://www.longevityworldcup.com/athlete/lauren" target="_blank" rel="noopener noreferrer">Lauren</a></td>
-<td>-17.4 years</td>
+<td data-label="Rank">12</td>
+<td data-label="Athlete"><a href="https://www.longevityworldcup.com/athlete/lauren" target="_blank" rel="noopener noreferrer">Lauren</a></td>
+<td data-label="Age reduction">-17.4 years</td>
 </tr>
 <tr>
-<td>13</td>
-<td><a href="https://www.longevityworldcup.com/athlete/john" target="_blank" rel="noopener noreferrer">John</a></td>
-<td>-17.4 years</td>
+<td data-label="Rank">13</td>
+<td data-label="Athlete"><a href="https://www.longevityworldcup.com/athlete/john" target="_blank" rel="noopener noreferrer">John</a></td>
+<td data-label="Age reduction">-17.4 years</td>
 </tr>
 <tr>
-<td>14</td>
-<td><a href="https://www.longevityworldcup.com/athlete/maria-olenina" target="_blank" rel="noopener noreferrer">Maria Olenina</a></td>
-<td>-17.4 years</td>
+<td data-label="Rank">14</td>
+<td data-label="Athlete"><a href="https://www.longevityworldcup.com/athlete/maria-olenina" target="_blank" rel="noopener noreferrer">Maria Olenina</a></td>
+<td data-label="Age reduction">-17.4 years</td>
 </tr>
 <tr>
-<td>15</td>
-<td><a href="https://www.longevityworldcup.com/athlete/david-x" target="_blank" rel="noopener noreferrer">David X</a></td>
-<td>-17.0 years</td>
+<td data-label="Rank">15</td>
+<td data-label="Athlete"><a href="https://www.longevityworldcup.com/athlete/david-x" target="_blank" rel="noopener noreferrer">David X</a></td>
+<td data-label="Age reduction">-17.0 years</td>
 </tr>
 <tr>
-<td>16</td>
-<td><a href="https://www.longevityworldcup.com/athlete/david-lo" target="_blank" rel="noopener noreferrer">David Lo</a></td>
-<td>-16.9 years</td>
+<td data-label="Rank">16</td>
+<td data-label="Athlete"><a href="https://www.longevityworldcup.com/athlete/david-lo" target="_blank" rel="noopener noreferrer">David Lo</a></td>
+<td data-label="Age reduction">-16.9 years</td>
 </tr>
 <tr>
-<td>17</td>
-<td><a href="https://www.longevityworldcup.com/athlete/julie-jiang" target="_blank" rel="noopener noreferrer">Julie Jiang</a></td>
-<td>-16.8 years</td>
+<td data-label="Rank">17</td>
+<td data-label="Athlete"><a href="https://www.longevityworldcup.com/athlete/julie-jiang" target="_blank" rel="noopener noreferrer">Julie Jiang</a></td>
+<td data-label="Age reduction">-16.8 years</td>
 </tr>
 <tr>
-<td>18</td>
-<td><a href="https://www.longevityworldcup.com/athlete/qingqingzhuo" target="_blank" rel="noopener noreferrer">QingqingZhuo</a></td>
-<td>-16.7 years</td>
+<td data-label="Rank">18</td>
+<td data-label="Athlete"><a href="https://www.longevityworldcup.com/athlete/qingqingzhuo" target="_blank" rel="noopener noreferrer">QingqingZhuo</a></td>
+<td data-label="Age reduction">-16.7 years</td>
 </tr>
 <tr>
-<td>19</td>
-<td><a href="https://www.longevityworldcup.com/athlete/dave-pascoe" target="_blank" rel="noopener noreferrer">Dave Pascoe</a></td>
-<td>-16.6 years</td>
+<td data-label="Rank">19</td>
+<td data-label="Athlete"><a href="https://www.longevityworldcup.com/athlete/dave-pascoe" target="_blank" rel="noopener noreferrer">Dave Pascoe</a></td>
+<td data-label="Age reduction">-16.6 years</td>
 </tr>
 <tr>
-<td>20</td>
-<td><a href="https://www.longevityworldcup.com/athlete/keith-blondin" target="_blank" rel="noopener noreferrer">Keith Blondin</a></td>
-<td>-16.4 years</td>
+<td data-label="Rank">20</td>
+<td data-label="Athlete"><a href="https://www.longevityworldcup.com/athlete/keith-blondin" target="_blank" rel="noopener noreferrer">Keith Blondin</a></td>
+<td data-label="Age reduction">-16.4 years</td>
 </tr>
 </tbody>
 </table>

--- a/LongevityWorldCup.Website/wwwroot/misc-pages/ruleset.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/ruleset.html
@@ -270,32 +270,88 @@
 
         @media (max-width: 360px) {
             .documentation-document table {
-                display: table;
-                table-layout: fixed;
+                display: block;
+                border-collapse: separate;
+                background: transparent;
+                border-radius: 0;
                 overflow: visible;
             }
 
-            .documentation-document th,
-            .documentation-document td {
-                padding: 0.52rem 0.45rem;
+            .documentation-document thead {
+                display: none;
+            }
+
+            .documentation-document tbody {
+                display: grid;
+                gap: 0.55rem;
+            }
+
+            .documentation-document tbody tr {
+                display: grid;
+                grid-template-columns: auto minmax(0, 1fr);
+                gap: 0.35rem 0.7rem;
+                padding: 0.62rem 0.7rem;
+                border: 1px solid rgba(148, 163, 184, 0.28);
+                border-radius: 8px;
+                background: rgba(248, 250, 252, 0.78);
+            }
+
+            .documentation-document tbody td {
+                padding: 0;
+                border-bottom: 0;
                 white-space: normal;
-                overflow-wrap: break-word;
-            }
-
-            .documentation-document th {
-                font-size: 0.82rem;
-                line-height: 1.25;
                 overflow-wrap: normal;
+                word-break: normal;
             }
 
-            .documentation-document th:first-child,
-            .documentation-document td:first-child {
-                width: 2.55rem;
+            .documentation-document tbody td {
+                display: grid;
+                grid-template-columns: auto minmax(0, 1fr);
+                gap: 0.35rem;
+                align-items: baseline;
+                color: #334155;
+                font-size: 0.86rem;
+                line-height: 1.28;
             }
 
-            .documentation-document th:last-child,
-            .documentation-document td:last-child {
-                width: 4.65rem;
+            .documentation-document tbody td::before {
+                content: attr(data-label);
+                color: #64748b;
+                font-size: 0.68rem;
+                font-weight: 800;
+                text-transform: uppercase;
+                letter-spacing: 0;
+            }
+
+            .documentation-document tbody td:first-child {
+                grid-column: 1;
+                grid-template-columns: auto auto;
+            }
+
+            .documentation-document tbody td:nth-child(2) {
+                grid-column: 1 / -1;
+                grid-row: 2;
+                font-size: 0.96rem;
+                font-weight: 700;
+                white-space: nowrap;
+            }
+
+            .documentation-document tbody td:nth-child(2)::before {
+                display: none;
+            }
+
+            .documentation-document tbody td:last-child {
+                grid-column: 2;
+                justify-self: end;
+                width: 6.25rem;
+                grid-template-columns: 1fr;
+                justify-items: end;
+                gap: 0.12rem;
+                text-align: right;
+            }
+
+            .documentation-document tbody td:last-child::before {
+                white-space: nowrap;
             }
         }
     </style>

--- a/LongevityWorldCup.Website/wwwroot/misc-pages/ruleset.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/ruleset.html
@@ -267,6 +267,37 @@
                 margin: 1.15rem auto 1.45rem;
             }
         }
+
+        @media (max-width: 360px) {
+            .documentation-document table {
+                display: table;
+                table-layout: fixed;
+                overflow: visible;
+            }
+
+            .documentation-document th,
+            .documentation-document td {
+                padding: 0.52rem 0.45rem;
+                white-space: normal;
+                overflow-wrap: break-word;
+            }
+
+            .documentation-document th {
+                font-size: 0.82rem;
+                line-height: 1.25;
+                overflow-wrap: normal;
+            }
+
+            .documentation-document th:first-child,
+            .documentation-document td:first-child {
+                width: 2.55rem;
+            }
+
+            .documentation-document th:last-child,
+            .documentation-document td:last-child {
+                width: 4.65rem;
+            }
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
## What changed

- Replaces the sub-360px documentation table squeeze with a stacked mobile row layout.
- Adds `data-label` attributes to generated Markdown table cells from their headers, so mobile rows can keep context after hiding the table header visually.
- Keeps athlete names on one line while still showing rank and age reduction inside a 280px viewport.

## Why

At a 280px viewport, the 2025 season table on `/history` originally hid the `Age reduction` column behind horizontal overflow. The first fix made the column visible but squeezed the athlete column enough to break names across lines. This update keeps the data visible without breaking athlete names.

## Screenshot proof

Gist: https://gist.github.com/nopara73/e1e18d2a2b9cb074b77a5174ef3e49ff

| Before | After |
| --- | --- |
| ![Before: History table hides the age-reduction column at 280px](https://gist.githubusercontent.com/nopara73/e1e18d2a2b9cb074b77a5174ef3e49ff/raw/6b14d9e3bb484c92ba9c05660f0523596cdb244b/pr-history-table-before-280.png) | ![After: History table shows rank, athlete, and age reduction at 280px without breaking athlete names](https://gist.githubusercontent.com/nopara73/e1e18d2a2b9cb074b77a5174ef3e49ff/raw/3e0ad5398735d601f63498238560907dc249bba4/pr-history-table-after-280.png) |

## Verification

- In-app browser crop at `/history`, 280x700: before the visible table only shows `Rank` and `Athlete`; the `Age reduction` column is off-screen.
- Playwright crop at `/history`, 280x700: after shows stacked rows with `Rank`, `Age reduction`, and athlete names on one line.
- Playwright metric check at 280x700: table `scrollWidth` equals `clientWidth` (211px), and page `docScrollWidth` remains 280px.
- `dotnet run --project LongevityWorldCup.MarkdownPageGenerator -- . LongevityWorldCup.Website`
- `dotnet build LongevityWorldCup.MarkdownPageGenerator/LongevityWorldCup.MarkdownPageGenerator.csproj`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes to static documentation HTML/CSS and the markdown generator; no auth, APIs, or data logic.
> 
> **Overview**
> Documentation pages get a **narrow-viewport table layout** (≤360px) so wide tables—especially the 2025 season standings on `/history`—no longer rely on horizontal scroll or hide columns like **Age reduction**.
> 
> The Markdown page generator now runs **`AddTableCellLabels`** on converted HTML so each `<td>` gets a **`data-label`** from its column header (HTML-encoded). Mobile CSS hides `<thead>`, stacks each row as a card, and uses **`td::before { content: attr(data-label) }`** so rank and age reduction stay labeled while the athlete column stays on one line.
> 
> The same responsive rules and regenerated table markup land in **`about.html`**, **`history.html`**, and **`ruleset.html`** via the embedded template in `Program.cs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fb826f564f18aa52d2ed29e508d968f62cf1c61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->