### PR TITLE
[codex] Improve documentation compact layouts

### DIFF
--- a/LongevityWorldCup.MarkdownPageGenerator/Program.cs
+++ b/LongevityWorldCup.MarkdownPageGenerator/Program.cs
@@ -454,7 +454,7 @@ static string RenderPage(string title, string documentHtml, string contentsHtml,
             }
         }
 
-        @media (max-width: 360px) {
+        @media (max-width: 480px) {
             .documentation-document table {
                 display: block;
                 border-collapse: separate;

--- a/LongevityWorldCup.MarkdownPageGenerator/Program.cs
+++ b/LongevityWorldCup.MarkdownPageGenerator/Program.cs
@@ -344,8 +344,11 @@ static string RenderPage(string title, string documentHtml, string contentsHtml,
             box-sizing: border-box;
             display: block;
             max-width: 100%;
+            max-width: min(100%, 48rem);
             max-height: 560px;
-            width: min(100%, 48rem);
+            max-height: min(560px, calc(100vh - 7rem));
+            max-height: min(560px, calc(100svh - 7rem));
+            width: auto;
             height: auto;
             object-fit: contain;
             margin: 1.45rem auto 1.8rem;
@@ -454,7 +457,7 @@ static string RenderPage(string title, string documentHtml, string contentsHtml,
             }
         }
 
-        @media (max-width: 480px) {
+        @media (max-width: 720px) {
             .documentation-document table {
                 display: block;
                 border-collapse: separate;

--- a/LongevityWorldCup.Website/wwwroot/misc-pages/about.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/about.html
@@ -158,8 +158,11 @@
             box-sizing: border-box;
             display: block;
             max-width: 100%;
+            max-width: min(100%, 48rem);
             max-height: 560px;
-            width: min(100%, 48rem);
+            max-height: min(560px, calc(100vh - 7rem));
+            max-height: min(560px, calc(100svh - 7rem));
+            width: auto;
             height: auto;
             object-fit: contain;
             margin: 1.45rem auto 1.8rem;
@@ -268,7 +271,7 @@
             }
         }
 
-        @media (max-width: 480px) {
+        @media (max-width: 720px) {
             .documentation-document table {
                 display: block;
                 border-collapse: separate;

--- a/LongevityWorldCup.Website/wwwroot/misc-pages/about.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/about.html
@@ -268,7 +268,7 @@
             }
         }
 
-        @media (max-width: 360px) {
+        @media (max-width: 480px) {
             .documentation-document table {
                 display: block;
                 border-collapse: separate;

--- a/LongevityWorldCup.Website/wwwroot/misc-pages/history.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/history.html
@@ -158,8 +158,11 @@
             box-sizing: border-box;
             display: block;
             max-width: 100%;
+            max-width: min(100%, 48rem);
             max-height: 560px;
-            width: min(100%, 48rem);
+            max-height: min(560px, calc(100vh - 7rem));
+            max-height: min(560px, calc(100svh - 7rem));
+            width: auto;
             height: auto;
             object-fit: contain;
             margin: 1.45rem auto 1.8rem;
@@ -268,7 +271,7 @@
             }
         }
 
-        @media (max-width: 480px) {
+        @media (max-width: 720px) {
             .documentation-document table {
                 display: block;
                 border-collapse: separate;

--- a/LongevityWorldCup.Website/wwwroot/misc-pages/history.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/history.html
@@ -268,7 +268,7 @@
             }
         }
 
-        @media (max-width: 360px) {
+        @media (max-width: 480px) {
             .documentation-document table {
                 display: block;
                 border-collapse: separate;

--- a/LongevityWorldCup.Website/wwwroot/misc-pages/ruleset.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/ruleset.html
@@ -158,8 +158,11 @@
             box-sizing: border-box;
             display: block;
             max-width: 100%;
+            max-width: min(100%, 48rem);
             max-height: 560px;
-            width: min(100%, 48rem);
+            max-height: min(560px, calc(100vh - 7rem));
+            max-height: min(560px, calc(100svh - 7rem));
+            width: auto;
             height: auto;
             object-fit: contain;
             margin: 1.45rem auto 1.8rem;
@@ -268,7 +271,7 @@
             }
         }
 
-        @media (max-width: 480px) {
+        @media (max-width: 720px) {
             .documentation-document table {
                 display: block;
                 border-collapse: separate;

--- a/LongevityWorldCup.Website/wwwroot/misc-pages/ruleset.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/ruleset.html
@@ -268,7 +268,7 @@
             }
         }
 
-        @media (max-width: 360px) {
+        @media (max-width: 480px) {
             .documentation-document table {
                 display: block;
                 border-collapse: separate;


### PR DESCRIPTION
## What changed

- Keeps generated documentation screenshots inside both the content width and compact landscape viewport height, so embedded history images stay inspectable instead of becoming oversized slices.
- Raises the generated documentation table stacking breakpoint through compact widths so tables use labeled rows before columns become cramped.
- Regenerates the static `about`, `history`, and `ruleset` pages from the Markdown page generator.

## Screenshot proof

Gist: https://gist.github.com/nopara73/8c0e891bbaab26dbe685fa15468c3375

### 667x375 phone landscape image

| Before | After |
| --- | --- |
| ![Before: the history screenshot is an oversized cropped slice in phone landscape](https://gist.githubusercontent.com/nopara73/8c0e891bbaab26dbe685fa15468c3375/raw/73afa742297c325d4f30a3a99c09a50ad66b60bf/before-landscape-667.png) | ![After: the same scroll position shows the image in context with article text](https://gist.githubusercontent.com/nopara73/8c0e891bbaab26dbe685fa15468c3375/raw/9188c3e3952cd4fe30682c7885415cb5743b4b9f/after-landscape-667.png) |

### 390px portrait table

| Before | After |
| --- | --- |
| ![Before: the history table clips the Age reduction column at 390px](https://gist.githubusercontent.com/nopara73/8c0e891bbaab26dbe685fa15468c3375/raw/997e5612c901c4d9b197ab25c9125fb3e9ff8c48/before-390.png) | ![After: the same history table stacks into labeled rows at 390px](https://gist.githubusercontent.com/nopara73/8c0e891bbaab26dbe685fa15468c3375/raw/a2b9714e8b47ed781293f0a688162ae1d80e27ce/after-390.png) |

Additional landscape table check: ![After: the history table also stacks in 667px landscape](https://gist.githubusercontent.com/nopara73/8c0e891bbaab26dbe685fa15468c3375/raw/43f6a06ebfb3343ac33f87d6e98eb302fcec5355/after-table-landscape-667.png)

## Verification

- Captured `/history` at 667x375, scrollY 1080: before the embedded screenshot filled the viewport as a cropped slice; after the same scroll position shows the image with surrounding article text.
- Captured `/history` table section at 667x375: table uses stacked labeled rows.
- Captured `/history` table section at 390x760: table remains stacked with zero wide elements.
- Raw Gist screenshot URLs return `image/png`.
- `dotnet run --project LongevityWorldCup.MarkdownPageGenerator\LongevityWorldCup.MarkdownPageGenerator.csproj`
- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o ..\build-doc-table-landscape-730`
- `git diff --check`