### PR TITLE
[codex] Fit custom event checklist on mobile

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
+++ b/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
@@ -48,6 +48,7 @@
             grid-template-columns: minmax(340px, 430px) minmax(600px, 1fr);
             gap: 18px;
             align-items: start;
+            min-width: 0;
         }
 
         .panel {
@@ -59,6 +60,7 @@
             display: grid;
             gap: 12px;
             align-content: start;
+            min-width: 0;
         }
 
         h1, h2 {
@@ -203,6 +205,7 @@
             padding: 12px;
             display: grid;
             gap: 10px;
+            min-width: 0;
         }
 
         .payload-actions {
@@ -272,10 +275,13 @@
             color: var(--muted);
             font-size: 12px;
             line-height: 1.55;
+            min-width: 0;
         }
 
         .live-checklist code {
             color: var(--text);
+            overflow-wrap: anywhere;
+            word-break: break-word;
         }
 
         .preview-stack {


### PR DESCRIPTION
## What changed

- Allows the internal custom-event designer grid/panel sections to shrink on ultranarrow screens.
- Wraps long inline code tokens in the live test checklist instead of letting them widen the panel.

## Screenshot proof

Gist: https://gist.github.com/nopara73/54cddad8cfa9f806def47d8e452b3f0b

| Before | After |
| --- | --- |
| ![Before: opened checklist widens the custom-event designer panel past a 240px viewport](https://gist.githubusercontent.com/nopara73/54cddad8cfa9f806def47d8e452b3f0b/raw/c07a626b2817af56758ade1e48ab169f639a1f2e/before-240.png) | ![After: opened checklist stays inside the 240px viewport](https://gist.githubusercontent.com/nopara73/54cddad8cfa9f806def47d8e452b3f0b/raw/fadd706aab975f15fd7e586ae77b4f139402c3cb/after-240.png) |

## Verification

- Captured `/internal/custom-event-designer.html` at 240x700 after opening `Live test checklist`.
- Before: `docScrollWidth` and `bodyScrollWidth` were 291px.
- After: `docScrollWidth` and `bodyScrollWidth` are 240px.
- Raw Gist screenshot URLs return `image/png`.
- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o .artifacts\build-custom-event-checklist`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS in a static internal HTML page; no API, auth, or data path changes.
> 
> **Overview**
> Fixes horizontal scrolling on very narrow viewports when the **Live test checklist** is expanded on the internal custom event designer page.
> 
> Adds **`min-width: 0`** on the main grid (`.page`), sidebar panels (`.panel`), payload sections (`.payload-box`), and the checklist (`.live-checklist`) so grid/flex children can shrink below their content width instead of forcing the layout wider than the viewport.
> 
> Adds **`overflow-wrap: anywhere`** and **`word-break: break-word`** on checklist **`<code>`** tokens (config keys, service names) so long unbroken strings wrap inside the panel rather than widening it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59e1a8756bed54b74c308ddfb73a969ae5558feb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->