### PR TITLE
[codex] Fit join track cards on ultranarrow screens

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/onboarding/join-game.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/join-game.html
@@ -409,6 +409,59 @@
         }
       }
 
+      @media (max-width: 300px) {
+        body #mainProgressBar.progress-container {
+          width: calc(100% - 20px);
+        }
+
+        body #mainProgressBar .stages {
+          gap: 6px;
+          justify-content: space-between;
+        }
+
+        body #mainProgressBar .stage {
+          flex: 1 1 0;
+          min-width: 0;
+        }
+
+        body #mainProgressBar .stage-label {
+          font-size: 0.78rem;
+        }
+
+        body #mainProgressBar .stage.active .stage-label {
+          padding: 0.25rem 0.42rem;
+        }
+
+        .track-card {
+          padding: 1rem;
+        }
+
+        .track-card-meta {
+          grid-template-columns: 1fr;
+          gap: 0.18rem;
+        }
+
+        .track-card-meta dd {
+          margin-bottom: 0.4rem;
+          overflow-wrap: anywhere;
+        }
+
+        .track-card-meta dd a {
+          display: inline;
+          min-height: 0;
+          margin: 0;
+          padding: 0;
+        }
+
+        .biomarkers-section {
+          padding: 0.62rem 0.65rem 0.72rem;
+        }
+
+        .biomarkers-section .card-bio-list li {
+          overflow-wrap: anywhere;
+        }
+      }
+
       /* Only the direct child is the ribbon band; .btc-symbol stays inline on it */
       .track-card-ribbon.prize-money > span {
         display: flex;
@@ -479,6 +532,46 @@
           text-align: center;
           white-space: normal;
           transform: none;
+        }
+      }
+
+      @media (max-width: 300px) {
+        .track-card.pro {
+          grid-template-rows: auto auto auto auto auto;
+        }
+
+        .track-card.pro .track-card-ribbon-slot {
+          display: flex;
+          justify-content: flex-end;
+          height: auto;
+          margin-bottom: 0.45rem;
+        }
+
+        .track-card.pro .track-card-ribbon-slot .track-card-ribbon {
+          position: static;
+          top: auto;
+          right: auto;
+        }
+
+        .track-card.pro h2 {
+          padding-right: 0;
+        }
+
+        .track-card-ribbon.prize-money {
+          width: auto;
+          height: auto;
+        }
+
+        .track-card-ribbon.prize-money > span {
+          display: inline-flex;
+          box-sizing: border-box;
+          width: auto;
+          max-width: none;
+          padding: 0.3rem 0.5rem;
+          border-radius: 6px;
+          font-size: 0.54rem;
+          line-height: 1;
+          white-space: nowrap;
         }
       }
 


### PR DESCRIPTION
## What changed
- Adds ultranarrow `/join` layout rules below 300px so the progress labels, track card metadata, biomarker list, and Professional prize badge fit inside the viewport.
- Moves the Professional prize badge into a real card row at 240px instead of letting it clip against the card edge.

## Screenshot proof
Gist: https://gist.github.com/nopara73/d2ca0c93a63a35475d2e68ca9bc144c5

| Before | After |
| --- | --- |
| ![Before](https://gist.githubusercontent.com/nopara73/d2ca0c93a63a35475d2e68ca9bc144c5/raw/812e653d772ad1ff3a91c1480a52e8ec87db01c2/before-240.png) | ![After](https://gist.githubusercontent.com/nopara73/d2ca0c93a63a35475d2e68ca9bc144c5/raw/74748321de63e33a25b8700ad858e99b05a19878/after-240.png) |

## Verification
- Captured `/join` at 240x700, scrollY 1200: before the Professional card/ribbon clipped and page body scroll width was 252px; after it fits with body scroll width 240px.
- VisualProbe wide-element count at the same viewport changed from 13 to 0.
- Captured the first viewport after the fix at 240x700: progress labels fit with body scroll width 240px.
- Raw Gist screenshot URLs return `image/png`.
- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o .artifacts\build-join-track-card`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only responsive tweaks scoped to join-game.html; no logic, API, or data changes.
> 
> **Overview**
> Adds **`@media (max-width: 300px)`** rules on `/join` so onboarding content stays within very narrow viewports (e.g. 240px) without horizontal overflow.
> 
> The **main progress bar** gets a slightly narrower width, tighter stage spacing, smaller labels, and flexible stages so step names still fit. **Track cards** use less padding; **metadata** switches to a single-column stack with wrapping links (touch targets no longer forced tall). **Biomarker** text wraps with `overflow-wrap: anywhere`.
> 
> For the **Professional** card, the prize ribbon stops using the corner-absolute layout: the ribbon slot becomes a normal flex row, the title loses extra right padding, and the badge renders as a compact inline pill instead of a rotated corner band—addressing clipping that widened the page past the viewport.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ced1b9bd135222e3ed4e086aab3b188ca174894e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->