### PR TITLE
[codex] Keep event donation amounts together

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
@@ -221,7 +221,8 @@
     .events-board.athlete-scroll td.event-message .event-message-cell .rank-badge,
     .events-board.athlete-scroll td.event-message .event-message-cell .badge-class,
     .events-board.athlete-scroll td.event-message .event-message-cell .badge-chip,
-    .events-board.athlete-scroll td.event-message .event-message-cell .more-link{
+    .events-board.athlete-scroll td.event-message .event-message-cell .more-link,
+    .events-board.athlete-scroll td.event-message .event-message-cell .donation-amount{
         white-space:nowrap;
     }
 
@@ -453,7 +454,8 @@
     .events-board td.event-message .event-message-cell .rank-badge,
     .events-board td.event-message .event-message-cell .badge-class,
     .events-board td.event-message .event-message-cell .badge-chip,
-    .events-board td.event-message .event-message-cell .more-link{
+    .events-board td.event-message .event-message-cell .more-link,
+    .events-board td.event-message .event-message-cell .donation-amount{
         white-space:nowrap;
     }
 
@@ -773,7 +775,8 @@
         .events-board:not(.athlete-scroll) td.event-message .event-message-cell .rank-badge,
         .events-board:not(.athlete-scroll) td.event-message .event-message-cell .badge-class,
         .events-board:not(.athlete-scroll) td.event-message .event-message-cell .badge-chip,
-        .events-board:not(.athlete-scroll) td.event-message .event-message-cell .more-link{
+        .events-board:not(.athlete-scroll) td.event-message .event-message-cell .more-link,
+        .events-board:not(.athlete-scroll) td.event-message .event-message-cell .donation-amount{
             white-space:nowrap;
         }
         .events-board:not(.athlete-scroll) .badge-with-from.show-from{
@@ -808,7 +811,8 @@
         .events-board.athlete-scroll td.event-message .event-message-cell .rank-badge,
         .events-board.athlete-scroll td.event-message .event-message-cell .badge-class,
         .events-board.athlete-scroll td.event-message .event-message-cell .badge-chip,
-        .events-board.athlete-scroll td.event-message .event-message-cell .more-link{
+        .events-board.athlete-scroll td.event-message .event-message-cell .more-link,
+        .events-board.athlete-scroll td.event-message .event-message-cell .donation-amount{
             white-space:nowrap;
         }
     }


### PR DESCRIPTION
## Summary
- keep event-board donation amount and BTC unit together as one visual token
- preserve normal row wrapping so tight mobile rows can still wrap without stranding the currency unit

## Screenshot proof
Gist: https://gist.github.com/nopara73/f8face68b3eb45b4f682d18bca84965b

### Before - 320x760
![Before: donation BTC unit stranded on its own line](https://gist.githubusercontent.com/nopara73/f8face68b3eb45b4f682d18bca84965b/raw/177fc745d6c930520bedf6664ae37addde5bb35e/events-donation-before-320x760.png)

### After - 320x760
![After: donation amount and BTC stay together](https://gist.githubusercontent.com/nopara73/f8face68b3eb45b4f682d18bca84965b/raw/e5f3fa9046131ad04a2afd75fd6a192e2ee63c60/events-donation-after-320x760.png)

### After checks
![After at 390x844](https://gist.githubusercontent.com/nopara73/f8face68b3eb45b4f682d18bca84965b/raw/317f7c7b6facac3575e0c5ac283b07f4d1c48edf/events-donation-after-390x844.png)

![After at 640x360](https://gist.githubusercontent.com/nopara73/f8face68b3eb45b4f682d18bca84965b/raw/d65dd38e309ab9cf83833e63a4850ae9c207f8a5/events-donation-after-640x360.png)

## Verification
- dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o .artifacts\build-event-donation-wrap
- git diff --check
- verified Gist raw image URLs return 200 image/png

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only presentation tweak in `event-board-content.html` with no API or data changes.
> 
> **Overview**
> Fixes **mobile wrapping** on the events/highlights board so donation lines no longer split the numeric amount from the **BTC** label on a second line.
> 
> The change adds `.donation-amount` to the existing `white-space: nowrap` exceptions alongside badges, names, and “more” links. That applies in the default board layout, athlete-scroll layout, and the compact mobile (`max-width: 600px`) rules—while the surrounding flex/wrap behavior for event message cells stays the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bacc07f84b22300c7a6f9d0a2c7dec1abd2130f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->