### PR TITLE
[codex] Fix Swagger mobile wrapping

### DIFF
--- a/LongevityWorldCup.Website/Program.cs
+++ b/LongevityWorldCup.Website/Program.cs
@@ -342,6 +342,7 @@ namespace LongevityWorldCup.Website
 
             var lf = app.Services.GetRequiredService<ILoggerFactory>();
             EnvironmentHelpers.Log = lf.CreateLogger(nameof(EnvironmentHelpers));
+            var assetVersionProvider = app.Services.GetRequiredService<AssetVersionProvider>();
 
             // Configure the HTTP request pipeline.
             if (!app.Environment.IsDevelopment())
@@ -382,7 +383,7 @@ namespace LongevityWorldCup.Website
                 options.DisplayRequestDuration();
                 options.EnableDeepLinking();
                 options.EnableFilter();
-                options.InjectStylesheet("/css/swagger-ui-mobile.css");
+                options.InjectStylesheet(assetVersionProvider.AppendVersion("/css/swagger-ui-mobile.css"));
                 options.EnableTryItOutByDefault();
                 options.ShowCommonExtensions();
                 options.ShowExtensions();

--- a/LongevityWorldCup.Website/Program.cs
+++ b/LongevityWorldCup.Website/Program.cs
@@ -382,6 +382,7 @@ namespace LongevityWorldCup.Website
                 options.DisplayRequestDuration();
                 options.EnableDeepLinking();
                 options.EnableFilter();
+                options.InjectStylesheet("/css/swagger-ui-mobile.css");
                 options.EnableTryItOutByDefault();
                 options.ShowCommonExtensions();
                 options.ShowExtensions();

--- a/LongevityWorldCup.Website/wwwroot/css/swagger-ui-mobile.css
+++ b/LongevityWorldCup.Website/wwwroot/css/swagger-ui-mobile.css
@@ -1,0 +1,124 @@
+@media (max-width: 640px) {
+    .swagger-ui .wrapper {
+        padding-left: 1.25rem;
+        padding-right: 1.25rem;
+    }
+
+    .swagger-ui .topbar .wrapper,
+    .swagger-ui .scheme-container .schemes,
+    .swagger-ui .servers,
+    .swagger-ui .schemes-server-container,
+    .swagger-ui .download-url-wrapper {
+        min-width: 0;
+        max-width: 100%;
+    }
+
+    .swagger-ui .topbar .download-url-wrapper select,
+    .swagger-ui .servers select {
+        min-width: 0;
+        max-width: 100%;
+        text-overflow: ellipsis;
+    }
+
+    .swagger-ui .opblock .opblock-summary {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) 2.75rem;
+        align-items: start;
+        gap: 0.35rem;
+    }
+
+    .swagger-ui .opblock .opblock-summary-control {
+        display: grid;
+        grid-template-columns: minmax(4.35rem, auto) minmax(0, 1fr);
+        grid-template-areas:
+            "method path"
+            "description description"
+            "operation operation";
+        grid-column: 1;
+        min-width: 0;
+        width: 100%;
+        gap: 0.35rem 0.55rem;
+        text-align: left;
+    }
+
+    .swagger-ui .opblock .opblock-summary-method {
+        grid-area: method;
+        align-self: start;
+    }
+
+    .swagger-ui .opblock .opblock-summary-path-description-wrapper {
+        display: contents;
+    }
+
+    .swagger-ui .opblock .opblock-summary-path {
+        grid-area: path;
+        min-width: 0;
+        white-space: normal;
+        overflow-wrap: anywhere;
+    }
+
+    .swagger-ui .opblock .opblock-summary-operation-id {
+        grid-area: operation;
+        min-width: 0;
+        display: block;
+        text-align: left;
+        white-space: normal;
+        overflow-wrap: anywhere;
+    }
+
+    .swagger-ui .opblock .opblock-summary-description {
+        grid-area: description;
+        min-width: 0;
+        white-space: normal;
+        overflow-wrap: normal;
+    }
+
+    .swagger-ui .opblock .opblock-control-arrow {
+        grid-column: 2;
+        grid-row: 1;
+        justify-self: end;
+        min-width: 2.75rem;
+        min-height: 2.75rem;
+        padding: 0;
+    }
+
+    .swagger-ui .models,
+    .swagger-ui .model-container,
+    .swagger-ui .model-box,
+    .swagger-ui .model-box-control,
+    .swagger-ui .model-title,
+    .swagger-ui .model-title__text,
+    .swagger-ui .model {
+        min-width: 0;
+        max-width: 100%;
+    }
+
+    .swagger-ui .model-box-control,
+    .swagger-ui .model-title,
+    .swagger-ui .model-title__text,
+    .swagger-ui .model {
+        white-space: normal;
+        overflow-wrap: anywhere;
+        word-break: normal;
+    }
+}
+
+@media (max-width: 360px) {
+    .swagger-ui .wrapper {
+        padding-left: 1rem;
+        padding-right: 1rem;
+    }
+
+    .swagger-ui .opblock .opblock-summary {
+        grid-template-columns: minmax(0, 1fr) 2.5rem;
+    }
+
+    .swagger-ui .opblock .opblock-summary-control {
+        grid-template-columns: minmax(3.8rem, auto) minmax(0, 1fr);
+    }
+
+    .swagger-ui .opblock .opblock-control-arrow {
+        min-width: 2.5rem;
+        min-height: 2.5rem;
+    }
+}


### PR DESCRIPTION
## Summary

- add a small Swagger-only mobile stylesheet
- stack Swagger operation row details at mobile widths so API names do not fracture into narrow columns
- allow long schema/model identifiers to wrap inside their cards instead of clipping off the right edge

## Screenshot proof

Gist: https://gist.github.com/nopara73/f29fc826c604fa9d5c73ec62eee889fc

### Operation rows at 320px

| Before | After |
| --- | --- |
| <img src="https://gist.githubusercontent.com/nopara73/f29fc826c604fa9d5c73ec62eee889fc/raw/before-operations-320.png" width="320" alt="Before Swagger operation rows at 320px"> | <img src="https://gist.githubusercontent.com/nopara73/f29fc826c604fa9d5c73ec62eee889fc/raw/after-operations-320.png" width="320" alt="After Swagger operation rows at 320px"> |

### Schema names at 320px

| Before | After |
| --- | --- |
| <img src="https://gist.githubusercontent.com/nopara73/f29fc826c604fa9d5c73ec62eee889fc/raw/before-schemas-320.png" width="320" alt="Before Swagger schema names at 320px"> | <img src="https://gist.githubusercontent.com/nopara73/f29fc826c604fa9d5c73ec62eee889fc/raw/after-schemas-320.png" width="320" alt="After Swagger schema names at 320px"> |

### Schema names at 390px

| Before | After |
| --- | --- |
| <img src="https://gist.githubusercontent.com/nopara73/f29fc826c604fa9d5c73ec62eee889fc/raw/before-schemas-390.png" width="390" alt="Before Swagger schema names at 390px"> | <img src="https://gist.githubusercontent.com/nopara73/f29fc826c604fa9d5c73ec62eee889fc/raw/after-schemas-390.png" width="390" alt="After Swagger schema names at 390px"> |

## Verification

- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o ..\build-swagger-mobile-wrapping`
- `git diff --check`
- Raw Gist screenshots return `200 image/png`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Swagger UI styling only; no API, auth, or data-path changes.
> 
> **Overview**
> Adds a **Swagger-only mobile stylesheet** and loads it on the Swagger UI page via `InjectStylesheet`, with cache-busting through the existing `AssetVersionProvider`.
> 
> At **≤640px** width, operation rows use CSS grid so method, path, description, and operation id stack instead of squeezing into narrow columns; long paths and operation ids wrap. Schema/model titles and boxes get `min-width: 0` and wrapping so long type names don’t clip off-screen. A **≤360px** breakpoint tightens padding and control sizes slightly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9149c53fc8d26b2427a1ad745ad0c6c75534afec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->