### PR TITLE
[codex] Wrap review contact email on mobile

### DIFF
--- a/LongevityWorldCup.Tests/ApplicationReviewPageTests.cs
+++ b/LongevityWorldCup.Tests/ApplicationReviewPageTests.cs
@@ -135,4 +135,23 @@ public sealed class ApplicationReviewPageTests
         Assert.Contains("applicantName: normalizeOptionalString(pending.applicantName)", script);
         Assert.Contains("submissionType: normalizePaymentSubmissionType(pending.submissionType)", script);
     }
+
+    [Fact]
+    public async Task ApplicationReview_WrapsLongStoredContactEmail()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var html = await client.GetStringAsync("/onboarding/application-review.html");
+        var ruleStart = html.IndexOf("#contactEmailPlaceholder", StringComparison.Ordinal);
+        Assert.True(ruleStart >= 0, "Could not find contact email wrapping rule.");
+
+        var ruleEnd = html.IndexOf('}', ruleStart);
+        Assert.True(ruleEnd > ruleStart, "Could not find end of contact email wrapping rule.");
+
+        var rule = html[ruleStart..ruleEnd];
+        Assert.Contains("overflow-wrap: anywhere;", rule);
+        Assert.Contains("word-break: break-word;", rule);
+        Assert.Contains("white-space: normal;", rule);
+    }
 }

--- a/LongevityWorldCup.Website/wwwroot/onboarding/application-review.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/application-review.html
@@ -76,6 +76,12 @@
             text-underline-offset: 0.14em;
         }
 
+        #contactEmailPlaceholder {
+            overflow-wrap: anywhere;
+            word-break: break-word;
+            white-space: normal;
+        }
+
         .application-review-actions {
             margin-top: 1.45rem;
         }


### PR DESCRIPTION
## Summary
- Allow the application review contact email to wrap inside the review message panel.
- Add a regression assertion for the review page wrapping rule.

## Screenshot proof
Gist: https://gist.github.com/nopara73/f8d63d35e530fbff5c8709244723f975

| Width | Before | After |
| --- | --- | --- |
| 320px | ![Before 320px](https://gist.githubusercontent.com/nopara73/f8d63d35e530fbff5c8709244723f975/raw/before-320.png) | ![After 320px](https://gist.githubusercontent.com/nopara73/f8d63d35e530fbff5c8709244723f975/raw/after-320.png) |
| 390px | ![Before 390px](https://gist.githubusercontent.com/nopara73/f8d63d35e530fbff5c8709244723f975/raw/before-390.png) | ![After 390px](https://gist.githubusercontent.com/nopara73/f8d63d35e530fbff5c8709244723f975/raw/after-390.png) |

## Verification
- `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --filter ApplicationReview_WrapsLongStoredContactEmail --no-restore --verbosity minimal`
- `git diff --check`
- Playwright stored a long contact email and checked `/review` at 320px, 360px, and 390px; after metrics reported no horizontal page overflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS on a static onboarding page with no logic or data-handling changes.
> 
> **Overview**
> Fixes **horizontal overflow on narrow viewports** when the stored contact email in the primary review message is very long.
> 
> Adds a `#contactEmailPlaceholder` style block on `application-review.html` with `overflow-wrap: anywhere`, `word-break: break-word`, and `white-space: normal` so the highlighted email breaks inside the green review panel instead of forcing the page wider.
> 
> Adds **`ApplicationReview_WrapsLongStoredContactEmail`** in `ApplicationReviewPageTests.cs`, which loads the page HTML and asserts that wrapping rule is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cadeef7edd03594f8bdeddc962b6075c988d4d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->