### PR TITLE
[codex] Fix select athlete placeholder fit

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/play/character-selection.html
+++ b/LongevityWorldCup.Website/wwwroot/play/character-selection.html
@@ -200,6 +200,16 @@
             }
         }
 
+        @media (max-width: 320px) {
+            .autocomplete-container input {
+                padding-inline: 0.78rem;
+            }
+
+            .autocomplete-container input::placeholder {
+                font-size: 0.92rem;
+            }
+        }
+
         @media (min-width: 640px) and (max-width: 932px) and (max-height: 480px) and (orientation: landscape) {
             .character-selection-main {
                 padding: 0.6rem 1rem 1.25rem;


### PR DESCRIPTION
## What changed

- Adds a narrow-phone breakpoint for the select-athlete autocomplete input.
- Slightly tightens horizontal input padding and placeholder font size below 320px.

## Why

At a 280px viewport, the placeholder text was visibly clipped at the right edge, ending at `nam` instead of showing the complete `name...` ending.

## Screenshot proof

Gist: https://gist.github.com/nopara73/619cbdaf2f1d9de8458ef40c0def08b3

| Before | After |
| --- | --- |
| ![Before: select-athlete placeholder is clipped at 280px](https://gist.githubusercontent.com/nopara73/619cbdaf2f1d9de8458ef40c0def08b3/raw/948f8dd70445ee43ec4df8ce77a7e5501d21eb11/select-athlete-placeholder-before-280.png) | ![After: select-athlete placeholder fits at 280px](https://gist.githubusercontent.com/nopara73/619cbdaf2f1d9de8458ef40c0def08b3/raw/8a74c2a15a60b49e9b66a43712e7984506867885/select-athlete-placeholder-after-280.png) |

## Verification

- Playwright screenshot at `/select-athlete`, 280x700: before the placeholder is clipped after `nam`.
- Playwright screenshot at `/select-athlete`, 280x700: after the placeholder fits and ends cleanly at `name...`.
- Playwright metric check at 280x700: page `docScrollWidth` and `bodyScrollWidth` remain 280px.
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS on the character selection page; no behavior, API, or data changes.
> 
> **Overview**
> Fixes **placeholder text clipping** on the select-athlete autocomplete input when the viewport is very narrow (e.g. 280px wide).
> 
> Adds a **`@media (max-width: 320px)`** block in `character-selection.html` that slightly reduces horizontal padding on `.autocomplete-container input` and sets a smaller **`::placeholder`** font size so “Start typing your athlete name…” fits without being cut off at the right edge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f64cc47d353cd026b673b902ce727fd7019144a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->