### PR TITLE
[codex] Fit error pages in mobile landscape

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/error/502.html
+++ b/LongevityWorldCup.Website/wwwroot/error/502.html
@@ -211,6 +211,75 @@
       }
     }
 
+    @media (min-width: 560px) and (max-width: 700px) and (max-height: 480px) {
+      body {
+        place-items: center;
+        padding: 0.75rem;
+      }
+
+      .error-card {
+        width: min(100%, 620px);
+      }
+
+      .card-bar {
+        min-height: 46px;
+        padding: 0.45rem 0.75rem;
+      }
+
+      .mark {
+        width: 1.75rem;
+        height: 1.75rem;
+        border-radius: 6px;
+        box-shadow: 2px 2px 0 var(--line);
+      }
+
+      .code {
+        padding: 0.2rem 0.45rem;
+        font-size: 0.75rem;
+      }
+
+      .card-body {
+        grid-template-columns: minmax(120px, 150px) minmax(0, 1fr);
+        gap: 1rem;
+        padding: 0.9rem 1rem;
+      }
+
+      .visual {
+        width: 100%;
+        box-shadow: 3px 3px 0 var(--line);
+      }
+
+      .visual img {
+        aspect-ratio: 4 / 3;
+        object-position: center 28%;
+      }
+
+      h1 {
+        font-size: clamp(2rem, 7vw, 3rem);
+      }
+
+      .joke {
+        margin-top: 0.45rem;
+        font-size: 1rem;
+        line-height: 1.25;
+      }
+
+      .note {
+        margin-top: 0.35rem;
+        font-size: 0.9rem;
+        line-height: 1.3;
+      }
+
+      .actions {
+        margin-top: 0.65rem;
+      }
+
+      button {
+        min-height: 40px;
+        padding: 0 0.85rem;
+      }
+    }
+
     @media (max-width: 480px) {
       .card-bar {
         align-items: flex-start;

--- a/LongevityWorldCup.Website/wwwroot/error/503.html
+++ b/LongevityWorldCup.Website/wwwroot/error/503.html
@@ -211,6 +211,75 @@
       }
     }
 
+    @media (min-width: 560px) and (max-width: 700px) and (max-height: 480px) {
+      body {
+        place-items: center;
+        padding: 0.75rem;
+      }
+
+      .error-card {
+        width: min(100%, 620px);
+      }
+
+      .card-bar {
+        min-height: 46px;
+        padding: 0.45rem 0.75rem;
+      }
+
+      .mark {
+        width: 1.75rem;
+        height: 1.75rem;
+        border-radius: 6px;
+        box-shadow: 2px 2px 0 var(--line);
+      }
+
+      .code {
+        padding: 0.2rem 0.45rem;
+        font-size: 0.75rem;
+      }
+
+      .card-body {
+        grid-template-columns: minmax(120px, 150px) minmax(0, 1fr);
+        gap: 1rem;
+        padding: 0.9rem 1rem;
+      }
+
+      .visual {
+        width: 100%;
+        box-shadow: 3px 3px 0 var(--line);
+      }
+
+      .visual img {
+        aspect-ratio: 4 / 3;
+        object-position: center 28%;
+      }
+
+      h1 {
+        font-size: clamp(2rem, 7vw, 3rem);
+      }
+
+      .joke {
+        margin-top: 0.45rem;
+        font-size: 1rem;
+        line-height: 1.25;
+      }
+
+      .note {
+        margin-top: 0.35rem;
+        font-size: 0.9rem;
+        line-height: 1.3;
+      }
+
+      .actions {
+        margin-top: 0.65rem;
+      }
+
+      button {
+        min-height: 40px;
+        padding: 0 0.85rem;
+      }
+    }
+
     @media (max-width: 480px) {
       .card-bar {
         align-items: flex-start;

--- a/LongevityWorldCup.Website/wwwroot/error/504.html
+++ b/LongevityWorldCup.Website/wwwroot/error/504.html
@@ -211,6 +211,75 @@
       }
     }
 
+    @media (min-width: 560px) and (max-width: 700px) and (max-height: 480px) {
+      body {
+        place-items: center;
+        padding: 0.75rem;
+      }
+
+      .error-card {
+        width: min(100%, 620px);
+      }
+
+      .card-bar {
+        min-height: 46px;
+        padding: 0.45rem 0.75rem;
+      }
+
+      .mark {
+        width: 1.75rem;
+        height: 1.75rem;
+        border-radius: 6px;
+        box-shadow: 2px 2px 0 var(--line);
+      }
+
+      .code {
+        padding: 0.2rem 0.45rem;
+        font-size: 0.75rem;
+      }
+
+      .card-body {
+        grid-template-columns: minmax(120px, 150px) minmax(0, 1fr);
+        gap: 1rem;
+        padding: 0.9rem 1rem;
+      }
+
+      .visual {
+        width: 100%;
+        box-shadow: 3px 3px 0 var(--line);
+      }
+
+      .visual img {
+        aspect-ratio: 4 / 3;
+        object-position: center 28%;
+      }
+
+      h1 {
+        font-size: clamp(2rem, 7vw, 3rem);
+      }
+
+      .joke {
+        margin-top: 0.45rem;
+        font-size: 1rem;
+        line-height: 1.25;
+      }
+
+      .note {
+        margin-top: 0.35rem;
+        font-size: 0.9rem;
+        line-height: 1.3;
+      }
+
+      .actions {
+        margin-top: 0.65rem;
+      }
+
+      button {
+        min-height: 40px;
+        padding: 0 0.85rem;
+      }
+    }
+
     @media (max-width: 480px) {
       .card-bar {
         align-items: flex-start;


### PR DESCRIPTION
## What changed

- Adds a compact mobile-landscape layout for the 502, 503, and 504 error cards.
- Keeps the existing portrait mobile stack, but uses a short-height two-column layout between 560px and 700px wide so the message and retry action fit in the first viewport.

## Why

At 640x360, the error card stacked the image above the copy, so the first viewport showed only the masthead and image. The actual message and retry button were pushed below the fold.

## Screenshot proof

Gist: https://gist.github.com/nopara73/1e8c4a375bf1f6a9a722fbd7dead052f

| Before | After |
| --- | --- |
| ![Before: 503 landscape first viewport hides the message and retry button](https://gist.githubusercontent.com/nopara73/1e8c4a375bf1f6a9a722fbd7dead052f/raw/58302f5b1d195e02c55099fbb9dc76029abb5850/error-503-landscape-before-640x360.png) | ![After: 503 landscape first viewport shows image, message, and retry button](https://gist.githubusercontent.com/nopara73/1e8c4a375bf1f6a9a722fbd7dead052f/raw/fcb1e0c803ee8c5e1bd651e98cf635a009d2ee26/error-503-landscape-after-640x360.png) |

## Verification

- Playwright screenshot at `/error/503.html`, 640x360: after view shows the image, message, and `Try again` button in the first viewport.
- Playwright metric checks at `/error/502.html`, `/error/503.html`, and `/error/504.html`, 640x360: `docScrollWidth` remains equal to viewport width and no wide elements are reported.
- Playwright portrait control at `/error/503.html`, 320x760: existing stacked mobile layout remains intact.
- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o .artifacts\build-error-landscape`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only responsive tweaks on static error HTML with no backend or security impact.
> 
> **Overview**
> Adds a **mobile-landscape** breakpoint to the static **502**, **503**, and **504** error pages so the outage message and **Try again** control stay visible without scrolling on short viewports (e.g. 640×360).
> 
> For viewports **560–700px** wide with **max-height 480px**, a new `@media` block overrides the existing `max-width: 700px` single-column stack: the card uses a **two-column** body (narrow image + copy), tighter padding and type, a shorter header bar, and a **4:3** hero crop. Portrait mobile behavior below 560px width is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 814df652be4730f67673c67abfc8f9d00f1c0553. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->