### PR TITLE
[codex] Fit mobile sticky header title

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/partials/header.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/header.html
@@ -678,14 +678,25 @@
         }
     }
 
+    @media (max-width: 360px) {
+        .site-sticky-header-link {
+            gap: 0.35rem;
+        }
+
+        .site-sticky-header-title {
+            font-size: 0.88rem;
+            letter-spacing: 0;
+        }
+    }
+
     @media (max-width: 300px) {
         .site-sticky-header-link {
             gap: 0.35rem;
         }
 
         .site-sticky-header-title {
-            font-size: 1.04rem;
-            letter-spacing: 1.35px;
+            font-size: 0.84rem;
+            letter-spacing: 0;
         }
     }
 


### PR DESCRIPTION
## What changed

- Tightens the shared sticky-header title typography on very narrow screens.
- Keeps the full `Longevity World Cup` title visible beside the logo when the fixed `PLAY` button is present.
- Leaves the wider sticky-header layout unchanged.

## Why

At a 280px viewport after scrolling, the sticky header title was clipped to `Longevity Wo...` because the `PLAY` button reserve left too little room for the title's desktop-sized letter spacing.

## Screenshot proof

Gist: https://gist.github.com/nopara73/63df8a8716f5d51bc90e70f28d8fdac0

| Before | After |
| --- | --- |
| ![Before: sticky header title is clipped at 280px](https://gist.githubusercontent.com/nopara73/63df8a8716f5d51bc90e70f28d8fdac0/raw/cc892d910fd81ce5989542eecdafd1d97c3eba17/sticky-header-before-280.png) | ![After: sticky header title fits at 280px](https://gist.githubusercontent.com/nopara73/63df8a8716f5d51bc90e70f28d8fdac0/raw/c03d320f74da27dd01b94bf2913bf3716af27cff/sticky-header-after-280.png) |

## Verification

- Playwright crop at `/leaderboard`, 280x700, scrollY 500: before title is clipped to `Longevity Wo...`.
- Playwright crop at `/leaderboard`, 280x700, scrollY 500: after title reads `Longevity World Cup`.
- Playwright metric check at 280x700: `site-sticky-header-title` is present in the before overflow list with `clientWidth` 130 and `scrollWidth` 180, and is absent from the after overflow list.
- Gist raw image URLs return `Content-Type: image/png`.
- `dotnet build LongevityWorldCup.Website/LongevityWorldCup.Website.csproj -o .artifacts/build-sticky-header`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only responsive typography in the shared header partial; no logic or data changes.
> 
> **Overview**
> Adds a **`max-width: 360px`** breakpoint so the sticky header link uses a tighter gap and the title drops to **0.88rem** with **no letter-spacing**.
> 
> At **`max-width: 300px`**, the title is further reduced from **1.04rem** to **0.84rem** and letter-spacing is removed (was **1.35px**), so **Longevity World Cup** fits beside the logo when the fixed **PLAY** button reserves right padding.
> 
> Wider sticky-header layout is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0b915f7a8f7a43e4bca86ff9549ec257122ab03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->