### PR TITLE
[codex] Fix Swagger mobile viewport

### DIFF
--- a/LongevityWorldCup.Website/Program.cs
+++ b/LongevityWorldCup.Website/Program.cs
@@ -375,6 +375,7 @@ namespace LongevityWorldCup.Website
                 options.RoutePrefix = "swagger";
                 options.SwaggerEndpoint("/swagger/v1/swagger.json", "Longevity World Cup Public API v1");
                 options.DocumentTitle = "Longevity World Cup Public API";
+                options.HeadContent = "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">";
                 options.DocExpansion(DocExpansion.List);
                 options.DefaultModelExpandDepth(2);
                 options.DefaultModelsExpandDepth(1);


### PR DESCRIPTION
## What changed

- Adds a viewport meta tag to the Swagger UI head content.
- Lets the existing `swagger-ui-mobile.css` rules apply at real mobile widths instead of receiving a 980px layout viewport.

## Why

On a phone-width browser, `/swagger` was rendered as a tiny desktop page because the Swagger HTML had no `viewport` meta tag. The mobile stylesheet was already injected, but the browser layout width stayed at 980px, so responsive rules did not apply.

## Screenshot proof

Gist: https://gist.github.com/nopara73/6693dc995d103bf71dddefdc79e88c00

### Before

![Before: Swagger UI renders as a tiny desktop page at 320px](https://gist.githubusercontent.com/nopara73/6693dc995d103bf71dddefdc79e88c00/raw/swagger-mobile-before-320.png)

### After

![After: Swagger UI renders as a legible mobile page at 320px](https://gist.githubusercontent.com/nopara73/6693dc995d103bf71dddefdc79e88c00/raw/swagger-mobile-after-320.png)

## Verification

- Before Playwright mobile probe at 320px: `innerWidth` was 980px, producing the shrunken desktop screenshot.
- After Playwright mobile probe at 320px: `innerWidth` is 320px, document width is 320px, and horizontal overflow is 0.
- After Playwright mobile probe at 390px: `innerWidth` is 390px, document width is 390px, and horizontal overflow is 0.
- Served `/swagger` now includes `<meta name="viewport" content="width=device-width, initial-scale=1">`.
- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o .artifacts\build-swagger-viewport`
- `git diff --check`
