### PR TITLE
[codex] Fit join prize ribbon on mobile

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/onboarding/join-game.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/join-game.html
@@ -507,6 +507,44 @@
         }
       }
 
+      @media (max-width: 700px) {
+        .track-card.pro {
+          grid-template-rows: auto auto auto auto auto;
+        }
+
+        .track-card.pro .track-card-ribbon-slot {
+          display: flex;
+          justify-content: flex-end;
+          height: auto;
+          margin-bottom: 0.55rem;
+        }
+
+        .track-card.pro .track-card-ribbon-slot .track-card-ribbon {
+          position: static;
+          top: auto;
+          right: auto;
+        }
+
+        .track-card-ribbon.prize-money {
+          width: auto;
+          height: auto;
+          overflow: visible;
+        }
+
+        .track-card-ribbon.prize-money > span {
+          position: static;
+          display: inline-flex;
+          width: auto;
+          max-width: none;
+          padding: 0.34rem 0.58rem;
+          border-radius: 999px;
+          font-size: 0.6rem;
+          line-height: 1;
+          white-space: nowrap;
+          transform: none;
+        }
+      }
+
       @media (max-width: 360px) {
         .track-card.pro .track-card-ribbon-slot .track-card-ribbon {
           top: -0.75rem;


### PR DESCRIPTION
## What changed

- Turns the Professional card prize ribbon into an in-flow badge when the track cards are stacked on mobile.
- Keeps the desktop diagonal corner ribbon unchanged for wider layouts.

## Why

At a realistic 390px mobile viewport, the stacked Professional card still used the desktop diagonal corner ribbon. The rotated ribbon extended past the card and was clipped by the viewport edge, making the "Prize money" label look broken.

## Screenshot proof

Gist: https://gist.github.com/nopara73/49aa7ec21ed02a56fd1a589805b380d2

| Before | After |
| --- | --- |
| ![Before: the Professional prize ribbon is clipped at the right edge on a 390px mobile viewport](https://gist.githubusercontent.com/nopara73/49aa7ec21ed02a56fd1a589805b380d2/raw/b510f910a9e1911617c7c68f1ce5b4349228cdc5/before-390.png) | ![After: the Professional prize ribbon becomes an in-flow badge inside the card on a 390px mobile viewport](https://gist.githubusercontent.com/nopara73/49aa7ec21ed02a56fd1a589805b380d2/raw/1ce08f65a1d8e6ef27cfc46bc63c27c325587ef1/after-390.png) |

## Verification

- VisualProbe capture at `/join`, 390x740, scrollY 700: before had one wide clipped ribbon element; after has zero wide elements and body scroll width remains 390px.
- VisualProbe capture at `/join`, 360x740, scrollY 700: zero wide elements after.
- VisualProbe capture at `/join`, 320x740, scrollY 700: zero wide elements after.
- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o ..\build-join-prize-ribbon-flow`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Join-page CSS only; no logic, API, or data changes.
> 
> **Overview**
> On viewports **≤700px** (when track cards stack), the Professional **“Prize money”** ribbon no longer uses the diagonal corner treatment that was getting clipped past the card edge.
> 
> The new rules give the pro card a full-height ribbon row, lay the ribbon slot out in-flow (flex, right-aligned), and restyle the label as a **pill badge** (`transform: none`, auto sizing) instead of an absolutely positioned rotated band. **Wider layouts are unchanged** and still use the corner ribbon.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f509328d6404478fb538442d08b1b1d8af95ed2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->