### PR TITLE
Revert "[codex] Keep age radar clear of modal header"

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/partials/age-visualization.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/age-visualization.html
@@ -160,8 +160,7 @@
     #detailsModal .age-visualization {
         width: min(100%, var(--athlete-modal-section-width, 640px));
         box-sizing: border-box;
-        padding: 1.45rem 1rem 1.05rem;
-        scroll-margin-top: 5.5rem;
+        padding: .95rem 1rem 1.05rem;
         background: linear-gradient(180deg, rgba(255,255,255,.09), rgba(255,255,255,.045));
         border-color: var(--athlete-modal-border, rgba(255,255,255,.16));
         border-radius: 22px;


### PR DESCRIPTION
Reverts nopara73/LongevityWorldCup#751

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic spacing only in the athlete details modal; no logic or data changes.
> 
> **Overview**
> Reverts the modal styling from #751 that tried to keep the age radar clear of the modal header.
> 
> **`#detailsModal .age-visualization`** top padding goes back from `1.45rem` to `.95rem`, and **`scroll-margin-top: 5.5rem`** is removed. The age block in the athlete details modal will sit tighter under the header again, with less reserved scroll offset when the section is focused or scrolled into view.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5443beabee6160768397603d138bcc655b3bb0fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->