### PR TITLE
[codex] Fix mobile leaderboard filter drawer

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -1811,6 +1811,7 @@
             background:linear-gradient(to bottom, rgba(0,188,212,.08), rgba(0,188,212,.42), rgba(0,188,212,.08));
             pointer-events:none;
         }
+        .sidebar:hover:not(.button-collapsed),
         .sidebar.expanded{
             display:block; width:min(82vw, 320px); max-width:calc(100vw - 2rem);
             padding:1rem 1rem 1.75rem; padding-bottom:calc(env(safe-area-inset-bottom) + 1.75rem);

--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -1814,6 +1814,7 @@
         .sidebar.expanded{
             display:block; width:min(82vw, 320px); max-width:calc(100vw - 2rem);
             padding:1rem 1rem 1.75rem; padding-bottom:calc(env(safe-area-inset-bottom) + 1.75rem);
+            position:fixed; top:0; left:0; height:100dvh; min-height:0; max-height:100dvh;
             transform:translateX(0); visibility:visible; pointer-events:auto; transition-delay:0s;
         }
         .sidebar.expanded .filter-section{ display:block; }


### PR DESCRIPTION
## What changed

- Restates fixed drawer positioning on the mobile expanded sidebar rule.
- Keeps the leaderboard filter drawer above the mobile backdrop at narrow widths.

## Why

At a 280px viewport, tapping the leaderboard filter button blurred the page but did not show the filter drawer. The desktop `.sidebar.expanded` rule had higher specificity than the mobile `.sidebar` rule, so the expanded drawer computed as `position: sticky` and stayed down in the page behind the backdrop.

## Screenshot proof

Gist: https://gist.github.com/nopara73/fe4cd6bdc5f735a26901b1512aa07fca

| Before | After |
| --- | --- |
| ![Before: tapping leaderboard filters at 280px only shows a blurred page](https://gist.githubusercontent.com/nopara73/fe4cd6bdc5f735a26901b1512aa07fca/raw/5b17575d5568a5b067b540a4b860e1d334bbfe19/leaderboard-filter-drawer-before-280.png) | ![After: leaderboard filter drawer is visible at 280px](https://gist.githubusercontent.com/nopara73/fe4cd6bdc5f735a26901b1512aa07fca/raw/e266c69352f2c279d18428b2506cba42cb25a067/leaderboard-filter-drawer-after-280.png) |

## Verification

- Playwright screenshot at `/leaderboard`, 280x700 after tapping the filter button: before the page is blurred and no drawer is visible.
- Playwright screenshot at `/leaderboard`, 280x700 after tapping the filter button: after the drawer is visible in the viewport.
- Playwright metric check at 280x700: after the fix `docScrollWidth` and `bodyScrollWidth` are both 280px, and `.sidebar.expanded` computes as `position: fixed`.
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only change scoped to mobile leaderboard sidebar layout; no auth, data, or API impact.
> 
> **Overview**
> Fixes the **mobile leaderboard filter drawer** not appearing at narrow widths (e.g. 280px) when filters are opened—only the blurred backdrop showed.
> 
> In the mobile breakpoint CSS in `leaderboard-content.html`, the expanded sidebar rule now also targets **hover-expanded** sidebars (not just `.expanded`) and sets **`position: fixed`** with full viewport height (`100dvh`, `top: 0`, `left: 0`). That overrides the desktop rule that used **`position: sticky`**, which kept the drawer in the document flow behind the backdrop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7df26c48831913037628684714b7fb22602556b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->