### PR TITLE
[codex] Frame edit profile image preview

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/play/edit-profile.html
+++ b/LongevityWorldCup.Website/wwwroot/play/edit-profile.html
@@ -30,13 +30,36 @@
         }
 
         .edit-profile-visual {
+            position: relative;
+            width: min(100%, 408px, 52dvh);
+            aspect-ratio: 1 / 1;
             margin: 0 auto 1.45rem;
-            text-align: center;
+            overflow: hidden;
+            border: 4px solid var(--dark-text-color);
+            border-radius: 8px;
+            background: #d4d4d4;
+            box-shadow: 0 4px 15px rgba(0, 0, 0, 0.4);
+            box-sizing: border-box;
+            line-height: 0;
+        }
+
+        .edit-profile-visual picture {
+            display: block;
+            width: 100%;
+            height: 100%;
         }
 
         .edit-profile-visual .illustration {
-            width: min(100%, 408px);
+            display: block;
+            width: 100%;
+            height: 100%;
+            max-width: none;
             margin-bottom: 0;
+            border: 0;
+            border-radius: 0;
+            box-shadow: none;
+            object-fit: contain;
+            object-position: center;
             box-sizing: border-box;
         }
 
@@ -374,14 +397,15 @@
             }
 
             .edit-profile-visual {
+                width: min(100%, 240px, 52dvh);
                 margin-bottom: 0.65rem;
             }
 
             .edit-profile-visual .illustration {
-                width: auto;
-                max-width: min(100%, 240px);
-                max-height: 26dvh;
-                object-fit: contain;
+                width: 100%;
+                height: 100%;
+                max-width: none;
+                max-height: none;
             }
 
             #editOptionsGroup {


### PR DESCRIPTION
## Summary
- Keeps the edit-profile profile image preview in a bounded square frame.
- Uses object-fit: contain so wide profile images do not render as a landscape banner.

## Screenshot proof
Gist: https://gist.github.com/nopara73/b4a66d852ad7e4e8082102882ecc0ff7

Before:
![Before](https://gist.githubusercontent.com/nopara73/b4a66d852ad7e4e8082102882ecc0ff7/raw/48ee0a747226f6bf24531435eddb2ced7a7f801a/before.png)

After:
![After](https://gist.githubusercontent.com/nopara73/b4a66d852ad7e4e8082102882ecc0ff7/raw/3c9ef64a8ca2634cf2510bdad5a0103ae9f18bf7/after.png)

## Verification
- git diff --check
- dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o .artifacts\build-edit-profile-frame
- Browser screenshot check at 390px mobile width for /play/edit-profile.html with a wide profile image

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only layout on the edit-profile page; no API, auth, or data-flow changes.
> 
> **Overview**
> The edit-profile **profile image preview** is now shown inside a fixed **square frame** instead of sizing only the `<img>`, so wide photos no longer stretch into a landscape banner.
> 
> **`.edit-profile-visual`** gets `aspect-ratio: 1 / 1`, bounded width (`min(100%, 408px, 52dvh)`), overflow clipping, border, radius, background, and shadow. The inner **`picture`** and **`.illustration`** fill the frame with **`object-fit: contain`** and **`object-position: center`**, with per-image border/shadow removed so styling lives on the container.
> 
> In **landscape mobile** (`640–932px` width, short height), the frame caps at **240px** and the image uses full width/height of the box instead of separate `max-height` rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b090cc7e35b182c11a6482a80d0def3d89fc369c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->