### PR TITLE
[codex] Stack proof upload actions on mobile

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/play/proof-upload.html
+++ b/LongevityWorldCup.Website/wwwroot/play/proof-upload.html
@@ -330,6 +330,18 @@
                 min-height: 56px;
             }
 
+            .proof-upload-primary-action .option-button {
+                flex-direction: column;
+                gap: 0.45rem;
+                padding-inline: 1.2rem;
+                line-height: 1.15;
+                text-align: center;
+            }
+
+            .proof-upload-primary-action .option-button i {
+                margin-right: 0;
+            }
+
             #biomarker-checklist {
                 margin: 1rem auto 1.1rem;
                 padding: 0.8rem 0.95rem;


### PR DESCRIPTION
## Summary
- Stacks proof upload action icons above their labels on mobile.
- Prevents enlarged mobile text from splitting action labels into letter fragments.

## Screenshot proof
Gist: https://gist.github.com/nopara73/57a82a52768af6b41aa0df459f1e7f2e

Before:
![Before](https://gist.githubusercontent.com/nopara73/57a82a52768af6b41aa0df459f1e7f2e/raw/1eca88dd009c722f25d5b87557215171c4b6b5d4/before.png)

After:
![After](https://gist.githubusercontent.com/nopara73/57a82a52768af6b41aa0df459f1e7f2e/raw/27789aeb31a7602dbbd9dcad3d633c88ce678a92/after.png)

## Verification
- git diff --check
- dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o .artifacts\build-proof-upload-actions
- Browser screenshot check at 320px mobile width with enlarged text for /play/proof-upload.html

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped CSS-only tweak in proof-upload.html for viewports ≤360px; no logic, API, or auth changes.
> 
> **Overview**
> On **very narrow screens** (`max-width: 360px`), the proof upload **Take photo** and **Upload proofs** buttons in `.proof-upload-primary-action` now use a **vertical layout**: icon above label (`flex-direction: column`), centered text, tighter line height, and **no right margin** on the icon.
> 
> This targets broken layouts when mobile text is enlarged—labels were wrapping one letter per line beside the icon. **Final actions** (submit/back) are unchanged; only the primary upload choice buttons get the new rules inside the existing `@media (max-width: 360px)` block in `proof-upload.html`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2c2d7407b933ef2a947c6538ebb21f70db8cf68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->