### PR TITLE
[codex] Show character suggestions in mobile landscape

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/play/character-selection.html
+++ b/LongevityWorldCup.Website/wwwroot/play/character-selection.html
@@ -317,11 +317,13 @@
 
             @supports selector(:has(*)) {
                 .autocomplete-wrapper:has(.autocomplete-items) {
-                    margin-bottom: calc(0.65rem + min(8.5rem, 42vh));
+                    margin-bottom: 0.65rem;
                 }
             }
 
             .autocomplete-items {
+                top: auto;
+                bottom: calc(100% + 0.45rem);
                 max-height: min(8.5rem, 42vh);
             }
 


### PR DESCRIPTION
## Summary
- Opens the character-selection autocomplete upward in short mobile landscape layouts so suggestions stay visible after typing.
- Keeps the normal portrait autocomplete behavior unchanged.

## Screenshot proof
Gist: https://gist.github.com/nopara73/55a3812997cf98331c9b296cd09383d5

### Before
At 667x375, the input sits at the bottom of the viewport and the suggestions open below it, outside the visible screen.

![Before](https://gist.githubusercontent.com/nopara73/55a3812997cf98331c9b296cd09383d5/raw/ff90fb9a9de5fe86a1024e5281e3488b21c0d038/before-character-selection-suggestions-landscape.png)

### After
The same autocomplete state opens upward, keeping the suggestions visible in the viewport.

![After](https://gist.githubusercontent.com/nopara73/55a3812997cf98331c9b296cd09383d5/raw/556193baca6053472a30641ffa542b01abc423d6/after-character-selection-suggestions-landscape.png)

## Verification
- Before metric: suggestion list `top=393`, `bottom=529` in a 375px-tall viewport.
- After metric: suggestion list `top=198`, `bottom=334` in the same viewport.
- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o .artifacts\build-character-selection-suggestions`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only layout tweak scoped to a landscape media query; no logic, API, or data changes.
> 
> **Overview**
> On **short mobile landscape** character selection (`max-height: 480px`), the athlete autocomplete **opens above the input** instead of below it, so suggestions stay in view when the field sits near the bottom of the viewport.
> 
> In that breakpoint, `.autocomplete-items` uses `bottom: calc(100% + 0.45rem)` with `top: auto`, and the extra bottom margin on `.autocomplete-wrapper:has(.autocomplete-items)` is removed because space no longer needs to be reserved for a downward list. **Portrait and other layouts** keep the existing downward dropdown and margin behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56c490879956c7e54b835c73536f4c78551278e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->