### PR TITLE
[codex] Keep sticky play button inside mobile header

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/partials/header.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/header.html
@@ -651,6 +651,7 @@
         .scrolled-button {
             top: max(0.35rem, env(safe-area-inset-top, 0px));
             right: max(0.5rem, env(safe-area-inset-right, 0px));
+            margin-top: 0;
             min-width: 4.25rem;
             padding: 0.55rem 0.85rem;
             font-size: 0.95rem;
@@ -726,7 +727,7 @@
             font-size: 0.96rem;
         }
 
-        .join-game {
+        .join-game:not(.scrolled-button) {
             padding-inline: 1.45rem;
         }
     }
@@ -753,7 +754,7 @@
             font-size: 0.95rem;
         }
 
-        .join-game {
+        .join-game:not(.scrolled-button) {
             margin-top: 0.9rem;
             padding: 0.75rem 1.45rem;
             font-size: 1.08rem;


### PR DESCRIPTION
## What changed

- Keeps the fixed sticky `PLAY` button inside the mobile sticky header.
- Scopes compact-screen hero button sizing so it no longer overrides `.scrolled-button`.
- Resets the fixed scrolled button margin inside the mobile sticky-button rule.

## Why

On the Longevitymaxxing page at normal mobile widths, the sticky `PLAY` button inherited the large hero button mobile margin and padding after scrolling. The button dropped below the sticky header and visually covered the Challenge content.

Proof route: `/longevitymaxxing/longevitymaxxing.html` at scroll position `720px`.

## Screenshot proof

Gist: https://gist.github.com/nopara73/1bd77a409b79ff91ba727950e5fd15f4

### 390px mobile width

| Before | After |
| --- | --- |
| ![Before: sticky PLAY button drops below the header and overlaps the Challenge content](https://gist.githubusercontent.com/nopara73/1bd77a409b79ff91ba727950e5fd15f4/raw/c7de7a19f4d6d6e14c1a89edb21f70f2c71ab1de/sticky-play-before-390.png) | ![After: sticky PLAY button stays inside the header and leaves the content clear](https://gist.githubusercontent.com/nopara73/1bd77a409b79ff91ba727950e5fd15f4/raw/fddac66a99e909aeb22fbe6d6a908eaf1fab4124/sticky-play-after-390.png) |

### 320px mobile width

| Before | After |
| --- | --- |
| ![Before: sticky PLAY button overlaps the Challenge cards at 320px](https://gist.githubusercontent.com/nopara73/1bd77a409b79ff91ba727950e5fd15f4/raw/09d6b147c70a38249d25b11971e31378085d3ef3/sticky-play-before-320.png) | ![After: sticky PLAY button is contained in the sticky header at 320px](https://gist.githubusercontent.com/nopara73/1bd77a409b79ff91ba727950e5fd15f4/raw/db892f3ce28b57011f8e16b0d5416287ae2f8d0e/sticky-play-after-320.png) |

## Verification

- Playwright screenshots at 390x760 and 320x760 after scrolling to 720px.
- Geometry check after the fix: sticky header bottom is 52px; button bottom is 50px at both 390px and 320px.
- Playwright metric check: document scroll width equals viewport width at 390px and 320px, with no wide elements or broken long words.
- dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o ..\build-sticky-play-mobile-overlap
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only presentation changes in shared header partials; no logic or data paths affected.
> 
> **Overview**
> Fixes mobile layout so the fixed **PLAY** button stays aligned with the sticky header after scroll instead of inheriting the hero CTA’s spacing and overlapping page content.
> 
> In the `max-width: 768px` block, **`.scrolled-button`** now explicitly sets **`margin-top: 0`**. Compact-screen rules that targeted **`.join-game`** for extra margin, padding, and font size now use **`.join-game:not(.scrolled-button)`**, so those hero-only tweaks no longer apply when the button has the scrolled/fixed styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63bfdd45de7fd476db0f8aacbf675f859c58d881. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->