### PR TITLE
[codex] Fix longevitymaxxing mobile title

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/css/longevitymaxxing.css
+++ b/LongevityWorldCup.Website/wwwroot/css/longevitymaxxing.css
@@ -3393,7 +3393,9 @@ body.lmx-quote-open {
 
 @media (max-width: 360px) {
     .lmx-title-row h1 {
-        font-size: 1.85rem;
+        font-size: clamp(1.58rem, 9vw, 1.85rem);
+        overflow-wrap: normal;
+        word-break: keep-all;
     }
 
     .lmx-life-strip {


### PR DESCRIPTION
## What changed

- Scales the Longevitymaxxing page title a little further on very narrow phones.
- Keeps the one-word title from breaking mid-word below 360px.

## Why

At a 280px viewport, the page title split `Longevitymaxxing` into `Longevitymaxxin` / `g`, which looked like a broken heading even though the surrounding page fit.

## Screenshot proof

Gist: https://gist.github.com/nopara73/d83e6d932018e728a98364579cf559a3

| Before | After |
| --- | --- |
| ![Before: Longevitymaxxing title wraps mid-word at 280px](https://gist.githubusercontent.com/nopara73/d83e6d932018e728a98364579cf559a3/raw/1b3f682f5aac8f35186a18509e325b91f960f7f1/longevitymaxxing-title-before-280.png) | ![After: Longevitymaxxing title stays on one line at 280px](https://gist.githubusercontent.com/nopara73/d83e6d932018e728a98364579cf559a3/raw/c99e234bc15e031311a073fb27f12a733783b710/longevitymaxxing-title-after-280.png) |

## Verification

- Playwright screenshot at `/longevitymaxxing`, 280x700: before the title splits mid-word.
- Playwright screenshot at `/longevitymaxxing`, 280x700: after the title fits on one line.
- Playwright metric check at 280x700: page `docScrollWidth` and `bodyScrollWidth` remain 280px.
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS in a narrow mobile media query; no logic, API, or data changes.
> 
> **Overview**
> On viewports **≤360px**, the Longevitymaxxing hero **`h1`** no longer uses a fixed `1.85rem` size. It now uses **`clamp(1.58rem, 9vw, 1.85rem)`** so the title scales down on very narrow widths (e.g. 280px) while capping at the previous size on slightly wider phones.
> 
> The same breakpoint adds **`overflow-wrap: normal`** and **`word-break: keep-all`** so the single-word title stays on one line instead of breaking mid-word (e.g. `Longevitymaxxin` / `g`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d88fd3d06ae67b10357d4fb7e7f37f4a687610db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->