### PR TITLE
[codex] Stop Events page auto-scrolling on load

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/event-board/event-board.html
+++ b/LongevityWorldCup.Website/wwwroot/event-board/event-board.html
@@ -128,12 +128,6 @@
     history.replaceState({}, '', '/events' + (window.location.search || '') + (window.location.hash || ''));
 
     function initEventBoard() {
-        const titleEl = document.getElementById('eventBoardTitle');
-        if (titleEl && titleEl.scrollIntoView) {
-            setTimeout(() => {
-                titleEl.scrollIntoView({ behavior: 'smooth', block: 'start' });
-            }, 500);
-        }
         if (typeof window.loadEventsTable === 'function') {
             window.loadEventsTable(Infinity, false);
         } else {


### PR DESCRIPTION
## What changed

- Removes the unconditional delayed `scrollIntoView` from the standalone Events page load.
- Keeps the canonical `/events` URL replacement and full events table loading behavior.

## Why

The Events page was auto-scrolling itself to the `Highlights` heading about half a second after load. On mobile this skipped the full site header and left the page opened under the compact sticky header before the user touched the page.

Proof route: `/events`.

## Screenshot proof

Gist: https://gist.github.com/nopara73/48facdbcc40ed600fe8efc469e5bcd10

### 390px mobile width

| Before | After |
| --- | --- |
| ![Before: events page loads already scrolled to the compact sticky header](https://gist.githubusercontent.com/nopara73/48facdbcc40ed600fe8efc469e5bcd10/raw/fd8046e4fd0974f4c7e21553f54423caca57ee60/events-load-before-390.png) | ![After: events page loads at the normal page top with the full header visible](https://gist.githubusercontent.com/nopara73/48facdbcc40ed600fe8efc469e5bcd10/raw/1d52cdd249b21143d6db70159d48e28bfa5ab80d/events-load-after-390.png) |

### 320px mobile width

| Before | After |
| --- | --- |
| ![Before: events page starts below the full header at 320px](https://gist.githubusercontent.com/nopara73/48facdbcc40ed600fe8efc469e5bcd10/raw/6d299b56210c093ea10169d464c31ae50d67750b/events-load-before-320.png) | ![After: events page starts at scroll position zero at 320px](https://gist.githubusercontent.com/nopara73/48facdbcc40ed600fe8efc469e5bcd10/raw/a033018b46f30805e367195aa31b7fb5577496f9/events-load-after-320.png) |

## Verification

- Playwright screenshot at 390x760: before loaded at `scrollY=162`; after loads at `scrollY=0`.
- Playwright screenshot at 320x760: before loaded at `scrollY=161`; after loads at `scrollY=0`.
- Playwright metric check: document scroll width equals viewport width at 390px and 320px, with no wide elements.
- dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o ..\build-events-load-scroll
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small client-side UX change on one static page; no auth, data, or API impact.
> 
> **Overview**
> Fixes the standalone **Events** page (`/events`) jumping down to the **Highlights** heading ~500ms after load, which on mobile hid the full site header and left users under the compact sticky header.
> 
> Removes the delayed `scrollIntoView` on `#eventBoardTitle` from `initEventBoard` in `event-board.html`. **Canonical URL** `history.replaceState` and **`loadEventsTable(Infinity, false)`** on init are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c45bc2795310b745764b9fcfe73370065e3ef111. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->