### PR TITLE
[codex] Fit challenge timezone picker in mobile landscape

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/css/longevitymaxxing.css
+++ b/LongevityWorldCup.Website/wwwroot/css/longevitymaxxing.css
@@ -1507,6 +1507,17 @@
     font-weight: 750;
 }
 
+@media (max-width: 932px) and (max-height: 480px) and (orientation: landscape) {
+    .lmx-timezone-list {
+        max-height: min(8rem, 34vh);
+    }
+
+    .lmx-timezone-option {
+        min-height: 38px;
+        padding-block: 0.34rem;
+    }
+}
+
 .lmx-profile-upload {
     display: grid;
     grid-template-columns: 3.25rem minmax(0, 1fr);

--- a/LongevityWorldCup.Website/wwwroot/js/longevitymaxxing.js
+++ b/LongevityWorldCup.Website/wwwroot/js/longevitymaxxing.js
@@ -3709,7 +3709,10 @@
         if (input) {
             input.value = "";
             renderTimeZoneOptions(picker, "");
-            requestAnimationFrame(() => input.focus());
+            requestAnimationFrame(() => {
+                popover?.scrollIntoView({ block: "nearest" });
+                input.focus({ preventScroll: true });
+            });
         }
     }
 


### PR DESCRIPTION
## What changed

- Scrolls the Longevitymaxxing timezone popover into view when it opens.
- Caps the timezone option list in short landscape viewports so the popover bottom remains visible and the list scrolls internally.

## Why

At a realistic 640x360 mobile landscape viewport, opening the signup timezone picker left the option list cut off at the bottom of the viewport. The picker now opens as a contained panel while preserving the normal 320px portrait layout.

## Screenshot proof

Gist: https://gist.github.com/nopara73/fafc92ddd8587008961eae6da27a8dbe

| Before | After |
| --- | --- |
| ![Before: timezone picker list is cut off at 640x360](https://gist.githubusercontent.com/nopara73/fafc92ddd8587008961eae6da27a8dbe/raw/0308881ca85718242ea38e70e76eee9fd8a4ce40/timezone-before-640x360.png) | ![After: timezone picker is contained at 640x360](https://gist.githubusercontent.com/nopara73/fafc92ddd8587008961eae6da27a8dbe/raw/0308881ca85718242ea38e70e76eee9fd8a4ce40/timezone-after-640x360.png) |

Portrait control:

![After: timezone picker remains usable at 320x760](https://gist.githubusercontent.com/nopara73/fafc92ddd8587008961eae6da27a8dbe/raw/0308881ca85718242ea38e70e76eee9fd8a4ce40/timezone-after-320x760.png)

## Verification

- Playwright screenshot at `/longevitymaxxing`, 640x360: before the timezone popover is cut off at the viewport edge; after the popover bottom is visible and the list scrolls inside the panel.
- Playwright screenshot at `/longevitymaxxing`, 320x760: picker remains usable in portrait.
- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o .artifacts\build-timezone-popover`
- `git diff --check`
