### PR TITLE
[codex] Keep bioage continue button on one line

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/css/bioageform.css
+++ b/LongevityWorldCup.Website/wwwroot/css/bioageform.css
@@ -91,6 +91,16 @@
     margin-top: 1rem;
 }
 
+.bioageform .lwc-step-actions .option-button {
+    box-sizing: border-box;
+    width: auto;
+    max-width: 100%;
+    min-width: min(100%, 9.25rem);
+    padding-inline: 1.6rem;
+    gap: 0.35rem;
+    white-space: nowrap;
+}
+
 .bioageform legend {
     display: inline-flex;
     align-items: center;


### PR DESCRIPTION
## What changed
- Adds shared bioage form styling for calculator step-action buttons.
- Keeps the `Continue` label and arrow together at ultranarrow widths instead of wrapping the final letter to a second line.

## Screenshot proof
Gist: https://gist.github.com/nopara73/4ddd93230bd197eb9b68c2bc215af02d

| Before | After |
| --- | --- |
| ![Before](https://gist.githubusercontent.com/nopara73/4ddd93230bd197eb9b68c2bc215af02d/raw/582d0e3d6ca396bb7f4519c6cf99ef57d1912dfd/pheno-button-before-240.png) | ![After](https://gist.githubusercontent.com/nopara73/4ddd93230bd197eb9b68c2bc215af02d/raw/b9ebb098922ac7eb32ae0d7d4bf2dc520e4d0efa/pheno-button-after-240.png) |

## Verification
- Captured `/pheno-age` at 240x700, scrollY 880: before the `Continue` button label split across two lines; after it stays on one line.
- Captured `/bortz-age` at 240x700, scrollY 900: before the same `Continue` label split; after it stays on one line.
- VisualProbe broken-word count for `Continue` changed from 1 to 0 on both pages.
- Raw Gist screenshot URLs return `image/png`.
- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o .artifacts\build-bioage-continue-ultranarrow`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS scoped to bioage forms; no auth, data, or backend changes.
> 
> **Overview**
> Adds scoped styles in `bioageform.css` for calculator step-action **Continue** buttons (`.bioageform .lwc-step-actions .option-button`).
> 
> Those rules override the global `.option-button` wrapping behavior (`white-space: normal` / `overflow-wrap: anywhere`) with **`white-space: nowrap`**, a **`min-width`** floor (`min(100%, 9.25rem)`), and adjusted horizontal padding so the label and arrow stay on one line at ultranarrow widths (e.g. 240px) on pages like `/pheno-age` and `/bortz-age`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36eeddc844ec6f73cacb5913e4094d7c5949a8b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->