### PR TITLE
[codex] Wrap long custom alert text

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/partials/header.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/header.html
@@ -451,6 +451,8 @@
             margin-bottom: 1rem;
             font-size: 1rem;
             line-height: 1.5;
+            overflow-wrap: anywhere;
+            word-break: break-word;
         }
 
         #custom-alert button {


### PR DESCRIPTION
## Summary
- Allows custom alert messages to wrap long unbroken text such as URLs, payment IDs, and server tokens.
- Keeps the shared alert dialog inside its panel at mobile and landscape widths.

## Screenshot proof
Gist: https://gist.github.com/nopara73/f1f3b5316500abed286dee90100c91b6

### Before
At 320px, a long unbroken payment/session value is clipped inside the alert panel.

![Before](https://gist.githubusercontent.com/nopara73/f1f3b5316500abed286dee90100c91b6/raw/9f762c40c730b5364037d7e8b6cbc6697da667db/before-custom-alert-long-token-320.png)

### After
The same alert text wraps inside the panel and remains readable.

![After](https://gist.githubusercontent.com/nopara73/f1f3b5316500abed286dee90100c91b6/raw/198a9e2b9added70efeb9106ff325278c8c11106/after-custom-alert-long-token-320.png)

## Verification
- Before metric at 320px: alert message `scrollWidth=1163`, `clientWidth=208`.
- After metric at 320px: alert message `scrollWidth=208`, `clientWidth=208`.
- Also recaptured 390px and 667x375 landscape with matching wrapped widths.
- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o .artifacts\build-custom-alert-wrap`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS on the shared alert message; no logic, API, or data-handling changes.
> 
> **Overview**
> Adds **`overflow-wrap: anywhere`** and **`word-break: break-word`** to the message paragraph inside the shared **`#custom-alert`** dialog in `header.html`.
> 
> Long unbroken strings (URLs, payment/session IDs, tokens) now wrap inside the alert panel instead of overflowing horizontally on narrow and landscape widths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b89a165035b8d4c5557db064eaa2e51f2d3281f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->