### PR TITLE
[codex] Expand mobile badge details

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/css/badges.css
+++ b/LongevityWorldCup.Website/wwwroot/css/badges.css
@@ -170,10 +170,19 @@ a.badge-class,.badge-class.badge-clickable,.badge-class[data-clickable="true"],.
     #detailsModal .modal-badge-item.expanded .modal-badge-detail{
         display:block;
     }
+    #detailsModal .modal-badge-strip .modal-badge-item.expanded{
+        flex-basis:100%;
+        width:100%;
+        max-width:100%;
+    }
     #detailsModal .modal-badge-item.expanded .modal-badge-name{
         -webkit-line-clamp:unset;
         max-height:none;
+        max-width:min(100%, 18rem);
+        font-size:.74rem;
+        line-height:1.18;
         overflow:visible;
+        margin-inline:auto;
     }
     #detailsModal .badge-class{pointer-events:none;cursor:default}
     #detailsModal .badge-class.badge-podcast{pointer-events:auto!important;cursor:pointer!important}


### PR DESCRIPTION
## What changed

- Expands an opened athlete badge to a full-width row inside the mobile details modal.
- Keeps the expanded badge detail readable with a bounded text width and tighter mobile line height.

## Why

On realistic mobile widths, tapping a badge in the athlete details modal squeezed the expanded badge description into the same narrow badge column. The text became a tall, hard-to-scan stack even though the modal had enough horizontal room.

## Screenshot proof

Gist: https://gist.github.com/nopara73/531fafc13c44bcd7ce09931195118b86

### Before, 320px

![Before: expanded badge text squeezed into one narrow badge column at 320px](https://gist.githubusercontent.com/nopara73/531fafc13c44bcd7ce09931195118b86/raw/ba2718f901b90eef7144efa824fb2e7b4de9cb1e/badge-expanded-before-320.png)

### After, 320px

![After: expanded badge uses a readable full-width row at 320px](https://gist.githubusercontent.com/nopara73/531fafc13c44bcd7ce09931195118b86/raw/7f061a307d4d5acd57e67330e22f0daaf2223ce5/badge-expanded-after-320.png)

### Before, 390px

![Before: expanded badge text stays constrained to the compact badge column at 390px](https://gist.githubusercontent.com/nopara73/531fafc13c44bcd7ce09931195118b86/raw/9126e401dc4dad67a3719b759dc2dfa4bf702c68/badge-expanded-before-390.png)

### After, 390px

![After: expanded badge detail spans the mobile modal row at 390px](https://gist.githubusercontent.com/nopara73/531fafc13c44bcd7ce09931195118b86/raw/b698f71e0922e627143d95ab1705a3e30c818f47/badge-expanded-after-390.png)

## Verification

- 320px expanded badge label width: 86px before -> 244px after.
- 390px expanded badge label width: 86px before -> 288px after.
- After screenshots keep the modal without horizontal overflow: 320px modal scroll/client width 318/318, 390px modal scroll/client width 388/388.
- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o .artifacts\build-mobile-badge-details`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped mobile presentation CSS in `badges.css` for `#detailsModal`; no logic, API, or data changes.
> 
> **Overview**
> On viewports **≤768px**, tapping a badge in the athlete **details** modal now lays out an **expanded** badge as a **full-width row** in the badge strip instead of keeping the ~92px column width.
> 
> Expanded label/detail text gets a **wider readable cap** (`max-width: min(100%, 18rem)`), slightly **larger type** and **line height**, and **horizontal centering**—so descriptions use the modal width without changing JS or desktop styles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 434d6f2ed05f903196a48f585b0780f9a92ba233. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->