### PR TITLE
[codex] Space Event rank tokens

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
@@ -1270,7 +1270,8 @@
                     : `<span class="athlete-name-text">${esc(name)}</span>`;
 
                 const extra=typeof afterSlug==="function"?afterSlug(key,a):"";
-                out += `<span class="name-and-rank">${piece}${extra}</span>`;
+                const extraSeparator=extra ? "&nbsp;" : "";
+                out += `<span class="name-and-rank">${piece}${extraSeparator}${extra}</span>`;
                 last=rx.lastIndex;
             }
             out += esc(s.slice(last));


### PR DESCRIPTION
## What changed

- Adds an explicit nonbreaking separator between event-board athlete names and their generated rank token.
- Keeps the name/rank pair non-wrapping while avoiding glued text like `Ron Lugbill(#125)` in embedded and public Event rows.

## Why

The athlete Event embed rendered names and rank links as a single visually attached token. The repeated `Name(#rank)` pattern was visible in the constrained embed, especially in the dark athlete history embed.

## Screenshot proof

Gist: https://gist.github.com/nopara73/badc538ea3be8be90132b4405e5a1b49

| Before | After |
| --- | --- |
| ![Before: event embed glues athlete names to rank tokens](https://gist.githubusercontent.com/nopara73/badc538ea3be8be90132b4405e5a1b49/raw/aa0fe084e9ee51eb77cb1c2228449999026579ef/event-embed-rank-gap-before-320.png) | ![After: event embed separates athlete names and rank tokens](https://gist.githubusercontent.com/nopara73/badc538ea3be8be90132b4405e5a1b49/raw/573ce3a29d57fc3e7d5f578f0d2949dc6e99d198/event-embed-rank-gap-after-320.png) |

## Verification

- Rendered `/event-board-embed.html?athlete=ron-lugbill&rows=all&viewAll=false&linkNames=false&embed=1&theme=dark` at 320px before and after.
- Verified `.name-and-rank` text now includes a separator, e.g. `Ron Lugbill (#125)`.
- Checked the embed and `/events` at 320px, 390px, and 568x320 with no horizontal overflow.
- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o .artifacts\build-event-rank-gap`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line presentation tweak in client-side event message HTML; no API, auth, or data changes.
> 
> **Overview**
> Fixes **event board** rows where athlete names and current-rank tokens (e.g. `(#125)`) rendered as one glued string like `Ron Lugbill(#125)`, especially in narrow **embed** views.
> 
> In `renderTextWithSlugLinks`, when the `afterSlug` callback supplies rank markup, the HTML now inserts a non-breaking space (`&nbsp;`) between the name link/text and that suffix inside `.name-and-rank`. Names without rank tokens are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6f04b77cf35117169ca76ea7aa21bd7f5e7350e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->