### PR TITLE
[codex] Wrap Swagger code blocks on mobile

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/css/swagger-ui-mobile.css
+++ b/LongevityWorldCup.Website/wwwroot/css/swagger-ui-mobile.css
@@ -86,6 +86,14 @@
         padding: 1rem 0.75rem;
     }
 
+    .swagger-ui .opblock pre code {
+        display: block;
+        max-width: 100%;
+        white-space: pre-wrap !important;
+        overflow-wrap: anywhere;
+        word-break: normal;
+    }
+
     .swagger-ui .responses-table .response-col_status {
         width: 2.4rem;
         min-width: 2.4rem;


### PR DESCRIPTION
## Summary
- Wrap Swagger `pre code` content inside mobile endpoint panels.
- Prevent generated curl snippets from clipping past the response panel after executing an endpoint on narrow mobile widths.

## Screenshot proof
Gist: https://gist.github.com/nopara73/391b1bc2a2ed234decd72fd995c30d51

## Verification
- `git diff --check`
- Playwright executed `/api/data/flags` in Swagger at 320px, 360px, and 390px and confirmed no visible overflow offenders.
- Manual before/after screenshots captured at 320px, 360px, and 390px.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS in the Swagger mobile stylesheet; no API, auth, or data behavior changes.
> 
> **Overview**
> On viewports **≤640px**, Swagger endpoint panels now **wrap** content inside **`.opblock pre code`** instead of letting long lines (e.g. generated **curl** after **Try it out**) extend past the response area.
> 
> The new rules set **`pre-wrap`**, **`overflow-wrap: anywhere`**, and **`max-width: 100%`** so snippets stay within the panel on narrow widths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff30d4f6b942e4ef85f07947e596f16de0f77d01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->