### PR TITLE
[codex] Stop proof upload load auto-scroll

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/play/proof-upload.html
+++ b/LongevityWorldCup.Website/wwwroot/play/proof-upload.html
@@ -728,11 +728,6 @@
         setSubmitButtonLabel();
 
         document.addEventListener('DOMContentLoaded', function () {
-            setTimeout(() => {
-                const viewTarget = document.querySelector('h1');
-                viewTarget.scrollIntoView({ behavior: 'smooth', block: 'start' });
-            }, 500);
-
             document.getElementById('character-title').textContent = getAthleteDisplayName();
 
             const mainProofInstructions = document.getElementById('mainProofInstructions');


### PR DESCRIPTION
## What changed

- Removes the proof-upload page's unconditional delayed `scrollIntoView` on load.
- Keeps selected-athlete validation, proof instructions, and upload setup unchanged.

## Why

When a player with a selected athlete lands on `/proofs`, the page was stealing the initial scroll position shortly after load. At realistic mobile widths the first viewport skipped the top hero/header context and landed partway down the proof upload flow.

## Screenshot proof

Gist: https://gist.github.com/nopara73/164926a6ee9b288fa8ee5a42e215324b

These screenshots use the normal selected-athlete session state required to access `/proofs`.

### 390px mobile

| Before | After |
| --- | --- |
| ![Before: proof upload page auto-scrolls under the sticky header at 390px](https://gist.githubusercontent.com/nopara73/164926a6ee9b288fa8ee5a42e215324b/raw/815cc7d0685a652b99034b7b9530b39c6cc29ea7/proof-upload-before-390.png) | ![After: proof upload page starts at the top at 390px](https://gist.githubusercontent.com/nopara73/164926a6ee9b288fa8ee5a42e215324b/raw/9d4797221e8c1ca9364f2ab41c10604f6941361e/proof-upload-after-390.png) |

### 320px mobile

| Before | After |
| --- | --- |
| ![Before: proof upload page auto-scrolls at 320px](https://gist.githubusercontent.com/nopara73/164926a6ee9b288fa8ee5a42e215324b/raw/dbb603999b2455ea366775544c63709ad71dd09c/proof-upload-before-320.png) | ![After: proof upload page starts at the top at 320px](https://gist.githubusercontent.com/nopara73/164926a6ee9b288fa8ee5a42e215324b/raw/ce6874a658666f6313c02fb2482e32be85467fe6/proof-upload-after-320.png) |

### Mobile landscape

| Before | After |
| --- | --- |
| ![Before: proof upload page auto-scrolls in mobile landscape](https://gist.githubusercontent.com/nopara73/164926a6ee9b288fa8ee5a42e215324b/raw/e0010f3e13575cc05f9bda8cba319ebd17e1e808/proof-upload-before-landscape.png) | ![After: proof upload page starts at the top in mobile landscape](https://gist.githubusercontent.com/nopara73/164926a6ee9b288fa8ee5a42e215324b/raw/3523f4876bf3dc4a3a16c227018281a7d2f6a455/proof-upload-after-landscape.png) |

## Verification

- Playwright screenshot probe at `/proofs` with selected-athlete session state, 390x760: before `scrollY=166`, after `scrollY=0`.
- Playwright screenshot probe at `/proofs` with selected-athlete session state, 320x760: before `scrollY=166`, after `scrollY=0`.
- Playwright screenshot probe at `/proofs` with selected-athlete session state, 667x375: before `scrollY=45`, after `scrollY=0`.
- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o ..\.artifacts\build-proof-upload-autoscroll`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-page client-side UX tweak with no API, auth, or data-path changes.
> 
> **Overview**
> Removes the **`DOMContentLoaded`** handler that waited 500ms and called **`scrollIntoView`** on the page **`h1`**, so `/proofs` keeps the browser’s natural scroll position (top of the page) instead of jumping partway down the flow.
> 
> Athlete title, proof instructions, and upload/submit wiring are unchanged; only the load-time scroll behavior is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab4d272f23ddbd505708cfc23f2219a2f4a17df2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->