### PR TITLE
[codex] Remove homepage leaderboard preview gap

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/index.html
+++ b/LongevityWorldCup.Website/wwwroot/index.html
@@ -1264,6 +1264,10 @@
             }
         }
 
+        main > .main-container .leaderboard {
+            min-height: 0;
+        }
+
         @media (max-width: 420px) {
             #events-root-index .events-board col.events-col-avatar {
                 width: 44px;


### PR DESCRIPTION
## What changed

- Scopes a homepage-only override so the embedded leaderboard preview sizes to its rendered rows instead of inheriting the full leaderboard viewport min-height.
- Leaves the standalone `/leaderboard` layout unchanged.

## Why

The shared leaderboard partial uses a viewport-based minimum height for the full leaderboard page. On the homepage, only 10 preview rows are rendered, so that minimum height creates a blank white tail below the table before the "View all athletes" action.

## Screenshot proof

Gist: https://gist.github.com/nopara73/3b820508c82262c4ee85524a5487b24f

| Before | After |
| --- | --- |
| ![Before: blank white space remains below the homepage leaderboard preview on a 320px mobile viewport](https://gist.githubusercontent.com/nopara73/3b820508c82262c4ee85524a5487b24f/raw/b1b402037dc2a2882e31f2342b592bf4a880226d/before-320.png) | ![After: the homepage leaderboard preview no longer leaves a blank tail before the next section](https://gist.githubusercontent.com/nopara73/3b820508c82262c4ee85524a5487b24f/raw/cd11a46f3299aa1bc091fa11d0e3a3dd4c647b2d/after-320.png) |

## Verification

- VisualProbe capture at `/`, 320x760, scrollY 2500: homepage `.leaderboard` height changes from the viewport-sized 728px preview shell to the actual 471px table height.
- VisualProbe capture at `/`, 390x800, scrollY 2500: no blank leaderboard tail before the highlights/swag section.
- VisualProbe capture at `/leaderboard`, 320x760: standalone leaderboard still uses the full long table layout.
- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o ..\build-homepage-leaderboard-gap`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single scoped CSS override on the homepage; no auth, data, or shared leaderboard page behavior changes beyond layout.
> 
> **Overview**
> Fixes a **blank white gap** below the homepage’s embedded leaderboard preview on mobile and other viewports.
> 
> The shared leaderboard partial applies a **viewport-based `min-height`** on `.leaderboard` for the full `/leaderboard` page. On the homepage only **10 preview rows** render, so that minimum left empty space before “View all athletes” and the next section. This PR adds a **homepage-scoped override** — `main > .main-container .leaderboard { min-height: 0; }` in `index.html` — so the preview shell **sizes to the table content** instead of inheriting the full-page height. The standalone leaderboard layout is **not** targeted by this selector.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb3bd4e204636e1ff6804df578c37b0cad4544a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->