### PR TITLE
[codex] Fix mobile discount badge spacing

### DIFF
--- a/LongevityWorldCup.Tests/PaymentOfferHandoffPageTests.cs
+++ b/LongevityWorldCup.Tests/PaymentOfferHandoffPageTests.cs
@@ -75,6 +75,22 @@ public sealed class PaymentOfferHandoffPageTests
     }
 
     [Fact]
+    public async Task JoinGamePricing_DiscountBadgeSlotFitsMobileTapTarget()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var html = await client.GetStringAsync("/onboarding/join-game.html");
+
+        Assert.Contains("#proDiscountBreakdown .pro-discount-badge-slot {\n        width: 44px;", html);
+        Assert.Contains("min-width: 44px;", html);
+        Assert.Contains("height: 44px;", html);
+        Assert.Contains("#proDiscountBreakdown .pro-discount-badge-slot:empty", html);
+        Assert.Contains("#proDiscountBreakdown .pro-discount-text", html);
+        Assert.Contains("overflow-wrap: anywhere;", html);
+    }
+
+    [Fact]
     public async Task SharedDashboardPaymentOffer_HaltsNavigationWhenStorageFails()
     {
         using var factory = new TestWebApplicationFactory();

--- a/LongevityWorldCup.Tests/PlayMenuPageTests.cs
+++ b/LongevityWorldCup.Tests/PlayMenuPageTests.cs
@@ -164,4 +164,20 @@ public sealed class PlayMenuPageTests
         Assert.Contains("/js/proof-helpers.js", html);
         Assert.Contains("/js/pro-discounts.js", html);
     }
+
+    [Fact]
+    public async Task PlayMenu_DiscountBadgeSlotFitsMobileTapTarget()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var html = await client.GetStringAsync("/play/menu.html");
+
+        Assert.Contains(".pro-discount-badge-slot {\n            width: 44px;", html);
+        Assert.Contains("min-width: 44px;", html);
+        Assert.Contains("height: 44px;", html);
+        Assert.Contains(".pro-discount-badge-slot:empty", html);
+        Assert.Contains(".pro-discount-text", html);
+        Assert.Contains("overflow-wrap: anywhere;", html);
+    }
 }

--- a/LongevityWorldCup.Website/wwwroot/onboarding/join-game.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/join-game.html
@@ -645,12 +645,21 @@
       }
 
       #proDiscountBreakdown .pro-discount-badge-slot {
-        width: 22px;
-        min-width: 22px;
-        height: 22px;
+        width: 44px;
+        min-width: 44px;
+        height: 44px;
         display: inline-flex;
         align-items: center;
         justify-content: center;
+      }
+
+      #proDiscountBreakdown .pro-discount-badge-slot:empty {
+        display: none;
+      }
+
+      #proDiscountBreakdown .pro-discount-text {
+        min-width: 0;
+        overflow-wrap: anywhere;
       }
 
       .pro-old-price {

--- a/LongevityWorldCup.Website/wwwroot/play/menu.html
+++ b/LongevityWorldCup.Website/wwwroot/play/menu.html
@@ -251,12 +251,21 @@
         }
 
         .pro-discount-box .pro-discount-breakdown .pro-discount-badge-slot {
-            width: 22px;
-            min-width: 22px;
-            height: 22px;
+            width: 44px;
+            min-width: 44px;
+            height: 44px;
             display: inline-flex;
             align-items: center;
             justify-content: center;
+        }
+
+        .pro-discount-box .pro-discount-breakdown .pro-discount-badge-slot:empty {
+            display: none;
+        }
+
+        .pro-discount-box .pro-discount-breakdown .pro-discount-text {
+            min-width: 0;
+            overflow-wrap: anywhere;
         }
 
         .pro-old-price {


### PR DESCRIPTION
## Summary

Fixes the mobile play dashboard discount summary where the clickable personal-page discount badge expanded to the global 44px mobile tap target but the discount row only reserved a 22px slot. The badge now gets a 44px slot, empty rows do not keep a fake badge gutter, and discount text can wrap beside the badge.

The same discount breakdown styling on the join-game pricing note is aligned so the sibling component does not keep the same overlap risk.

## Screenshot proof

Gist: https://gist.github.com/nopara73/8d168c20d91373b24b1b08170fcf64f0

| Before | After |
| --- | --- |
| ![Before mobile dashboard discount badge overlap](https://gist.githubusercontent.com/nopara73/8d168c20d91373b24b1b08170fcf64f0/raw/before-dashboard-discount-320.png) | ![After mobile dashboard discount badge spacing](https://gist.githubusercontent.com/nopara73/8d168c20d91373b24b1b08170fcf64f0/raw/after-dashboard-discount-320.png) |

## Verification

- `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --filter "PlayMenu_DiscountBadgeSlotFitsMobileTapTarget|JoinGamePricing_DiscountBadgeSlotFitsMobileTapTarget" --no-restore --verbosity minimal`
- `git diff --check`
- Playwright render at 320/360/390px verified no horizontal scroll and no badge/text intersection in the dashboard discount rows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped CSS and snapshot-style page tests only; no payment, auth, or shared JS logic changes.
> 
> **Overview**
> Fixes mobile layout where **clickable discount badges** use a **44px** tap target but each breakdown row only reserved a **22px** badge column, causing overlap with discount text.
> 
> **`play/menu.html`** and **`join-game.html`** now size `.pro-discount-badge-slot` at **44×44px**, hide **empty** badge slots so rows without a badge do not keep a gutter, and let **`.pro-discount-text`** wrap with `min-width: 0` and `overflow-wrap: anywhere`.
> 
> Adds **`PlayMenu_DiscountBadgeSlotFitsMobileTapTarget`** and **`JoinGamePricing_DiscountBadgeSlotFitsMobileTapTarget`** tests that assert the embedded CSS in those pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28c31cb4be820d383b1e55096ab41d6189e85d3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->