### PR TITLE
[codex] Fix event embed font fallback

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/event-board-embed.html
+++ b/LongevityWorldCup.Website/wwwroot/event-board-embed.html
@@ -18,7 +18,8 @@
             padding: 0;
             height: auto;
             min-height: 0;
-            background: transparent
+            background: transparent;
+            font-family: Roboto, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
         }
         :root[data-embed-theme="dark"]{
             --card-bg:rgba(255,255,255,.045);


### PR DESCRIPTION
## What changed

- Adds a local UI font stack to the standalone event-board embed shell.
- Keeps the existing iframe parent/message font override behavior intact.

## Why

A valid direct embed URL loaded without the normal site header body styles, so event text fell back to the browser-default serif font. The embed should still look like the Longevity World Cup UI when viewed directly or embedded before a parent page sends theme values.

Valid proof URL:

/event-board-embed.html?athlete=andressa-lohana-de-almeida&rows=all&viewAll=false&linkNames=false&embed=1

## Screenshot proof

Gist: https://gist.github.com/nopara73/816806932d9950962408e60f90a7226b

### Light theme, 320px

| Before | After |
| --- | --- |
| ![Before: direct event embed uses a browser-default serif font](https://gist.githubusercontent.com/nopara73/816806932d9950962408e60f90a7226b/raw/696bc6682621cd955265b187530c48ce4e3aa519/event-embed-font-before-320.png) | ![After: direct event embed uses the site UI sans-serif font](https://gist.githubusercontent.com/nopara73/816806932d9950962408e60f90a7226b/raw/e5a54327c224b4d3ba90430975b783fe1faf2f5f/event-embed-font-after-320.png) |

### Dark theme, 320px

| Before | After |
| --- | --- |
| ![Before: dark direct event embed uses a browser-default serif font](https://gist.githubusercontent.com/nopara73/816806932d9950962408e60f90a7226b/raw/5948af0665d9101978b52d974df0dfc94e9abc0f/event-embed-font-before-dark-320.png) | ![After: dark direct event embed uses the site UI sans-serif font](https://gist.githubusercontent.com/nopara73/816806932d9950962408e60f90a7226b/raw/fbd6159ec19213ccfdb0acfc01f9f9079670887c/event-embed-font-after-dark-320.png) |

## Verification

- Playwright screenshot at 320x700: light direct embed changes from browser-default serif event text to the site UI sans-serif font.
- Playwright screenshot at 320x700: dark direct embed receives the same font correction.
- Playwright metric check at 320 and 390: document scroll width equals viewport width, with no wide elements and no broken long words.
- dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o ..\build-event-embed-font
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file CSS tweak in a static embed shell; no auth, data, or runtime logic changes.
> 
> **Overview**
> **Fixes browser-default serif typography** when `event-board-embed.html` is opened directly (without the main site layout styles).
> 
> The embed shell now sets a **Roboto / system UI sans-serif stack** on `html, body`, matching the Longevity World Cup look before any parent iframe theme runs. Existing **parent `font-family` copy** and **`events-theme-vars` message overrides** are unchanged, so embedded views can still inherit the host page font.
> 
> Also corrects a missing semicolon on `background: transparent` in the same rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8936ad543f46b8e24847efcc3fe315fcb08cfe3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->