### PR TITLE
[codex] Fix Swagger mobile schema labels

### DIFF
--- a/LongevityWorldCup.Tests/SwaggerOpenApiTests.cs
+++ b/LongevityWorldCup.Tests/SwaggerOpenApiTests.cs
@@ -252,6 +252,18 @@ public sealed class SwaggerOpenApiTests
             $"Unexpected /swagger status code: {(int)response.StatusCode} {response.StatusCode}.");
     }
 
+    [Fact]
+    public async Task SwaggerUiMobileCss_PreservesExpandedModelToggle()
+    {
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        var css = await client.GetStringAsync("/css/swagger-ui-mobile.css");
+
+        Assert.Contains(".swagger-ui .model-box-control > span:last-child:not(.model-toggle)", css);
+        Assert.DoesNotContain(".swagger-ui .model-box-control > span:last-child {", css);
+    }
+
     private static async Task<JsonDocument> LoadSwaggerDocumentAsync()
     {
         using var factory = CreateFactory();

--- a/LongevityWorldCup.Website/wwwroot/css/swagger-ui-mobile.css
+++ b/LongevityWorldCup.Website/wwwroot/css/swagger-ui-mobile.css
@@ -101,6 +101,51 @@
         overflow-wrap: anywhere;
         word-break: normal;
     }
+
+    .swagger-ui .models .model-container {
+        margin-left: 0 !important;
+        margin-right: 0 !important;
+    }
+
+    .swagger-ui .model-container .model-box-control {
+        display: grid !important;
+        grid-template-columns: minmax(0, 1fr) 1.75rem;
+        align-items: center;
+        column-gap: 0.5rem;
+        width: 100% !important;
+        min-height: 4rem;
+        margin: 0 !important;
+        padding: 0.85rem;
+        text-align: left;
+    }
+
+    .swagger-ui .model-box-control > .pointer,
+    .swagger-ui .model-box-control .model-box,
+    .swagger-ui .model-box-control .model-title {
+        display: block;
+        width: 100%;
+        min-width: 0;
+        max-width: 100%;
+    }
+
+    .swagger-ui .model-box-control .model-box {
+        padding: 0;
+    }
+
+    .swagger-ui .model-box-control .model-title {
+        font-size: clamp(0.82rem, 3.45vw, 0.95rem);
+        line-height: 1.18;
+        text-align: left;
+    }
+
+    .swagger-ui .model-box-control .model-toggle {
+        justify-self: end;
+        min-width: 1.75rem;
+    }
+
+    .swagger-ui .model-box-control > span:last-child {
+        display: none;
+    }
 }
 
 @media (max-width: 360px) {

--- a/LongevityWorldCup.Website/wwwroot/css/swagger-ui-mobile.css
+++ b/LongevityWorldCup.Website/wwwroot/css/swagger-ui-mobile.css
@@ -143,7 +143,7 @@
         min-width: 1.75rem;
     }
 
-    .swagger-ui .model-box-control > span:last-child {
+    .swagger-ui .model-box-control > span:last-child:not(.model-toggle) {
         display: none;
     }
 }


### PR DESCRIPTION
## What changed

- Tightens the mobile Swagger schema-card layout so model names get the full available width.
- Keeps the disclosure arrow in a fixed slot instead of letting it drop onto its own line.
- Slightly scales schema-title text on narrow screens so long API model names remain readable.

## Why

At a 320px viewport, the Swagger `Schemas` list split model names into tiny trailing fragments like `BortzAgeCalculationRequ` / `est`, and the disclosure arrow dropped to a separate line. This made the API docs look broken even though the content was present.

## Screenshot proof

Gist: https://gist.github.com/nopara73/9c85b31e18753d42fb232bc4364cfe97

| Before | After |
| --- | --- |
| ![Before: Swagger schema model names break into awkward fragments at 320px](https://gist.githubusercontent.com/nopara73/9c85b31e18753d42fb232bc4364cfe97/raw/6592e7627fe9269e646772cacc2eb7af6cf48dbe/swagger-schema-before-320.png) | ![After: Swagger schema model names use the available width and keep arrows aligned at 320px](https://gist.githubusercontent.com/nopara73/9c85b31e18753d42fb232bc4364cfe97/raw/7e70a86329d9942be9d2c93435687620c9a15759/swagger-schema-after-320.png) |

## Verification

- Playwright screenshot at `/swagger/index.html`, 320x720: before names split into trailing fragments and arrows fall below labels; after names are readable and arrows stay aligned.
- Playwright metric check at 320x720, 360x720, and 390x844: document `scrollWidth` equals viewport width and schema titles have no horizontal text overflow.
- `git diff --check`
- `dotnet build LongevityWorldCup.Website\LongevityWorldCup.Website.csproj -o .artifacts\build\swagger-mobile-schema`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only styling and a regression test; no API, auth, or data-path changes.
> 
> **Overview**
> **Mobile Swagger `Schemas` cards** get a grid layout in `swagger-ui-mobile.css` so model titles use the full row width and the disclosure control stays in a fixed right column, with slightly scaled title text on small screens.
> 
> The rule that hides an extra trailing `span` now targets **only non-toggle** last children (`:not(.model-toggle)`), so expanded schema toggles are not accidentally hidden.
> 
> A new **`SwaggerUiMobileCss_PreservesExpandedModelToggle`** test fetches the stylesheet and asserts that selector is present and the broader `> span:last-child {` rule is not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83384a1537dc86b2c70e8a1de9c37abd9f49d015. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->