### PR TITLE
[codex] Fit character search placeholder on ultranarrow screens

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/play/character-selection.html
+++ b/LongevityWorldCup.Website/wwwroot/play/character-selection.html
@@ -269,6 +269,16 @@
             }
         }
 
+        @media (max-width: 260px) {
+            .autocomplete-container input {
+                padding-inline: 0.64rem;
+            }
+
+            .autocomplete-container input::placeholder {
+                font-size: 0.8rem;
+            }
+        }
+
         @media (min-width: 640px) and (max-width: 932px) and (max-height: 480px) and (orientation: landscape) {
             .character-selection-main {
                 padding: 0.6rem 1rem 1.25rem;


### PR DESCRIPTION
## What changed
- Adds an ultranarrow character-selection input rule below 260px.
- Reduces the placeholder size and horizontal padding just enough for the athlete-name placeholder to fit inside the input.

## Screenshot proof
Gist: https://gist.github.com/nopara73/2966357a8275a2f58b3dc95fff6e927f

| Before | After |
| --- | --- |
| ![Before](https://gist.githubusercontent.com/nopara73/2966357a8275a2f58b3dc95fff6e927f/raw/87b7494bdac57c21d122af6db54f1eb568ab63df/before-240.png) | ![After](https://gist.githubusercontent.com/nopara73/2966357a8275a2f58b3dc95fff6e927f/raw/a7890fb4676b792cbc71038b693aaa1c2aa61714/after-240.png) |

## Verification
- Captured `/play/character-selection.html` at 240x700: before the athlete-name placeholder was visibly clipped inside the input; after the full placeholder fits.
- Body scroll width stayed at 240px before and after.
- Raw Gist screenshot URLs return `image/png`.
- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o .artifacts\build-character-placeholder-fit`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS on a single play page; no logic, API, or data changes.
> 
> **Overview**
> Adds a **`@media (max-width: 260px)`** rule on character selection so the athlete search field stays readable on very narrow viewports.
> 
> Below 260px, **horizontal padding** on `.autocomplete-container input` drops from the 320px tier (`0.78rem`) to **`0.64rem`**, and the **placeholder** font size goes from **`0.92rem`** to **`0.8rem`**. That tightens layout just enough for the “Start typing your athlete name…” placeholder to fit without clipping, without changing behavior or markup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bb36f320b36ea8fac47d4e228565e1d2eeb1bf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->