### PR TITLE
[codex] Keep mobile share menu visible

### DIFF
--- a/LongevityWorldCup.Tests/LeaderboardBestRankScriptTests.cs
+++ b/LongevityWorldCup.Tests/LeaderboardBestRankScriptTests.cs
@@ -97,6 +97,16 @@ public class LeaderboardBestRankScriptTests
         Assert.Contains("https://www.linkedin.com/sharing/share-offsite/?url=", html);
         Assert.Contains("mailto:?subject=", html);
         Assert.Contains("openAthleteShareMenu(button, sharePayload)", html);
+        Assert.Contains("#detailsModal .athlete-share-menu.is-above", html);
+        Assert.Contains("function positionAthleteShareMenu(menu)", html);
+        Assert.Contains("const viewportBottom = Math.min(window.innerHeight, modalRect ? modalRect.bottom : window.innerHeight);", html);
+        Assert.Contains("menu.classList.add('is-above');", html);
+        Assert.Contains("positionAthleteShareMenu(menu);", html);
+        Assert.Contains("function keepAthleteShareMenuInView(menu)", html);
+        Assert.Contains("menu.scrollIntoView({ block: 'nearest', inline: 'nearest' });", html);
+        Assert.Contains("keepAthleteShareMenuInView(menu);", html);
+        Assert.Contains("requestAnimationFrame(() => keepAthleteShareMenuInView(menu));", html);
+        Assert.Contains("menu.classList.remove('is-above');", html);
         Assert.Contains("copyTextToClipboard(sharePayload.url)", html);
         Assert.Contains("if (shouldUseNativeAthleteShare(sharePayload))", html);
         Assert.DoesNotContain("if (navigator.share &&", html);

--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -1389,6 +1389,10 @@
         background:rgb(18,20,20);
         box-shadow:0 20px 42px rgba(0,0,0,.42), inset 0 1px 0 rgba(255,255,255,.06);
     }
+    #detailsModal .athlete-share-menu.is-above{
+        top:auto;
+        bottom:calc(100% + .45rem);
+    }
     #detailsModal .athlete-share-menu[hidden]{ display:none; }
     #detailsModal .athlete-share-menu a,
     #detailsModal .athlete-share-menu button{
@@ -6734,6 +6738,7 @@
         }
 
         menu.hidden = true;
+        menu.classList.remove('is-above');
         setShareMenuCopyState('Copy link', false);
 
         const button = document.getElementById('shareAthleteProfile');
@@ -6745,6 +6750,32 @@
         }
 
         return true;
+    }
+
+    function positionAthleteShareMenu(menu) {
+        if (!menu || menu.hidden) return;
+
+        menu.classList.remove('is-above');
+        const modalContent = document.querySelector('#detailsModal .modal-content');
+        const modalRect = modalContent ? modalContent.getBoundingClientRect() : null;
+        const viewportBottom = Math.min(window.innerHeight, modalRect ? modalRect.bottom : window.innerHeight);
+        const viewportTop = Math.max(0, modalRect ? modalRect.top : 0);
+        const padding = 12;
+        const belowRect = menu.getBoundingClientRect();
+
+        if (belowRect.bottom <= viewportBottom - padding) return;
+
+        menu.classList.add('is-above');
+        const aboveRect = menu.getBoundingClientRect();
+        if (aboveRect.top < viewportTop + padding) {
+            menu.classList.remove('is-above');
+        }
+    }
+
+    function keepAthleteShareMenuInView(menu) {
+        if (!menu || menu.hidden) return;
+        positionAthleteShareMenu(menu);
+        menu.scrollIntoView({ block: 'nearest', inline: 'nearest' });
     }
 
     function getAthleteSharePayload(button) {
@@ -6820,6 +6851,8 @@
         if (copyButton) {
             copyButton.focus({ preventScroll: true });
         }
+        keepAthleteShareMenuInView(menu);
+        requestAnimationFrame(() => keepAthleteShareMenuInView(menu));
     }
 
     function configureAthleteShareButton(displayName, athleteSlug, ultimateRank) {


### PR DESCRIPTION
## Summary

Fixes the athlete detail modal share menu on narrow mobile viewports. When the Share button was near the bottom of the visible modal area, tapping it opened the menu below the viewport, so nothing visible appeared.

The share menu now flips above the button when below placement would fall out of the modal viewport, and it is kept in view after the browser settles the opened menu layout.

## Screenshot proof

Gist: https://gist.github.com/nopara73/3529b6da6378c22e61d3d0f95e4c9e1e

| Before | After |
| --- | --- |
| ![Before mobile share menu hidden below viewport](https://gist.githubusercontent.com/nopara73/3529b6da6378c22e61d3d0f95e4c9e1e/raw/before-share-menu-320.png) | ![After mobile share menu visible](https://gist.githubusercontent.com/nopara73/3529b6da6378c22e61d3d0f95e4c9e1e/raw/after-share-menu-320.png) |

## Verification

- `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --filter AthleteShareButton_UsesDesktopShareMenuInsteadOfDesktopNativeShare --no-restore --verbosity minimal`
- `git diff --check`
- Playwright render at 320/360/390px verified the opened share menu remains visible and the page has no horizontal scroll.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only positioning for the athlete share dropdown in the details modal, with regression tests on embedded HTML/JS strings.
> 
> **Overview**
> Fixes the athlete detail modal **Share** menu opening off-screen on narrow viewports when the button sits near the bottom of the visible modal area.
> 
> Adds an **`is-above`** CSS state so the dropdown can open above the button instead of below. New **`positionAthleteShareMenu`** compares the menu’s bounds to the modal viewport (capped by `window.innerHeight`) and toggles **`is-above`** when below placement would clip; it falls back to below if above would also clip. **`keepAthleteShareMenuInView`** runs that logic plus **`scrollIntoView({ block: 'nearest' })`** when the menu opens, with a **`requestAnimationFrame`** pass so layout settles correctly. Closing the menu clears **`is-above`**.
> 
> Unit tests in **`LeaderboardBestRankScriptTests`** were extended to lock in the new CSS selector, functions, and call sites in **`leaderboard-content.html`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1b94a2b7ba6aa21191d50ee69dff94b20ab85d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->