### PR TITLE
[codex] Fit progress labels on ultranarrow screens

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/partials/main-progress-bar.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/main-progress-bar.html
@@ -77,6 +77,30 @@
         color: #666;
     }
 
+    @media (max-width: 300px) {
+        .progress-container {
+            width: calc(100% - 20px);
+        }
+
+        .stages {
+            justify-content: space-between;
+            gap: 6px;
+        }
+
+        .stage {
+            flex: 1 1 0;
+            min-width: 0;
+        }
+
+        .stage-label {
+            font-size: 12px;
+        }
+
+        .stage.active .stage-label {
+            padding: 0.25rem 0.42rem;
+        }
+    }
+
     /* Sticky progress row (under LWC bar): same dark strip as header */
     #site-sticky-progress {
         position: fixed;


### PR DESCRIPTION
## What changed
- Adds an ultranarrow shared progress-bar layout below 300px.
- Lets the three stage slots shrink evenly so `Test`, `Calculate`, and `Submit` stay inside the viewport on calculator pages.

## Screenshot proof
Gist: https://gist.github.com/nopara73/662c71b476f963f75e6820c1473ff7d8

| Before | After |
| --- | --- |
| ![Before](https://gist.githubusercontent.com/nopara73/662c71b476f963f75e6820c1473ff7d8/raw/24862b3e40957e4b4890dac081971f97c93f4128/pheno-before-240.png) | ![After](https://gist.githubusercontent.com/nopara73/662c71b476f963f75e6820c1473ff7d8/raw/c952d85142f2367caab3c4cd8ffd1ea3ad3d2678/pheno-after-240.png) |

## Verification
- Captured `/pheno-age` at 240x700: before the `Submit` stage label clipped past the right edge; after all three progress labels fit.
- `/pheno-age` body scroll width changed from 252px to 240px, and wide elements changed from 1 to 0.
- Captured `/bortz-age` at 240x700 with the same shared fix: body scroll width changed from 252px to 240px, and wide elements changed from 1 to 0.
- Raw Gist screenshot URLs return `image/png`.
- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o .artifacts\build-progress-label-ultranarrow`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only responsive tweaks in a shared partial; no logic, auth, or data changes.
> 
> **Overview**
> Adds a **`@media (max-width: 300px)`** block to the shared **`main-progress-bar`** partial so **Test / Calculate / Submit** stay inside the viewport on very narrow calculator pages.
> 
> On ultranarrow widths the layout **tightens horizontal padding**, **spreads the three stage slots evenly** (`flex: 1 1 0`, `min-width: 0`), **reduces label size**, and **shrinks active-step pill padding** so labels no longer force horizontal overflow (e.g. ~240px-wide screens).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ccfb7413de7fdb6255ded900a013b70b6391873. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->