### PR TITLE
[codex] Fit customization actions in mobile landscape

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/play/character-customization.html
+++ b/LongevityWorldCup.Website/wwwroot/play/character-customization.html
@@ -173,21 +173,33 @@
 
         @media (min-width: 640px) and (max-width: 932px) and (max-height: 480px) and (orientation: landscape) {
             .character-dashboard-main {
-                padding: 0.6rem 1rem 1.25rem;
+                display: grid;
+                grid-template-columns: minmax(10.5rem, 14rem) minmax(0, 1fr);
+                grid-template-areas:
+                    "title actions"
+                    "visual actions";
+                column-gap: 1rem;
+                row-gap: 0.45rem;
+                align-items: start;
+                max-width: 42rem;
+                padding: 0.6rem 1rem 1rem;
             }
 
             .character-dashboard-title {
+                grid-area: title;
+                width: 100%;
                 margin-bottom: 0.45rem;
                 font-size: clamp(1.55rem, 8vh, 2rem);
                 line-height: 1.05;
             }
 
             .character-dashboard-visual {
-                margin-bottom: 0.65rem;
+                grid-area: visual;
+                margin-bottom: 0;
             }
 
             .athlete-picture-frame {
-                width: min(100%, 240px);
+                width: min(100%, 14rem, calc(100dvh - 8.25rem));
             }
 
             .athlete-picture-frame .illustration {
@@ -197,13 +209,21 @@
             }
 
             .character-dashboard-actions {
+                grid-area: actions;
+                align-self: start;
+                width: 100%;
+                max-width: none;
+                max-height: calc(100dvh - 4.7rem);
+                overflow-y: auto;
                 gap: 0.55rem;
                 margin-top: 0;
+                padding-right: 0.15rem;
+                scrollbar-width: thin;
             }
 
             .character-dashboard-actions .option-button {
-                min-height: 42px;
-                padding-block: 0.55rem;
+                min-height: 40px;
+                padding-block: 0.48rem;
             }
 
             .pro-discount-box {


### PR DESCRIPTION
## Summary
- Uses a two-column short-landscape layout for the selected-athlete customization screen.
- Keeps portrait as the existing vertical flow while making the action buttons visible in mobile landscape.

## Screenshot proof
Gist: https://gist.github.com/nopara73/3315a737702dc0610d44469abf9b3192

### Before
At 667x375 with a selected athlete, the first viewport shows only the name and image; the workflow actions are below the fold.

![Before](https://gist.githubusercontent.com/nopara73/3315a737702dc0610d44469abf9b3192/raw/0d60e61d72e1b2cf231fd713a7afd3d8188d1b30/before-customization-actions-landscape.png)

### After
The same selected-athlete state uses the landscape width so the actions are visible immediately.

![After](https://gist.githubusercontent.com/nopara73/3315a737702dc0610d44469abf9b3192/raw/db6bf27793a12b5072f82bdc5a0cfda849ed5018/after-customization-actions-landscape.png)

## Verification
- Seeded `sessionStorage.selectedAthlete` and captured `/play/character-customization.html` at 667x375.
- Confirmed 320px and 390px portrait captures still have no horizontal overflow or clipped controls.
- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o .artifacts\build-customization-actions`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only responsive layout scoped to a single landscape media query on one play page; no logic, auth, or API changes.
> 
> **Overview**
> **Mobile landscape** on the selected-athlete customization screen (`character-customization.html`) now uses a **CSS grid** instead of the stacked vertical flow, so workflow buttons stay in the first viewport.
> 
> For viewports matching `640–932px` width, `≤480px` height, and landscape, `.character-dashboard-main` becomes a two-column grid: title and athlete image on the left, **`.character-dashboard-actions`** on the right. The action column gets a **`max-height` + `overflow-y: auto`** (thin scrollbar) so long pro/discount content can scroll without pushing controls below the fold.
> 
> The athlete frame width is capped with **`14rem`** and **`calc(100dvh - 8.25rem)`**; action buttons are slightly tightened (`min-height` / padding). Portrait and other breakpoints are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77887e15a8905a120a59db2e83eae2dbbeee23f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->