### PR TITLE
[codex] Fit 404 page in mobile landscape

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/error/404.html
+++ b/LongevityWorldCup.Website/wwwroot/error/404.html
@@ -87,6 +87,48 @@
                 width: min(100%, 300px);
             }
         }
+
+        @media (min-width: 560px) and (max-width: 760px) and (max-height: 480px) {
+            .not-found-main {
+                max-width: 620px;
+                padding: 1rem;
+                display: grid;
+                grid-template-columns: minmax(130px, 150px) minmax(0, 1fr);
+                gap: 0.55rem 1.25rem;
+                align-items: center;
+            }
+
+            .not-found-title {
+                grid-column: 2;
+                margin: 0;
+                text-align: left;
+                font-size: clamp(2rem, 6vw, 2.6rem);
+                line-height: 1;
+            }
+
+            .not-found-visual {
+                grid-column: 1;
+                grid-row: 1 / span 3;
+                margin: 0;
+            }
+
+            .not-found-visual .illustration {
+                width: min(100%, 150px);
+            }
+
+            .not-found-copy {
+                grid-column: 2;
+                margin: 0;
+                text-align: left;
+                line-height: 1.3;
+            }
+
+            .not-found-actions {
+                grid-column: 2;
+                width: min(100%, 220px);
+                margin: 0;
+            }
+        }
     </style>
 </head>
 <body>

--- a/LongevityWorldCup.Website/wwwroot/error/404.html
+++ b/LongevityWorldCup.Website/wwwroot/error/404.html
@@ -88,7 +88,7 @@
             }
         }
 
-        @media (min-width: 560px) and (max-width: 760px) and (max-height: 480px) {
+        @media (min-width: 560px) and (max-width: 932px) and (max-height: 480px) {
             .not-found-main {
                 max-width: 620px;
                 padding: 1rem;


### PR DESCRIPTION
## What changed

- Adds a compact mobile-landscape layout for the 404 page.
- Keeps the existing portrait mobile stack while placing the illustration beside the title, copy, and Home action on short landscape screens up to the shared header's compact-landscape range.

## Why

At 640x360, the 404 page showed the header, title, and illustration, but the explanatory copy and Home action were below the first viewport. The recovery action should be visible without scrolling in that common mobile-landscape shape.

## Screenshot proof

Gist: https://gist.github.com/nopara73/bb1a8cebb6e15f19114c54681a767344

| Before | After |
| --- | --- |
| ![Before: 404 landscape first viewport hides the copy and Home action](https://gist.githubusercontent.com/nopara73/bb1a8cebb6e15f19114c54681a767344/raw/64e40ea4071989f62d394b36d7872b39ce96af69/error404-before-640x360.png) | ![After: 404 landscape first viewport shows the copy and Home action](https://gist.githubusercontent.com/nopara73/bb1a8cebb6e15f19114c54681a767344/raw/c07c2b5712b94d01657ebbfd5fbaf22aa338b297/error404-after-640x360.png) |
| ![Before: 404 wider landscape first viewport still hides the copy and Home action at 844x390](https://gist.githubusercontent.com/nopara73/bb1a8cebb6e15f19114c54681a767344/raw/ab34c46c96b3160ad015213c4f26db8860139440/error404-before-844x390.png) | ![After: 404 wider landscape first viewport shows the copy and Home action at 844x390](https://gist.githubusercontent.com/nopara73/bb1a8cebb6e15f19114c54681a767344/raw/384a6507a981c009c3b2579dae496ea91e714ca0/error404-after-844x390.png) |

## Verification

- Playwright screenshot at `/error/404.html`, 640x360: after view shows title, illustration, explanatory copy, and Home action in the first viewport.
- Playwright screenshot at `/error/404.html`, 844x390: after view shows title, illustration, explanatory copy, and Home action in the first viewport.
- Playwright metric checks at `/error/404.html`, 640x360 and 844x390: `docScrollWidth` remains equal to viewport width and no wide elements are reported.
- Playwright portrait control at `/error/404.html`, 320x760: existing stacked mobile layout remains intact.
- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o .artifacts\build-404-landscape`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static CSS-only change to the error page; no backend, auth, or shared layout logic.
> 
> **Overview**
> Adds a **mobile-landscape** breakpoint on `404.html` so short, wide viewports (roughly 560–932px wide and ≤480px tall) use a **two-column grid** instead of the stacked portrait layout.
> 
> On those screens, the illustration sits in the left column while the title, explanatory copy, and **Home** action align left in the right column, with tighter padding and a smaller illustration so the recovery action stays visible without scrolling (e.g. 640×360).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0b0a5a68d631fa4ba74bca7dd57dc55620fb829. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->