### PR TITLE
[codex] Keep mobile filter counts together

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -458,6 +458,7 @@
     .filter-section input[type="checkbox"]{
         flex:0 0 auto; width:18px; height:18px; margin:0 .55rem 0 0; accent-color:var(--primary-color); cursor:inherit;
     }
+    .filter-section .filter-label-copy{ min-width:0; }
     .lwc-flag-icon{
         flex:0 0 auto; margin-right:.4rem; border-radius:2px; box-shadow:0 0 0 1px rgba(0,0,0,.08);
     }
@@ -476,6 +477,7 @@
     .filter-section .filter-count{
         color:#666; font-size:.95em; font-weight:700;
     }
+    .filter-section .filter-count-group{ white-space:nowrap; }
     .filter-section label.active .filter-count{ color:var(--secondary-color); }
     .filter-section label.is-zero-count:not(.active) .filter-count{ color:#909090; }
     .filter-section label:has(input[type="checkbox"]:focus-visible){
@@ -2560,31 +2562,31 @@
                         <li>
                             <label data-aging-clock-view="bortz">
                                 <input type="checkbox" name="agingClockView" value="bortz">
-                                🩸 Bortz Age (<span class="filter-count">0</span>)
+                                <span class="filter-label-copy">🩸 Bortz Age <span class="filter-count-group">(<span class="filter-count">0</span>)</span></span>
                             </label>
                         </li>
                         <li>
                             <label data-aging-clock-view="pheno">
                                 <input type="checkbox" name="agingClockView" value="pheno">
-                                🩸 Pheno Age (<span class="filter-count">0</span>)
+                                <span class="filter-label-copy">🩸 Pheno Age <span class="filter-count-group">(<span class="filter-count">0</span>)</span></span>
                             </label>
                         </li>
                         <li>
                             <label data-aging-clock-view="improvement">
                                 <input type="checkbox" name="agingClockView" value="improvement">
-                                📉 Pheno Improvement (<span class="filter-count">0</span>)
+                                <span class="filter-label-copy">📉 Pheno Improvement <span class="filter-count-group">(<span class="filter-count">0</span>)</span></span>
                             </label>
                         </li>
                         <li>
                             <label data-aging-clock-view="bortz-improvement">
                                 <input type="checkbox" name="agingClockView" value="bortz-improvement">
-                                📉 Bortz Improvement (<span class="filter-count">0</span>)
+                                <span class="filter-label-copy">📉 Bortz Improvement <span class="filter-count-group">(<span class="filter-count">0</span>)</span></span>
                             </label>
                         </li>
                         <li>
                             <label data-aging-clock-view="crowd">
                                 <input type="checkbox" name="agingClockView" value="crowd">
-                                👥 Crowd Age (<span class="filter-count">0</span>)
+                                <span class="filter-label-copy">👥 Crowd Age <span class="filter-count-group">(<span class="filter-count">0</span>)</span></span>
                             </label>
                         </li>
                     </ul>
@@ -6321,7 +6323,7 @@
             li.innerHTML = `
         <label data-division="${division}">
             <input type="checkbox" name="division" value="${division}">
-            ${icon} ${division.charAt(0).toUpperCase() + division.slice(1)} (<span class="filter-count">${count}</span>)
+            <span class="filter-label-copy">${icon} ${division.charAt(0).toUpperCase() + division.slice(1)} <span class="filter-count-group">(<span class="filter-count">${count}</span>)</span></span>
         </label>
     `;
             filterSection.appendChild(li);
@@ -6344,7 +6346,7 @@
                 li.innerHTML = `
             <label data-flag="${escapeHtml(name)}" data-flag-key="${escapeHtml(flagKey)}">
                 <input type="checkbox" name="flag" value="${escapeHtml(name)}">
-                ${renderFlagLabel(name)} (<span class="filter-count">${count}</span>)
+                <span class="filter-label-copy">${renderFlagLabel(name)} <span class="filter-count-group">(<span class="filter-count">${count}</span>)</span></span>
             </label>
         `;
                 filterSection.appendChild(li);
@@ -6379,7 +6381,7 @@
                 li.innerHTML = `
             <label data-generation="${generation}">
                 <input type="checkbox" name="generation" value="${generation}">
-                ${icon} ${generation} (<span class="filter-count">${count}</span>)
+                <span class="filter-label-copy">${icon} ${generation} <span class="filter-count-group">(<span class="filter-count">${count}</span>)</span></span>
             </label>
         `;
                 filterSection.appendChild(li);
@@ -6405,7 +6407,7 @@
             li.innerHTML = `
             <label data-exclusive-league="Prosperan">
                 <input type="checkbox" name="exclusiveLeague" value="Prosperan">
-                🏝️ Prosperan (<span class="filter-count">${prosperanCount}</span>)
+                <span class="filter-label-copy">🏝️ Prosperan <span class="filter-count-group">(<span class="filter-count">${prosperanCount}</span>)</span></span>
             </label>
         `;
             filterSection.appendChild(li);
@@ -6437,7 +6439,7 @@
             li.innerHTML = `
                 <label data-league-track="${value}">
                     <input type="checkbox" name="leagueTrack" value="${value}">
-                    ${icon} ${label} (<span class="filter-count">${count}</span>)
+                    <span class="filter-label-copy">${icon} ${label} <span class="filter-count-group">(<span class="filter-count">${count}</span>)</span></span>
                 </label>
             `;
             filterSection.appendChild(li);


### PR DESCRIPTION
## What changed

- Wraps each sidebar filter label's visible text in a label-copy span.
- Keeps the filter count and parentheses together with a non-wrapping count group.
- Leaves checkbox names, filter data attributes, and count update logic unchanged.

## Why

At a 280px viewport with the mobile filter drawer open, the aging-clock counts could wrap as orphan parentheses, for example `Pheno Age (` on one line and `206)` on the next.

## Screenshot proof

Gist: https://gist.github.com/nopara73/e77e15e814e3cb27054e32909b1a5b48

| Before | After |
| --- | --- |
| ![Before: mobile filter counts split away from their parentheses](https://gist.githubusercontent.com/nopara73/e77e15e814e3cb27054e32909b1a5b48/raw/90b916b4efc94133256c55e460e8a92d73f3f8b9/filter-count-before-280.png) | ![After: mobile filter counts stay grouped with their parentheses](https://gist.githubusercontent.com/nopara73/e77e15e814e3cb27054e32909b1a5b48/raw/567b60423299dd3670507abc923939e71fe7d245/filter-count-after-280.png) |

## Verification

- Playwright crop at `/leaderboard`, 280x700, filter drawer open: before shows orphaned count parentheses in the aging-clock filters.
- Playwright crop at `/leaderboard`, 280x700, filter drawer open: after keeps counts grouped as `(206)`, `(49)`, `(2)` when labels wrap.
- Playwright metric check at 280x700: page `bodyScrollWidth` remains 280px before and after.
- Gist raw image URLs return `Content-Type: image/png`.
- `dotnet build LongevityWorldCup.Website/LongevityWorldCup.Website.csproj -o .artifacts/build-filter-count-wrap`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only HTML/CSS in the leaderboard filter sidebar; no filter logic or data handling changes.
> 
> **Overview**
> Fixes awkward line breaks in the leaderboard mobile filter drawer where a count could split from its opening parenthesis (e.g. `Pheno Age (` on one line and `206)` on the next).
> 
> Sidebar filter labels now wrap visible text in **`filter-label-copy`** and put **`(count)`** inside **`filter-count-group`** with **`white-space: nowrap`**, plus **`min-width: 0`** on the label copy so flex layout can still shrink. The same markup is applied to static aging-clock filters and to every dynamically built filter (divisions, flags, generations, Prosperan, tracks). Checkbox values, data attributes, and **`.filter-count`** update behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c48e670d157b8ebd2642fbda9d6e5ef3febe4c88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->