### PR TITLE
[codex] Fit play athlete suggestions on mobile

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/play/menu.html
+++ b/LongevityWorldCup.Website/wwwroot/play/menu.html
@@ -445,6 +445,22 @@
                 .play-autocomplete-wrapper:has(.autocomplete-items) {
                     margin-bottom: calc(1rem + min(11.5rem, 34vh));
                 }
+
+                .play-athlete-panel:has(.autocomplete-items) {
+                    padding-top: 0.75rem;
+                }
+
+                .play-athlete-panel:has(.autocomplete-items) .play-athlete-title {
+                    margin-bottom: 0.45rem;
+                }
+
+                .play-athlete-panel:has(.autocomplete-items) .play-athlete-visual {
+                    margin-bottom: 0.55rem;
+                }
+
+                .play-athlete-panel:has(.autocomplete-items) .athlete-picture-frame {
+                    width: min(100%, 200px);
+                }
             }
 
             .play-dashboard-actions {


### PR DESCRIPTION
## What changed

- When the play hub athlete autocomplete is open on mobile, the athlete selection panel tightens its local spacing and temporarily shrinks the decorative athlete image.
- The suggestion list gets enough vertical room to remain visible at realistic mobile widths.

## Why

At 320px and 390px, opening the athlete autocomplete in the play hub left the suggestion panel below the viewport. The user could see the top of the list, but the lower suggestions were cut off by the bottom of the screen.

## Screenshot proof

Gist: https://gist.github.com/nopara73/7d3015e5b038948f7f2b5e1ab3e6bb17

### Before, 320px

![Before: play athlete autocomplete suggestions are cut off below the 320px viewport](https://gist.githubusercontent.com/nopara73/7d3015e5b038948f7f2b5e1ab3e6bb17/raw/2ea693f49b41ff5b4e05f9f5628b49f3b9eb5f05/play-athlete-autocomplete-before-320.png)

### After, 320px

![After: play athlete autocomplete suggestions fit within the 320px viewport](https://gist.githubusercontent.com/nopara73/7d3015e5b038948f7f2b5e1ab3e6bb17/raw/c10cd60ae83c133989fcbc2096535869a4564987/play-athlete-autocomplete-after-320.png)

### Before, 390px

![Before: play athlete autocomplete suggestions extend below the 390px viewport](https://gist.githubusercontent.com/nopara73/7d3015e5b038948f7f2b5e1ab3e6bb17/raw/582bc8d7690d8508f00ab35edf7037ded8d65dd7/play-athlete-autocomplete-before-390.png)

### After, 390px

![After: play athlete autocomplete suggestions fit comfortably at 390px](https://gist.githubusercontent.com/nopara73/7d3015e5b038948f7f2b5e1ab3e6bb17/raw/efb95014d97510126ea36d86fac32f499f6910b7/play-athlete-autocomplete-after-390.png)

## Verification

- 320px autocomplete list moved from top/bottom 632/824 before to 521/713 after, fitting inside the 760px viewport.
- 390px autocomplete list moved from top/bottom 695/887 before to 514/706 after, fitting inside the 844px viewport.
- Gist raw images return `200 image/png`.
- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o .artifacts\build-play-athlete-suggestions`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS behind `:has()` and an existing mobile media query; no logic or API changes.
> 
> **Overview**
> On **mobile** (`max-width: 600px`), when the play hub athlete autocomplete is open, new **`:has(.autocomplete-items)`** rules tighten the athlete selection panel so the suggestion list stays in view.
> 
> The panel gets less top padding; title and hero image spacing shrink; the **`.athlete-picture-frame`** caps at **200px** wide while suggestions are shown. This works alongside the existing autocomplete wrapper bottom margin and only applies in browsers that support **`:has()`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e44c7603e3577f87ca5d83fcf2fb5e7f20d87f08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->