### PR TITLE
[codex] Fit sticky header title on ultranarrow screens

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/partials/header.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/header.html
@@ -690,12 +690,27 @@
     }
 
     @media (max-width: 300px) {
+        .scrolled-button {
+            right: max(0.45rem, env(safe-area-inset-right, 0px));
+            min-width: 3.55rem;
+            padding: 0.5rem 0.65rem;
+            font-size: 0.86rem;
+        }
+
+        .site-sticky-header {
+            padding-right: calc(max(0.45rem, env(safe-area-inset-right, 0px)) + 4.05rem);
+        }
+
         .site-sticky-header-link {
-            gap: 0.35rem;
+            gap: 0.24rem;
+        }
+
+        .site-sticky-header-logo {
+            display: none;
         }
 
         .site-sticky-header-title {
-            font-size: 0.84rem;
+            font-size: 0.8rem;
             letter-spacing: 0;
         }
     }


### PR DESCRIPTION
## What changed
- Tightens the sticky header layout below 300px so the full `Longevity World Cup` title fits beside the sticky `PLAY` button.
- Uses the full title as the retained ultranarrow brand signal and hides the sticky logo only at this width.

## Screenshot proof
Gist: https://gist.github.com/nopara73/d008effaa4ec5ef3ad6e5a8931748597

| Before | After |
| --- | --- |
| ![Before](https://gist.githubusercontent.com/nopara73/d008effaa4ec5ef3ad6e5a8931748597/raw/1a46c389038099e5d5dc8bbe358b98219c8a34e8/before-240.png) | ![After](https://gist.githubusercontent.com/nopara73/d008effaa4ec5ef3ad6e5a8931748597/raw/e67e40d052721c7a897a69685e9704dece0f137f/after-240.png) |

## Verification
- Captured `/about` at 240x700, scrollY 600: before the sticky title clipped to `Longevity W...`; after the full `Longevity World Cup` title is visible beside `PLAY`.
- Body scroll width stayed at 240px before and after.
- Raw Gist screenshot URLs return `image/png`.
- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o .artifacts\build-sticky-header-title-fit`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only responsive tweaks in the shared header partial; no auth, data, or backend behavior changes.
> 
> **Overview**
> Extends the existing **≤300px** sticky-header rules in `header.html` so the full **Longevity World Cup** title stays visible next to the fixed **PLAY** button instead of ellipsizing.
> 
> The sticky **PLAY** control is tightened (smaller min-width, padding, and font size) with safe-area-aware right inset. The sticky bar gets matching **padding-right** reserved for that button. The sticky logo is **hidden** at this width, link gap is reduced, and the title drops to **0.8rem** so the text label carries branding on the narrowest viewports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c45f1785bd85a71381cc9ce5ccdfcd421571bae8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->