### PR TITLE
[codex] Fit unsubscribe form in mobile landscape

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/unsubscribe.html
+++ b/LongevityWorldCup.Website/wwwroot/unsubscribe.html
@@ -124,6 +124,43 @@
             }
         }
 
+        @media (min-width: 560px) and (max-width: 932px) and (max-height: 480px) {
+            .unsubscribe-panel {
+                max-width: 620px;
+                margin: 0.8rem auto 1.5rem;
+                padding: 1rem 1.25rem;
+            }
+
+            .unsubscribe-panel h1 {
+                margin-bottom: 0.45rem;
+                font-size: clamp(2rem, 6vw, 2.55rem);
+            }
+
+            .unsubscribe-copy {
+                line-height: 1.3;
+            }
+
+            .unsubscribe-form {
+                max-width: none;
+                margin-top: 1rem;
+                grid-template-columns: minmax(0, 1fr) minmax(9rem, 12rem);
+                align-items: end;
+            }
+
+            .unsubscribe-form label {
+                grid-column: 1 / -1;
+            }
+
+            .unsubscribe-form input,
+            .unsubscribe-button {
+                min-height: 44px;
+            }
+
+            .unsubscribe-button {
+                margin-top: 0;
+            }
+        }
+
         @media (max-width: 300px) {
             .unsubscribe-panel {
                 margin: 1.25rem 0.45rem;


### PR DESCRIPTION
## What changed

- Adds a compact short-landscape layout for the unsubscribe panel.
- Keeps the existing portrait mobile stack, but places the email field and Unsubscribe button on one row for 560-932px wide, <=480px tall screens.

## Why

At 640x360, the page showed the email field but cut the primary Unsubscribe action below the first viewport. The recovery action should be visible with the field in that common mobile-landscape shape.

## Screenshot proof

Gist: https://gist.github.com/nopara73/9b42227a87be561fb12f92e84867f27b

| Before | After |
| --- | --- |
| ![Before: Unsubscribe action is cut off below the 640x360 first viewport](https://gist.githubusercontent.com/nopara73/9b42227a87be561fb12f92e84867f27b/raw/69775d5efc8d2dc49c7a35e9f6e39e22426a67d3/unsubscribe-before-640x360.png) | ![After: Email field and Unsubscribe action are visible together at 640x360](https://gist.githubusercontent.com/nopara73/9b42227a87be561fb12f92e84867f27b/raw/24c228a92df136933f455fd5d2cc5a792db457f1/unsubscribe-after-640x360.png) |

## Verification

- Playwright screenshot at `/unsubscribe`, 640x360: after view shows the email field and Unsubscribe action together in the first viewport.
- Playwright screenshot at `/unsubscribe`, 844x390: after view keeps the same compact landscape layout.
- Playwright metric checks at `/unsubscribe`, 640x360 and 844x390: `docScrollWidth` remains equal to viewport width and no wide elements are reported.
- Playwright portrait control at `/unsubscribe`, 320x760: existing stacked mobile layout remains intact.
- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o .artifacts\build-unsubscribe-landscape`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static-page CSS only; no auth, data, or API behavior changes.
> 
> **Overview**
> Adds a **short-landscape** `@media` block on `unsubscribe.html` for viewports roughly **560–932px wide and ≤480px tall** (e.g. 640×360).
> 
> In that range the panel uses **tighter margins/padding** and smaller heading/copy spacing. The form switches from a stacked layout to a **two-column grid** so the email field and **Unsubscribe** button sit on one row (label still full width), keeping the primary action visible in the first viewport without changing unsubscribe API or markup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a1b00e7be5cb9b524fbbf02617a53d3127b4aaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->