### PR TITLE
[codex] Fit prize ribbon on narrow cards

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/onboarding/join-game.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/join-game.html
@@ -498,12 +498,12 @@
 
       @media (max-width: 1100px) {
         .track-card-ribbon.prize-money > span {
-          right: -32px;
-          top: 22px;
-          width: 132px;
-          padding: 5px 10px;
-          font-size: 0.62rem;
-          letter-spacing: 0.035em;
+          right: -10px;
+          top: 24px;
+          width: 118px;
+          padding: 5px 8px;
+          font-size: 0.58rem;
+          letter-spacing: 0.025em;
         }
       }
 


### PR DESCRIPTION
## Summary

- Tightened the Pro track card prize-money ribbon at tablet/mobile widths so the rotated label stays inside the card edge.
- Kept the existing ribbon treatment and only adjusted the existing `max-width: 1100px` sizing/positioning rule.

## Screenshot proof

Gist: https://gist.github.com/nopara73/015edbc7635fee33caf3043c3131cb68

| Before | After |
| --- | --- |
| ![Before](https://gist.githubusercontent.com/nopara73/015edbc7635fee33caf3043c3131cb68/raw/before.png) | ![After](https://gist.githubusercontent.com/nopara73/015edbc7635fee33caf3043c3131cb68/raw/after.png) |

## Verification

- `git diff --check`
- Playwright targeted checks at 320px, 360px, 390px, and 768px confirmed the ribbon label stays inside both the viewport and card, with no ribbon self-overflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only positioning/sizing in onboarding HTML; no behavior, auth, or data changes.
> 
> **Overview**
> On **join-game**, the Pro track **₿ Prize money** corner ribbon was clipping past the card on tablet and mid-width layouts.
> 
> This PR **only** retunes the existing `@media (max-width: 1100px)` rule for `.track-card-ribbon.prize-money > span`: less negative `right`, slightly higher `top`, narrower band, tighter padding, and smaller type/letter-spacing so the rotated label stays inside the card edge. Wider desktop and the separate `360px` / `300px` ribbon rules are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a52331ee5e63ebee8152fdd688a6c1c22edd682. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->