### PR TITLE
[codex] Fit custom event previews on mobile

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
+++ b/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
@@ -833,6 +833,30 @@
             .preview-surface,
             .webpage-surface { width: 100%; max-width: 100%; }
         }
+
+        @media (max-width: 640px) {
+            .slack-shell,
+            .x-post,
+            .x-main,
+            .x-text,
+            .og-card,
+            .x-media {
+                width: 100%;
+                max-width: 100%;
+            }
+
+            .x-post {
+                display: grid;
+                grid-template-columns: 40px minmax(0, 1fr);
+            }
+
+            .og-card-media-fallback-badge,
+            .og-card-media-fallback-domain {
+                max-width: calc(100% - 24px);
+                overflow-wrap: anywhere;
+                text-align: center;
+            }
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
## What changed

- Lets the internal custom-event designer social preview internals use the available mobile column width below 640px.
- Keeps X preview content in a stable avatar/content grid and prevents Open Graph fallback labels from clipping inside narrow cards.

## Screenshot proof

Gist: https://gist.github.com/nopara73/a0e464114f603ff382d341354e530c65

| Before | After |
| --- | --- |
| ![Before: custom-event social previews are squeezed at 320px and the placeholder badge clips](https://gist.githubusercontent.com/nopara73/a0e464114f603ff382d341354e530c65/raw/ab06fe6ea504bebc70906565f939391259df2e9a/before-320.png) | ![After: custom-event social previews use the mobile column width](https://gist.githubusercontent.com/nopara73/a0e464114f603ff382d341354e530c65/raw/9e3a673855e5da0ecfe44e533a16a360bddbed7c/after-320.png) |

## Verification

- Captured `/internal/custom-event-designer.html` at 320x740, social preview section.
- Before: the preview surface was 140px wide inside a 320px viewport and the Open Graph placeholder badge clipped.
- After: the same section uses the mobile column width; scrollable descendants dropped from 8 to 1 in the captured area.
- Also checked the same section at 360px: page width remained 360px and there were no wide elements.
- Raw Gist screenshot URLs return `image/png`.
- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o ..\build-custom-event-preview-mobile`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS on an internal static page; no API, auth, or posting behavior changes.
> 
> **Overview**
> Adds a **640px breakpoint** so social preview chrome in the internal custom-event designer uses the full mobile column instead of staying at `fit-content` / `min(560px, calc(100vw - 180px))` widths that squeezed previews on ~320px screens.
> 
> Below that width, **Slack shell, X post layout, OG cards, and media** are set to `width` / `max-width: 100%`. The **X preview** switches from `inline-flex` to a **40px avatar + flexible content grid** so the post body stays aligned. **Open Graph placeholder** badge and domain labels get constrained width, `overflow-wrap: anywhere`, and centered text so long domains do not clip inside narrow cards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02c80ae77b08ed6d86ae59d901ae2d7725c6b2c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->