### PR TITLE
[codex] Stop application review auto-scroll on load

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/onboarding/application-review.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/application-review.html
@@ -325,11 +325,6 @@
         removeSessionItem("came-from");
 
         document.addEventListener('DOMContentLoaded', function () {
-            setTimeout(() => {
-                const viewTarget = document.querySelector('h1');
-                viewTarget.scrollIntoView({ behavior: 'smooth', block: 'start' });
-            }, 500);
-
             if (isNewResultsUploaded) {
                 document.getElementById("appReviewText").textContent = "Result review";
                 document.getElementById("whatAreWeReviewing").textContent = "your new results";


### PR DESCRIPTION
## What changed

- Removes the unconditional delayed `scrollIntoView` from the application review page load.
- Keeps the review-source text changes and paid-invoice notification logic untouched.

## Why

The application review page was auto-scrolling itself to the page title shortly after load. On mobile and landscape widths this skipped the full site header and opened the page under the compact sticky bar before the user touched the page.

Proof route: `/onboarding/application-review.html`.

## Screenshot proof

Gist: https://gist.github.com/nopara73/3bc61a021f3340661517055cf942e40e

### 390px mobile width

| Before | After |
| --- | --- |
| ![Before: application review loads under the compact sticky header](https://gist.githubusercontent.com/nopara73/3bc61a021f3340661517055cf942e40e/raw/3e3337fd657129e19094462de41d689a984b9bdf/application-review-before-390.png) | ![After: application review starts at the normal page top with the full header visible](https://gist.githubusercontent.com/nopara73/3bc61a021f3340661517055cf942e40e/raw/8e2e3e441b0d3b061c9d251de4c730fe1b9c74ba/application-review-after-390.png) |

### 320px mobile width

| Before | After |
| --- | --- |
| ![Before: application review starts after the full header at 320px](https://gist.githubusercontent.com/nopara73/3bc61a021f3340661517055cf942e40e/raw/4fa11040b6cf00c682b1ebe8c6274ad11f86eddd/application-review-before-320.png) | ![After: application review starts at scroll position zero at 320px](https://gist.githubusercontent.com/nopara73/3bc61a021f3340661517055cf942e40e/raw/bc708fe8c95c914c7507d4690236da0834a7129d/application-review-after-320.png) |

### Mobile landscape

| Before | After |
| --- | --- |
| ![Before: landscape application review opens below the full header](https://gist.githubusercontent.com/nopara73/3bc61a021f3340661517055cf942e40e/raw/a12cd7fd37f0907903d4ac0d1d3c65546f6cf70d/application-review-before-landscape.png) | ![After: landscape application review opens at the full header](https://gist.githubusercontent.com/nopara73/3bc61a021f3340661517055cf942e40e/raw/520cd267b701ab00c52eae802b075ed792311d3a/application-review-after-landscape.png) |

## Verification

- Playwright screenshot at 390x760: before loaded at `scrollY=180`; after loads at `scrollY=0`.
- Playwright screenshot at 320x760: before loaded at `scrollY=180`; after loads at `scrollY=0`.
- Playwright landscape screenshot at 667x375: before loaded at `scrollY=101`; after loads at `scrollY=0`.
- Playwright metric check: document scroll width equals viewport width at 390px, 320px, and 667px landscape, with no wide elements or broken long words.
- dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o ..\build-application-review-load-scroll
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-page UX tweak with no API, auth, or data-handling changes.
> 
> **Overview**
> Removes the **500ms delayed `scrollIntoView` on the page `h1`** from `application-review.html`’s `DOMContentLoaded` handler so the route loads at the natural top of the document.
> 
> Review-source copy updates (result vs edit vs application) and **`maybeNotifyPaidInvoice`** behavior are unchanged; only the automatic scroll-on-load is gone, which fixes mobile and landscape cases where the page opened under the compact sticky header instead of showing the full site header.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a030f0542648d06fd7319275ac1ba2264bdc3624. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->