### PR TITLE
[codex] Fit edit profile autocomplete

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/play/edit-profile.html
+++ b/LongevityWorldCup.Website/wwwroot/play/edit-profile.html
@@ -42,7 +42,8 @@
 
         .autocomplete-items {
             position: absolute;
-            top: calc(100% + 0.45rem);
+            top: auto;
+            bottom: calc(100% + 0.45rem);
             left: 0;
             right: 0;
             padding: 0.25rem;
@@ -101,7 +102,7 @@
 
         @supports selector(:has(*)) {
             .niceInputFieldDisplayWrapper:has(.autocomplete-items) {
-                margin-bottom: calc(min(12rem, 36vh) + 0.65rem);
+                margin-bottom: 0;
             }
         }
 
@@ -234,7 +235,7 @@
 
         @supports selector(:has(*)) {
             .options-container.inline-option-group.niceInputFieldDisplayWrapper:has(.autocomplete-items) {
-                margin-bottom: calc(min(12rem, 36vh) + 0.65rem);
+                margin-bottom: 0;
             }
         }
 


### PR DESCRIPTION
## Summary
- Flips the edit-profile flag autocomplete menu above the input so it remains visible near the bottom of the viewport.
- Removes the extra below-input spacing that is no longer needed when suggestions open upward.

## Screenshot proof
Gist: https://gist.github.com/nopara73/a5e85f11680df9a3a9a0c0fc45337105

Before:
![Before](https://gist.githubusercontent.com/nopara73/a5e85f11680df9a3a9a0c0fc45337105/raw/0195355f7565c162b09006437e0c2b519985736e/before.png)

After:
![After](https://gist.githubusercontent.com/nopara73/a5e85f11680df9a3a9a0c0fc45337105/raw/a7b90555ea5f7122b87d73cb6b58964ac43a3552/after.png)

## Verification
- git diff --check
- dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o .artifacts\build-edit-profile-autocomplete
- Browser screenshot check at mobile landscape viewport for /play/edit-profile.html flag autocomplete

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Page-local presentation CSS on edit-profile only; no API, auth, or submission logic changes.
> 
> **Overview**
> Fixes flag (and shared `.autocomplete-items`) dropdowns on **edit profile** so suggestions open **above** the field instead of below, keeping them visible when the flag input sits near the bottom of the viewport (e.g. mobile landscape).
> 
> **CSS-only** in `edit-profile.html`: `.autocomplete-items` now uses `bottom: calc(100% + 0.45rem)` with `top: auto` instead of anchoring below the input. The `:has(.autocomplete-items)` rules on `.niceInputFieldDisplayWrapper` and inline option groups no longer add extra `margin-bottom` reserved for a downward-opening list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c66316196cd74f0fa789079b182142592f673c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->