### PR TITLE
[codex] Fit leaderboard search placeholder on mobile

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -1784,6 +1784,7 @@
         }
         .search-container{ flex:1 1 auto; min-width:0; width:auto; max-width:none; margin-top:0; margin-right:0; }
         #athleteSearch{ padding:.5rem 5.4rem .5rem 1rem; font-size:1rem; }
+        #athleteSearch:placeholder-shown{ padding-right:2.55rem; }
         .search-icon{ right:1rem; }
         .clear-icon{ right:2.2rem; }
         .search-wrapper{


### PR DESCRIPTION
## What changed
- Lets the empty mobile leaderboard search field reserve only search-icon space while the clear button is hidden.
- Keeps the full `Search athletes` placeholder visible at ultranarrow widths.

## Screenshot proof
Gist: https://gist.github.com/nopara73/fe26cfb3461565f5dd30967e27eeb886

| Before | After |
| --- | --- |
| ![Before](https://gist.githubusercontent.com/nopara73/fe26cfb3461565f5dd30967e27eeb886/raw/f95d1ee52a93b75b137228710d8f0889d5b3d6c9/before-240.png) | ![After](https://gist.githubusercontent.com/nopara73/fe26cfb3461565f5dd30967e27eeb886/raw/b511eccf6d8e9511fd233e7b1f569ab6b8797573/after-240.png) |

## Verification
- Captured `/leaderboard` at 240x700, scrollY 520: before the placeholder clipped to `Search at`; after the full `Search athletes` placeholder is visible.
- Body scroll width stayed at 240px before and after.
- Raw Gist screenshot URLs return `image/png`.
- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o .artifacts\build-leaderboard-search-placeholder`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single responsive CSS tweak to search input padding with no logic, API, or data changes.
> 
> **Overview**
> On **narrow mobile leaderboard layouts**, `#athleteSearch` no longer keeps the wide right padding meant for both the search and clear icons when the field is empty.
> 
> A mobile-only `#athleteSearch:placeholder-shown` rule lowers `padding-right` from `5.4rem` to `2.55rem` so the full **Search athletes** placeholder can render without clipping, while typed input still reserves space for the clear control.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f555811567069aa2ed5c727a650c0f20cf345d2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->