### PR TITLE
[codex] Fit Swagger response controls

### DIFF
--- a/LongevityWorldCup.Tests/SwaggerOpenApiTests.cs
+++ b/LongevityWorldCup.Tests/SwaggerOpenApiTests.cs
@@ -264,6 +264,21 @@ public sealed class SwaggerOpenApiTests
         Assert.DoesNotContain(".swagger-ui .model-box-control > span:last-child {", css);
     }
 
+    [Fact]
+    public async Task SwaggerUiMobileCss_PreservesResponseMediaTypeControls()
+    {
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        var css = await client.GetStringAsync("/css/swagger-ui-mobile.css");
+
+        Assert.Contains(".swagger-ui .responses-inner", css);
+        Assert.Contains(".swagger-ui .responses-table .response-col_status", css);
+        Assert.Contains(".swagger-ui .responses-table .response-col_links", css);
+        Assert.Contains(".swagger-ui .content-type-wrapper select.content-type", css);
+        Assert.Contains("width: min(100%, 11rem);", css);
+    }
+
     private static async Task<JsonDocument> LoadSwaggerDocumentAsync()
     {
         using var factory = CreateFactory();

--- a/LongevityWorldCup.Website/wwwroot/css/swagger-ui-mobile.css
+++ b/LongevityWorldCup.Website/wwwroot/css/swagger-ui-mobile.css
@@ -82,6 +82,42 @@
         padding: 0;
     }
 
+    .swagger-ui .responses-inner {
+        padding: 1rem 0.75rem;
+    }
+
+    .swagger-ui .responses-table .response-col_status {
+        width: 2.4rem;
+        min-width: 2.4rem;
+    }
+
+    .swagger-ui .responses-table .response-col_links {
+        width: 3rem;
+        min-width: 3rem;
+        max-width: 3rem;
+    }
+
+    .swagger-ui .responses-table .response-col_description {
+        max-width: none;
+    }
+
+    .swagger-ui .response-controls,
+    .swagger-ui .response-control-media-type,
+    .swagger-ui .content-type-wrapper {
+        min-width: 0;
+        max-width: 100%;
+    }
+
+    .swagger-ui .response-controls {
+        display: block;
+    }
+
+    .swagger-ui .content-type-wrapper select.content-type {
+        width: min(100%, 11rem);
+        min-width: min(100%, 11rem);
+        max-width: 100%;
+    }
+
     .swagger-ui .models,
     .swagger-ui .model-container,
     .swagger-ui .model-box,


### PR DESCRIPTION
## What changed
- Tightened Swagger UI mobile response-table gutters and side columns.
- Let the response media-type controls use the recovered width so `application/json` no longer clips inside expanded endpoint responses.
- Added a CSS regression assertion for the mobile response controls.

## Screenshot proof
Gist: https://gist.github.com/nopara73/d61280a06b4301caff93983a83ae150f

| 320 before | 320 after |
| --- | --- |
| ![before 320](https://gist.githubusercontent.com/nopara73/d61280a06b4301caff93983a83ae150f/raw/before-320.png) | ![after 320](https://gist.githubusercontent.com/nopara73/d61280a06b4301caff93983a83ae150f/raw/after-320.png) |

| 390 before | 390 after |
| --- | --- |
| ![before 390](https://gist.githubusercontent.com/nopara73/d61280a06b4301caff93983a83ae150f/raw/before-390.png) | ![after 390](https://gist.githubusercontent.com/nopara73/d61280a06b4301caff93983a83ae150f/raw/after-390.png) |

## Verification
- `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --filter SwaggerUiMobileCss_PreservesResponseMediaTypeControls --no-restore --verbosity minimal`
- `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --filter SwaggerOpenApiTests --no-restore --verbosity minimal`
- `git diff --check`
- Playwright screenshot check at 320px and 390px on `/swagger/index.html` with the first endpoint expanded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static CSS and test-only assertions for Swagger UI presentation; no API, auth, or data-path changes.
> 
> **Overview**
> **Swagger UI mobile CSS** now lays out expanded endpoint **response** sections so status/links columns are narrower, the description column can use full width, and the **content-type** dropdown (`application/json`) is capped at `min(100%, 11rem)` so labels no longer clip on narrow viewports.
> 
> A new integration test **`SwaggerUiMobileCss_PreservesResponseMediaTypeControls`** fetches `/css/swagger-ui-mobile.css` and asserts those selectors and sizing rules stay present, matching the existing pattern for mobile model-toggle CSS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 587bbfe00ec650a84f15f7dcc258c7c1d84b82c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->