### PR TITLE
[codex] Stop progress load auto-scroll

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/partials/main-progress-bar.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/main-progress-bar.html
@@ -201,22 +201,6 @@
         document.addEventListener('DOMContentLoaded', function () {
             var stickyProgressContentGap = 12;
 
-            setTimeout(function () {
-                // Scroll to the content under the progress bar so it sits just below the sticky header + progress bar (no overscroll)
-                var stickyHeader = document.getElementById('site-sticky-header');
-                var stickyProgress = document.getElementById('site-sticky-progress');
-                var contentStart = stickyProgress && stickyProgress.nextElementSibling;
-                if (contentStart && contentStart.tagName === 'SCRIPT') contentStart = contentStart.nextElementSibling;
-                if (contentStart) {
-                    var headerHeight = (stickyHeader && stickyHeader.offsetHeight) || 52;
-                    var progressHeight = 44; /* #site-sticky-progress when visible */
-                    var topOffset = headerHeight + progressHeight + stickyProgressContentGap;
-                    var contentTop = contentStart.getBoundingClientRect().top + (window.scrollY || window.pageYOffset);
-                    var targetScroll = contentTop - topOffset;
-                    window.scrollTo({ top: Math.max(0, targetScroll), behavior: 'smooth' });
-                }
-            }, 500);
-
             // Sticky progress: show only when it would completely cover the in-page progress bar (not the main site header)
             var mainProgressBar = document.getElementById('mainProgressBar');
             var stickyHeader = document.getElementById('site-sticky-header');


### PR DESCRIPTION
## What changed

- Removes the shared progress partial's unconditional delayed scroll on page load.
- Keeps the sticky progress visibility and scroll-padding behavior intact.

## Why

Pages that include the shared progress bar, such as `/apply`, were stealing the initial scroll position shortly after load. At realistic mobile widths the first viewport jumped past the site header and started in the middle of the application flow.

## Screenshot proof

Gist: https://gist.github.com/nopara73/6521660b1e38a2a30bcce90b24e0d16b

### 390px mobile

| Before | After |
| --- | --- |
| ![Before: apply page auto-scrolls to the form content at 390px](https://gist.githubusercontent.com/nopara73/6521660b1e38a2a30bcce90b24e0d16b/raw/47f43b1e07a1ddd446b302dc31d7e38ccc1bb61a/apply-before-390.png) | ![After: apply page starts at the top at 390px](https://gist.githubusercontent.com/nopara73/6521660b1e38a2a30bcce90b24e0d16b/raw/cfd48ee9655fe1968fa85dbd9641745c2f100e08/apply-after-390.png) |

### 320px mobile

| Before | After |
| --- | --- |
| ![Before: apply page auto-scrolls at 320px](https://gist.githubusercontent.com/nopara73/6521660b1e38a2a30bcce90b24e0d16b/raw/d6cfa24a60369597a3d9e3440f4b5fb6ed11fb35/apply-before-320.png) | ![After: apply page stays at the top at 320px](https://gist.githubusercontent.com/nopara73/6521660b1e38a2a30bcce90b24e0d16b/raw/2f31d904dbfa434cae50779cb98e751d63a5599b/apply-after-320.png) |

### Mobile landscape

| Before | After |
| --- | --- |
| ![Before: apply page auto-scrolls in mobile landscape](https://gist.githubusercontent.com/nopara73/6521660b1e38a2a30bcce90b24e0d16b/raw/cdc8f779cd1e62979c7f472c7aed650b0439aa09/apply-before-landscape.png) | ![After: apply page stays at the top in mobile landscape](https://gist.githubusercontent.com/nopara73/6521660b1e38a2a30bcce90b24e0d16b/raw/54bb5b7f3c48fe48a77bd6f3b9a3f4696e907a69/apply-after-landscape.png) |

## Verification

- Playwright screenshot probe at `/apply`, 390x760: before `scrollY=228`, after `scrollY=0`.
- Playwright screenshot probe at `/apply`, 320x760: before `scrollY=228`, after `scrollY=0`.
- Playwright screenshot probe at `/apply`, 667x375: before `scrollY=122`, after `scrollY=0`.
- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o ..\.artifacts\build-progress-autoscroll`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small client-side UX change in one partial with no auth, data, or API impact; only risk is if something relied on the old auto-scroll positioning.
> 
> **Overview**
> **Removes** the shared `main-progress-bar` partial’s **500ms delayed `window.scrollTo`** on `DOMContentLoaded`, which had been scrolling past the site header to the first content block below the progress bar.
> 
> Pages that inject this partial (e.g. `/apply`) now **keep the initial scroll at the top** instead of jumping mid-flow on mobile. **Sticky progress** show/hide, `scrollPaddingTop`, and `updateMainProgress` / `hideMainProgress` behavior are **unchanged**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 044594cdcda6dcf54732001005cf9f70a4026954. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->