### PR TITLE
[codex] Keep application review contact tokens together

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/onboarding/application-review.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/application-review.html
@@ -128,6 +128,15 @@
                 line-height: 1.42;
             }
 
+            .application-review-copy:not(.primary) .smaller-text {
+                font-size: 0.88rem;
+            }
+
+            .application-review-copy:not(.primary) a,
+            .application-review-copy:not(.primary) .application-review-highlight {
+                white-space: nowrap;
+            }
+
             .application-review-actions {
                 margin-top: 1.1rem;
             }
@@ -135,6 +144,12 @@
             .application-review-actions .option-button {
                 width: 100%;
                 min-width: 0;
+            }
+        }
+
+        @media (max-width: 300px) {
+            .application-review-copy:not(.primary) .smaller-text {
+                font-size: 0.82rem;
             }
         }
     </style>


### PR DESCRIPTION
## What changed
- Adds narrow-screen styling for the secondary contact copy on the application review page.
- Keeps the support email and `#longevity-world-cup` Slack room token intact at ultranarrow widths.

## Screenshot proof
Gist: https://gist.github.com/nopara73/b1bf744ab4f27ff035f0d90aae6c2d64

| Before | After |
| --- | --- |
| ![Before](https://gist.githubusercontent.com/nopara73/b1bf744ab4f27ff035f0d90aae6c2d64/raw/419d37d9e9d1df6a2a50fd9b10fb211dd39d7598/before-240.png) | ![After](https://gist.githubusercontent.com/nopara73/b1bf744ab4f27ff035f0d90aae6c2d64/raw/1bec4157c8e6c94790ca66b25453afa7118c357d/after-240.png) |

## Verification
- Captured `/onboarding/application-review.html` at 240x700, scrollY 500: before the contact email and `#longevity-world-cup` token split awkwardly; after both stay intact.
- VisualProbe broken highlighted token count changed from 1 to 0.
- Body scroll width stayed at 240px before and after, so the fix does not introduce horizontal overflow.
- Raw Gist screenshot URLs return `image/png`.
- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o .artifacts\build-application-review-contact-wrap`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only presentation tweaks on a static onboarding page; no auth, API, or data-path changes.
> 
> **Overview**
> Improves **application review** secondary contact copy on small viewports so support details stay readable without awkward mid-token line breaks.
> 
> Within the existing `max-width: 600px` rules, non-primary `.application-review-copy` blocks get slightly smaller `.smaller-text` and **`white-space: nowrap`** on mailto links and `.application-review-highlight` (e.g. `#longevity-world-cup`), keeping the email and Slack room label on one line. A new **`max-width: 300px`** breakpoint shrinks that secondary text a bit more to fit ultranarrow widths without horizontal overflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6df458bd5718d3b50333ba69fff7d21abcd66ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->