### PR TITLE
[codex] Fit unsubscribe title on ultranarrow screens

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/unsubscribe.html
+++ b/LongevityWorldCup.Website/wwwroot/unsubscribe.html
@@ -123,6 +123,17 @@
                 min-height: 46px;
             }
         }
+
+        @media (max-width: 300px) {
+            .unsubscribe-panel {
+                margin: 1.25rem 0.45rem;
+                padding: 1.2rem 0.75rem;
+            }
+
+            .unsubscribe-panel h1 {
+                font-size: 1.65rem;
+            }
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
## What changed

- Adds an ultranarrow `/unsubscribe` layout override below 300px.
- Slightly reduces panel spacing and heading size only at that breakpoint.
- Leaves the normal mobile and desktop unsubscribe layout unchanged.

## Why

At a 240px viewport, the single-word `Unsubscribe` heading was wider than the panel content and clipped off the right edge.

## Screenshot proof

Gist: https://gist.github.com/nopara73/7c2f856b781d60641d2809b2bde93e28

| Before | After |
| --- | --- |
| ![Before: unsubscribe title clips off the right edge at 240px](https://gist.githubusercontent.com/nopara73/7c2f856b781d60641d2809b2bde93e28/raw/52d4179e1dbebbf004adaa2286c790581339d833/unsubscribe-before-240.png) | ![After: unsubscribe title fits inside the panel at 240px](https://gist.githubusercontent.com/nopara73/7c2f856b781d60641d2809b2bde93e28/raw/3a6978ff850d78e65d975df553e7e1731fab3c82/unsubscribe-after-240.png) |

## Verification

- Playwright crop at `/unsubscribe`, 240x700: before the `Unsubscribe` heading is clipped off the right side.
- Playwright crop at `/unsubscribe`, 240x700: after the heading fits inside the card.
- Playwright metric check at 240x700: page `bodyScrollWidth` drops from 249px to 240px.
- Gist raw image URLs return `Content-Type: image/png`.
- `dotnet build LongevityWorldCup.Website/LongevityWorldCup.Website.csproj -o .artifacts/build-unsubscribe-title`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS on a static unsubscribe page; no auth, API, or data-path changes.
> 
> **Overview**
> Adds a **`@media (max-width: 300px)`** override on `/unsubscribe` so the **Unsubscribe** heading and panel spacing fit very narrow widths (e.g. 240px) without horizontal clipping.
> 
> At that breakpoint only, panel **margin/padding** are tightened and the **h1** uses a fixed **1.65rem** size instead of the existing mobile `clamp` rule. Wider mobile and desktop layouts are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ab3c0c34291df45227eaf1a5656d07aa0e77977. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->