### PR TITLE
[codex] Fix application profile preview frame

### DIFF
--- a/LongevityWorldCup.Tests/ApplicationOnboardingPageTests.cs
+++ b/LongevityWorldCup.Tests/ApplicationOnboardingPageTests.cs
@@ -47,7 +47,16 @@ public sealed class ApplicationOnboardingPageTests
         Assert.Contains(".convergence-visual", html);
         Assert.Contains("#profileImage.illustration", html);
         Assert.Contains("aspect-ratio: 4 / 3;", html);
-        Assert.Contains("object-fit: cover;", html);
+        var profileRuleStart = html.IndexOf("#profileImage.illustration", StringComparison.Ordinal);
+        Assert.True(profileRuleStart >= 0, "Could not find profile image rule.");
+
+        var profileRuleEnd = html.IndexOf('}', profileRuleStart);
+        Assert.True(profileRuleEnd > profileRuleStart, "Could not find end of profile image rule.");
+
+        var profileRule = html[profileRuleStart..profileRuleEnd];
+        Assert.Contains("object-fit: contain;", profileRule);
+        Assert.DoesNotContain("object-fit: cover;", profileRule);
+        Assert.Contains("#descriptionForm #profileImage.illustration", html);
     }
 
     [Fact]

--- a/LongevityWorldCup.Tests/ApplicationOnboardingPageTests.cs
+++ b/LongevityWorldCup.Tests/ApplicationOnboardingPageTests.cs
@@ -36,6 +36,21 @@ public sealed class ApplicationOnboardingPageTests
     }
 
     [Fact]
+    public async Task ApplicationProfilePreview_UsesStableIllustrationFrame()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var html = await client.GetStringAsync("/onboarding/convergence.html");
+
+        Assert.Contains("class=\"convergence-visual\"", html);
+        Assert.Contains(".convergence-visual", html);
+        Assert.Contains("#profileImage.illustration", html);
+        Assert.Contains("aspect-ratio: 4 / 3;", html);
+        Assert.Contains("object-fit: cover;", html);
+    }
+
+    [Fact]
     public async Task ApplicationSubmissionTimeout_WaitsForServerPublicWorkTimeout()
     {
         using var factory = new TestWebApplicationFactory();

--- a/LongevityWorldCup.Website/wwwroot/onboarding/convergence.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/convergence.html
@@ -449,7 +449,7 @@
             width: 100%;
             max-width: 408px;
             aspect-ratio: 4 / 3;
-            object-fit: cover;
+            object-fit: contain;
         }
 
         .convergence-application-copy {
@@ -497,9 +497,16 @@
             #descriptionForm .illustration {
                 width: min(100%, 290px);
                 max-height: 218px;
-                object-fit: cover;
                 border-width: 3px;
                 margin-bottom: 1rem;
+            }
+
+            #descriptionForm #illustrationImage.illustration {
+                object-fit: cover;
+            }
+
+            #descriptionForm #profileImage.illustration {
+                object-fit: contain;
             }
 
             #descriptionForm .sub-progress-container {

--- a/LongevityWorldCup.Website/wwwroot/onboarding/convergence.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/convergence.html
@@ -440,6 +440,18 @@
             color: #1f2937;
         }
 
+        .convergence-visual {
+            width: 100%;
+            text-align: center;
+        }
+
+        #profileImage.illustration {
+            width: 100%;
+            max-width: 408px;
+            aspect-ratio: 4 / 3;
+            object-fit: cover;
+        }
+
         .convergence-application-copy {
             margin: 0.75rem 0 1.1rem;
             padding: 0.85rem 0.95rem;
@@ -525,7 +537,7 @@
         <!--MAIN-PROGRESS-BAR-->
         <h1 data-aos="fade" data-aos-duration="700" data-aos-delay="400">1. Enter the arena</h1>
         <form id="descriptionForm" class="bioageform" data-aos="fade" data-aos-duration="700" data-aos-delay="450">
-            <div style="text-align: center;">
+            <div class="convergence-visual">
                 <picture id="illustrationPicture" style="display:''">
                     <source type="image/webp" srcset="../assets/content-images/enter-arena.webp">
                     <source type="image/jpeg" srcset="../assets/content-images/enter-arena.jpg">
@@ -805,7 +817,7 @@
         }
 
         function fillFakeData() {
-            const tinyPng = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9pQ9JxwAAAAASUVORK5CYII=';
+            const tinyPng = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAANSURBVBhXY5izeP1/AAa7Au6XP8FKAAAAAElFTkSuQmCC';
 
             const nameInput = document.getElementById('name');
             const flagInput = document.getElementById('flag');


### PR DESCRIPTION
## Summary
- Keeps the application onboarding profile preview in a stable 4:3 visual frame when stage 4 swaps the illustration for the selected profile image.
- Replaces the fake-mode 1px profile image with a visible neutral placeholder so the deterministic fake application flow does not collapse into a dot.
- Adds a regression test for the profile preview wrapper and frame CSS.

## Root cause
The stage 4 image swap hid the `<picture>` illustration and showed `#profileImage`, but the image kept its intrinsic 1x1 fake-mode size. At mobile width that rendered as a tiny dot above the progress bar instead of preserving the visual frame used by the previous illustration.

## Screenshot proof
Gist: https://gist.github.com/nopara73/2660a5b51212121a7f3a517e40ead7d5

| Before (320px) | After (320px) |
| --- | --- |
| ![Before at 320px](https://gist.githubusercontent.com/nopara73/2660a5b51212121a7f3a517e40ead7d5/raw/before-320.png) | ![After at 320px](https://gist.githubusercontent.com/nopara73/2660a5b51212121a7f3a517e40ead7d5/raw/after-320.png) |

| Before (390px) | After (390px) |
| --- | --- |
| ![Before at 390px](https://gist.githubusercontent.com/nopara73/2660a5b51212121a7f3a517e40ead7d5/raw/before-390.png) | ![After at 390px](https://gist.githubusercontent.com/nopara73/2660a5b51212121a7f3a517e40ead7d5/raw/after-390.png) |

## Verification
- `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --filter ApplicationProfilePreview_UsesStableIllustrationFrame --no-restore --verbosity minimal`
- `git diff --check`
- Browser smoke: `/apply?fake=1` stage 4 at 320px and 390px; document width stayed equal to viewport width.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding UI/CSS and test-only fake data only; no API, auth, or submission logic changes.
> 
> **Overview**
> Fixes application onboarding **stage 4** so swapping the hero illustration for the user’s profile image no longer collapses to a tiny dot on narrow viewports (especially fake-mode testing).
> 
> Adds a **`convergence-visual`** wrapper and **`#profileImage.illustration`** rules (**4:3** `aspect-ratio`, **`object-fit: contain`**, max width aligned with upload UI). Mobile styles now apply **`object-fit: cover`** only to **`#illustrationImage`**, not the profile preview. **`fillFakeData`** uses a larger neutral PNG placeholder instead of a 1×1 pixel.
> 
> Adds **`ApplicationProfilePreview_UsesStableIllustrationFrame`** to lock in the wrapper and CSS contract in served **`convergence.html`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f4e660b181c946f857b4a209c88492b25c4011b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->