### PR TITLE
[codex] Fix review mobile title wrap

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/onboarding/application-review.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/application-review.html
@@ -102,6 +102,8 @@
                 padding-top: 0.3rem;
                 font-size: clamp(1.75rem, 8vw, 1.9rem);
                 line-height: 1.05;
+                overflow-wrap: normal;
+                word-break: normal;
             }
 
             .application-review-title i {


### PR DESCRIPTION
## What changed

- Overrides the shared mobile `h1` anywhere-wrap rule for the application review page title.
- Keeps the title wrapping at normal word boundaries on narrow phones.

## Why

At a 280px viewport, the `/review` heading rendered as `Applicatio` / `n review`, splitting the word `Application` in the first viewport.

## Screenshot proof

Gist: https://gist.github.com/nopara73/6fec4b82635324e8672a9213bbbdc6ca

| Before | After |
| --- | --- |
| ![Before: review page title splits Application mid-word at 280px](https://gist.githubusercontent.com/nopara73/6fec4b82635324e8672a9213bbbdc6ca/raw/64f5702635627f2d66446b9ca83a871ed36386b5/review-title-before-280.png) | ![After: review page title wraps between Application and review at 280px](https://gist.githubusercontent.com/nopara73/6fec4b82635324e8672a9213bbbdc6ca/raw/c84cb9ed569551d06fcf7c225d9f938d28165ae1/review-title-after-280.png) |

## Verification

- Playwright screenshot at `/review`, 280x700: before the heading splits `Application` mid-word.
- Playwright screenshot at `/review`, 280x700: after the heading wraps between words.
- Playwright metric check at 280x700: page `docScrollWidth` and `bodyScrollWidth` remain 280px.
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only, page-local mobile typography fix with no logic or data impact.
> 
> **Overview**
> On viewports **≤600px**, the application review page heading (`Application review` and variants) no longer breaks inside words like **Application**.
> 
> The mobile stylesheet’s shared **`h1`** rule uses **`overflow-wrap: anywhere`**, which caused ugly splits on very narrow phones (~280px). This change scopes **`overflow-wrap: normal`** and **`word-break: normal`** to **`.application-review-title`** in that breakpoint so wrapping stays at word boundaries only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4577eaad70c393c11230fc997ad9b7c0ee2f513. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->