### PR TITLE
[codex] Keep page OG divider out of title

### DIFF
--- a/LongevityWorldCup.Website/Business/PageOgImageService.cs
+++ b/LongevityWorldCup.Website/Business/PageOgImageService.cs
@@ -19,6 +19,7 @@ public sealed class PageOgImageService
     private const float AccentY = 192f;
     private const float TitleY = 258f;
     private const float TitleWidth = 760f;
+    private const float ContentPanelWidth = ContentX + TitleWidth + 48f;
 
     private static readonly Color BackgroundTop = ParseHex("030708");
     private static readonly Color BackgroundBottom = ParseHex("111515");
@@ -258,7 +259,7 @@ public sealed class PageOgImageService
 
             image.Mutate(ctx =>
             {
-                ctx.DrawImage(backgroundLogo, new Point(610, -24), 0.20f);
+                ctx.DrawImage(backgroundLogo, new Point(884, -24), 0.20f);
                 ctx.DrawImage(smallLogo, new Point((int)ContentX, 52), 0.98f);
             });
         }
@@ -402,8 +403,8 @@ public sealed class PageOgImageService
 
         image.Mutate(ctx =>
         {
-            ctx.Fill(new Rgba32(0, 0, 0, 92), new RectangularPolygon(0, 0, 455f, CanvasHeight));
-            ctx.Fill(new Rgba32(255, 255, 255, 12), new RectangularPolygon(455f, 0, 1f, CanvasHeight));
+            ctx.Fill(new Rgba32(0, 0, 0, 92), new RectangularPolygon(0, 0, ContentPanelWidth, CanvasHeight));
+            ctx.Fill(new Rgba32(255, 255, 255, 12), new RectangularPolygon(ContentPanelWidth, 0, 1f, CanvasHeight));
         });
     }
 
@@ -425,7 +426,7 @@ public sealed class PageOgImageService
         var regularFontTicks = File.Exists(_regularFontPath) ? File.GetLastWriteTimeUtc(_regularFontPath).Ticks : 0L;
 
         var raw = string.Join("|",
-            "page-og-v9",
+            "page-og-v10",
             definition.Slug,
             definition.Kicker,
             definition.Title,


### PR DESCRIPTION
## What changed

- Moves the page OG content panel divider to the outside of the headline text column.
- Starts the large decorative logo mark to the right of that text-safe column.
- Bumps the page OG signature key so existing generated images are refreshed.

## Why

Page OG images allowed the headline to extend far past the old 455px panel edge. On pages like `ruleset`, the vertical divider and decorative logo sat underneath the headline, visibly cutting through the title.

## Screenshot proof

Gist: https://gist.github.com/nopara73/03c6fb6b1bcf1825c0331eeb0c1b64e2

### Before

![Before: the page OG divider and decorative mark run under the headline](https://gist.githubusercontent.com/nopara73/03c6fb6b1bcf1825c0331eeb0c1b64e2/raw/page-og-divider-before.png)

### After

![After: the page OG headline sits in a clear text-safe column](https://gist.githubusercontent.com/nopara73/03c6fb6b1bcf1825c0331eeb0c1b64e2/raw/page-og-divider-after.png)

## Verification

- Downloaded `/og/page/ruleset.png` before and after; the before image has the divider/mark under `Competition rules`, while the after image keeps them outside the headline column.
- Checked `/og/page/longevitymaxxing.png` after the change to verify the longest page OG title still clears the divider and decorative mark.
- Confirmed no open Codex PR touches `LongevityWorldCup.Website/Business/PageOgImageService.cs`.
- Rebased onto current `origin/master` at `c8e2b370`.
- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o .artifacts\build-page-og-divider`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only OG image layout and cache-bust; no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes page Open Graph images where long headlines (e.g. **ruleset**) extended past a fixed **455px** left panel, so the vertical divider and large decorative logo drew **under** the title.
> 
> **`PageOgImageService`** now defines **`ContentPanelWidth`** as the text column (`ContentX` + `TitleWidth` + padding) and uses it for the dark overlay and divider instead of **455px**. The background logo is shifted right (**610 → 884**) so it sits outside that text-safe area. The render cache signature is bumped to **`page-og-v10`** so existing generated PNGs are regenerated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44882b8bba57ddefbb6887fcc15ade221b27949e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->