### PR TITLE
[codex] Stop edit profile load auto-scroll

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/play/edit-profile.html
+++ b/LongevityWorldCup.Website/wwwroot/play/edit-profile.html
@@ -676,11 +676,6 @@
         setSubmitChangeRequestButton();
 
         document.addEventListener('DOMContentLoaded', function () {
-            setTimeout(() => {
-                const viewTarget = document.querySelector('h1');
-                viewTarget.scrollIntoView({ behavior: 'smooth', block: 'start' });
-            }, 500);
-
             const athleteDisplayName = getAthleteDisplayName();
             document.getElementById('character-title').textContent = athleteDisplayName;
             const athleteImage = document.createElement('img');


### PR DESCRIPTION
## What changed

- Removes the edit-profile page's unconditional delayed `scrollIntoView` on load.
- Keeps selected-athlete validation, profile field setup, and form behavior unchanged.

## Why

When a player with a selected athlete lands on `/edit-profile`, the page was stealing the initial scroll position shortly after load. At realistic mobile widths the first viewport skipped the top hero/header context and landed partway down the edit flow.

## Screenshot proof

Gist: https://gist.github.com/nopara73/7e3e04cefe5ef01f6e6cd021a8bc0292

These screenshots use the normal selected-athlete session state required to access `/edit-profile`.

### 390px mobile

| Before | After |
| --- | --- |
| ![Before: edit profile page auto-scrolls under the sticky header at 390px](https://gist.githubusercontent.com/nopara73/7e3e04cefe5ef01f6e6cd021a8bc0292/raw/46b937bff6892403b79e9870806589c5cc3953bc/edit-profile-before-390.png) | ![After: edit profile page starts at the top at 390px](https://gist.githubusercontent.com/nopara73/7e3e04cefe5ef01f6e6cd021a8bc0292/raw/2deeba69e751c42c4da46094f59e7259223ac1bd/edit-profile-after-390.png) |

### 320px mobile

| Before | After |
| --- | --- |
| ![Before: edit profile page auto-scrolls at 320px](https://gist.githubusercontent.com/nopara73/7e3e04cefe5ef01f6e6cd021a8bc0292/raw/e4a907ecf694c71c9e3d3aaa68df1be856e7f482/edit-profile-before-320.png) | ![After: edit profile page starts at the top at 320px](https://gist.githubusercontent.com/nopara73/7e3e04cefe5ef01f6e6cd021a8bc0292/raw/75b1a561022d1052bff7d894be69092db7fe3274/edit-profile-after-320.png) |

### Mobile landscape

| Before | After |
| --- | --- |
| ![Before: edit profile page auto-scrolls in mobile landscape](https://gist.githubusercontent.com/nopara73/7e3e04cefe5ef01f6e6cd021a8bc0292/raw/aaa6c14fbf31c95d184924f89db20d42dbe59488/edit-profile-before-landscape.png) | ![After: edit profile page starts at the top in mobile landscape](https://gist.githubusercontent.com/nopara73/7e3e04cefe5ef01f6e6cd021a8bc0292/raw/09f4deae1a69ed32bd8dbc6a395b4d1c65044d2b/edit-profile-after-landscape.png) |

## Verification

- Playwright screenshot probe at `/edit-profile` with selected-athlete session state, 390x760: before `scrollY=174`, after `scrollY=0`.
- Playwright screenshot probe at `/edit-profile` with selected-athlete session state, 320x760: before `scrollY=174`, after `scrollY=0`.
- Playwright screenshot probe at `/edit-profile` with selected-athlete session state, 667x375: before `scrollY=45`, after `scrollY=0`.
- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o ..\.artifacts\build-edit-profile-autoscroll`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line deletion of client-side scroll behavior on one static page; no API, auth, or data changes.
> 
> **Overview**
> Removes the **500ms delayed `scrollIntoView` on the page `h1`** that ran inside the `DOMContentLoaded` handler on `edit-profile.html`. The page no longer jumps the viewport after load; users land at the natural top scroll position (including under the sticky header on narrow mobile widths).
> 
> All other load-time setup in that handler—title, headshot, restore buttons, division/flag fields, and submit logic—is unchanged. **Flag autocomplete keyboard navigation** still uses `scrollIntoView({ block: 'nearest' })` for list items only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7975e193e2f6b6901ebc10b0ad7e3d8fe9198f4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->