### PR TITLE
[codex] Center Meta callback result pages

### DIFF
--- a/LongevityWorldCup.Website/Controllers/FacebookController.cs
+++ b/LongevityWorldCup.Website/Controllers/FacebookController.cs
@@ -22,13 +22,15 @@ namespace LongevityWorldCup.Website.Controllers
                 .AppendLine("    <title>Facebook Callback</title>")
                 .AppendLine("    <style>")
                 .AppendLine("        * { box-sizing: border-box; }")
-                .AppendLine("        body { margin: 0; padding: clamp(1rem, 4vw, 2rem); max-width: 48rem; font-family: system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", sans-serif; line-height: 1.5; color: #172033; background: #f7f8fb; }")
+                .AppendLine("        body { margin: 0; min-height: 100vh; padding: clamp(1rem, 4vw, 2rem); display: flex; justify-content: center; align-items: flex-start; font-family: system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", sans-serif; line-height: 1.5; color: #172033; background: #f7f8fb; }")
+                .AppendLine("        .callback-card { width: min(100%, 48rem); padding: clamp(1.25rem, 4vw, 2rem); border: 1px solid rgba(23, 32, 51, 0.12); border-radius: 8px; background: #fff; box-shadow: 0 1rem 2.5rem rgba(23, 32, 51, 0.08); }")
                 .AppendLine("        h1 { margin: 0 0 1rem; font-size: clamp(1.6rem, 7vw, 2.25rem); line-height: 1.1; }")
                 .AppendLine("        p { margin: 0 0 1rem; }")
                 .AppendLine("        code { display: inline-block; max-width: 100%; overflow-wrap: anywhere; word-break: break-word; font-family: ui-monospace, SFMono-Regular, Consolas, \"Liberation Mono\", monospace; }")
                 .AppendLine("    </style>")
                 .AppendLine("</head>")
                 .AppendLine("<body>")
+                .AppendLine("  <main class=\"callback-card\">")
                 .AppendLine("    <h1>Facebook callback received.</h1>")
                 .AppendLine("    <p>Copy the full URL from your browser address bar and paste it into the Facebook OAuth helper.</p>");
 
@@ -44,7 +46,8 @@ namespace LongevityWorldCup.Website.Controllers
             if (Request.Query.TryGetValue("error_description", out var errorDescription))
                 html.AppendLine($"    <p>error_description: <code>{System.Net.WebUtility.HtmlEncode(errorDescription.ToString())}</code></p>");
 
-            html.AppendLine("</body>")
+            html.AppendLine("  </main>")
+                .AppendLine("</body>")
                 .AppendLine("</html>");
 
             return Content(html.ToString(), "text/html; charset=utf-8");

--- a/LongevityWorldCup.Website/Controllers/ThreadsController.cs
+++ b/LongevityWorldCup.Website/Controllers/ThreadsController.cs
@@ -20,13 +20,15 @@ namespace LongevityWorldCup.Website.Controllers
                 .AppendLine("    <title>Threads Callback</title>")
                 .AppendLine("    <style>")
                 .AppendLine("        * { box-sizing: border-box; }")
-                .AppendLine("        body { margin: 0; padding: clamp(1rem, 4vw, 2rem); max-width: 48rem; font-family: system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", sans-serif; line-height: 1.5; color: #172033; background: #f7f8fb; }")
+                .AppendLine("        body { margin: 0; min-height: 100vh; padding: clamp(1rem, 4vw, 2rem); display: flex; justify-content: center; align-items: flex-start; font-family: system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", sans-serif; line-height: 1.5; color: #172033; background: #f7f8fb; }")
+                .AppendLine("        .callback-card { width: min(100%, 48rem); padding: clamp(1.25rem, 4vw, 2rem); border: 1px solid rgba(23, 32, 51, 0.12); border-radius: 8px; background: #fff; box-shadow: 0 1rem 2.5rem rgba(23, 32, 51, 0.08); }")
                 .AppendLine("        h1 { margin: 0 0 1rem; font-size: clamp(1.6rem, 7vw, 2.25rem); line-height: 1.1; }")
                 .AppendLine("        p { margin: 0 0 1rem; }")
                 .AppendLine("        code { display: inline-block; max-width: 100%; overflow-wrap: anywhere; word-break: break-word; font-family: ui-monospace, SFMono-Regular, Consolas, \"Liberation Mono\", monospace; }")
                 .AppendLine("    </style>")
                 .AppendLine("</head>")
                 .AppendLine("<body>")
+                .AppendLine("  <main class=\"callback-card\">")
                 .AppendLine("    <h1>Threads callback received.</h1>");
 
             if (Request.Query.TryGetValue("code", out var code))
@@ -41,7 +43,8 @@ namespace LongevityWorldCup.Website.Controllers
             if (Request.Query.TryGetValue("error_description", out var errorDescription))
                 html.AppendLine($"    <p>error_description: <code>{System.Net.WebUtility.HtmlEncode(errorDescription.ToString())}</code></p>");
 
-            html.AppendLine("</body>")
+            html.AppendLine("  </main>")
+                .AppendLine("</body>")
                 .AppendLine("</html>");
 
             return Content(html.ToString(), "text/html; charset=utf-8");


### PR DESCRIPTION
## What changed

- Centers the Threads and Facebook callback result pages inside a bounded panel on wide screens.
- Keeps the existing long-code wrapping behavior for callback query values.

## Why

The callback result pages had a max-width body but no centering surface, so on desktop the useful content sat in the far-left corner with the rest of the viewport empty.

## Screenshot proof

Gist: https://gist.github.com/nopara73/91b52bd3edda6143088b0ef92ff88dc3

### Before

![Before: callback content sits in the far-left corner on desktop](https://gist.githubusercontent.com/nopara73/91b52bd3edda6143088b0ef92ff88dc3/raw/meta-callback-before.png)

### After

![After: callback content is centered in a bounded panel on desktop](https://gist.githubusercontent.com/nopara73/91b52bd3edda6143088b0ef92ff88dc3/raw/meta-callback-after.png)

## Verification

- Playwright desktop capture at 1366px: content moved from `left=32` to `left=332`.
- Playwright mobile capture at 390px: document width remains 390px and long callback values wrap inside the panel.
- Checked open Codex PRs; none touch `FacebookController` or `ThreadsController`.
- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o .artifacts\build-callback-layout`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentational-only changes to dev/helper callback HTML; no auth, routing, or data-handling logic changes.
> 
> **Overview**
> Updates the **Facebook** and **Threads** OAuth callback HTML so the result content is centered on wide viewports instead of hugging the left edge.
> 
> The `body` layout switches to a full-height flex container with horizontal centering, and callback text is wrapped in a **`main.callback-card`** panel (max ~48rem, bordered, white background, light shadow). Query-parameter display and `code` wrapping behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d4d0c69afb27e9fbb3d6efe9011e96829343cf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->