### PR TITLE
[codex] Keep mobile play shortcut in header

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/partials/header.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/header.html
@@ -644,7 +644,7 @@
             padding-inline: 0.5rem;
         }
 
-        .join-game {
+        .join-game:not(.scrolled-button) {
             margin-top: 1rem;
             padding: 0.78rem 1.55rem;
             max-width: calc(100vw - 3rem);
@@ -728,7 +728,7 @@
             font-size: 0.96rem;
         }
 
-        .join-game {
+        .join-game:not(.scrolled-button) {
             padding-inline: 1.45rem;
         }
     }
@@ -755,7 +755,7 @@
             font-size: 0.95rem;
         }
 
-        .join-game {
+        .join-game:not(.scrolled-button) {
             margin-top: 0.9rem;
             padding: 0.75rem 1.45rem;
             font-size: 1.08rem;


### PR DESCRIPTION
## Summary
- Keep the fixed mobile PLAY shortcut scoped to the sticky header instead of inheriting hero button spacing.
- Prevent the shortcut from hanging below the sticky header and covering scrolled page content on narrow mobile widths.

## Screenshot proof
Gist: https://gist.github.com/nopara73/4a9c1ec7fce76a679221d097e2c98754

## Verification
- `git diff --check`
- Playwright smoke at 320px, 360px, and 390px confirmed the fixed PLAY button stays inside the 52px sticky header.
- Manual screenshots captured before/after at 320px, 360px, and 390px.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only selector tightening for mobile header buttons; no logic, auth, or data changes.
> 
> **Overview**
> **Fixes mobile layout for the fixed PLAY shortcut** when the page is scrolled.
> 
> Responsive rules in `header.html` that set hero CTA spacing (`margin-top`, padding, `max-width`) previously matched every `.join-game` element. The sticky shortcut uses the same class plus `.scrolled-button`, so it inherited hero margins and could sit below the ~52px sticky bar and overlap page content on narrow widths.
> 
> Those mobile breakpoints now use **`.join-game:not(.scrolled-button)`** so only the in-header hero button gets hero spacing; `.scrolled-button` keeps its fixed positioning and compact sticky-header styles unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4850f18835d1f056aee61f77bff2b8c5fa73b709. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->