### PR TITLE
[codex] Fix media kit file name wrapping

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/misc-pages/media.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/media.html
@@ -176,7 +176,7 @@
                 line-height: 1.32;
                 display: -webkit-box;
                 overflow: hidden;
-                overflow-wrap: anywhere;
+                overflow-wrap: normal;
                 -webkit-box-orient: vertical;
                 -webkit-line-clamp: 3;
             }
@@ -270,6 +270,17 @@
         const listEl = document.getElementById('fileList');
         const fallbackEl = document.getElementById('fallback');
 
+        function appendFileName(target, path) {
+            for (const part of path.split(/([/_-])/)) {
+                if (!part) continue;
+
+                target.appendChild(document.createTextNode(part));
+                if (part === "/" || part === "_" || part === "-") {
+                    target.appendChild(document.createElement("wbr"));
+                }
+            }
+        }
+
         async function fetchZip(url) {
             const res = await fetch(url, { cache: 'no-store' });
             if (!res.ok) throw new Error("HTTP " + res.status);
@@ -295,8 +306,8 @@
                     li.className = 'media-file-row';
 
                     const name = document.createElement('span');
-                    name.textContent = path;
                     name.className = 'media-file-name';
+                    appendFileName(name, path);
 
                     const btn = document.createElement('button');
                     btn.textContent = 'Download';


### PR DESCRIPTION
## What changed

- Adds explicit word-break opportunities after media-kit path separators when rendering ZIP file names.
- Stops mobile file names from breaking inside names like `AdamFicsor` and `TeamPhoto2025`.
- Keeps long names constrained to the existing clamped file-name area.

## Why

At a 280px viewport, media-kit file rows split names mid-word, rendering examples like `AdamFi` / `csor.jpg` and `TeamPh` / `oto2025.png`. These are paths, so the cleaner break point is after `/`, `_`, or `-`.

## Screenshot proof

Gist: https://gist.github.com/nopara73/2189d0c24b2769504b1e3de70ff6a8da

| Before | After |
| --- | --- |
| ![Before: media kit file names split inside AdamFicsor and TeamPhoto2025 at 280px](https://gist.githubusercontent.com/nopara73/2189d0c24b2769504b1e3de70ff6a8da/raw/c5a95cc534cfa827b23ebb227f68ff5e6faf4fed/media-file-name-before-280.png) | ![After: media kit file names wrap at path separators at 280px](https://gist.githubusercontent.com/nopara73/2189d0c24b2769504b1e3de70ff6a8da/raw/6bea7331c32700646642b8fc1c8621910a49d5dd/media-file-name-after-280.png) |

## Verification

- Playwright screenshot at `/media`, 280x700 scrolled to the file list: before file names split inside `AdamFicsor` and `TeamPhoto2025`.
- Playwright screenshot at `/media`, 280x700 at the same scroll position: after file names wrap at path separators and stay inside the cards.
- Playwright metric check at 280x700: page `docScrollWidth` and `bodyScrollWidth` remain 280px, with no detected broken words in the file names.
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static media page presentation only; no auth, APIs, or data handling.
> 
> **Overview**
> On narrow viewports, media kit ZIP file names no longer break mid-word (e.g. inside `AdamFicsor`). **Mobile** `.media-file-name` styling switches from `overflow-wrap: anywhere` to `overflow-wrap: normal`, and the file list now builds labels with a new **`appendFileName`** helper instead of a single `textContent` string.
> 
> That helper splits each path on `/`, `_`, and `-`, keeps the separators in the DOM, and inserts **`<wbr>`** after each separator so line breaks prefer path boundaries while the existing three-line clamp still applies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4ced24c9233bf63c4dc91c1ccc61a8e0db3853c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->