### PR TITLE
[codex] Keep age radar clear of modal header

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/partials/age-visualization.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/age-visualization.html
@@ -160,7 +160,8 @@
     #detailsModal .age-visualization {
         width: min(100%, var(--athlete-modal-section-width, 640px));
         box-sizing: border-box;
-        padding: .95rem 1rem 1.05rem;
+        padding: 1.45rem 1rem 1.05rem;
+        scroll-margin-top: 5.5rem;
         background: linear-gradient(180deg, rgba(255,255,255,.09), rgba(255,255,255,.045));
         border-color: var(--athlete-modal-border, rgba(255,255,255,.16));
         border-radius: 22px;


### PR DESCRIPTION
## Summary
- keep the athlete modal age visualization from scrolling under the sticky modal header
- add top inset and scroll margin to the age visualization card so the radar labels remain visible in constrained modal views

## Screenshot proof
Gist: https://gist.github.com/nopara73/d864cc1e0ffb2292802b700cc3e4c172

### Before - 640x360
![Before: age radar top label hidden by sticky modal header](https://gist.githubusercontent.com/nopara73/d864cc1e0ffb2292802b700cc3e4c172/raw/26d4910d95a40f4fe3e4fa9fd22acf93a4ec3327/ageviz-before-640x360.png)

### After - 640x360
![After: age radar labels clear of sticky modal header](https://gist.githubusercontent.com/nopara73/d864cc1e0ffb2292802b700cc3e4c172/raw/db44a524293fd165ea7bad165e14986bda9b1774/ageviz-after-640x360.png)

### After checks
![After at 320x760](https://gist.githubusercontent.com/nopara73/d864cc1e0ffb2292802b700cc3e4c172/raw/02b620e72ef74aceb359bae5ca0e7e0e602b5f91/ageviz-after-320x760.png)

![After at 390x844](https://gist.githubusercontent.com/nopara73/d864cc1e0ffb2292802b700cc3e4c172/raw/37e8c9d54b487816f86d7c8895902312630ef83d/ageviz-after-390x844.png)

## Verification
- dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o .artifacts\build-age-radar-modal
- git diff --check
- verified Gist raw image URLs return 200 image/png

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only layout tweak scoped to `#detailsModal .age-visualization`; no logic, API, or data changes.
> 
> **Overview**
> Adjusts **modal-only** styling for `#detailsModal .age-visualization` so the age radar chart stays readable when the athlete details modal scrolls.
> 
> **Top padding** on the card increases from `0.95rem` to `1.45rem`, adding visual space above the radar. **`scroll-margin-top: 5.5rem`** is added so in-view scrolling (e.g. focus or anchor navigation) leaves room below the sticky modal header and top radar labels are not clipped on short viewports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb153b0fab156d6341b5de5dfeddb39543bdcb49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->