### PR TITLE
[codex] Stop leaderboard load auto-scroll

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/leaderboard/leaderboard.html
+++ b/LongevityWorldCup.Website/wwwroot/leaderboard/leaderboard.html
@@ -24,10 +24,6 @@
     history.replaceState({}, '', '/leaderboard' + (window.location.search || '') + (window.location.hash || ''));
 
     document.addEventListener('DOMContentLoaded', function () {
-        setTimeout(() => {
-            const leaderboardTitle = document.getElementById('leaderboardTitle');
-            leaderboardTitle.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        }, 500);
         LoadLeaderboard(false, Infinity);
     });
 </script>


### PR DESCRIPTION
## What changed

- Removes the leaderboard page's unconditional delayed `scrollIntoView` on load.
- Keeps the canonical `/leaderboard` URL rewrite and `LoadLeaderboard(false, Infinity)` initialization unchanged.

## Why

The leaderboard page was stealing the initial scroll position shortly after load. At realistic mobile widths the first viewport skipped the top hero/header context and landed partway down the page.

## Screenshot proof

Gist: https://gist.github.com/nopara73/c2c2a6242a33d4907a4fe33a6260336a

### 390px mobile

| Before | After |
| --- | --- |
| ![Before: leaderboard page auto-scrolls under the sticky header at 390px](https://gist.githubusercontent.com/nopara73/c2c2a6242a33d4907a4fe33a6260336a/raw/6f16997503babd72205f1e11c2e4168987eea3a7/leaderboard-before-390.png) | ![After: leaderboard page starts at the top at 390px](https://gist.githubusercontent.com/nopara73/c2c2a6242a33d4907a4fe33a6260336a/raw/6b45adf3f1c943e0a1229c07ceb32010b4ef1fcf/leaderboard-after-390.png) |

### 320px mobile

| Before | After |
| --- | --- |
| ![Before: leaderboard page auto-scrolls at 320px](https://gist.githubusercontent.com/nopara73/c2c2a6242a33d4907a4fe33a6260336a/raw/b3fc4056cad7d87635a68e2c9d584e96ff589086/leaderboard-before-320.png) | ![After: leaderboard page starts at the top at 320px](https://gist.githubusercontent.com/nopara73/c2c2a6242a33d4907a4fe33a6260336a/raw/15393a5e3f73f50ede3ad73b9a55b551ba72e8d6/leaderboard-after-320.png) |

### Mobile landscape

| Before | After |
| --- | --- |
| ![Before: leaderboard page auto-scrolls in mobile landscape](https://gist.githubusercontent.com/nopara73/c2c2a6242a33d4907a4fe33a6260336a/raw/1e71d7f957cfb7c2e919b731e1be6f6aea2201d1/leaderboard-before-landscape.png) | ![After: leaderboard page starts at the top in mobile landscape](https://gist.githubusercontent.com/nopara73/c2c2a6242a33d4907a4fe33a6260336a/raw/f26d843018e0064b838d1097fafa1d11de244034/leaderboard-after-landscape.png) |

## Verification

- Playwright screenshot probe at `/leaderboard`, 390x760: before `scrollY=221`, after `scrollY=0`.
- Playwright screenshot probe at `/leaderboard`, 320x760: before `scrollY=219`, after `scrollY=0`.
- Playwright screenshot probe at `/leaderboard`, 667x375: before `scrollY=55`, after `scrollY=0`.
- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o ..\.artifacts\build-leaderboard-autoscroll`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-page client-side scroll behavior removal with no auth, data, or API impact.
> 
> **Overview**
> Removes the **500ms delayed `scrollIntoView`** on `#leaderboardTitle` when the dedicated leaderboard page loads, so the viewport stays at the top instead of jumping past the hero/header (especially on narrow mobile widths).
> 
> **Unchanged:** canonical `/leaderboard` URL rewrite via `history.replaceState` and `LoadLeaderboard(false, Infinity)` on `DOMContentLoaded`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 980051ae89f4c0ab6c32ef708fd98e37108c1188. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->