### PR TITLE
[codex] Fix mobile leaderboard name breaks

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -851,13 +851,14 @@
         align-items:center;
         text-align:left;
         gap:.5rem;
+        min-width:0;
     }
     .athlete-td .badge-section{ flex:0 0 auto; flex-wrap:nowrap; }
 
     .athlete-name{
         color:var(--primary-color); text-decoration:underline; text-decoration-thickness:.08em; text-underline-offset:.18em; text-align:left; cursor:pointer;
         transition:color .2s ease-in-out, background-color .2s ease-in-out, box-shadow .2s ease-in-out;
-        display:inline-block; padding:.5rem .45rem; white-space:pre-wrap; border-radius:8px;
+        display:inline-block; padding:.5rem .45rem; white-space:pre-wrap; overflow-wrap:normal; word-break:normal; hyphens:none; border-radius:8px;
     }
     .athlete-name:hover{
         color:var(--secondary-color); background-color:rgba(255,64,129,.08); box-shadow:inset 0 0 0 1px rgba(255,64,129,.12);
@@ -1884,6 +1885,17 @@
             padding-left:1rem;
             padding-right:.65rem;
         }
+        .leaderboard table tbody tr:not(.no-results):not(.tier-separator) .athlete-td{
+            gap:.35rem;
+            min-width:0;
+        }
+        .leaderboard table tbody .athlete-name{
+            max-width:100%;
+            padding-left:.24rem;
+            padding-right:.24rem;
+            line-height:1.15;
+            white-space:nowrap;
+        }
 
         @media (min-width: 601px) and (max-width: 932px) and (max-height: 480px) and (orientation: landscape) {
             .leaderboard table th:nth-child(4),
@@ -2100,30 +2112,35 @@
             }
         }
 
-        @media (max-width: 300px) {
+        @media (max-width: 480px) {
             .leaderboard table {
                 border-spacing: 0 0.45rem;
                 table-layout: auto;
             }
 
             .leaderboard .portrait {
-                width: 32px;
-                height: 32px;
+                width: 36px;
+                height: 36px;
             }
 
             .leaderboard table thead {
                 display: none;
             }
 
+            .leaderboard table tbody {
+                display: block;
+            }
+
             .leaderboard table tbody tr:not(.no-results):not(.tier-separator) {
                 display: grid;
-                grid-template-columns: 2rem minmax(0, 1fr);
+                grid-template-columns: 2.35rem minmax(0, 1fr);
                 grid-template-areas:
                     "rank athlete"
                     "rank score";
                 align-items: center;
-                column-gap: 0.45rem;
-                padding: 0.45rem 0.55rem;
+                column-gap: 0.55rem;
+                row-gap: 0.12rem;
+                padding: 0.5rem 0.65rem;
             }
 
             .leaderboard table tbody tr.tier-separator {
@@ -2154,14 +2171,16 @@
 
             .leaderboard .athlete-td .portrait-wrapper,
             .leaderboard .athlete-td .rank-change {
-                flex: 0 0 32px;
-                width: 32px;
-                min-width: 32px;
+                flex: 0 0 36px;
+                width: 36px;
+                min-width: 36px;
             }
 
             .leaderboard table td.age-reduction-td {
                 grid-area: score;
-                display: block;
+                display: flex;
+                align-items: baseline;
+                gap: 0.35rem;
                 width: auto;
                 min-width: 0;
                 padding: 0.1rem 0 0;
@@ -2170,23 +2189,38 @@
 
             .leaderboard table td.age-reduction-td::before {
                 content: attr(data-label);
-                display: block;
-                margin-bottom: 0.08rem;
+                display: inline-block;
                 color: #64748b;
                 font-size: 0.58rem;
                 font-weight: 700;
                 letter-spacing: 0.04em;
                 text-transform: uppercase;
+                white-space: nowrap;
             }
 
             .leaderboard table td.age-reduction-td .age-reduction {
                 display: inline-block;
                 line-height: 1.2;
+                white-space: nowrap;
             }
 
             .athlete-name {
                 padding-left: 0.25rem;
                 padding-right: 0.25rem;
+            }
+        }
+
+        @media (max-width: 300px) {
+            .leaderboard .portrait {
+                width: 32px;
+                height: 32px;
+            }
+
+            .leaderboard .athlete-td .portrait-wrapper,
+            .leaderboard .athlete-td .rank-change {
+                flex: 0 0 32px;
+                width: 32px;
+                min-width: 32px;
             }
         }
 

--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -1894,7 +1894,8 @@
             padding-left:.24rem;
             padding-right:.24rem;
             line-height:1.15;
-            white-space:nowrap;
+            white-space:normal;
+            word-break:keep-all;
         }
 
         @media (min-width: 601px) and (max-width: 932px) and (max-height: 480px) and (orientation: landscape) {


### PR DESCRIPTION
## What changed

- Switches the leaderboard table to the existing stacked row pattern at realistic mobile widths (<=480px), so the athlete name and age reduction do not fight for the same narrow row.
- Keeps athlete names from breaking inside words/hyphenated surnames on mobile rows.
- Leaves compact landscape and wider table layouts unchanged.

## Why

At 320-390px widths, the mobile leaderboard squeezed the athlete column enough to split the hyphenated surname `Franz-Montan` across lines. The same row still needed the age-reduction value to remain visible, so the fix uses a stacked mobile row instead of forcing the desktop table shape into the viewport.

## Screenshot proof

Gist: https://gist.github.com/nopara73/56e8a47aa2189f123817c3b594a16aaa

### 320px

| Before | After |
| --- | --- |
| ![Before: hyphenated athlete surname breaks across lines at 320px](https://gist.githubusercontent.com/nopara73/56e8a47aa2189f123817c3b594a16aaa/raw/before-320.png) | ![After: athlete surname stays intact and age reduction remains visible at 320px](https://gist.githubusercontent.com/nopara73/56e8a47aa2189f123817c3b594a16aaa/raw/after-320.png) |

### 390px

| Before | After |
| --- | --- |
| ![Before: hyphenated athlete surname breaks across lines at 390px](https://gist.githubusercontent.com/nopara73/56e8a47aa2189f123817c3b594a16aaa/raw/before-390.png) | ![After: athlete surname stays intact and age reduction remains visible at 390px](https://gist.githubusercontent.com/nopara73/56e8a47aa2189f123817c3b594a16aaa/raw/after-390.png) |

## Verification

- Playwright screenshot checks at `/leaderboard`, row `#rank-64`: 320px, 360px, 390px, and 667x375.
- Text-break metric check after fix: `brokenWords=0`, `wide=0`, and document width equals viewport at all checked sizes.
- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o ..\build-mobile-leaderboard-name-break`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only presentation changes in the leaderboard partial with no auth, data, or API impact.
> 
> **Overview**
> **Mobile leaderboard layout** now uses the stacked rank / athlete / score grid from **≤480px** (previously only at **≤300px**), so narrow viewports don’t cram the athlete column and age reduction into one tight table row.
> 
> Athlete names get **word-break** and **overflow** rules (`keep-all`, no hyphens inside names) plus **`min-width: 0`** on athlete cells so hyphenated surnames stay on one line. The age-reduction cell on small screens is a **flex** row with an inline label instead of a block label above the value. **≤300px** only reduces portrait size; the main mobile behavior lives in the **480px** block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4dff9d175cbabe19d5652821e7d267650468a5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->