### PR TITLE
[codex] Fit bioage step cards on mobile

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/css/bioageform.css
+++ b/LongevityWorldCup.Website/wwwroot/css/bioageform.css
@@ -73,6 +73,13 @@
     }
 }
 
+.bioageform .lwc-step {
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
+}
+
 /* Fieldset Styles */
 .bioageform fieldset {
     border: 1px solid rgba(148, 163, 184, 0.35);
@@ -84,6 +91,8 @@
     max-width: 100%;
     box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.85), 0 1px 2px rgba(15, 23, 42, 0.04);
     min-width: 0;
+    min-inline-size: 0;
+    align-self: stretch;
     box-sizing: border-box;
 }
 


### PR DESCRIPTION
## Summary

- make biological-age wizard steps fill the calculator form instead of sizing to max-content
- reset fieldset inline sizing so biomarker groups stay inside the mobile form surface

## Screenshot proof

Gist: https://gist.github.com/nopara73/aa7e6379ca5a1bcc7421d18c6885c34c

### Pheno age step 2 at 320px

| Before | After |
| --- | --- |
| <img src="https://gist.githubusercontent.com/nopara73/aa7e6379ca5a1bcc7421d18c6885c34c/raw/before-pheno-step2-320.png" width="320" alt="Before Pheno age step-2 fieldsets at 320px"> | <img src="https://gist.githubusercontent.com/nopara73/aa7e6379ca5a1bcc7421d18c6885c34c/raw/after-pheno-step2-320.png" width="320" alt="After Pheno age step-2 fieldsets at 320px"> |

### 390px verification

<img src="https://gist.githubusercontent.com/nopara73/aa7e6379ca5a1bcc7421d18c6885c34c/raw/after-pheno-step2-390.png" width="390" alt="After Pheno age step-2 fieldsets at 390px">

## Verification

- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o ..\build-bioage-step-fieldsets-mobile`
- `git diff --check`
- 320px Pheno step-2 metrics: body scroll width `323 -> 320`, wide elements `5 -> 0`
- 390px Pheno step-2 metrics: wide elements `0`
- Raw Gist screenshots return `200 image/png`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS in `bioageform.css` with no backend, auth, or data changes.
> 
> **Overview**
> **Mobile layout fix** for the biological-age calculator so wizard steps and biomarker fieldsets stay inside the form instead of sizing to content and causing horizontal overflow.
> 
> Adds `.bioageform .lwc-step` rules so each step uses **100% width** with `min-width: 0` and border-box sizing. Updates `.bioageform fieldset` with **`min-inline-size: 0`** and **`align-self: stretch`** so grouped inputs respect the flex column and don’t spill past ~320px viewports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d95d45501254041ba681f1056e9a19f88755936a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->