### PR TITLE
[codex] Fit apply name placeholder on mobile

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/onboarding/convergence.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/convergence.html
@@ -562,7 +562,7 @@
 
                 <!-- Name Field -->
                 <label for="name">Name</label>
-                <input type="text" id="name" name="name" required aria-required="true" aria-describedby="nameError" minlength="3" maxlength="100" autocomplete="name" autocapitalize="none" spellcheck="false" placeholder="Real name or cyber alias — your call">
+                <input type="text" id="name" name="name" required aria-required="true" aria-describedby="nameError" minlength="3" maxlength="100" autocomplete="name" autocapitalize="none" spellcheck="false" placeholder="Name or cyber alias">
                 <span id="nameError" class="error-message" aria-live="polite"></span>
 
                 <!-- Division Field -->


### PR DESCRIPTION
## Summary
- Shorten the `/apply` Name field placeholder so it fits the mobile form input instead of truncating at 320px.

## Screenshot proof
Gist: https://gist.github.com/nopara73/41da03dff42d84887b28314156541df6

| Before | After |
| --- | --- |
| ![Before 320x760](https://gist.githubusercontent.com/nopara73/41da03dff42d84887b28314156541df6/raw/6a6b98a01e7ad39b3731872deb62c69d9476e0f0/apply-placeholder-before-320x760.png) | ![After 320x760](https://gist.githubusercontent.com/nopara73/41da03dff42d84887b28314156541df6/raw/304b86a1a58dff78833536e0e6942dfb39671737/apply-placeholder-after-320x760.png) |

Additional checks:

| 390px portrait | 640px landscape |
| --- | --- |
| ![After 390x844](https://gist.githubusercontent.com/nopara73/41da03dff42d84887b28314156541df6/raw/d2907226a369dcbe11eb2f105f9cf3f7708124ef/apply-placeholder-after-390x844.png) | ![After 640x360](https://gist.githubusercontent.com/nopara73/41da03dff42d84887b28314156541df6/raw/63d023d282364c880d75790f59f4d584810cbfd4/apply-placeholder-after-640x360.png) |

## Verification
- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o .artifacts\build-apply-placeholder`
- `git diff --check`
- Verified all Gist raw image URLs return `200 image/png`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single placeholder string change in static HTML with no logic or API impact.
> 
> **Overview**
> Shortens the **Name** field placeholder on the onboarding/apply form (`convergence.html`) from *"Real name or cyber alias — your call"* to **"Name or cyber alias"** so the hint fits narrow viewports (e.g. 320px) without truncating.
> 
> Copy-only change; validation and field behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42c6a5b1b061c2cea0387d050f2dffb38b3b1f14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->