### PR TITLE
[codex] Fix apply name placeholder fit

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/onboarding/convergence.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/convergence.html
@@ -27,6 +27,17 @@
             }
         }
 
+        @media (max-width: 320px) {
+            #name {
+                padding-inline: 0.65rem;
+                text-overflow: ellipsis;
+            }
+
+            #name::placeholder {
+                font-size: 0.92rem;
+            }
+        }
+
         #flag {
             margin-bottom: 0; /* Reset any margin added here */
         }


### PR DESCRIPTION
## What changed

- Adds a narrow-phone treatment for the `/apply` name input.
- Slightly tightens horizontal padding and placeholder font size below 320px.
- Uses text overflow ellipsis so the placeholder ends cleanly instead of hard-clipping mid-word.

## Why

At a 280px viewport, the name placeholder hard-clipped as `Real name or cyber alia`, cutting off the end of `alias` with no visual truncation cue.

## Screenshot proof

Gist: https://gist.github.com/nopara73/65e03c2d2630145a7de41c409308d318

| Before | After |
| --- | --- |
| ![Before: apply name placeholder clips mid-word at 280px](https://gist.githubusercontent.com/nopara73/65e03c2d2630145a7de41c409308d318/raw/60cec5d26f4756aa9e1e977c99855625f5a34ef8/apply-name-placeholder-before-280.png) | ![After: apply name placeholder ends cleanly with an ellipsis at 280px](https://gist.githubusercontent.com/nopara73/65e03c2d2630145a7de41c409308d318/raw/9d413b159b36dbf589ad73f3b2bf6cfd9bb1848a/apply-name-placeholder-after-280.png) |

## Verification

- Playwright screenshot at `/apply`, 280x700: before the name placeholder hard-clips at `alia`.
- Playwright screenshot at `/apply`, 280x700: after it shows `Real name or cyber alias...` with a proper ellipsis.
- Playwright metric check at 280x700: page `docScrollWidth` and `bodyScrollWidth` remain 280px.
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only responsive tweak on a single input; no logic, API, or data changes.
> 
> **Overview**
> On the `/apply` onboarding page (`convergence.html`), a new **`@media (max-width: 320px)`** rule targets the athlete **Name** field (`#name`) so the long placeholder (“Real name or cyber alias — your call”) fits better on very narrow phones.
> 
> Below 320px width, horizontal padding is slightly reduced, the placeholder font size is lowered to **0.92rem**, and **`text-overflow: ellipsis`** is applied so overflow truncates with an ellipsis instead of clipping mid-word (e.g. at ~280px).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3719aefbf35e608a9103ff84199ccbabb80319b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->