### PR TITLE
[codex] Show guess age prompt on mobile

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/partials/guess-my-age.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/guess-my-age.html
@@ -866,8 +866,7 @@
             width: 100%;
             padding: 1.75rem 1.25rem 2rem;
         }
-        #detailsModal .modal-content.guess-mode .gma-heading,
-        #detailsModal .modal-content.guess-mode .chrono-age-heading {
+        #detailsModal .modal-content.guess-mode .gma-heading {
             display: block;
             width: 100%;
             min-width: 100%;
@@ -1006,6 +1005,9 @@
         #detailsModal .modal-content.guess-mode .chrono-age-heading {
             font-size: clamp(1.35rem, 6vh, 1.75rem);
             margin-bottom: .45rem;
+        }
+
+        #detailsModal .modal-content.guess-mode .gma-heading {
             display: block;
             width: 100%;
             min-width: 100%;

--- a/LongevityWorldCup.Website/wwwroot/partials/guess-my-age.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/guess-my-age.html
@@ -866,6 +866,16 @@
             width: 100%;
             padding: 1.75rem 1.25rem 2rem;
         }
+        #detailsModal .modal-content.guess-mode .gma-heading,
+        #detailsModal .modal-content.guess-mode .chrono-age-heading {
+            display: block;
+            width: 100%;
+            min-width: 100%;
+            overflow: visible;
+            white-space: normal;
+            animation: none !important;
+            opacity: 1;
+        }
         #detailsModal .gma-slider-wrap {
             width: 86%;
         }
@@ -996,6 +1006,13 @@
         #detailsModal .modal-content.guess-mode .chrono-age-heading {
             font-size: clamp(1.35rem, 6vh, 1.75rem);
             margin-bottom: .45rem;
+            display: block;
+            width: 100%;
+            min-width: 100%;
+            overflow: visible;
+            white-space: normal;
+            animation: none !important;
+            opacity: 1;
         }
 
         #detailsModal .modal-content.guess-mode .gma-slider-wrap {


### PR DESCRIPTION
## What changed

- Lets the Guess my age heading use the full available width in constrained mobile layouts.
- Keeps the existing slider and action layout while avoiding typewriter clipping on the first mobile frame.

## Why

At realistic mobile sizes, opening an athlete profile in guess mode initially clipped the heading to a single letter at 320x760 and to `Guess m` at 640x360. The prompt now renders fully in those same mobile states.

## Screenshot proof

Gist: https://gist.github.com/nopara73/fdbcf0833446d382d2f678c80fa9e01c

| Viewport | Before | After |
| --- | --- | --- |
| 320x760 | ![Before: guess age prompt clipped to one letter at 320x760](https://gist.githubusercontent.com/nopara73/fdbcf0833446d382d2f678c80fa9e01c/raw/dedba5706d0983a76da93c154152657a3b2336a2/guess-heading-before-320x760.png) | ![After: full guess age prompt visible at 320x760](https://gist.githubusercontent.com/nopara73/fdbcf0833446d382d2f678c80fa9e01c/raw/dedba5706d0983a76da93c154152657a3b2336a2/guess-heading-after-320x760.png) |
| 640x360 | ![Before: guess age prompt clipped in landscape at 640x360](https://gist.githubusercontent.com/nopara73/fdbcf0833446d382d2f678c80fa9e01c/raw/dedba5706d0983a76da93c154152657a3b2336a2/guess-heading-before-640x360.png) | ![After: full guess age prompt visible in landscape at 640x360](https://gist.githubusercontent.com/nopara73/fdbcf0833446d382d2f678c80fa9e01c/raw/dedba5706d0983a76da93c154152657a3b2336a2/guess-heading-after-640x360.png) |

## Verification

- Playwright screenshots at `/athlete/michael-lustgarten?guessmyage=1`, 320x760 and 640x360.
- Control screenshots at 390x844, 844x390, and `/athlete/ana-paula-de-souza?guessmyage=1`.
- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o .artifacts\build-guess-heading-mobile`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only presentation fix in the guess-my-age partial; no API or logic changes.
> 
> **Overview**
> On narrow mobile and landscape guess-mode layouts, the **Guess my age!** heading was clipped because the shared `.gma-heading` styles use an inline typewriter animation (`overflow: hidden`, `white-space: nowrap`, width animation).
> 
> This PR adds scoped overrides under `#detailsModal .modal-content.guess-mode` for **max-width 768px** and **landscape phones (640–932px, max-height 480px)**: the heading becomes a full-width block, wraps normally, and the typing animation is disabled so the full prompt is visible on first paint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7e1ca1ea9008a69564d5759e3f9e8a4ae305674. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->