### PR TITLE
[codex] Show full media filenames on mobile

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/misc-pages/media.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/media.html
@@ -174,11 +174,7 @@
             .media-file-name {
                 font-size: 0.88rem;
                 line-height: 1.32;
-                display: -webkit-box;
-                overflow: hidden;
-                overflow-wrap: normal;
-                -webkit-box-orient: vertical;
-                -webkit-line-clamp: 3;
+                overflow-wrap: anywhere;
             }
 
             .media-file-button {


### PR DESCRIPTION
## What changed
- Removes the mobile line clamp from media kit filenames.
- Allows long filenames to wrap fully instead of clipping before the Download button.

## Screenshot proof
Gist: https://gist.github.com/nopara73/5b2bc23b5a636c66422383430ff75db1

| Before | After |
| --- | --- |
| ![Before](https://gist.githubusercontent.com/nopara73/5b2bc23b5a636c66422383430ff75db1/raw/6d2c816d8d9351a5cc6a8467f128dda8e59d7b69/before-240.png) | ![After](https://gist.githubusercontent.com/nopara73/5b2bc23b5a636c66422383430ff75db1/raw/395f52e9fff1b2349dfcce8175877eff1b3ec8ac/after-240.png) |

## Verification
- Captured `/media` at 240x700, scrollY 560: before the long `BlackOnTransparent.png` filename was clipped; after the full `.png` ending is visible.
- Body scroll width stayed at 240px before and after.
- Raw Gist screenshot URLs return `image/png`.
- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o .artifacts\build-media-filename-wrap`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only presentation change on the static media page; no auth, data, or backend impact.
> 
> **Overview**
> On narrow viewports (≤600px), **media kit file rows** no longer **clamp filenames to three lines** with `-webkit-line-clamp` and hidden overflow.
> 
> Mobile `.media-file-name` now uses **`overflow-wrap: anywhere`** so long paths (e.g. asset names with extensions) **wrap in full** above the full-width Download button instead of being ellipsized or cut off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30415c16e82bf9f9b8e8c788b9fb5229cec3c629. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->