### PR TITLE
[codex] Wrap newsletter success email on mobile

### DIFF
--- a/LongevityWorldCup.Tests/HomepageNewsletterModalTests.cs
+++ b/LongevityWorldCup.Tests/HomepageNewsletterModalTests.cs
@@ -1,0 +1,47 @@
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class HomepageNewsletterModalTests
+{
+    [Fact]
+    public void NewsletterSuccessDialog_AllowsLongEmailToWrap()
+    {
+        var indexHtml = File.ReadAllText(Path.Combine(
+            FindRepoRoot(),
+            "LongevityWorldCup.Website",
+            "wwwroot",
+            "index.html"));
+
+        Assert.Contains("id=\"newsletterSuccessMessage\"", indexHtml);
+
+        var ruleStart = indexHtml.IndexOf("#newsletterSuccessMessage,", StringComparison.Ordinal);
+        Assert.True(ruleStart >= 0, "Could not find newsletter success message wrapping rule.");
+
+        var ruleEnd = indexHtml.IndexOf('}', ruleStart);
+        Assert.True(ruleEnd > ruleStart, "Could not find end of newsletter success message wrapping rule.");
+
+        var rule = indexHtml[ruleStart..ruleEnd];
+        Assert.Contains("#newsletterSuccessMessage strong", rule);
+        Assert.Contains("overflow-wrap: anywhere;", rule);
+        Assert.Contains("word-break: break-word;", rule);
+    }
+
+    private static string FindRepoRoot([CallerFilePath] string sourceFilePath = "")
+    {
+        var startDirectory = Path.GetDirectoryName(sourceFilePath) ?? AppContext.BaseDirectory;
+        var current = new DirectoryInfo(startDirectory);
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "LongevityWorldCup.sln")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException($"Could not find repository root from {startDirectory}.");
+    }
+}

--- a/LongevityWorldCup.Website/wwwroot/index.html
+++ b/LongevityWorldCup.Website/wwwroot/index.html
@@ -80,6 +80,12 @@
             line-height: 1.5;
         }
 
+        #newsletterSuccessMessage,
+        #newsletterSuccessMessage strong {
+            overflow-wrap: anywhere;
+            word-break: break-word;
+        }
+
         .dialog-button {
             display: inline-block;
             padding: 0.7rem 1.5rem;


### PR DESCRIPTION
## Summary
- Allow the newsletter success dialog email text to wrap inside the modal.
- Add a static regression test covering the wrapping rule.

## Screenshot proof
Gist: https://gist.github.com/nopara73/d55566995b4f0d1bcdc0da2991a26816

| Width | Before | After |
| --- | --- | --- |
| 320px | ![Before 320px](https://gist.githubusercontent.com/nopara73/d55566995b4f0d1bcdc0da2991a26816/raw/before-320.png) | ![After 320px](https://gist.githubusercontent.com/nopara73/d55566995b4f0d1bcdc0da2991a26816/raw/after-320.png) |
| 390px | ![Before 390px](https://gist.githubusercontent.com/nopara73/d55566995b4f0d1bcdc0da2991a26816/raw/before-390.png) | ![After 390px](https://gist.githubusercontent.com/nopara73/d55566995b4f0d1bcdc0da2991a26816/raw/after-390.png) |

## Verification
- `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --filter NewsletterSuccessDialog_AllowsLongEmailToWrap --no-restore --verbosity minimal`
- `git diff --check`
- Playwright mocked the successful newsletter subscription flow at 320px, 360px, and 390px; after metrics reported no message overflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS plus a static HTML assertion test; no API, auth, or subscription logic changes.
> 
> **Overview**
> Fixes **horizontal overflow** in the newsletter subscription success dialog when the submitted email is long on narrow screens (e.g. mobile).
> 
> Adds inline CSS on `#newsletterSuccessMessage` and its `strong` child with `overflow-wrap: anywhere` and `word-break: break-word` in `index.html`, so the dynamic email in the success copy stays inside the modal instead of clipping past the dialog width.
> 
> Adds **`HomepageNewsletterModalTests`** with `NewsletterSuccessDialog_AllowsLongEmailToWrap`, which loads `wwwroot/index.html` and asserts that wrapping rule is present—guarding against accidental removal of the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1c9eb1cb01ef15192bf700dbefb4bd0a7d5ca2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->