### PR TITLE
[codex] Wrap challenge participant headings

### DIFF
--- a/LongevityWorldCup.Website/wwwroot/css/longevitymaxxing.css
+++ b/LongevityWorldCup.Website/wwwroot/css/longevitymaxxing.css
@@ -799,6 +799,7 @@
 }
 
 .lmx-card-head {
+    min-width: 0;
     display: grid;
     gap: 0.45rem;
     margin-bottom: 0.8rem;
@@ -861,10 +862,12 @@
 
 .lmx-card h2,
 .lmx-card h3 {
+    min-width: 0;
     margin: 0 0 0.8rem;
     text-align: left;
     font-size: 1.2rem;
     letter-spacing: 0;
+    overflow-wrap: anywhere;
 }
 
 .lmx-form {
@@ -2219,6 +2222,7 @@ body.lmx-quote-open {
 }
 
 .lmx-participant-actions {
+    min-width: 0;
     display: grid;
     gap: 0.8rem;
 }


### PR DESCRIPTION
## Summary

- Let Longevitymaxxing card headings shrink and wrap unbroken participant names.
- Added `min-width: 0` on the participant heading/grid path so one long display name cannot widen the private participant panel.

## Screenshot proof

Gist: https://gist.github.com/nopara73/4e9b5fabb64e919c68e1448439b883ba

| Before | After |
| --- | --- |
| ![Before](https://gist.githubusercontent.com/nopara73/4e9b5fabb64e919c68e1448439b883ba/raw/before.png) | ![After](https://gist.githubusercontent.com/nopara73/4e9b5fabb64e919c68e1448439b883ba/raw/after.png) |

## Verification

- `git diff --check`
- Playwright mocked Longevitymaxxing due, unbroken-name, and commitment states at 320px and 390px; confirmed participant panels stay inside the viewport with no overflow after the fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS in longevitymaxxing styles; no logic, auth, or data changes.
> 
> **Overview**
> Fixes **horizontal overflow** on the Longevitymaxxing **private participant / action card** when a display name is one long unbroken string (especially on ~320–390px widths).
> 
> Adds **`min-width: 0`** on `.lmx-card-head`, `.lmx-participant-actions`, and card **`h2`/`h3`** so grid/flex children can shrink instead of forcing the sticky side panel wider than the viewport. Adds **`overflow-wrap: anywhere`** on those headings so names wrap instead of staying on a single line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e8f19b75f7c1c8ea42694a56e2cb34b5587ee0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->