### PR TITLE
[codex] Wrap play menu action labels

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/play/menu.html
+++ b/LongevityWorldCup.Website/wwwroot/play/menu.html
@@ -356,7 +356,9 @@
 
             .play-menu-actions .option-button {
                 padding-inline: 1.25rem;
-                white-space: nowrap;
+                line-height: 1.2;
+                white-space: normal;
+                overflow-wrap: anywhere;
             }
 
             .play-athlete-panel,


### PR DESCRIPTION
## Summary
- Allows mobile play menu action labels to wrap when text is enlarged.
- Keeps long action labels inside their pill buttons instead of forcing them to overflow horizontally.

## Screenshot proof
Gist: https://gist.github.com/nopara73/f863e77952229d2ad53eb63cbb076489

Before:
![Before](https://gist.githubusercontent.com/nopara73/f863e77952229d2ad53eb63cbb076489/raw/bf9eee5c647f70fa489ada99dce218c66b945dca/before.png)

After:
![After](https://gist.githubusercontent.com/nopara73/f863e77952229d2ad53eb63cbb076489/raw/d20e1312279a63399e688a2e5c975e9514c3c17d/after.png)

## Verification
- git diff --check
- dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o .artifacts\build-play-menu-text-wrap
- Browser screenshot check at 320px mobile width with enlarged text for /play/menu.html

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only mobile layout tweak in `menu.html` with no logic, API, or data changes.
> 
> **Overview**
> On **narrow viewports** (`max-width: 600px`), the play hub’s main menu pills (“I’m a new athlete” / “I’m already an athlete”) no longer force **single-line** labels.
> 
> The mobile rule for `.play-menu-actions .option-button` drops `white-space: nowrap` in favor of **`white-space: normal`**, **`overflow-wrap: anywhere`**, and **`line-height: 1.2`** so enlarged or long text stays inside the button instead of overflowing horizontally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ba6c55b62ad0f96f4cec2f8587eaeb5570366fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->