### PR TITLE
[codex] Wrap athlete autocomplete matches inline

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/play/menu.html
+++ b/LongevityWorldCup.Website/wwwroot/play/menu.html
@@ -157,8 +157,7 @@
         }
 
             .autocomplete-items div {
-                display: flex;
-                align-items: center;
+                display: block;
                 min-height: 44px;
                 padding: 0.6rem 0.7rem;
                 border-radius: 6px;
@@ -167,6 +166,7 @@
                 cursor: pointer;
                 font-size: 1rem;
                 line-height: 1.25;
+                overflow-wrap: anywhere;
             }
 
                 .autocomplete-items div + div {
@@ -180,6 +180,7 @@
                 }
 
                 .autocomplete-items div strong {
+                    display: inline;
                     padding: 0 0.12rem;
                     border-radius: 4px;
                     background: rgba(0, 188, 212, 0.16);


### PR DESCRIPTION
## Summary

- Changed Play athlete autocomplete rows from flex items to normal block text flow.
- Kept the match highlight inline so long names wrap naturally instead of detaching the highlighted prefix.

## Screenshot proof

Gist: https://gist.github.com/nopara73/a4ef1593c53e2e12d16808e8d336ca61

| Before | After |
| --- | --- |
| ![Before](https://gist.githubusercontent.com/nopara73/a4ef1593c53e2e12d16808e8d336ca61/raw/before.png) | ![After](https://gist.githubusercontent.com/nopara73/a4ef1593c53e2e12d16808e8d336ca61/raw/after.png) |

## Verification

- `git diff --check`
- Playwright mocked long athlete names at 320px, 390px, and 768px; confirmed the autocomplete has no overflow and highlighted text remains inline.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only presentation change to the Play menu autocomplete; no JS or API behavior changes.
> 
> **Overview**
> Updates **Play** athlete autocomplete dropdown styling in `menu.html` so long names wrap cleanly on narrow viewports.
> 
> Autocomplete suggestion rows no longer use **flex** layout; they use normal **block** text flow with **`overflow-wrap: anywhere`**. Match highlights in **`strong`** are explicitly **inline**, so the highlighted prefix stays in the same line flow as the rest of the name instead of sitting on a separate flex line when text wraps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e5fc477f1a9b372aaffa2f2de6e37a565000383. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->