### PR TITLE
[codex] Improve builtin site statistics

### DIFF
--- a/LongevityWorldCup.Tests/ApplicationControllerValidationTests.cs
+++ b/LongevityWorldCup.Tests/ApplicationControllerValidationTests.cs
@@ -418,7 +418,7 @@ public sealed class ApplicationControllerValidationTests
         {
             Name = "Applicant Ada",
             Biomarkers = [new BiomarkerData { Date = "2026-02-02", AlbGL = 45 }],
-            ProofPics = Enumerable.Repeat("data:image/png;base64,AA==", 31).ToList()
+            ProofPics = ["data:image/png;base64,not-base64"]
         }, CancellationToken.None);
 
         Assert.IsType<BadRequestObjectResult>(result);
@@ -432,12 +432,13 @@ public sealed class ApplicationControllerValidationTests
 
         var submitFailure = Assert.Single(dashboard.Events, ev => ev.EventName == "application_submit_failed");
         Assert.Equal("failed", submitFailure.Outcome);
-        Assert.Equal("too_many_proofs", submitFailure.ErrorCode);
+        Assert.Equal("proof_parse_failed", submitFailure.ErrorCode);
 
         var proofFailure = Assert.Single(dashboard.Events, ev => ev.EventName == "proof_processing_failed");
         Assert.Equal("failed", proofFailure.Outcome);
-        Assert.Equal("too_many_proofs", proofFailure.ErrorCode);
-        Assert.Equal("31", proofFailure.Metadata["proofCount"]);
+        Assert.Equal("proof_parse_failed", proofFailure.ErrorCode);
+        Assert.Equal("1", proofFailure.Metadata["proofCount"]);
+        Assert.Equal("1", proofFailure.Metadata["proofIndex"]);
     }
 
     [Fact]

--- a/LongevityWorldCup.Tests/ApplicationControllerValidationTests.cs
+++ b/LongevityWorldCup.Tests/ApplicationControllerValidationTests.cs
@@ -408,6 +408,39 @@ public sealed class ApplicationControllerValidationTests
     }
 
     [Fact]
+    public async Task ResultSubmissionProofValidationRecordsServerStatistics()
+    {
+        using var factory = new TestWebApplicationFactory();
+        var statistics = factory.Services.GetRequiredService<SiteStatisticsService>();
+        var controller = CreateController(factory, statistics);
+
+        var result = await controller.Application(new ApplicantData
+        {
+            Name = "Applicant Ada",
+            Biomarkers = [new BiomarkerData { Date = "2026-02-02", AlbGL = 45 }],
+            ProofPics = Enumerable.Repeat("data:image/png;base64,AA==", 31).ToList()
+        }, CancellationToken.None);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+
+        var dashboard = await statistics.GetDashboardAsync(new SiteStatisticsDashboardQuery
+        {
+            Range = "30d",
+            Flow = "application",
+            Limit = 20
+        });
+
+        var submitFailure = Assert.Single(dashboard.Events, ev => ev.EventName == "application_submit_failed");
+        Assert.Equal("failed", submitFailure.Outcome);
+        Assert.Equal("too_many_proofs", submitFailure.ErrorCode);
+
+        var proofFailure = Assert.Single(dashboard.Events, ev => ev.EventName == "proof_processing_failed");
+        Assert.Equal("failed", proofFailure.Outcome);
+        Assert.Equal("too_many_proofs", proofFailure.ErrorCode);
+        Assert.Equal("31", proofFailure.Metadata["proofCount"]);
+    }
+
+    [Fact]
     public async Task ResultSubmissionMissingBiomarkersReturnsBadRequestBeforeProcessing()
     {
         using var factory = new TestWebApplicationFactory();
@@ -811,7 +844,7 @@ public sealed class ApplicationControllerValidationTests
         Assert.Contains("archivedSubmissionPath = await PersistApplicationSubmissionArchiveAsync(zipPath, folderKey, submissionId, ct);", emailBody);
         Assert.Contains("Application submission email failed after archive was saved.", emailBody);
         Assert.Contains("Application submission email failed and archive could not be saved.", emailBody);
-        Assert.Contains("return StatusCode(500, \"Internal server error: application could not be saved.\");", emailBody);
+        Assert.Contains("return await StatusCodeWithStatsAsync(500, \"application_archive_failed\", \"Internal server error: application could not be saved.\").ConfigureAwait(false);", emailBody);
         Assert.Contains("return Ok(new", freeSubmissionBody);
         Assert.Contains("paymentRequired = false", freeSubmissionBody);
         Assert.Contains("AuditEmailDelivered={AuditEmailDelivered} ArchivePath={ArchivePath}", freeSubmissionBody);
@@ -918,17 +951,22 @@ public sealed class ApplicationControllerValidationTests
         throw new FileNotFoundException("ApplicationController.cs was not found.");
     }
 
-    private static ApplicationController CreateController(TestWebApplicationFactory factory)
+    private static ApplicationController CreateController(TestWebApplicationFactory factory, SiteStatisticsService? statistics = null)
     {
         return new ApplicationController(
             factory.Services.GetRequiredService<IWebHostEnvironment>(),
-            NullLogger<HomeController>.Instance)
+            NullLogger<HomeController>.Instance,
+            statistics: statistics)
         {
             ControllerContext = new ControllerContext
             {
                 HttpContext = new DefaultHttpContext
                 {
-                    RequestServices = factory.Services
+                    RequestServices = factory.Services,
+                    Request =
+                    {
+                        Path = "/api/application/application"
+                    }
                 }
             }
         };

--- a/LongevityWorldCup.Tests/LongevitymaxxingChallengeServiceTests.cs
+++ b/LongevityWorldCup.Tests/LongevitymaxxingChallengeServiceTests.cs
@@ -93,6 +93,80 @@ public sealed class LongevitymaxxingChallengeServiceTests
     }
 
     [Fact]
+    public async Task ServerStatisticsCaptureSignupAndCheckInOutcomes()
+    {
+        using var fixture = TestChallengeFixture.Create();
+        var signupAt = DateTimeOffset.Parse("2026-06-07T12:00:00Z");
+
+        await fixture.Service.SignupAsync(new LongevitymaxxingSignupRequest(
+            "stats@example.com",
+            "Stats Sam",
+            "UTC",
+            null,
+            25m), signupAt);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => fixture.Service.SignupAsync(new LongevitymaxxingSignupRequest(
+            "bad-email",
+            "Bad Email",
+            "UTC",
+            null,
+            25m), signupAt));
+
+        var access = await fixture.Service.ConfirmAsync(
+            ReadQueryToken(fixture.Email.Confirmations.Single().Url, "confirm"),
+            signupAt.AddMinutes(1));
+
+        fixture.Service.SubmitCheckIn(new LongevitymaxxingCheckInRequest(
+            access.AccessToken,
+            1,
+            2,
+            2,
+            2,
+            2,
+            null), DateTimeOffset.Parse("2026-06-09T08:00:00Z"));
+
+        fixture.Service.SubmitCheckIn(new LongevitymaxxingCheckInRequest(
+            access.AccessToken,
+            2,
+            2,
+            2,
+            2,
+            2,
+            null), DateTimeOffset.Parse("2026-06-10T08:00:00Z"));
+
+        Assert.Throws<InvalidOperationException>(() => fixture.Service.SubmitCheckIn(new LongevitymaxxingCheckInRequest(
+            access.AccessToken,
+            99,
+            2,
+            2,
+            2,
+            2,
+            null), DateTimeOffset.Parse("2026-06-10T08:00:00Z")));
+
+        var dashboard = await fixture.Statistics.GetDashboardAsync(new SiteStatisticsDashboardQuery
+        {
+            Range = "30d",
+            Flow = "challenge",
+            Limit = 100
+        });
+        var eventNames = dashboard.Events.Select(ev => ev.EventName).ToList();
+
+        Assert.Contains("challenge_signup_succeeded", eventNames);
+        Assert.Contains("challenge_signup_failed", eventNames);
+        Assert.Contains("challenge_practice_checkin_submitted", eventNames);
+        Assert.Contains("challenge_scored_checkin_submitted", eventNames);
+        Assert.Contains("challenge_checkin_failed", eventNames);
+
+        var practice = Assert.Single(dashboard.Events, ev => ev.EventName == "challenge_practice_checkin_submitted");
+        Assert.Equal("practice", practice.Metadata["checkInKind"]);
+        Assert.Equal("1", practice.Metadata["challengeDay"]);
+
+        var scored = Assert.Single(dashboard.Events, ev => ev.EventName == "challenge_scored_checkin_submitted");
+        Assert.Equal("scored", scored.Metadata["checkInKind"]);
+        Assert.Equal("2", scored.Metadata["challengeDay"]);
+    }
+
+    [Fact]
     public async Task SignupStaysOpenDuringActiveChallengeWithoutBackfillingBeforeSignup()
     {
         using var fixture = TestChallengeFixture.Create(signupClosesAtUtc: "2026-06-09T22:00:00Z");
@@ -1892,6 +1966,50 @@ public sealed class LongevitymaxxingChallengeServiceTests
     }
 
     [Fact]
+    public async Task ServerStatisticsCaptureCommitmentPaymentAndResolutionOutcomes()
+    {
+        using var fixture = TestChallengeFixture.Create();
+        var access = await CreateCommitmentDueParticipantAsync(fixture, "stats-pay@example.com", "Stats Pay");
+
+        await fixture.Service.CreateCommitmentPaymentInvoiceAsync(access, DateTimeOffset.Parse("2026-06-13T09:01:00Z"));
+        fixture.Btcpay.LookupResults["lmx-invoice-1"] = new BtcpayInvoiceLookupResult(
+            true,
+            true,
+            "Settled",
+            null,
+            "25",
+            "USD",
+            "25",
+            25m,
+            25m,
+            "https://btcpay.example.test/i/lmx-invoice-1",
+            null,
+            null,
+            null,
+            null);
+
+        await fixture.Service.RefreshCommitmentPaymentStatusAsync(access, DateTimeOffset.Parse("2026-06-13T09:02:00Z"));
+
+        var dashboard = await fixture.Statistics.GetDashboardAsync(new SiteStatisticsDashboardQuery
+        {
+            Range = "30d",
+            Flow = "challenge",
+            Limit = 100
+        });
+        var eventNames = dashboard.Events.Select(ev => ev.EventName).ToList();
+
+        Assert.Contains("challenge_commitment_payment_opened", eventNames);
+        Assert.Contains("challenge_commitment_payment_status_checked", eventNames);
+        Assert.Contains("challenge_commitment_resolved", eventNames);
+
+        var resolved = Assert.Single(dashboard.Events, ev => ev.EventName == "challenge_commitment_resolved");
+        Assert.Equal("payment", resolved.Metadata["resolutionSource"]);
+        Assert.Equal("5", resolved.Metadata["triggerChallengeDay"]);
+        Assert.False(resolved.Metadata.ContainsKey("amountUsd"));
+        Assert.False(resolved.Metadata.ContainsKey("owedAmountUsd"));
+    }
+
+    [Fact]
     public async Task CommitmentPaymentRequiresFullInvoiceAmountBeforeClearingBlock()
     {
         using var fixture = TestChallengeFixture.Create();
@@ -2242,6 +2360,7 @@ public sealed class LongevitymaxxingChallengeServiceTests
             FakeBtcpayInvoiceClient btcpay,
             Config config,
             FakeEnvironment environment,
+            SiteStatisticsService statistics,
             LongevitymaxxingChallengeService service)
         {
             ContentRoot = root;
@@ -2252,6 +2371,7 @@ public sealed class LongevitymaxxingChallengeServiceTests
             Btcpay = btcpay;
             Config = config;
             Environment = environment;
+            Statistics = statistics;
             Service = service;
         }
 
@@ -2263,6 +2383,7 @@ public sealed class LongevitymaxxingChallengeServiceTests
         public FakeBtcpayInvoiceClient Btcpay { get; }
         public Config Config { get; }
         public FakeEnvironment Environment { get; }
+        public SiteStatisticsService Statistics { get; }
         public LongevitymaxxingChallengeService Service { get; }
 
         public static TestChallengeFixture Create(
@@ -2281,6 +2402,7 @@ public sealed class LongevitymaxxingChallengeServiceTests
             var athletes = new FakeAthleteSnapshotProvider();
             var btcpay = new FakeBtcpayInvoiceClient();
             var env = new FakeEnvironment(root);
+            var statistics = new SiteStatisticsService(db, NullLogger<SiteStatisticsService>.Instance);
             var config = new Config
             {
                 EmailFrom = "hi@example.test",
@@ -2310,8 +2432,9 @@ public sealed class LongevitymaxxingChallengeServiceTests
                 email,
                 NullLogger<LongevitymaxxingChallengeService>.Instance,
                 athletes,
-                btcpay);
-            return new TestChallengeFixture(root, db, email, http, athletes, btcpay, config, env, service);
+                btcpay,
+                statistics);
+            return new TestChallengeFixture(root, db, email, http, athletes, btcpay, config, env, statistics, service);
         }
 
         public void AddAthleteTieBreak(string slug, int? currentPlacement, int birthYear, int birthMonth, int birthDay)

--- a/LongevityWorldCup.Tests/LongevitymaxxingChallengeServiceTests.cs
+++ b/LongevityWorldCup.Tests/LongevitymaxxingChallengeServiceTests.cs
@@ -167,6 +167,40 @@ public sealed class LongevitymaxxingChallengeServiceTests
     }
 
     [Fact]
+    public async Task ServerStatisticsUseParticipantSessionFallbackWithoutHttpContext()
+    {
+        using var fixture = TestChallengeFixture.Create(signupClosesAtUtc: "2026-06-09T22:00:00Z");
+        var signupAt = DateTimeOffset.Parse("2026-06-08T08:00:00Z");
+
+        await fixture.Service.SignupAsync(new LongevitymaxxingSignupRequest(
+            "one@example.test",
+            "One Participant",
+            "UTC",
+            null,
+            25m), signupAt);
+        await fixture.Service.SignupAsync(new LongevitymaxxingSignupRequest(
+            "two@example.test",
+            "Two Participant",
+            "UTC",
+            null,
+            25m), signupAt.AddMinutes(1));
+
+        var dashboard = await fixture.Statistics.GetDashboardAsync(new SiteStatisticsDashboardQuery
+        {
+            Range = "30d",
+            Flow = "challenge",
+            Limit = 100
+        });
+        var signups = dashboard.Events
+            .Where(ev => ev.EventName == "challenge_signup_succeeded")
+            .ToList();
+
+        Assert.Equal(2, signups.Count);
+        Assert.Equal(2, signups.Select(ev => ev.SessionHash).Distinct().Count());
+        Assert.Equal(2, signups.Select(ev => ev.ActorHash).Distinct().Count());
+    }
+
+    [Fact]
     public async Task SignupStaysOpenDuringActiveChallengeWithoutBackfillingBeforeSignup()
     {
         using var fixture = TestChallengeFixture.Create(signupClosesAtUtc: "2026-06-09T22:00:00Z");

--- a/LongevityWorldCup.Tests/PlayAthleteFlowBrowserTests.cs
+++ b/LongevityWorldCup.Tests/PlayAthleteFlowBrowserTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Playwright;
+using System.Text.Json;
 using Xunit;
 
 namespace LongevityWorldCup.Tests;
@@ -35,8 +36,21 @@ public sealed class PlayAthleteFlowBrowserTests
         await ExpectActivePlayPanelAsync(page, "playStartPanel");
         Assert.Equal("/play", new Uri(page.Url).AbsolutePath);
 
+        var joinStatsRequestTask = page.WaitForRequestAsync(request =>
+            request.Url.Contains("/api/site-statistics/event", StringComparison.OrdinalIgnoreCase) &&
+            (request.PostData ?? string.Empty).Contains("\"eventName\":\"onboarding_entry_viewed\"", StringComparison.Ordinal));
         await page.Locator("#newGameBtn").ClickAsync();
         await page.WaitForURLAsync("**/join");
+        var joinStatsRequest = await joinStatsRequestTask;
+        using (var statsPayload = JsonDocument.Parse(joinStatsRequest.PostData ?? "{}"))
+        {
+            var root = statsPayload.RootElement;
+            Assert.Equal("onboarding_entry_viewed", root.GetProperty("eventName").GetString());
+            Assert.Equal("onboarding", root.GetProperty("flow").GetString());
+            Assert.Equal("/join", root.GetProperty("route").GetString());
+            Assert.Equal("join_game", root.GetProperty("component").GetString());
+            Assert.Equal("viewed", root.GetProperty("outcome").GetString());
+        }
         await ExpectActivePlayPanelAsync(page, "joinTrackPanel");
         await ExpectNoPlayPanelTransitionAsync(page);
         Assert.Equal("/join", new Uri(page.Url).AbsolutePath);

--- a/LongevityWorldCup.Tests/SiteStatisticsDashboardBrowserTests.cs
+++ b/LongevityWorldCup.Tests/SiteStatisticsDashboardBrowserTests.cs
@@ -41,9 +41,11 @@ public sealed class SiteStatisticsDashboardBrowserTests
         await page.WaitForSelectorAsync("#decisionBrief .decision-card");
         await page.WaitForSelectorAsync("#outcomeStrip .metric-tile");
         await page.Locator("#decisionBrief").GetByText("Calculator completions are not reaching proof flow").WaitForAsync();
+        await page.GetByText("Calculator completion sources").WaitForAsync();
         await page.GetByText("Recommended Investigations").WaitForAsync();
         await page.GetByText("Segment Comparison").WaitForAsync();
         await page.GetByText("Trend Watch").WaitForAsync();
+        var onboardingDetailText = await page.Locator("#detailSections").InnerTextAsync();
         await page.Locator("#statsTabs").GetByRole(AriaRole.Button, new() { Name = "Challenge" }).ClickAsync();
         await page.Locator("#primaryFunnel").GetByRole(AriaRole.Button, new() { Name = "Signup accepted" }).ClickAsync();
         await page.Locator("#sessionTimeline .timeline-row").First.WaitForAsync();
@@ -55,6 +57,8 @@ public sealed class SiteStatisticsDashboardBrowserTests
         Assert.Contains("Page views", visibleText);
         Assert.Contains("Challenge signups", visibleText);
         Assert.Contains("Signup accepted", visibleText);
+        Assert.Contains("prefilled / initial", onboardingDetailText);
+        Assert.Contains("AUTO", onboardingDetailText);
         Assert.Contains("baseline pending", visibleText);
         Assert.Contains("S-", visibleText);
         Assert.DoesNotContain("raw-browser-session", visibleText);
@@ -131,7 +135,9 @@ public sealed class SiteStatisticsDashboardBrowserTests
             new Dictionary<string, JsonElement>
             {
                 ["fieldKey"] = JsonSerializer.SerializeToElement("albumin"),
-                ["requiredCompleted"] = JsonSerializer.SerializeToElement(4)
+                ["requiredCompleted"] = JsonSerializer.SerializeToElement(4),
+                ["entryMode"] = JsonSerializer.SerializeToElement("prefilled"),
+                ["completionSource"] = JsonSerializer.SerializeToElement("initial")
             });
         await PostEventAsync(client, "calculator_result_generated", "pheno", "raw-browser-session", "/pheno-age", "calculator", "succeeded",
             new Dictionary<string, JsonElement>

--- a/LongevityWorldCup.Tests/SiteStatisticsDashboardBrowserTests.cs
+++ b/LongevityWorldCup.Tests/SiteStatisticsDashboardBrowserTests.cs
@@ -95,6 +95,12 @@ public sealed class SiteStatisticsDashboardBrowserTests
         await page.GotoAsync("/internal/site-statistics.html", new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
         await page.Locator("#decisionBrief").GetByText("Join track selection bottleneck").WaitForAsync();
         await page.Locator("#eventSamples").GetByText("burst x30").WaitForAsync();
+        var pageViewsValue = await page.Locator("#outcomeStrip").EvaluateAsync<string>(
+            """
+            host => Array.from(host.querySelectorAll('.metric-tile'))
+                .find(tile => tile.querySelector('.metric-label')?.textContent?.trim() === 'Page views')
+                ?.querySelector('.metric-value')?.textContent?.trim() || ''
+            """);
         var investigationText = await page.Locator("#recommendedInvestigations").InnerTextAsync();
 
         var visibleText = await page.Locator("body").InnerTextAsync();
@@ -102,6 +108,7 @@ public sealed class SiteStatisticsDashboardBrowserTests
         Assert.Contains("Noisy sessions", visibleText);
         Assert.Contains("Page views", visibleText);
         Assert.Contains("burst x30", visibleText);
+        Assert.Equal("4", pageViewsValue);
         Assert.Contains("baseline pending", visibleText);
         Assert.DoesNotContain("pheno age bottleneck at Amateur selected", visibleText);
         Assert.DoesNotContain("bortz age bottleneck at Pro selected", visibleText);

--- a/LongevityWorldCup.Tests/SiteStatisticsDashboardPageTests.cs
+++ b/LongevityWorldCup.Tests/SiteStatisticsDashboardPageTests.cs
@@ -134,6 +134,24 @@ public sealed class SiteStatisticsDashboardPageTests
         Assert.Contains("trackPublicPageViews", tracker);
     }
 
+    [Fact]
+    public void SiteStatisticsTracker_RecordsPrefilledCalculatorProgress()
+    {
+        var repoRoot = FindRepoRoot();
+        var tracker = File.ReadAllText(Path.Combine(repoRoot, "LongevityWorldCup.Website", "wwwroot", "js", "site-statistics-tracking.js"));
+
+        Assert.Contains("function fieldHasRequiredValue(el)", tracker);
+        Assert.Contains("function recordFieldCompletion(el, source)", tracker);
+        Assert.Contains("function scanRequiredFields(source)", tracker);
+        Assert.Contains("scanRequiredFields(\"initial\")", tracker);
+        Assert.Contains("scanRequiredFields(\"autofill\")", tracker);
+        Assert.Contains("scanRequiredFields(\"submit\")", tracker);
+        Assert.Contains("scanRequiredFields(\"result\")", tracker);
+        Assert.Contains("completionSource", tracker);
+        Assert.Contains("listen(form, \"input\"", tracker);
+        Assert.Contains("listen(window, \"pageshow\"", tracker);
+    }
+
     private static string FindRepoRoot([CallerFilePath] string sourceFilePath = "")
     {
         var dir = Path.GetDirectoryName(sourceFilePath)!;

--- a/LongevityWorldCup.Tests/SiteStatisticsDashboardPageTests.cs
+++ b/LongevityWorldCup.Tests/SiteStatisticsDashboardPageTests.cs
@@ -152,6 +152,25 @@ public sealed class SiteStatisticsDashboardPageTests
         Assert.Contains("listen(window, \"pageshow\"", tracker);
     }
 
+    [Fact]
+    public void SiteStatisticsDashboard_SurfacesCalculatorCompletionSources()
+    {
+        var repoRoot = FindRepoRoot();
+        var dashboard = File.ReadAllText(Path.Combine(repoRoot, "LongevityWorldCup.Website", "wwwroot", "js", "site-statistics.js"));
+
+        Assert.Contains("Calculator completion sources", dashboard);
+        Assert.Contains("function calculatorCompletionSourceTable(events)", dashboard);
+        Assert.Contains("function completionSourceLabel(source)", dashboard);
+        Assert.Contains("completionSource", dashboard);
+        Assert.Contains("entryMode", dashboard);
+        Assert.Contains("source-visual-list", dashboard);
+        Assert.Contains("field-visual-list", dashboard);
+        Assert.Contains("completionLegend", dashboard);
+        Assert.Contains("stacked-bar", dashboard);
+        Assert.Contains("\"Auto\"", dashboard);
+        Assert.Contains("\"Late\"", dashboard);
+    }
+
     private static string FindRepoRoot([CallerFilePath] string sourceFilePath = "")
     {
         var dir = Path.GetDirectoryName(sourceFilePath)!;

--- a/LongevityWorldCup.Tests/SiteStatisticsDashboardPageTests.cs
+++ b/LongevityWorldCup.Tests/SiteStatisticsDashboardPageTests.cs
@@ -59,6 +59,9 @@ public sealed class SiteStatisticsDashboardPageTests
         Assert.Contains("joinGoProButton", tracker);
         Assert.Contains(".play-join-biomarkers details", tracker);
         Assert.Contains(".play-join-card--pro", tracker);
+        Assert.Contains("function setupSpaRouteTracking()", tracker);
+        Assert.Contains("trackJoinPanelViewForCurrentRoute", tracker);
+        Assert.Contains("window.history[method] = function ()", tracker);
         Assert.Contains("return \"internal\";", tracker);
     }
 

--- a/LongevityWorldCup.Tests/SiteStatisticsDashboardPageTests.cs
+++ b/LongevityWorldCup.Tests/SiteStatisticsDashboardPageTests.cs
@@ -46,6 +46,23 @@ public sealed class SiteStatisticsDashboardPageTests
         Assert.DoesNotContain("{{ASSET_SITE_STATISTICS_TRACKING_JS}}", html);
     }
 
+    [Theory]
+    [InlineData("/")]
+    [InlineData("/leaderboard")]
+    [InlineData("/events")]
+    [InlineData("/athlete/michael-lustgarten")]
+    [InlineData("/league/pheno")]
+    public async Task PublicDashboardEventPages_UseVersionedStatisticsTracker(string path)
+    {
+        await using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var html = await client.GetStringAsync(path);
+
+        Assert.Contains("/js/site-statistics-tracking.js?v=", html);
+        Assert.DoesNotContain("{{ASSET_SITE_STATISTICS_TRACKING_JS}}", html);
+    }
+
     [Fact]
     public void SiteStatisticsTracker_SupportsCurrentJoinMenuControls()
     {
@@ -70,6 +87,51 @@ public sealed class SiteStatisticsDashboardPageTests
         Assert.Contains(searchSourceLine, tracker);
         Assert.True(tracker.IndexOf(emailSourceLine, StringComparison.Ordinal) < tracker.IndexOf(searchSourceLine, StringComparison.Ordinal));
         Assert.Contains("return \"internal\";", tracker);
+    }
+
+    [Fact]
+    public void SiteStatisticsTracker_EmitsDashboardDefinedPublicAndChallengeEvents()
+    {
+        var repoRoot = FindRepoRoot();
+        var tracker = File.ReadAllText(Path.Combine(repoRoot, "LongevityWorldCup.Website", "wwwroot", "js", "site-statistics-tracking.js"));
+        var dashboard = File.ReadAllText(Path.Combine(repoRoot, "LongevityWorldCup.Website", "wwwroot", "js", "site-statistics.js"));
+        var rankPreview = File.ReadAllText(Path.Combine(repoRoot, "LongevityWorldCup.Website", "wwwroot", "js", "bioage-rank-preview.js"));
+        var proofHelpers = File.ReadAllText(Path.Combine(repoRoot, "LongevityWorldCup.Website", "wwwroot", "js", "proof-helpers.js"));
+
+        var expectedDashboardEvents = new[]
+        {
+            "rank_preview_requested",
+            "proof_file_rejected",
+            "challenge_athlete_search_result_selected",
+            "challenge_commitment_block_seen",
+            "homepage_highlight_viewed",
+            "homepage_highlight_clicked",
+            "event_viewed",
+            "event_link_clicked",
+            "athlete_profile_viewed",
+            "league_viewed"
+        };
+
+        foreach (var eventName in expectedDashboardEvents)
+        {
+            Assert.Contains(eventName, dashboard);
+        }
+
+        Assert.Contains("challenge_athlete_search_result_selected", tracker);
+        Assert.Contains("challenge_commitment_block_seen", tracker);
+        Assert.Contains("homepage_highlight_viewed", tracker);
+        Assert.Contains("homepage_highlight_clicked", tracker);
+        Assert.Contains("event_viewed", tracker);
+        Assert.Contains("event_link_clicked", tracker);
+        Assert.Contains("athlete_profile_viewed", tracker);
+        Assert.Contains("league_viewed", tracker);
+        Assert.Contains("rank_preview_requested", rankPreview);
+        Assert.Contains("rank_preview_failed", rankPreview);
+        Assert.Contains("proof_file_rejected", proofHelpers);
+        Assert.Contains("#lmxSignupAthlete-autocomplete-list .lmx-athlete-option", tracker);
+        Assert.Contains("lmxCommitmentPanel", tracker);
+        Assert.Contains("setupPublicContentTracking", tracker);
+        Assert.Contains("trackPublicPageViews", tracker);
     }
 
     private static string FindRepoRoot([CallerFilePath] string sourceFilePath = "")

--- a/LongevityWorldCup.Tests/SiteStatisticsDashboardPageTests.cs
+++ b/LongevityWorldCup.Tests/SiteStatisticsDashboardPageTests.cs
@@ -20,6 +20,7 @@ public sealed class SiteStatisticsDashboardPageTests
         Assert.Contains("Segment Comparison", html);
         Assert.Contains("Trend Watch", html);
         Assert.Contains("dataQualityStrip", html);
+        Assert.Contains("<option value=\"email\">Email</option>", html);
         Assert.Contains("<option value=\"internal\">Internal</option>", html);
         Assert.DoesNotContain("{{ASSET_SITE_STATISTICS_CSS}}", html);
         Assert.DoesNotContain("{{ASSET_SITE_STATISTICS_JS}}", html);
@@ -62,6 +63,12 @@ public sealed class SiteStatisticsDashboardPageTests
         Assert.Contains("function setupSpaRouteTracking()", tracker);
         Assert.Contains("trackJoinPanelViewForCurrentRoute", tracker);
         Assert.Contains("window.history[method] = function ()", tracker);
+        Assert.Contains("function isEmailReferrer(host)", tracker);
+        const string emailSourceLine = "if (isEmailReferrer(host)) return \"email\";";
+        const string searchSourceLine = "if (/google|bing|duckduckgo|yahoo|brave|search/i.test(host)) return \"search\";";
+        Assert.Contains(emailSourceLine, tracker);
+        Assert.Contains(searchSourceLine, tracker);
+        Assert.True(tracker.IndexOf(emailSourceLine, StringComparison.Ordinal) < tracker.IndexOf(searchSourceLine, StringComparison.Ordinal));
         Assert.Contains("return \"internal\";", tracker);
     }
 

--- a/LongevityWorldCup.Tests/SiteStatisticsServiceTests.cs
+++ b/LongevityWorldCup.Tests/SiteStatisticsServiceTests.cs
@@ -314,6 +314,79 @@ public sealed class SiteStatisticsServiceTests
         Assert.Empty(searchOnly.Events);
     }
 
+    [Fact]
+    public async Task RecordServerEventAsync_UsesStatsSessionHeaderToMatchClientSession()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), "LongevityWorldCup.Tests", $"{Guid.NewGuid():N}.db");
+        Directory.CreateDirectory(Path.GetDirectoryName(dbPath)!);
+        await using var cleanup = new TempDatabaseCleanup(dbPath);
+        using var database = new DatabaseManager(dbPath: dbPath);
+        var service = new SiteStatisticsService(database, NullLogger<SiteStatisticsService>.Instance);
+        var context = new DefaultHttpContext();
+        context.Request.Headers["X-LWC-Stats-Session"] = "browser-session";
+
+        await service.RecordClientEventAsync(new SiteStatisticsEventRequest
+        {
+            EventName = "challenge_page_viewed",
+            SessionId = "browser-session",
+            Flow = "challenge",
+            Route = "/longevitymaxxing",
+            Component = "challenge",
+            Outcome = "viewed"
+        }, new DefaultHttpContext());
+
+        await service.RecordServerEventAsync(
+            "challenge_signup_succeeded",
+            context,
+            actorId: "participant-1",
+            flow: "challenge",
+            route: "/longevitymaxxing",
+            component: "signup",
+            step: "submit",
+            outcome: "succeeded",
+            sessionId: "challenge:participant-1");
+
+        var dashboard = await service.GetDashboardAsync(new SiteStatisticsDashboardQuery { Range = "30d", Flow = "challenge" });
+
+        Assert.Equal(2, dashboard.Events.Count);
+        Assert.Single(dashboard.Events.Select(ev => ev.SessionHash).Distinct());
+    }
+
+    [Fact]
+    public async Task RecordServerEventAsync_UsesExplicitSessionIdWithoutHttpContext()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), "LongevityWorldCup.Tests", $"{Guid.NewGuid():N}.db");
+        Directory.CreateDirectory(Path.GetDirectoryName(dbPath)!);
+        await using var cleanup = new TempDatabaseCleanup(dbPath);
+        using var database = new DatabaseManager(dbPath: dbPath);
+        var service = new SiteStatisticsService(database, NullLogger<SiteStatisticsService>.Instance);
+
+        await service.RecordServerEventAsync(
+            "challenge_signup_succeeded",
+            actorId: "participant-1",
+            flow: "challenge",
+            route: "/longevitymaxxing",
+            component: "signup",
+            step: "submit",
+            outcome: "succeeded",
+            sessionId: "challenge:participant-1");
+        await service.RecordServerEventAsync(
+            "challenge_signup_succeeded",
+            actorId: "participant-2",
+            flow: "challenge",
+            route: "/longevitymaxxing",
+            component: "signup",
+            step: "submit",
+            outcome: "succeeded",
+            sessionId: "challenge:participant-2");
+
+        var dashboard = await service.GetDashboardAsync(new SiteStatisticsDashboardQuery { Range = "30d", Flow = "challenge" });
+
+        Assert.Equal(2, dashboard.Events.Count);
+        Assert.Equal(2, dashboard.Events.Select(ev => ev.SessionHash).Distinct().Count());
+        Assert.Equal(2, dashboard.Events.Select(ev => ev.ActorHash).Distinct().Count());
+    }
+
     [Theory]
     [InlineData(
         "/pheno-age?Year=1980&Month=5&Day=20&Date=2026-06-01&AlbGL=44&CreatUmolL=80&GluMmolL=5.2",

--- a/LongevityWorldCup.Tests/SiteStatisticsServiceTests.cs
+++ b/LongevityWorldCup.Tests/SiteStatisticsServiceTests.cs
@@ -314,6 +314,92 @@ public sealed class SiteStatisticsServiceTests
         Assert.Empty(searchOnly.Events);
     }
 
+    [Theory]
+    [InlineData(
+        "/pheno-age?Year=1980&Month=5&Day=20&Date=2026-06-01&AlbGL=44&CreatUmolL=80&GluMmolL=5.2",
+        "/pheno-age",
+        "prefilled")]
+    [InlineData(
+        "/pheno-age?update=1&Year=1980&Month=5&Day=20&AlbGL=44",
+        "/pheno-age",
+        "update")]
+    [InlineData(
+        "/bortz-age?discount=MIGHTYKLAUS&Year=1980&Wbc1000cellsuL=6.5",
+        "/bortz-age",
+        "discount")]
+    [InlineData(
+        "/bortz-age?fake=1&Year=1980&Wbc1000cellsuL=6.5",
+        "/bortz-age",
+        "fake")]
+    [InlineData(
+        "/onboarding/pheno-age.html?freepass=perfect&Year=1980&AlbGL=44",
+        "/pheno-age",
+        "discount")]
+    public async Task Dashboard_CanonicalizesBioageCalculatorRoutesAndStoresEntryMode(
+        string route,
+        string expectedRoute,
+        string expectedEntryMode)
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), "LongevityWorldCup.Tests", $"{Guid.NewGuid():N}.db");
+        Directory.CreateDirectory(Path.GetDirectoryName(dbPath)!);
+        await using var cleanup = new TempDatabaseCleanup(dbPath);
+        using var database = new DatabaseManager(dbPath: dbPath);
+        var service = new SiteStatisticsService(database, NullLogger<SiteStatisticsService>.Instance);
+        var context = new DefaultHttpContext();
+
+        await service.RecordClientEventAsync(new SiteStatisticsEventRequest
+        {
+            EventName = "calculator_started",
+            SessionId = Guid.NewGuid().ToString("N"),
+            Flow = expectedRoute.Contains("bortz", StringComparison.OrdinalIgnoreCase) ? "bortz" : "pheno",
+            Route = route,
+            Component = "calculator"
+        }, context);
+
+        var dashboard = await service.GetDashboardAsync(new SiteStatisticsDashboardQuery { Range = "30d" });
+        var ev = Assert.Single(dashboard.Events);
+        var json = JsonSerializer.Serialize(dashboard);
+
+        Assert.Equal(expectedRoute, ev.Route);
+        Assert.Equal(expectedRoute, ev.LandingRoute);
+        Assert.Equal(expectedEntryMode, ev.Metadata["entryMode"]);
+        Assert.DoesNotContain("Year=redacted", json);
+        Assert.DoesNotContain("AlbGL=redacted", json);
+        Assert.DoesNotContain("Wbc1000cellsuL=redacted", json);
+        Assert.DoesNotContain("MIGHTYKLAUS", json);
+        Assert.DoesNotContain("perfect", json);
+        Assert.DoesNotContain("1980", json);
+    }
+
+    [Fact]
+    public async Task Dashboard_CanonicalizesLegacyRedactedBioageRoutesOnRead()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), "LongevityWorldCup.Tests", $"{Guid.NewGuid():N}.db");
+        Directory.CreateDirectory(Path.GetDirectoryName(dbPath)!);
+        await using var cleanup = new TempDatabaseCleanup(dbPath);
+        using var database = new DatabaseManager(dbPath: dbPath);
+        var service = new SiteStatisticsService(database, NullLogger<SiteStatisticsService>.Instance);
+
+        await service.GetDashboardAsync(new SiteStatisticsDashboardQuery { Range = "7d" });
+        InsertDashboardEvent(
+            database,
+            DateTimeOffset.UtcNow.AddMinutes(-5),
+            "S-LEGACY-BIOAGE",
+            "calculator_started",
+            "pheno",
+            route: "/pheno-age?update=redacted&Year=redacted&Month=redacted&Day=redacted&AlbGL=redacted&CreatUmolL=redacted");
+
+        var dashboard = await service.GetDashboardAsync(new SiteStatisticsDashboardQuery { Range = "7d" });
+        var ev = Assert.Single(dashboard.Events);
+        var json = JsonSerializer.Serialize(dashboard);
+
+        Assert.Equal("/pheno-age", ev.Route);
+        Assert.Equal("update", ev.Metadata["entryMode"]);
+        Assert.DoesNotContain("update=redacted", json);
+        Assert.DoesNotContain("Year=redacted", json);
+        Assert.DoesNotContain("AlbGL=redacted", json);
+    }
+
     private static void InsertDashboardEvent(
         DatabaseManager database,
         DateTimeOffset occurredAtUtc,
@@ -321,7 +407,8 @@ public sealed class SiteStatisticsServiceTests
         string eventName,
         string flow,
         string source = "direct",
-        string? referrerDomain = null)
+        string? referrerDomain = null,
+        string route = "/pheno-age")
     {
         database.Run(sqlite =>
         {
@@ -340,7 +427,7 @@ public sealed class SiteStatisticsServiceTests
             cmd.Parameters.AddWithValue("@session", sessionHash);
             cmd.Parameters.AddWithValue("@eventName", eventName);
             cmd.Parameters.AddWithValue("@flow", flow);
-            cmd.Parameters.AddWithValue("@route", "/pheno-age");
+            cmd.Parameters.AddWithValue("@route", route);
             cmd.Parameters.AddWithValue("@component", "calculator");
             cmd.Parameters.AddWithValue("@step", "glucose");
             cmd.Parameters.AddWithValue("@outcome", "failed");

--- a/LongevityWorldCup.Tests/SiteStatisticsServiceTests.cs
+++ b/LongevityWorldCup.Tests/SiteStatisticsServiceTests.cs
@@ -269,6 +269,51 @@ public sealed class SiteStatisticsServiceTests
         Assert.Single(campaignOnly.Events);
     }
 
+    [Fact]
+    public async Task Dashboard_ClassifiesGmailAppReferrerAsEmail()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), "LongevityWorldCup.Tests", $"{Guid.NewGuid():N}.db");
+        Directory.CreateDirectory(Path.GetDirectoryName(dbPath)!);
+        await using var cleanup = new TempDatabaseCleanup(dbPath);
+        using var database = new DatabaseManager(dbPath: dbPath);
+        var service = new SiteStatisticsService(database, NullLogger<SiteStatisticsService>.Instance);
+
+        await service.GetDashboardAsync(new SiteStatisticsDashboardQuery { Range = "7d" });
+        InsertDashboardEvent(
+            database,
+            DateTimeOffset.UtcNow.AddMinutes(-5),
+            "S-GMAIL-LEGACY",
+            "site_page_viewed",
+            "site",
+            source: "search",
+            referrerDomain: "com.google.android.gm");
+
+        var context = new DefaultHttpContext();
+        await service.RecordClientEventAsync(new SiteStatisticsEventRequest
+        {
+            EventName = "onboarding_entry_viewed",
+            SessionId = "gmail-app-session",
+            Flow = "onboarding",
+            Route = "/join",
+            Source = "search",
+            ReferrerDomain = "com.google.android.gm"
+        }, context);
+
+        var dashboard = await service.GetDashboardAsync(new SiteStatisticsDashboardQuery { Range = "7d" });
+
+        Assert.Equal(2, dashboard.Events.Count);
+        Assert.All(dashboard.Events, ev => Assert.Equal("email", ev.Source));
+        var recordedEvent = Assert.Single(dashboard.Events, ev => ev.EventName == "onboarding_entry_viewed");
+        Assert.Equal("email", recordedEvent.FirstSource);
+        Assert.Equal("com.google.android.gm", recordedEvent.FirstReferrerDomain);
+
+        var emailOnly = await service.GetDashboardAsync(new SiteStatisticsDashboardQuery { Range = "7d", Source = "email" });
+        Assert.Equal(2, emailOnly.Events.Count);
+
+        var searchOnly = await service.GetDashboardAsync(new SiteStatisticsDashboardQuery { Range = "7d", Source = "search" });
+        Assert.Empty(searchOnly.Events);
+    }
+
     private static void InsertDashboardEvent(
         DatabaseManager database,
         DateTimeOffset occurredAtUtc,

--- a/LongevityWorldCup.Tests/SiteStatisticsServiceTests.cs
+++ b/LongevityWorldCup.Tests/SiteStatisticsServiceTests.cs
@@ -181,6 +181,94 @@ public sealed class SiteStatisticsServiceTests
         Assert.Empty(referralOnly.Events);
     }
 
+    [Fact]
+    public async Task Dashboard_UsesSessionFirstTouchForAcquisitionSource()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), "LongevityWorldCup.Tests", $"{Guid.NewGuid():N}.db");
+        Directory.CreateDirectory(Path.GetDirectoryName(dbPath)!);
+        await using var cleanup = new TempDatabaseCleanup(dbPath);
+        using var database = new DatabaseManager(dbPath: dbPath);
+        var service = new SiteStatisticsService(database, NullLogger<SiteStatisticsService>.Instance);
+        var context = new DefaultHttpContext();
+
+        await service.RecordClientEventAsync(new SiteStatisticsEventRequest
+        {
+            EventName = "onboarding_entry_viewed",
+            SessionId = "acquisition-session",
+            Flow = "onboarding",
+            Route = "/join?utm_source=google&utm_medium=cpc&utm_campaign=summer2026&campaign=summer-launch&token=private-token",
+            ReferrerDomain = "www.google.com",
+            Source = "search"
+        }, context);
+
+        await service.RecordClientEventAsync(new SiteStatisticsEventRequest
+        {
+            EventName = "calculator_started",
+            SessionId = "acquisition-session",
+            Flow = "pheno",
+            Route = "/pheno-age",
+            ReferrerDomain = "longevityworldcup.com",
+            Source = "internal"
+        }, context);
+
+        var dashboard = await service.GetDashboardAsync(new SiteStatisticsDashboardQuery { Range = "30d" });
+        Assert.Equal(2, dashboard.Events.Count);
+        Assert.All(dashboard.Events, ev =>
+        {
+            Assert.Equal("search", ev.FirstSource);
+            Assert.Equal("www.google.com", ev.FirstReferrerDomain);
+            Assert.Equal("google", ev.FirstUtmSource);
+            Assert.Equal("cpc", ev.FirstUtmMedium);
+            Assert.Equal("summer2026", ev.FirstUtmCampaign);
+            Assert.Equal("summer-launch", ev.FirstCampaign);
+            Assert.Equal("/join?utm_source=redacted&utm_medium=redacted&utm_campaign=redacted&campaign=redacted", ev.LandingRoute);
+        });
+
+        var internalEvent = Assert.Single(dashboard.Events, ev => ev.EventName == "calculator_started");
+        Assert.Equal("internal", internalEvent.Source);
+        Assert.Equal("search", internalEvent.FirstSource);
+
+        var searchOnly = await service.GetDashboardAsync(new SiteStatisticsDashboardQuery { Range = "30d", Source = "search" });
+        Assert.Equal(2, searchOnly.Events.Count);
+
+        var internalOnly = await service.GetDashboardAsync(new SiteStatisticsDashboardQuery { Range = "30d", Source = "internal" });
+        Assert.Empty(internalOnly.Events);
+
+        var json = JsonSerializer.Serialize(dashboard);
+        Assert.DoesNotContain("private-token", json);
+    }
+
+    [Fact]
+    public async Task Dashboard_ClassifiesCampaignTaggedDirectLandingAsCampaign()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), "LongevityWorldCup.Tests", $"{Guid.NewGuid():N}.db");
+        Directory.CreateDirectory(Path.GetDirectoryName(dbPath)!);
+        await using var cleanup = new TempDatabaseCleanup(dbPath);
+        using var database = new DatabaseManager(dbPath: dbPath);
+        var service = new SiteStatisticsService(database, NullLogger<SiteStatisticsService>.Instance);
+        var context = new DefaultHttpContext();
+
+        await service.RecordClientEventAsync(new SiteStatisticsEventRequest
+        {
+            EventName = "onboarding_entry_viewed",
+            SessionId = "campaign-direct-session",
+            Flow = "onboarding",
+            Route = "/join?utm_source=newsletter&utm_medium=email&utm_campaign=challenge_launch"
+        }, context);
+
+        var dashboard = await service.GetDashboardAsync(new SiteStatisticsDashboardQuery { Range = "30d" });
+        var ev = Assert.Single(dashboard.Events);
+
+        Assert.Equal("campaign", ev.FirstSource);
+        Assert.Equal("newsletter", ev.FirstUtmSource);
+        Assert.Equal("email", ev.FirstUtmMedium);
+        Assert.Equal("challenge_launch", ev.FirstUtmCampaign);
+        Assert.Equal("challenge_launch", ev.FirstCampaign);
+
+        var campaignOnly = await service.GetDashboardAsync(new SiteStatisticsDashboardQuery { Range = "30d", Source = "campaign" });
+        Assert.Single(campaignOnly.Events);
+    }
+
     private static void InsertDashboardEvent(
         DatabaseManager database,
         DateTimeOffset occurredAtUtc,

--- a/LongevityWorldCup.Website/Business/LongevitymaxxingChallengeService.cs
+++ b/LongevityWorldCup.Website/Business/LongevitymaxxingChallengeService.cs
@@ -156,7 +156,11 @@ public sealed class LongevitymaxxingChallengeService
             .ToList();
     }
 
-    public async Task<LongevitymaxxingSignupResult> SignupAsync(LongevitymaxxingSignupRequest request, DateTimeOffset? nowUtc = null, CancellationToken ct = default)
+    public async Task<LongevitymaxxingSignupResult> SignupAsync(
+        LongevitymaxxingSignupRequest request,
+        DateTimeOffset? nowUtc = null,
+        HttpContext? context = null,
+        CancellationToken ct = default)
     {
         var startedAt = Stopwatch.GetTimestamp();
         try
@@ -259,6 +263,7 @@ public sealed class LongevitymaxxingChallengeService
                     ["athleteLinked"] = athleteSlug is not null,
                     ["commitmentConfigured"] = request.CommitmentAmountUsd is not null
                 },
+                context: context,
                 ct: ct).ConfigureAwait(false);
 
             return new LongevitymaxxingSignupResult("Check your email.");
@@ -278,6 +283,7 @@ public sealed class LongevitymaxxingChallengeService
                     ["athleteLinked"] = !string.IsNullOrWhiteSpace(request?.AthleteLink),
                     ["commitmentConfigured"] = request?.CommitmentAmountUsd is not null
                 },
+                context: context,
                 ct: ct).ConfigureAwait(false);
             throw;
         }
@@ -475,6 +481,7 @@ public sealed class LongevitymaxxingChallengeService
     public async Task<LongevitymaxxingParticipantState> CreateCommitmentPaymentInvoiceAsync(
         string accessToken,
         DateTimeOffset? nowUtc = null,
+        HttpContext? context = null,
         CancellationToken ct = default)
     {
         var startedAt = Stopwatch.GetTimestamp();
@@ -498,6 +505,7 @@ public sealed class LongevitymaxxingChallengeService
                     errorCode: null,
                     durationMs: ElapsedMilliseconds(startedAt),
                     metadata: CommitmentStatsMetadata(obligation, ("paymentPageState", "reused")),
+                    context: context,
                     ct: ct).ConfigureAwait(false);
                 return state;
             }
@@ -557,6 +565,7 @@ public sealed class LongevitymaxxingChallengeService
                 errorCode: null,
                 durationMs: ElapsedMilliseconds(startedAt),
                 metadata: CommitmentStatsMetadata(obligation, ("paymentPageState", "created")),
+                context: context,
                 ct: ct).ConfigureAwait(false);
             return updatedState;
         }
@@ -571,6 +580,7 @@ public sealed class LongevitymaxxingChallengeService
                 errorCode: StatsErrorCode(ex),
                 durationMs: ElapsedMilliseconds(startedAt),
                 metadata: CommitmentStatsMetadata(obligation),
+                context: context,
                 ct: ct).ConfigureAwait(false);
             throw;
         }
@@ -579,6 +589,7 @@ public sealed class LongevitymaxxingChallengeService
     public async Task<LongevitymaxxingParticipantState> RefreshCommitmentPaymentStatusAsync(
         string accessToken,
         DateTimeOffset? nowUtc = null,
+        HttpContext? context = null,
         CancellationToken ct = default)
     {
         var startedAt = Stopwatch.GetTimestamp();
@@ -601,6 +612,7 @@ public sealed class LongevitymaxxingChallengeService
                     errorCode: null,
                     durationMs: ElapsedMilliseconds(startedAt),
                     metadata: CommitmentStatsMetadata(obligation, ("paymentState", obligation is null ? "not_due" : "missing_invoice")),
+                    context: context,
                     ct: ct).ConfigureAwait(false);
                 return unchangedState;
             }
@@ -650,6 +662,7 @@ public sealed class LongevitymaxxingChallengeService
                     ("paymentState", invoicePaid ? "paid" : "open"),
                     ("status", TrimToNull(invoice.Status) ?? "unknown"),
                     ("additionalStatus", TrimToNull(invoice.AdditionalStatus) ?? "none")),
+                context: context,
                 ct: ct).ConfigureAwait(false);
 
             if (invoicePaid)
@@ -663,6 +676,7 @@ public sealed class LongevitymaxxingChallengeService
                     errorCode: null,
                     durationMs: ElapsedMilliseconds(startedAt),
                     metadata: CommitmentStatsMetadata(obligation, ("resolutionSource", "payment")),
+                    context: context,
                     ct: ct).ConfigureAwait(false);
             }
 
@@ -679,12 +693,16 @@ public sealed class LongevitymaxxingChallengeService
                 errorCode: StatsErrorCode(ex),
                 durationMs: ElapsedMilliseconds(startedAt),
                 metadata: CommitmentStatsMetadata(obligation),
+                context: context,
                 ct: ct).ConfigureAwait(false);
             throw;
         }
     }
 
-    public LongevitymaxxingParticipantState SubmitCheckIn(LongevitymaxxingCheckInRequest request, DateTimeOffset? nowUtc = null)
+    public LongevitymaxxingParticipantState SubmitCheckIn(
+        LongevitymaxxingCheckInRequest request,
+        DateTimeOffset? nowUtc = null,
+        HttpContext? context = null)
     {
         var startedAt = Stopwatch.GetTimestamp();
         ValidatedCheckIn? checkIn = null;
@@ -699,12 +717,13 @@ public sealed class LongevitymaxxingChallengeService
                 outcome: "succeeded",
                 errorCode: null,
                 notePhotoCount: 0,
-                durationMs: ElapsedMilliseconds(startedAt));
+                durationMs: ElapsedMilliseconds(startedAt),
+                context: context);
             return state;
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            TrackCheckInFailure(request, checkIn, ex, notePhotoCount: 0, durationMs: ElapsedMilliseconds(startedAt));
+            TrackCheckInFailure(request, checkIn, ex, notePhotoCount: 0, durationMs: ElapsedMilliseconds(startedAt), context: context);
             throw;
         }
     }
@@ -713,6 +732,7 @@ public sealed class LongevitymaxxingChallengeService
         LongevitymaxxingCheckInRequest request,
         IReadOnlyList<IFormFile>? notePhotos,
         DateTimeOffset? nowUtc = null,
+        HttpContext? context = null,
         CancellationToken ct = default)
     {
         var startedAt = Stopwatch.GetTimestamp();
@@ -738,6 +758,7 @@ public sealed class LongevitymaxxingChallengeService
                     errorCode: null,
                     notePhotoCount: notePhotoCount,
                     durationMs: ElapsedMilliseconds(startedAt),
+                    context: context,
                     ct: ct).ConfigureAwait(false);
                 return stateWithoutPhotos;
             }
@@ -767,6 +788,7 @@ public sealed class LongevitymaxxingChallengeService
                 errorCode: null,
                 notePhotoCount: notePhotoCount,
                 durationMs: ElapsedMilliseconds(startedAt),
+                context: context,
                 ct: ct).ConfigureAwait(false);
             return state;
         }
@@ -777,7 +799,7 @@ public sealed class LongevitymaxxingChallengeService
 
             if (ex is not OperationCanceledException)
             {
-                await TrackCheckInFailureAsync(request, checkIn, ex, notePhotoCount, ElapsedMilliseconds(startedAt), ct).ConfigureAwait(false);
+                await TrackCheckInFailureAsync(request, checkIn, ex, notePhotoCount, ElapsedMilliseconds(startedAt), context, ct).ConfigureAwait(false);
             }
 
             throw;
@@ -872,7 +894,8 @@ public sealed class LongevitymaxxingChallengeService
         string outcome,
         string? errorCode,
         int notePhotoCount,
-        long? durationMs)
+        long? durationMs,
+        HttpContext? context = null)
         => TrackChallengeEvent(
             eventName,
             actorId: checkIn.Participant.Id,
@@ -881,7 +904,8 @@ public sealed class LongevitymaxxingChallengeService
             outcome: outcome,
             errorCode: errorCode,
             durationMs: durationMs,
-            metadata: CheckInStatsMetadata(checkIn.Request, checkIn, state, notePhotoCount));
+            metadata: CheckInStatsMetadata(checkIn.Request, checkIn, state, notePhotoCount),
+            context: context);
 
     private Task TrackCheckInEventAsync(
         string eventName,
@@ -891,6 +915,7 @@ public sealed class LongevitymaxxingChallengeService
         string? errorCode,
         int notePhotoCount,
         long? durationMs,
+        HttpContext? context,
         CancellationToken ct)
         => TrackChallengeEventAsync(
             eventName,
@@ -901,6 +926,7 @@ public sealed class LongevitymaxxingChallengeService
             errorCode: errorCode,
             durationMs: durationMs,
             metadata: CheckInStatsMetadata(checkIn.Request, checkIn, state, notePhotoCount),
+            context: context,
             ct: ct);
 
     private void TrackCheckInFailure(
@@ -908,7 +934,8 @@ public sealed class LongevitymaxxingChallengeService
         ValidatedCheckIn? checkIn,
         Exception ex,
         int notePhotoCount,
-        long? durationMs)
+        long? durationMs,
+        HttpContext? context = null)
         => TrackChallengeEvent(
             checkIn is null ? "challenge_checkin_failed" : CheckInEventName(checkIn.CountsForScore, "failed"),
             actorId: checkIn?.Participant.Id,
@@ -917,7 +944,8 @@ public sealed class LongevitymaxxingChallengeService
             outcome: "failed",
             errorCode: StatsErrorCode(ex),
             durationMs: durationMs,
-            metadata: CheckInStatsMetadata(request, checkIn, state: null, notePhotoCount));
+            metadata: CheckInStatsMetadata(request, checkIn, state: null, notePhotoCount),
+            context: context);
 
     private Task TrackCheckInFailureAsync(
         LongevitymaxxingCheckInRequest? request,
@@ -925,6 +953,7 @@ public sealed class LongevitymaxxingChallengeService
         Exception ex,
         int notePhotoCount,
         long? durationMs,
+        HttpContext? context,
         CancellationToken ct)
         => TrackChallengeEventAsync(
             checkIn is null ? "challenge_checkin_failed" : CheckInEventName(checkIn.CountsForScore, "failed"),
@@ -935,6 +964,7 @@ public sealed class LongevitymaxxingChallengeService
             errorCode: StatsErrorCode(ex),
             durationMs: durationMs,
             metadata: CheckInStatsMetadata(request, checkIn, state: null, notePhotoCount),
+            context: context,
             ct: ct);
 
     private Task TrackChallengeEventAsync(
@@ -946,9 +976,11 @@ public sealed class LongevitymaxxingChallengeService
         string? errorCode,
         long? durationMs,
         IReadOnlyDictionary<string, object?>? metadata,
+        HttpContext? context = null,
         CancellationToken ct = default)
         => _statistics?.RecordServerEventAsync(
             eventName,
+            context,
             actorId: actorId,
             flow: "challenge",
             route: "/longevitymaxxing",
@@ -957,6 +989,7 @@ public sealed class LongevitymaxxingChallengeService
             outcome: outcome,
             errorCode: errorCode,
             durationMs: durationMs,
+            sessionId: ChallengeStatsSessionId(actorId),
             metadata: metadata,
             ct: ct) ?? Task.CompletedTask;
 
@@ -968,7 +1001,8 @@ public sealed class LongevitymaxxingChallengeService
         string outcome,
         string? errorCode,
         long? durationMs,
-        IReadOnlyDictionary<string, object?>? metadata)
+        IReadOnlyDictionary<string, object?>? metadata,
+        HttpContext? context = null)
         => TrackChallengeEventAsync(
             eventName,
             actorId,
@@ -977,7 +1011,11 @@ public sealed class LongevitymaxxingChallengeService
             outcome,
             errorCode,
             durationMs,
-            metadata).GetAwaiter().GetResult();
+            metadata,
+            context).GetAwaiter().GetResult();
+
+    private static string? ChallengeStatsSessionId(string? actorId)
+        => string.IsNullOrWhiteSpace(actorId) ? null : $"challenge:{actorId}";
 
     private static Dictionary<string, object?> CheckInStatsMetadata(
         LongevitymaxxingCheckInRequest? request,

--- a/LongevityWorldCup.Website/Business/LongevitymaxxingChallengeService.cs
+++ b/LongevityWorldCup.Website/Business/LongevitymaxxingChallengeService.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Globalization;
 using System.Net;
 using System.Security.Cryptography;
@@ -60,6 +61,7 @@ public sealed class LongevitymaxxingChallengeService
     private readonly ILogger<LongevitymaxxingChallengeService> _logger;
     private readonly IAthleteSnapshotProvider? _athletes;
     private readonly IBtcpayInvoiceClient? _btcpayInvoices;
+    private readonly SiteStatisticsService? _statistics;
     private readonly ConcurrentDictionary<string, byte> _profilePictureWarmups = new(StringComparer.Ordinal);
 
     public LongevitymaxxingChallengeService(
@@ -70,7 +72,8 @@ public sealed class LongevitymaxxingChallengeService
         ILongevitymaxxingEmailSender email,
         ILogger<LongevitymaxxingChallengeService> logger,
         IAthleteSnapshotProvider? athletes = null,
-        IBtcpayInvoiceClient? btcpayInvoices = null)
+        IBtcpayInvoiceClient? btcpayInvoices = null,
+        SiteStatisticsService? statistics = null)
     {
         _db = db;
         _config = config;
@@ -80,6 +83,7 @@ public sealed class LongevitymaxxingChallengeService
         _logger = logger;
         _athletes = athletes;
         _btcpayInvoices = btcpayInvoices;
+        _statistics = statistics;
         EnsureTables();
     }
 
@@ -154,91 +158,129 @@ public sealed class LongevitymaxxingChallengeService
 
     public async Task<LongevitymaxxingSignupResult> SignupAsync(LongevitymaxxingSignupRequest request, DateTimeOffset? nowUtc = null, CancellationToken ct = default)
     {
-        var now = EnsureUtc(nowUtc ?? DateTimeOffset.UtcNow);
-        var settings = BuildSettings(now);
-
-        var email = NormalizeEmail(request.Email);
-        var timeZoneId = NormalizeTimeZone(request.TimeZoneId);
-        var athleteSlug = TryNormalizeAthleteSlug(request.AthleteLink);
-        var athleteProfile = ResolveAthleteProfile(athleteSlug);
-        var displayName = ResolveSignupDisplayName(request.DisplayName, athleteSlug, athleteProfile);
-        var commitmentAmountUsd = NormalizeCommitmentAmount(request.CommitmentAmountUsd);
-
-        var confirmationToken = CreateToken();
-        var accessToken = CreateToken();
-        var stopToken = CreateToken();
-        var participantId = "";
-        var alreadyConfirmed = false;
-
-        _db.Run(sqlite =>
+        var startedAt = Stopwatch.GetTimestamp();
+        try
         {
-            var existing = FindParticipantByEmail(sqlite, email);
-            if (existing is null)
+            var now = EnsureUtc(nowUtc ?? DateTimeOffset.UtcNow);
+            var settings = BuildSettings(now);
+
+            var email = NormalizeEmail(request.Email);
+            var timeZoneId = NormalizeTimeZone(request.TimeZoneId);
+            var athleteSlug = TryNormalizeAthleteSlug(request.AthleteLink);
+            var athleteProfile = ResolveAthleteProfile(athleteSlug);
+            var displayName = ResolveSignupDisplayName(request.DisplayName, athleteSlug, athleteProfile);
+            var commitmentAmountUsd = NormalizeCommitmentAmount(request.CommitmentAmountUsd);
+
+            var confirmationToken = CreateToken();
+            var accessToken = CreateToken();
+            var stopToken = CreateToken();
+            var participantId = "";
+            var alreadyConfirmed = false;
+
+            _db.Run(sqlite =>
             {
-                EnsureParticipantIdentityAvailable(sqlite, displayName, athleteSlug, null);
-                participantId = Guid.NewGuid().ToString("N");
-                using var insert = sqlite.CreateCommand();
-                insert.CommandText =
-                    """
-                    INSERT INTO LongevitymaxxingParticipants
-                    (Id, Email, DisplayName, TimeZoneId, AthleteSlug, AccessToken, ConfirmationToken, StopToken, CommitmentAmountUsd, CreatedAtUtc, UpdatedAtUtc)
-                    VALUES (@id, @email, @name, @tz, @athlete, @access, @confirm, @stop, @commitmentAmount, @created, @updated);
-                    """;
-                Add(insert, "@id", participantId);
-                Add(insert, "@email", email);
-                Add(insert, "@name", displayName);
-                Add(insert, "@tz", timeZoneId);
-                Add(insert, "@athlete", athleteSlug);
-                Add(insert, "@access", accessToken);
-                Add(insert, "@confirm", confirmationToken);
-                Add(insert, "@stop", stopToken);
-                Add(insert, "@commitmentAmount", FormatDecimal(commitmentAmountUsd));
-                Add(insert, "@created", now.ToString("o"));
-                Add(insert, "@updated", now.ToString("o"));
-                insert.ExecuteNonQuery();
-            }
+                var existing = FindParticipantByEmail(sqlite, email);
+                if (existing is null)
+                {
+                    EnsureParticipantIdentityAvailable(sqlite, displayName, athleteSlug, null);
+                    participantId = Guid.NewGuid().ToString("N");
+                    using var insert = sqlite.CreateCommand();
+                    insert.CommandText =
+                        """
+                        INSERT INTO LongevitymaxxingParticipants
+                        (Id, Email, DisplayName, TimeZoneId, AthleteSlug, AccessToken, ConfirmationToken, StopToken, CommitmentAmountUsd, CreatedAtUtc, UpdatedAtUtc)
+                        VALUES (@id, @email, @name, @tz, @athlete, @access, @confirm, @stop, @commitmentAmount, @created, @updated);
+                        """;
+                    Add(insert, "@id", participantId);
+                    Add(insert, "@email", email);
+                    Add(insert, "@name", displayName);
+                    Add(insert, "@tz", timeZoneId);
+                    Add(insert, "@athlete", athleteSlug);
+                    Add(insert, "@access", accessToken);
+                    Add(insert, "@confirm", confirmationToken);
+                    Add(insert, "@stop", stopToken);
+                    Add(insert, "@commitmentAmount", FormatDecimal(commitmentAmountUsd));
+                    Add(insert, "@created", now.ToString("o"));
+                    Add(insert, "@updated", now.ToString("o"));
+                    insert.ExecuteNonQuery();
+                }
+                else
+                {
+                    participantId = existing.Id;
+                    alreadyConfirmed = existing.ConfirmedAtUtc is not null;
+                    confirmationToken = existing.ConfirmationToken;
+                    accessToken = existing.AccessToken;
+                    stopToken = existing.StopToken;
+                    if (HasActivePaymentObligation(sqlite, existing.Id))
+                        return;
+
+                    EnsureParticipantIdentityAvailable(sqlite, displayName, athleteSlug, existing.Id);
+                    using var update = sqlite.CreateCommand();
+                    update.CommandText =
+                        """
+                        UPDATE LongevitymaxxingParticipants
+                        SET DisplayName = @name,
+                            TimeZoneId = @tz,
+                            AthleteSlug = @athlete,
+                            CommitmentAmountUsd = @commitmentAmount,
+                            UpdatedAtUtc = @updated
+                        WHERE Id = @id;
+                        """;
+                    Add(update, "@name", displayName);
+                    Add(update, "@tz", timeZoneId);
+                    Add(update, "@athlete", athleteSlug);
+                    Add(update, "@commitmentAmount", FormatDecimal(commitmentAmountUsd));
+                    Add(update, "@updated", now.ToString("o"));
+                    Add(update, "@id", participantId);
+                    update.ExecuteNonQuery();
+                }
+            });
+
+            var url = alreadyConfirmed
+                ? BuildAccessUrl(accessToken)
+                : BuildChallengeUrl(("confirm", confirmationToken));
+
+            if (alreadyConfirmed)
+                await _email.SendAccessLinkAsync(email, displayName, url, ct).ConfigureAwait(false);
             else
-            {
-                participantId = existing.Id;
-                alreadyConfirmed = existing.ConfirmedAtUtc is not null;
-                confirmationToken = existing.ConfirmationToken;
-                accessToken = existing.AccessToken;
-                stopToken = existing.StopToken;
-                if (HasActivePaymentObligation(sqlite, existing.Id))
-                    return;
+                await _email.SendConfirmationAsync(email, displayName, url, ct).ConfigureAwait(false);
 
-                EnsureParticipantIdentityAvailable(sqlite, displayName, athleteSlug, existing.Id);
-                using var update = sqlite.CreateCommand();
-                update.CommandText =
-                    """
-                    UPDATE LongevitymaxxingParticipants
-                    SET DisplayName = @name,
-                        TimeZoneId = @tz,
-                        AthleteSlug = @athlete,
-                        CommitmentAmountUsd = @commitmentAmount,
-                        UpdatedAtUtc = @updated
-                    WHERE Id = @id;
-                    """;
-                Add(update, "@name", displayName);
-                Add(update, "@tz", timeZoneId);
-                Add(update, "@athlete", athleteSlug);
-                Add(update, "@commitmentAmount", FormatDecimal(commitmentAmountUsd));
-                Add(update, "@updated", now.ToString("o"));
-                Add(update, "@id", participantId);
-                update.ExecuteNonQuery();
-            }
-        });
+            await TrackChallengeEventAsync(
+                "challenge_signup_succeeded",
+                actorId: participantId,
+                component: "signup",
+                step: "submit",
+                outcome: "succeeded",
+                errorCode: null,
+                durationMs: ElapsedMilliseconds(startedAt),
+                metadata: new Dictionary<string, object?>
+                {
+                    ["signupState"] = alreadyConfirmed ? "existing" : "new",
+                    ["athleteLinked"] = athleteSlug is not null,
+                    ["commitmentConfigured"] = request.CommitmentAmountUsd is not null
+                },
+                ct: ct).ConfigureAwait(false);
 
-        var url = alreadyConfirmed
-            ? BuildAccessUrl(accessToken)
-            : BuildChallengeUrl(("confirm", confirmationToken));
-
-        if (alreadyConfirmed)
-            await _email.SendAccessLinkAsync(email, displayName, url, ct).ConfigureAwait(false);
-        else
-            await _email.SendConfirmationAsync(email, displayName, url, ct).ConfigureAwait(false);
-
-        return new LongevitymaxxingSignupResult("Check your email.");
+            return new LongevitymaxxingSignupResult("Check your email.");
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            await TrackChallengeEventAsync(
+                "challenge_signup_failed",
+                actorId: null,
+                component: "signup",
+                step: "submit",
+                outcome: "failed",
+                errorCode: StatsErrorCode(ex),
+                durationMs: ElapsedMilliseconds(startedAt),
+                metadata: new Dictionary<string, object?>
+                {
+                    ["athleteLinked"] = !string.IsNullOrWhiteSpace(request?.AthleteLink),
+                    ["commitmentConfigured"] = request?.CommitmentAmountUsd is not null
+                },
+                ct: ct).ConfigureAwait(false);
+            throw;
+        }
     }
 
     public async Task<LongevitymaxxingAccessResult> ConfirmAsync(string confirmationToken, DateTimeOffset? nowUtc = null, CancellationToken ct = default)
@@ -435,59 +477,103 @@ public sealed class LongevitymaxxingChallengeService
         DateTimeOffset? nowUtc = null,
         CancellationToken ct = default)
     {
-        var now = EnsureUtc(nowUtc ?? DateTimeOffset.UtcNow);
-        var participant = RequireParticipantByAccessToken(accessToken);
-        var obligation = GetActivePaymentObligation(participant.Id)
-            ?? throw new InvalidOperationException("No commitment payment is due.");
-        if (CanReuseCommitmentInvoice(obligation))
-            return GetParticipantState(accessToken, now);
-
-        var invoiceResult = await GetBtcpayInvoiceClient().CreateInvoiceAsync(
-            _config,
-            new BtcpayInvoiceCreateRequest(
-                obligation.AmountUsd,
-                "USD",
-                $"lmx-commitment-{obligation.Id}",
-                participant.Email,
-                participant.DisplayName,
-                new Dictionary<string, object?>
-                {
-                    ["source"] = "longevitymaxxing-commitment",
-                    ["participantId"] = participant.Id,
-                    ["triggerChallengeDay"] = obligation.TriggerChallengeDay,
-                    ["triggerScore"] = obligation.TriggerScore,
-                    ["thresholdAverage"] = FormatDecimal(obligation.ThresholdAverage)
-                }),
-            ct).ConfigureAwait(false);
-
-        if (!invoiceResult.Success || string.IsNullOrWhiteSpace(invoiceResult.InvoiceId) || string.IsNullOrWhiteSpace(invoiceResult.CheckoutLink))
-            throw new InvalidOperationException($"Could not create commitment invoice: {invoiceResult.Error ?? "unknown BTCPay error"}");
-
-        _db.Run(sqlite =>
+        var startedAt = Stopwatch.GetTimestamp();
+        ParticipantRecord? participant = null;
+        PaymentObligation? obligation = null;
+        try
         {
-            using var update = sqlite.CreateCommand();
-            update.CommandText =
-                """
-                UPDATE LongevitymaxxingPaymentObligations
-                SET InvoiceId = @invoiceId,
-                    CheckoutLink = @checkoutLink,
-                    InvoiceStatus = NULL,
-                    InvoiceAdditionalStatus = NULL,
-                    InvoiceCreatedAtUtc = @invoiceCreated,
-                    UpdatedAtUtc = @updated
-                WHERE Id = @id
-                  AND PaidAtUtc IS NULL
-                  AND ClearedAtUtc IS NULL;
-                """;
-            Add(update, "@invoiceId", invoiceResult.InvoiceId);
-            Add(update, "@checkoutLink", invoiceResult.CheckoutLink);
-            Add(update, "@invoiceCreated", now.ToString("o"));
-            Add(update, "@updated", now.ToString("o"));
-            Add(update, "@id", obligation.Id);
-            update.ExecuteNonQuery();
-        });
+            var now = EnsureUtc(nowUtc ?? DateTimeOffset.UtcNow);
+            participant = RequireParticipantByAccessToken(accessToken);
+            obligation = GetActivePaymentObligation(participant.Id)
+                ?? throw new InvalidOperationException("No commitment payment is due.");
+            if (CanReuseCommitmentInvoice(obligation))
+            {
+                var state = GetParticipantState(accessToken, now);
+                await TrackChallengeEventAsync(
+                    "challenge_commitment_payment_opened",
+                    actorId: participant.Id,
+                    component: "commitment",
+                    step: "payment",
+                    outcome: "succeeded",
+                    errorCode: null,
+                    durationMs: ElapsedMilliseconds(startedAt),
+                    metadata: CommitmentStatsMetadata(obligation, ("paymentPageState", "reused")),
+                    ct: ct).ConfigureAwait(false);
+                return state;
+            }
 
-        return GetParticipantState(accessToken, now);
+            var invoiceResult = await GetBtcpayInvoiceClient().CreateInvoiceAsync(
+                _config,
+                new BtcpayInvoiceCreateRequest(
+                    obligation.AmountUsd,
+                    "USD",
+                    $"lmx-commitment-{obligation.Id}",
+                    participant.Email,
+                    participant.DisplayName,
+                    new Dictionary<string, object?>
+                    {
+                        ["source"] = "longevitymaxxing-commitment",
+                        ["participantId"] = participant.Id,
+                        ["triggerChallengeDay"] = obligation.TriggerChallengeDay,
+                        ["triggerScore"] = obligation.TriggerScore,
+                        ["thresholdAverage"] = FormatDecimal(obligation.ThresholdAverage)
+                    }),
+                ct).ConfigureAwait(false);
+
+            if (!invoiceResult.Success || string.IsNullOrWhiteSpace(invoiceResult.InvoiceId) || string.IsNullOrWhiteSpace(invoiceResult.CheckoutLink))
+                throw new InvalidOperationException($"Could not create commitment invoice: {invoiceResult.Error ?? "unknown BTCPay error"}");
+
+            _db.Run(sqlite =>
+            {
+                using var update = sqlite.CreateCommand();
+                update.CommandText =
+                    """
+                    UPDATE LongevitymaxxingPaymentObligations
+                    SET InvoiceId = @invoiceId,
+                        CheckoutLink = @checkoutLink,
+                        InvoiceStatus = NULL,
+                        InvoiceAdditionalStatus = NULL,
+                        InvoiceCreatedAtUtc = @invoiceCreated,
+                        UpdatedAtUtc = @updated
+                    WHERE Id = @id
+                      AND PaidAtUtc IS NULL
+                      AND ClearedAtUtc IS NULL;
+                    """;
+                Add(update, "@invoiceId", invoiceResult.InvoiceId);
+                Add(update, "@checkoutLink", invoiceResult.CheckoutLink);
+                Add(update, "@invoiceCreated", now.ToString("o"));
+                Add(update, "@updated", now.ToString("o"));
+                Add(update, "@id", obligation.Id);
+                update.ExecuteNonQuery();
+            });
+
+            var updatedState = GetParticipantState(accessToken, now);
+            await TrackChallengeEventAsync(
+                "challenge_commitment_payment_opened",
+                actorId: participant.Id,
+                component: "commitment",
+                step: "payment",
+                outcome: "succeeded",
+                errorCode: null,
+                durationMs: ElapsedMilliseconds(startedAt),
+                metadata: CommitmentStatsMetadata(obligation, ("paymentPageState", "created")),
+                ct: ct).ConfigureAwait(false);
+            return updatedState;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            await TrackChallengeEventAsync(
+                "challenge_commitment_payment_failed",
+                actorId: participant?.Id,
+                component: "commitment",
+                step: "payment",
+                outcome: "failed",
+                errorCode: StatsErrorCode(ex),
+                durationMs: ElapsedMilliseconds(startedAt),
+                metadata: CommitmentStatsMetadata(obligation),
+                ct: ct).ConfigureAwait(false);
+            throw;
+        }
     }
 
     public async Task<LongevitymaxxingParticipantState> RefreshCommitmentPaymentStatusAsync(
@@ -495,50 +581,132 @@ public sealed class LongevitymaxxingChallengeService
         DateTimeOffset? nowUtc = null,
         CancellationToken ct = default)
     {
-        var now = EnsureUtc(nowUtc ?? DateTimeOffset.UtcNow);
-        var participant = RequireParticipantByAccessToken(accessToken);
-        var obligation = GetActivePaymentObligation(participant.Id);
-        if (obligation is null || string.IsNullOrWhiteSpace(obligation.InvoiceId))
-            return GetParticipantState(accessToken, now);
-
-        var invoice = await GetBtcpayInvoiceClient()
-            .GetInvoiceAsync(_config, obligation.InvoiceId, ct)
-            .ConfigureAwait(false);
-        if (!invoice.Success)
-            throw new InvalidOperationException($"Could not refresh commitment payment: {invoice.Error ?? "unknown BTCPay error"}");
-        var invoicePaid = IsCommitmentInvoicePaid(invoice, obligation);
-
-        _db.Run(sqlite =>
+        var startedAt = Stopwatch.GetTimestamp();
+        ParticipantRecord? participant = null;
+        PaymentObligation? obligation = null;
+        try
         {
-            using var update = sqlite.CreateCommand();
-            update.CommandText =
-                """
-                UPDATE LongevitymaxxingPaymentObligations
-                SET InvoiceStatus = @status,
-                    InvoiceAdditionalStatus = @additionalStatus,
-                    PaidAtUtc = CASE WHEN @isPaid = 1 THEN COALESCE(PaidAtUtc, @paid) ELSE PaidAtUtc END,
-                    UpdatedAtUtc = @updated
-                WHERE Id = @id;
-                """;
-            Add(update, "@status", TrimToNull(invoice.Status));
-            Add(update, "@additionalStatus", TrimToNull(invoice.AdditionalStatus));
-            Add(update, "@isPaid", invoicePaid ? 1 : 0);
-            Add(update, "@paid", now.ToString("o"));
-            Add(update, "@updated", now.ToString("o"));
-            Add(update, "@id", obligation.Id);
-            update.ExecuteNonQuery();
+            var now = EnsureUtc(nowUtc ?? DateTimeOffset.UtcNow);
+            participant = RequireParticipantByAccessToken(accessToken);
+            obligation = GetActivePaymentObligation(participant.Id);
+            if (obligation is null || string.IsNullOrWhiteSpace(obligation.InvoiceId))
+            {
+                var unchangedState = GetParticipantState(accessToken, now);
+                await TrackChallengeEventAsync(
+                    "challenge_commitment_payment_status_checked",
+                    actorId: participant.Id,
+                    component: "commitment",
+                    step: "payment_status",
+                    outcome: "succeeded",
+                    errorCode: null,
+                    durationMs: ElapsedMilliseconds(startedAt),
+                    metadata: CommitmentStatsMetadata(obligation, ("paymentState", obligation is null ? "not_due" : "missing_invoice")),
+                    ct: ct).ConfigureAwait(false);
+                return unchangedState;
+            }
+
+            var invoice = await GetBtcpayInvoiceClient()
+                .GetInvoiceAsync(_config, obligation.InvoiceId, ct)
+                .ConfigureAwait(false);
+            if (!invoice.Success)
+                throw new InvalidOperationException($"Could not refresh commitment payment: {invoice.Error ?? "unknown BTCPay error"}");
+            var invoicePaid = IsCommitmentInvoicePaid(invoice, obligation);
+
+            _db.Run(sqlite =>
+            {
+                using var update = sqlite.CreateCommand();
+                update.CommandText =
+                    """
+                    UPDATE LongevitymaxxingPaymentObligations
+                    SET InvoiceStatus = @status,
+                        InvoiceAdditionalStatus = @additionalStatus,
+                        PaidAtUtc = CASE WHEN @isPaid = 1 THEN COALESCE(PaidAtUtc, @paid) ELSE PaidAtUtc END,
+                        UpdatedAtUtc = @updated
+                    WHERE Id = @id;
+                    """;
+                Add(update, "@status", TrimToNull(invoice.Status));
+                Add(update, "@additionalStatus", TrimToNull(invoice.AdditionalStatus));
+                Add(update, "@isPaid", invoicePaid ? 1 : 0);
+                Add(update, "@paid", now.ToString("o"));
+                Add(update, "@updated", now.ToString("o"));
+                Add(update, "@id", obligation.Id);
+                update.ExecuteNonQuery();
+
+                if (invoicePaid)
+                    ReactivateParticipantChallenge(sqlite, participant.Id, now);
+            });
+
+            var state = GetParticipantState(accessToken, now);
+            await TrackChallengeEventAsync(
+                "challenge_commitment_payment_status_checked",
+                actorId: participant.Id,
+                component: "commitment",
+                step: "payment_status",
+                outcome: "succeeded",
+                errorCode: null,
+                durationMs: ElapsedMilliseconds(startedAt),
+                metadata: CommitmentStatsMetadata(
+                    obligation,
+                    ("paymentState", invoicePaid ? "paid" : "open"),
+                    ("status", TrimToNull(invoice.Status) ?? "unknown"),
+                    ("additionalStatus", TrimToNull(invoice.AdditionalStatus) ?? "none")),
+                ct: ct).ConfigureAwait(false);
 
             if (invoicePaid)
-                ReactivateParticipantChallenge(sqlite, participant.Id, now);
-        });
+            {
+                await TrackChallengeEventAsync(
+                    "challenge_commitment_resolved",
+                    actorId: participant.Id,
+                    component: "commitment",
+                    step: "resolution",
+                    outcome: "succeeded",
+                    errorCode: null,
+                    durationMs: ElapsedMilliseconds(startedAt),
+                    metadata: CommitmentStatsMetadata(obligation, ("resolutionSource", "payment")),
+                    ct: ct).ConfigureAwait(false);
+            }
 
-        return GetParticipantState(accessToken, now);
+            return state;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            await TrackChallengeEventAsync(
+                "challenge_commitment_payment_status_failed",
+                actorId: participant?.Id,
+                component: "commitment",
+                step: "payment_status",
+                outcome: "failed",
+                errorCode: StatsErrorCode(ex),
+                durationMs: ElapsedMilliseconds(startedAt),
+                metadata: CommitmentStatsMetadata(obligation),
+                ct: ct).ConfigureAwait(false);
+            throw;
+        }
     }
 
     public LongevitymaxxingParticipantState SubmitCheckIn(LongevitymaxxingCheckInRequest request, DateTimeOffset? nowUtc = null)
     {
-        var checkIn = ValidateCheckIn(request, nowUtc);
-        return SaveCheckIn(checkIn, []);
+        var startedAt = Stopwatch.GetTimestamp();
+        ValidatedCheckIn? checkIn = null;
+        try
+        {
+            checkIn = ValidateCheckIn(request, nowUtc);
+            var state = SaveCheckIn(checkIn, []);
+            TrackCheckInEvent(
+                CheckInEventName(checkIn.CountsForScore, "submitted"),
+                checkIn,
+                state,
+                outcome: "succeeded",
+                errorCode: null,
+                notePhotoCount: 0,
+                durationMs: ElapsedMilliseconds(startedAt));
+            return state;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            TrackCheckInFailure(request, checkIn, ex, notePhotoCount: 0, durationMs: ElapsedMilliseconds(startedAt));
+            throw;
+        }
     }
 
     public async Task<LongevitymaxxingParticipantState> SubmitCheckInAsync(
@@ -547,22 +715,38 @@ public sealed class LongevitymaxxingChallengeService
         DateTimeOffset? nowUtc = null,
         CancellationToken ct = default)
     {
-        var checkIn = ValidateCheckIn(request, nowUtc);
-        var photoFiles = (notePhotos ?? [])
-            .Where(photo => photo is { Length: > 0 })
-            .ToList();
-
-        if (photoFiles.Count == 0)
-            return SaveCheckIn(checkIn, []);
-
-        var existingImages = GetCheckInImagesFor(checkIn.Participant.Id, checkIn.Request.ChallengeDay);
-        if (existingImages.Count + photoFiles.Count > MaxCheckInPhotoCount)
-            throw new InvalidOperationException($"Each check-in can have up to {MaxCheckInPhotoCount} photos.");
-
-        var nextIndex = existingImages.Count == 0 ? 1 : existingImages.Max(image => image.ImageIndex) + 1;
+        var startedAt = Stopwatch.GetTimestamp();
+        ValidatedCheckIn? checkIn = null;
+        var notePhotoCount = 0;
         var processedImages = new List<PendingCheckInImage>();
         try
         {
+            checkIn = ValidateCheckIn(request, nowUtc);
+            var photoFiles = (notePhotos ?? [])
+                .Where(photo => photo is { Length: > 0 })
+                .ToList();
+            notePhotoCount = photoFiles.Count;
+
+            if (photoFiles.Count == 0)
+            {
+                var stateWithoutPhotos = SaveCheckIn(checkIn, []);
+                await TrackCheckInEventAsync(
+                    CheckInEventName(checkIn.CountsForScore, "submitted"),
+                    checkIn,
+                    stateWithoutPhotos,
+                    outcome: "succeeded",
+                    errorCode: null,
+                    notePhotoCount: notePhotoCount,
+                    durationMs: ElapsedMilliseconds(startedAt),
+                    ct: ct).ConfigureAwait(false);
+                return stateWithoutPhotos;
+            }
+
+            var existingImages = GetCheckInImagesFor(checkIn.Participant.Id, checkIn.Request.ChallengeDay);
+            if (existingImages.Count + photoFiles.Count > MaxCheckInPhotoCount)
+                throw new InvalidOperationException($"Each check-in can have up to {MaxCheckInPhotoCount} photos.");
+
+            var nextIndex = existingImages.Count == 0 ? 1 : existingImages.Max(image => image.ImageIndex) + 1;
             foreach (var photo in photoFiles)
             {
                 processedImages.Add(await ProcessCheckInPhotoAsync(
@@ -574,12 +758,28 @@ public sealed class LongevitymaxxingChallengeService
                     ct).ConfigureAwait(false));
             }
 
-            return SaveCheckIn(checkIn, processedImages);
+            var state = SaveCheckIn(checkIn, processedImages);
+            await TrackCheckInEventAsync(
+                CheckInEventName(checkIn.CountsForScore, "submitted"),
+                checkIn,
+                state,
+                outcome: "succeeded",
+                errorCode: null,
+                notePhotoCount: notePhotoCount,
+                durationMs: ElapsedMilliseconds(startedAt),
+                ct: ct).ConfigureAwait(false);
+            return state;
         }
-        catch
+        catch (Exception ex)
         {
             foreach (var image in processedImages)
                 TryDeleteFile(image.OutputPath);
+
+            if (ex is not OperationCanceledException)
+            {
+                await TrackCheckInFailureAsync(request, checkIn, ex, notePhotoCount, ElapsedMilliseconds(startedAt), ct).ConfigureAwait(false);
+            }
+
             throw;
         }
     }
@@ -607,7 +807,7 @@ public sealed class LongevitymaxxingChallengeService
         var note = NormalizeNote(request.Note);
         var challengeDate = settings.StartDate.AddDays(request.ChallengeDay - 1);
 
-        return new ValidatedCheckIn(request, now, participant, values.Sleep, values.Exercise, values.Nutrition, values.Vices, note, challengeDate);
+        return new ValidatedCheckIn(request, now, participant, values.Sleep, values.Exercise, values.Nutrition, values.Vices, note, challengeDate, eligible.CountsForScore);
     }
 
     private LongevitymaxxingParticipantState SaveCheckIn(ValidatedCheckIn checkIn, IReadOnlyList<PendingCheckInImage> newImages)
@@ -664,6 +864,176 @@ public sealed class LongevitymaxxingChallengeService
         ReactivateMissedDayInactiveParticipantIfCaughtUp(checkIn.Participant, checkIn.NowUtc);
         return GetParticipantState(checkIn.Request.AccessToken, checkIn.NowUtc);
     }
+
+    private void TrackCheckInEvent(
+        string eventName,
+        ValidatedCheckIn checkIn,
+        LongevitymaxxingParticipantState state,
+        string outcome,
+        string? errorCode,
+        int notePhotoCount,
+        long? durationMs)
+        => TrackChallengeEvent(
+            eventName,
+            actorId: checkIn.Participant.Id,
+            component: "checkin",
+            step: "submit",
+            outcome: outcome,
+            errorCode: errorCode,
+            durationMs: durationMs,
+            metadata: CheckInStatsMetadata(checkIn.Request, checkIn, state, notePhotoCount));
+
+    private Task TrackCheckInEventAsync(
+        string eventName,
+        ValidatedCheckIn checkIn,
+        LongevitymaxxingParticipantState state,
+        string outcome,
+        string? errorCode,
+        int notePhotoCount,
+        long? durationMs,
+        CancellationToken ct)
+        => TrackChallengeEventAsync(
+            eventName,
+            actorId: checkIn.Participant.Id,
+            component: "checkin",
+            step: "submit",
+            outcome: outcome,
+            errorCode: errorCode,
+            durationMs: durationMs,
+            metadata: CheckInStatsMetadata(checkIn.Request, checkIn, state, notePhotoCount),
+            ct: ct);
+
+    private void TrackCheckInFailure(
+        LongevitymaxxingCheckInRequest? request,
+        ValidatedCheckIn? checkIn,
+        Exception ex,
+        int notePhotoCount,
+        long? durationMs)
+        => TrackChallengeEvent(
+            checkIn is null ? "challenge_checkin_failed" : CheckInEventName(checkIn.CountsForScore, "failed"),
+            actorId: checkIn?.Participant.Id,
+            component: "checkin",
+            step: "submit",
+            outcome: "failed",
+            errorCode: StatsErrorCode(ex),
+            durationMs: durationMs,
+            metadata: CheckInStatsMetadata(request, checkIn, state: null, notePhotoCount));
+
+    private Task TrackCheckInFailureAsync(
+        LongevitymaxxingCheckInRequest? request,
+        ValidatedCheckIn? checkIn,
+        Exception ex,
+        int notePhotoCount,
+        long? durationMs,
+        CancellationToken ct)
+        => TrackChallengeEventAsync(
+            checkIn is null ? "challenge_checkin_failed" : CheckInEventName(checkIn.CountsForScore, "failed"),
+            actorId: checkIn?.Participant.Id,
+            component: "checkin",
+            step: "submit",
+            outcome: "failed",
+            errorCode: StatsErrorCode(ex),
+            durationMs: durationMs,
+            metadata: CheckInStatsMetadata(request, checkIn, state: null, notePhotoCount),
+            ct: ct);
+
+    private Task TrackChallengeEventAsync(
+        string eventName,
+        string? actorId,
+        string component,
+        string step,
+        string outcome,
+        string? errorCode,
+        long? durationMs,
+        IReadOnlyDictionary<string, object?>? metadata,
+        CancellationToken ct = default)
+        => _statistics?.RecordServerEventAsync(
+            eventName,
+            actorId: actorId,
+            flow: "challenge",
+            route: "/longevitymaxxing",
+            component: component,
+            step: step,
+            outcome: outcome,
+            errorCode: errorCode,
+            durationMs: durationMs,
+            metadata: metadata,
+            ct: ct) ?? Task.CompletedTask;
+
+    private void TrackChallengeEvent(
+        string eventName,
+        string? actorId,
+        string component,
+        string step,
+        string outcome,
+        string? errorCode,
+        long? durationMs,
+        IReadOnlyDictionary<string, object?>? metadata)
+        => TrackChallengeEventAsync(
+            eventName,
+            actorId,
+            component,
+            step,
+            outcome,
+            errorCode,
+            durationMs,
+            metadata).GetAwaiter().GetResult();
+
+    private static Dictionary<string, object?> CheckInStatsMetadata(
+        LongevitymaxxingCheckInRequest? request,
+        ValidatedCheckIn? checkIn,
+        LongevitymaxxingParticipantState? state,
+        int notePhotoCount)
+    {
+        var metadata = new Dictionary<string, object?>
+        {
+            ["checkInKind"] = checkIn is null ? "unknown" : checkIn.CountsForScore ? "scored" : "practice",
+            ["notePhotoCount"] = notePhotoCount
+        };
+
+        var challengeDay = checkIn?.Request.ChallengeDay ?? request?.ChallengeDay;
+        if (challengeDay is > 0)
+            metadata["challengeDay"] = challengeDay.Value;
+
+        if (state is not null)
+            metadata["commitmentStatus"] = state.Commitment.Status;
+
+        return metadata;
+    }
+
+    private static Dictionary<string, object?> CommitmentStatsMetadata(
+        PaymentObligation? obligation,
+        params (string Key, object? Value)[] extra)
+    {
+        var metadata = new Dictionary<string, object?>();
+        if (obligation is not null)
+        {
+            metadata["triggerChallengeDay"] = obligation.TriggerChallengeDay;
+            metadata["triggerScore"] = obligation.TriggerScore;
+        }
+
+        foreach (var (key, value) in extra)
+            metadata[key] = value;
+
+        return metadata;
+    }
+
+    private static string CheckInEventName(bool countsForScore, string suffix)
+        => countsForScore
+            ? $"challenge_scored_checkin_{suffix}"
+            : $"challenge_practice_checkin_{suffix}";
+
+    private static string StatsErrorCode(Exception ex)
+        => ex switch
+        {
+            UnauthorizedAccessException => "unauthorized",
+            InvalidOperationException => "client_error",
+            ArgumentException => "client_error",
+            _ => "server_error"
+        };
+
+    private static long ElapsedMilliseconds(long startTimestamp)
+        => (long)Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
 
     private async Task<PendingCheckInImage> ProcessCheckInPhotoAsync(
         ParticipantRecord participant,
@@ -1801,7 +2171,7 @@ public sealed class LongevitymaxxingChallengeService
             {
                 var triggerScore = GetScoredPoints(settings, checkIn.Participant, saved, byDay);
                 if (!IsBelowCommitmentPledgeFloor(settings, checkIn.Participant, byDay, saved, activeObligation.ThresholdAverage))
-                    ClearPaymentObligation(activeObligation.Id, checkIn.NowUtc);
+                    ClearPaymentObligation(activeObligation, checkIn.Participant.Id, checkIn.NowUtc, resolutionSource: "checkin_edit");
                 else
                     UpdatePaymentObligationTriggerScore(activeObligation.Id, triggerScore, checkIn.NowUtc);
             }
@@ -1954,7 +2324,7 @@ public sealed class LongevitymaxxingChallengeService
         });
     }
 
-    private void ClearPaymentObligation(string obligationId, DateTimeOffset now)
+    private void ClearPaymentObligation(PaymentObligation obligation, string participantId, DateTimeOffset now, string resolutionSource)
     {
         _db.Run(sqlite =>
         {
@@ -1969,9 +2339,19 @@ public sealed class LongevitymaxxingChallengeService
                 """;
             Add(update, "@cleared", now.ToString("o"));
             Add(update, "@updated", now.ToString("o"));
-            Add(update, "@id", obligationId);
+            Add(update, "@id", obligation.Id);
             update.ExecuteNonQuery();
         });
+
+        TrackChallengeEvent(
+            "challenge_commitment_resolved",
+            actorId: participantId,
+            component: "commitment",
+            step: "resolution",
+            outcome: "succeeded",
+            errorCode: null,
+            durationMs: null,
+            metadata: CommitmentStatsMetadata(obligation, ("resolutionSource", resolutionSource)));
     }
 
     private PaymentObligation? GetActivePaymentObligation(string participantId)
@@ -3757,7 +4137,8 @@ public sealed class LongevitymaxxingChallengeService
         int Nutrition,
         int Vices,
         string? Note,
-        DateOnly ChallengeDate);
+        DateOnly ChallengeDate,
+        bool CountsForScore);
 
     private sealed record PendingCheckInImage(
         int ImageIndex,

--- a/LongevityWorldCup.Website/Business/SiteStatisticsService.cs
+++ b/LongevityWorldCup.Website/Business/SiteStatisticsService.cs
@@ -4,6 +4,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Hosting;
 using LongevityWorldCup.Website.Tools;
@@ -14,6 +15,7 @@ public sealed class SiteStatisticsService : IHostedService
 {
     private const int MaxEventNameLength = 96;
     private const int MaxTextLength = 160;
+    private const int MaxCampaignTextLength = 96;
     private const int MaxMetadataJsonLength = 4096;
     private const int DefaultDashboardLimit = 2500;
     private const int MaxDashboardLimit = 5000;
@@ -172,20 +174,23 @@ public sealed class SiteStatisticsService : IHostedService
         using var cmd = sqlite.CreateCommand();
         cmd.CommandText =
             """
-            SELECT OccurredAtUtc, SessionHash, ActorHash, EventName, Flow, Route, Component, Step, Outcome,
-                   ErrorCode, DurationMs, DeviceClass, BrowserFamily, ReferrerDomain, Source, MetadataJson
-            FROM SiteStatisticEvents
-            WHERE OccurredAtUtc >= @from
-              AND OccurredAtUtc < @to
-              AND (@flow = '' OR Flow = @flow)
-              AND (@device = '' OR DeviceClass = @device)
-              AND (
-                    @source = ''
-                    OR (@source = 'internal' AND lower(coalesce(ReferrerDomain, '')) IN ('longevityworldcup.com', 'www.longevityworldcup.com'))
-                    OR (@source = 'referral' AND Source = 'referral' AND lower(coalesce(ReferrerDomain, '')) NOT IN ('longevityworldcup.com', 'www.longevityworldcup.com'))
-                    OR (@source NOT IN ('internal', 'referral') AND Source = @source AND lower(coalesce(ReferrerDomain, '')) NOT IN ('longevityworldcup.com', 'www.longevityworldcup.com'))
-                  )
-            ORDER BY OccurredAtUtc DESC
+            SELECT e.OccurredAtUtc, e.SessionHash, e.ActorHash, e.EventName, e.Flow, e.Route, e.Component, e.Step, e.Outcome,
+                   e.ErrorCode, e.DurationMs, e.DeviceClass, e.BrowserFamily, e.ReferrerDomain, e.Source, e.MetadataJson,
+                   s.LandingRoute, s.FirstReferrerDomain, s.FirstSource, s.FirstCampaign, s.FirstUtmSource,
+                   s.FirstUtmMedium, s.FirstUtmCampaign, s.FirstUtmTerm, s.FirstUtmContent
+            FROM SiteStatisticEvents e
+            LEFT JOIN SiteStatisticSessions s ON s.SessionHash = e.SessionHash
+            WHERE e.OccurredAtUtc >= @from
+              AND e.OccurredAtUtc < @to
+              AND (@flow = '' OR e.Flow = @flow)
+              AND (@device = '' OR e.DeviceClass = @device)
+              AND (@source = '' OR (
+                    CASE
+                        WHEN lower(coalesce(s.FirstReferrerDomain, e.ReferrerDomain, '')) IN ('longevityworldcup.com', 'www.longevityworldcup.com') THEN 'internal'
+                        ELSE coalesce(s.FirstSource, e.Source, 'direct')
+                    END
+                  ) = @source)
+            ORDER BY e.OccurredAtUtc DESC
             LIMIT @limit;
             """;
         Add(cmd, "@from", from.ToString("O", CultureInfo.InvariantCulture));
@@ -200,6 +205,7 @@ public sealed class SiteStatisticsService : IHostedService
         while (reader.Read())
         {
             var referrerDomain = ReadNullableString(reader, 13);
+            var firstReferrerDomain = ReadNullableString(reader, 17);
             events.Add(new SiteStatisticsDashboardEvent(
                 OccurredAtUtc: RoundToMinute(ReadString(reader, 0)),
                 SessionHash: ReadString(reader, 1),
@@ -216,6 +222,15 @@ public sealed class SiteStatisticsService : IHostedService
                 BrowserFamily: ReadNullableString(reader, 12),
                 ReferrerDomain: referrerDomain,
                 Source: NormalizeSource(ReadNullableString(reader, 14), referrerDomain),
+                LandingRoute: ReadNullableString(reader, 16),
+                FirstReferrerDomain: firstReferrerDomain,
+                FirstSource: NormalizeSource(ReadNullableString(reader, 18), firstReferrerDomain),
+                FirstCampaign: ReadNullableString(reader, 19),
+                FirstUtmSource: ReadNullableString(reader, 20),
+                FirstUtmMedium: ReadNullableString(reader, 21),
+                FirstUtmCampaign: ReadNullableString(reader, 22),
+                FirstUtmTerm: ReadNullableString(reader, 23),
+                FirstUtmContent: ReadNullableString(reader, 24),
                 Metadata: ReadMetadata(ReadNullableString(reader, 15))));
         }
 
@@ -253,7 +268,8 @@ public sealed class SiteStatisticsService : IHostedService
         if (string.IsNullOrWhiteSpace(eventName) || LooksSensitiveValue(eventName))
             return null;
 
-        var route = SanitizeRoute(request.Route ?? context?.Request.Path.Value ?? string.Empty);
+        var rawRoute = request.Route ?? ContextRoute(context) ?? string.Empty;
+        var route = SanitizeRoute(rawRoute);
         var metadata = SanitizeMetadata(request.Metadata);
         var metadataJson = metadata.Count == 0 ? null : JsonSerializer.Serialize(metadata, JsonOptions);
         if (metadataJson is { Length: > MaxMetadataJsonLength })
@@ -262,11 +278,14 @@ public sealed class SiteStatisticsService : IHostedService
         }
 
         var referrerDomain = SafeDomain(request.ReferrerDomain) ?? SafeDomain(context?.Request.Headers.Referer.FirstOrDefault());
+        var source = NormalizeSource(request.Source, referrerDomain);
+        var sessionHash = BuildHash("S", request.SessionId ?? ClientIdentifier.From(context ?? new DefaultHttpContext()));
+        var firstTouch = BuildFirstTouch(request, rawRoute, route, referrerDomain, source);
 
         return new QueuedSiteStatisticEvent(
             Id: Guid.NewGuid().ToString("N"),
             OccurredAtUtc: occurredAt.ToString("O", CultureInfo.InvariantCulture),
-            SessionHash: BuildHash("S", request.SessionId ?? ClientIdentifier.From(context ?? new DefaultHttpContext())),
+            SessionHash: sessionHash,
             ActorHash: string.IsNullOrWhiteSpace(actorId) ? null : BuildHash("A", actorId),
             EventName: eventName,
             Flow: SafeDisplayToken(request.Flow, MaxTextLength),
@@ -279,7 +298,16 @@ public sealed class SiteStatisticsService : IHostedService
             DeviceClass: SafeDisplayToken(request.DeviceClass, MaxTextLength) ?? DetectDeviceClass(context),
             BrowserFamily: SafeDisplayToken(request.BrowserFamily, MaxTextLength) ?? DetectBrowserFamily(context),
             ReferrerDomain: referrerDomain,
-            Source: NormalizeSource(request.Source, referrerDomain),
+            Source: source,
+            LandingRoute: firstTouch.LandingRoute,
+            FirstReferrerDomain: firstTouch.FirstReferrerDomain,
+            FirstSource: firstTouch.FirstSource,
+            FirstCampaign: firstTouch.FirstCampaign,
+            FirstUtmSource: firstTouch.FirstUtmSource,
+            FirstUtmMedium: firstTouch.FirstUtmMedium,
+            FirstUtmCampaign: firstTouch.FirstUtmCampaign,
+            FirstUtmTerm: firstTouch.FirstUtmTerm,
+            FirstUtmContent: firstTouch.FirstUtmContent,
             MetadataJson: metadataJson);
     }
 
@@ -346,6 +374,70 @@ public sealed class SiteStatisticsService : IHostedService
         return _database.RunAsync(sqlite =>
         {
             using var tx = sqlite.BeginTransaction();
+            using var sessionCmd = sqlite.CreateCommand();
+            sessionCmd.Transaction = tx;
+            sessionCmd.CommandText =
+                """
+                INSERT INTO SiteStatisticSessions
+                (SessionHash, FirstSeenAtUtc, LandingRoute, FirstReferrerDomain, FirstSource, FirstCampaign,
+                 FirstUtmSource, FirstUtmMedium, FirstUtmCampaign, FirstUtmTerm, FirstUtmContent)
+                VALUES
+                (@sessionHash, @firstSeen, @landingRoute, @firstReferrer, @firstSource, @firstCampaign,
+                 @firstUtmSource, @firstUtmMedium, @firstUtmCampaign, @firstUtmTerm, @firstUtmContent)
+                ON CONFLICT(SessionHash) DO UPDATE SET
+                    FirstSeenAtUtc = CASE
+                        WHEN excluded.FirstSeenAtUtc < SiteStatisticSessions.FirstSeenAtUtc THEN excluded.FirstSeenAtUtc
+                        ELSE SiteStatisticSessions.FirstSeenAtUtc
+                    END,
+                    LandingRoute = CASE
+                        WHEN excluded.FirstSeenAtUtc < SiteStatisticSessions.FirstSeenAtUtc OR SiteStatisticSessions.LandingRoute IS NULL THEN COALESCE(excluded.LandingRoute, SiteStatisticSessions.LandingRoute)
+                        ELSE SiteStatisticSessions.LandingRoute
+                    END,
+                    FirstReferrerDomain = CASE
+                        WHEN excluded.FirstSeenAtUtc < SiteStatisticSessions.FirstSeenAtUtc OR SiteStatisticSessions.FirstReferrerDomain IS NULL THEN COALESCE(excluded.FirstReferrerDomain, SiteStatisticSessions.FirstReferrerDomain)
+                        ELSE SiteStatisticSessions.FirstReferrerDomain
+                    END,
+                    FirstSource = CASE
+                        WHEN excluded.FirstSeenAtUtc < SiteStatisticSessions.FirstSeenAtUtc OR SiteStatisticSessions.FirstSource IS NULL THEN COALESCE(excluded.FirstSource, SiteStatisticSessions.FirstSource)
+                        ELSE SiteStatisticSessions.FirstSource
+                    END,
+                    FirstCampaign = CASE
+                        WHEN excluded.FirstSeenAtUtc < SiteStatisticSessions.FirstSeenAtUtc OR SiteStatisticSessions.FirstCampaign IS NULL THEN COALESCE(excluded.FirstCampaign, SiteStatisticSessions.FirstCampaign)
+                        ELSE SiteStatisticSessions.FirstCampaign
+                    END,
+                    FirstUtmSource = CASE
+                        WHEN excluded.FirstSeenAtUtc < SiteStatisticSessions.FirstSeenAtUtc OR SiteStatisticSessions.FirstUtmSource IS NULL THEN COALESCE(excluded.FirstUtmSource, SiteStatisticSessions.FirstUtmSource)
+                        ELSE SiteStatisticSessions.FirstUtmSource
+                    END,
+                    FirstUtmMedium = CASE
+                        WHEN excluded.FirstSeenAtUtc < SiteStatisticSessions.FirstSeenAtUtc OR SiteStatisticSessions.FirstUtmMedium IS NULL THEN COALESCE(excluded.FirstUtmMedium, SiteStatisticSessions.FirstUtmMedium)
+                        ELSE SiteStatisticSessions.FirstUtmMedium
+                    END,
+                    FirstUtmCampaign = CASE
+                        WHEN excluded.FirstSeenAtUtc < SiteStatisticSessions.FirstSeenAtUtc OR SiteStatisticSessions.FirstUtmCampaign IS NULL THEN COALESCE(excluded.FirstUtmCampaign, SiteStatisticSessions.FirstUtmCampaign)
+                        ELSE SiteStatisticSessions.FirstUtmCampaign
+                    END,
+                    FirstUtmTerm = CASE
+                        WHEN excluded.FirstSeenAtUtc < SiteStatisticSessions.FirstSeenAtUtc OR SiteStatisticSessions.FirstUtmTerm IS NULL THEN COALESCE(excluded.FirstUtmTerm, SiteStatisticSessions.FirstUtmTerm)
+                        ELSE SiteStatisticSessions.FirstUtmTerm
+                    END,
+                    FirstUtmContent = CASE
+                        WHEN excluded.FirstSeenAtUtc < SiteStatisticSessions.FirstSeenAtUtc OR SiteStatisticSessions.FirstUtmContent IS NULL THEN COALESCE(excluded.FirstUtmContent, SiteStatisticSessions.FirstUtmContent)
+                        ELSE SiteStatisticSessions.FirstUtmContent
+                    END;
+                """;
+            var sessionHashParam = sessionCmd.Parameters.Add("@sessionHash", SqliteType.Text);
+            var firstSeenParam = sessionCmd.Parameters.Add("@firstSeen", SqliteType.Text);
+            var landingRouteParam = sessionCmd.Parameters.Add("@landingRoute", SqliteType.Text);
+            var firstReferrerParam = sessionCmd.Parameters.Add("@firstReferrer", SqliteType.Text);
+            var firstSourceParam = sessionCmd.Parameters.Add("@firstSource", SqliteType.Text);
+            var firstCampaignParam = sessionCmd.Parameters.Add("@firstCampaign", SqliteType.Text);
+            var firstUtmSourceParam = sessionCmd.Parameters.Add("@firstUtmSource", SqliteType.Text);
+            var firstUtmMediumParam = sessionCmd.Parameters.Add("@firstUtmMedium", SqliteType.Text);
+            var firstUtmCampaignParam = sessionCmd.Parameters.Add("@firstUtmCampaign", SqliteType.Text);
+            var firstUtmTermParam = sessionCmd.Parameters.Add("@firstUtmTerm", SqliteType.Text);
+            var firstUtmContentParam = sessionCmd.Parameters.Add("@firstUtmContent", SqliteType.Text);
+
             using var cmd = sqlite.CreateCommand();
             cmd.Transaction = tx;
             cmd.CommandText =
@@ -378,6 +470,19 @@ public sealed class SiteStatisticsService : IHostedService
 
             foreach (var item in events)
             {
+                sessionHashParam.Value = item.SessionHash;
+                firstSeenParam.Value = item.OccurredAtUtc;
+                landingRouteParam.Value = item.LandingRoute ?? (object)DBNull.Value;
+                firstReferrerParam.Value = item.FirstReferrerDomain ?? (object)DBNull.Value;
+                firstSourceParam.Value = item.FirstSource ?? (object)DBNull.Value;
+                firstCampaignParam.Value = item.FirstCampaign ?? (object)DBNull.Value;
+                firstUtmSourceParam.Value = item.FirstUtmSource ?? (object)DBNull.Value;
+                firstUtmMediumParam.Value = item.FirstUtmMedium ?? (object)DBNull.Value;
+                firstUtmCampaignParam.Value = item.FirstUtmCampaign ?? (object)DBNull.Value;
+                firstUtmTermParam.Value = item.FirstUtmTerm ?? (object)DBNull.Value;
+                firstUtmContentParam.Value = item.FirstUtmContent ?? (object)DBNull.Value;
+                sessionCmd.ExecuteNonQuery();
+
                 id.Value = item.Id;
                 occurred.Value = item.OccurredAtUtc;
                 session.Value = item.SessionHash;
@@ -441,11 +546,121 @@ public sealed class SiteStatisticsService : IHostedService
                     CREATE INDEX IF NOT EXISTS IX_SiteStatisticEvents_Flow ON SiteStatisticEvents(Flow);
                     CREATE INDEX IF NOT EXISTS IX_SiteStatisticEvents_EventName ON SiteStatisticEvents(EventName);
                     CREATE INDEX IF NOT EXISTS IX_SiteStatisticEvents_SessionHash ON SiteStatisticEvents(SessionHash);
+
+                    CREATE TABLE IF NOT EXISTS SiteStatisticSessions (
+                        SessionHash TEXT PRIMARY KEY,
+                        FirstSeenAtUtc TEXT NOT NULL,
+                        LandingRoute TEXT NULL,
+                        FirstReferrerDomain TEXT NULL,
+                        FirstSource TEXT NULL,
+                        FirstCampaign TEXT NULL,
+                        FirstUtmSource TEXT NULL,
+                        FirstUtmMedium TEXT NULL,
+                        FirstUtmCampaign TEXT NULL,
+                        FirstUtmTerm TEXT NULL,
+                        FirstUtmContent TEXT NULL
+                    );
+                    CREATE INDEX IF NOT EXISTS IX_SiteStatisticSessions_FirstSeenAtUtc ON SiteStatisticSessions(FirstSeenAtUtc);
+                    CREATE INDEX IF NOT EXISTS IX_SiteStatisticSessions_FirstSource ON SiteStatisticSessions(FirstSource);
+
+                    INSERT OR IGNORE INTO SiteStatisticSessions
+                    (SessionHash, FirstSeenAtUtc, LandingRoute, FirstReferrerDomain, FirstSource)
+                    SELECT e.SessionHash,
+                           e.OccurredAtUtc,
+                           e.Route,
+                           e.ReferrerDomain,
+                           CASE
+                               WHEN lower(coalesce(e.ReferrerDomain, '')) IN ('longevityworldcup.com', 'www.longevityworldcup.com') THEN 'internal'
+                               ELSE coalesce(e.Source, 'direct')
+                           END
+                    FROM SiteStatisticEvents e
+                    INNER JOIN (
+                        SELECT SessionHash, MIN(OccurredAtUtc) AS FirstSeenAtUtc
+                        FROM SiteStatisticEvents
+                        GROUP BY SessionHash
+                    ) first_events
+                      ON first_events.SessionHash = e.SessionHash
+                     AND first_events.FirstSeenAtUtc = e.OccurredAtUtc;
                     """;
                 cmd.ExecuteNonQuery();
             });
 
             _initialized = true;
+        }
+    }
+
+    private static SessionFirstTouch BuildFirstTouch(
+        SiteStatisticsEventRequest request,
+        string rawRoute,
+        string? sanitizedRoute,
+        string? referrerDomain,
+        string source)
+    {
+        var landingRouteRaw = string.IsNullOrWhiteSpace(request.LandingRoute)
+            ? rawRoute
+            : request.LandingRoute!;
+        var landingRoute = SanitizeRoute(landingRouteRaw) ?? sanitizedRoute;
+        var firstReferrerDomain = SafeDomain(request.FirstReferrerDomain) ?? referrerDomain;
+        var firstUtmSource = SafeCampaignValue(request.FirstUtmSource) ?? QueryValue(landingRouteRaw, "utm_source");
+        var firstUtmMedium = SafeCampaignValue(request.FirstUtmMedium) ?? QueryValue(landingRouteRaw, "utm_medium");
+        var firstUtmCampaign = SafeCampaignValue(request.FirstUtmCampaign) ?? QueryValue(landingRouteRaw, "utm_campaign");
+        var firstUtmTerm = SafeCampaignValue(request.FirstUtmTerm) ?? QueryValue(landingRouteRaw, "utm_term");
+        var firstUtmContent = SafeCampaignValue(request.FirstUtmContent) ?? QueryValue(landingRouteRaw, "utm_content");
+        var firstCampaign = SafeCampaignValue(request.FirstCampaign)
+            ?? QueryValue(landingRouteRaw, "campaign")
+            ?? firstUtmCampaign;
+        var hasCampaign = !string.IsNullOrWhiteSpace(firstCampaign)
+            || !string.IsNullOrWhiteSpace(firstUtmSource)
+            || !string.IsNullOrWhiteSpace(firstUtmMedium)
+            || !string.IsNullOrWhiteSpace(firstUtmCampaign)
+            || !string.IsNullOrWhiteSpace(firstUtmTerm)
+            || !string.IsNullOrWhiteSpace(firstUtmContent);
+        var firstSource = NormalizeSource(
+            string.IsNullOrWhiteSpace(request.FirstSource) && hasCampaign && string.IsNullOrWhiteSpace(firstReferrerDomain)
+                ? "campaign"
+                : request.FirstSource ?? source,
+            firstReferrerDomain);
+
+        return new SessionFirstTouch(
+            landingRoute,
+            firstReferrerDomain,
+            firstSource,
+            firstCampaign,
+            firstUtmSource,
+            firstUtmMedium,
+            firstUtmCampaign,
+            firstUtmTerm,
+            firstUtmContent);
+    }
+
+    private static string? ContextRoute(HttpContext? context)
+    {
+        if (context is null)
+            return null;
+
+        return $"{context.Request.Path.Value}{context.Request.QueryString.Value}";
+    }
+
+    private static string? QueryValue(string? route, string key)
+    {
+        if (string.IsNullOrWhiteSpace(route))
+            return null;
+
+        var queryStart = route.IndexOf('?', StringComparison.Ordinal);
+        if (queryStart < 0 || queryStart == route.Length - 1)
+            return null;
+
+        var query = route[(queryStart + 1)..];
+        try
+        {
+            var parsed = QueryHelpers.ParseQuery(query);
+            return parsed.TryGetValue(key, out var values)
+                ? SafeCampaignValue(values.FirstOrDefault())
+                : null;
+        }
+        catch
+        {
+            return null;
         }
     }
 
@@ -542,6 +757,12 @@ public sealed class SiteStatisticsService : IHostedService
     private static string? SafeDisplayToken(string? value, int maxLength)
     {
         var token = SafeToken(value, maxLength);
+        return LooksSensitiveValue(token) ? null : token;
+    }
+
+    private static string? SafeCampaignValue(string? value)
+    {
+        var token = SafeToken(value, MaxCampaignTextLength);
         return LooksSensitiveValue(token) ? null : token;
     }
 
@@ -657,7 +878,41 @@ public sealed class SiteStatisticsService : IHostedService
         if (IsInternalReferrerDomain(referrerDomain))
             return "internal";
 
-        return SafeDisplayToken(source, MaxTextLength) ?? "direct";
+        return SafeDisplayToken(source, MaxTextLength)
+            ?? ClassifyExternalReferrer(referrerDomain)
+            ?? "direct";
+    }
+
+    private static string? ClassifyExternalReferrer(string? referrerDomain)
+    {
+        if (string.IsNullOrWhiteSpace(referrerDomain))
+            return null;
+
+        var normalized = referrerDomain.Trim().ToLowerInvariant();
+        if (normalized.Contains("google", StringComparison.Ordinal) ||
+            normalized.Contains("bing", StringComparison.Ordinal) ||
+            normalized.Contains("duckduckgo", StringComparison.Ordinal) ||
+            normalized.Contains("yahoo", StringComparison.Ordinal) ||
+            normalized.Contains("brave", StringComparison.Ordinal) ||
+            normalized.Contains("search", StringComparison.Ordinal))
+        {
+            return "search";
+        }
+
+        if (normalized.Contains("x.com", StringComparison.Ordinal) ||
+            normalized.Contains("twitter", StringComparison.Ordinal) ||
+            normalized.Contains("facebook", StringComparison.Ordinal) ||
+            normalized.Contains("instagram", StringComparison.Ordinal) ||
+            normalized.Contains("threads", StringComparison.Ordinal) ||
+            normalized.Contains("youtube", StringComparison.Ordinal) ||
+            normalized.Contains("linkedin", StringComparison.Ordinal) ||
+            normalized.Contains("reddit", StringComparison.Ordinal) ||
+            normalized.Contains("slack", StringComparison.Ordinal))
+        {
+            return "social";
+        }
+
+        return "referral";
     }
 
     private static bool IsInternalReferrerDomain(string? referrerDomain)
@@ -719,6 +974,17 @@ public sealed class SiteStatisticsService : IHostedService
         => cmd.Parameters.AddWithValue(name, value ?? DBNull.Value);
 }
 
+internal sealed record SessionFirstTouch(
+    string? LandingRoute,
+    string? FirstReferrerDomain,
+    string FirstSource,
+    string? FirstCampaign,
+    string? FirstUtmSource,
+    string? FirstUtmMedium,
+    string? FirstUtmCampaign,
+    string? FirstUtmTerm,
+    string? FirstUtmContent);
+
 internal sealed record QueuedSiteStatisticEvent(
     string Id,
     string OccurredAtUtc,
@@ -736,6 +1002,15 @@ internal sealed record QueuedSiteStatisticEvent(
     string? BrowserFamily,
     string? ReferrerDomain,
     string? Source,
+    string? LandingRoute,
+    string? FirstReferrerDomain,
+    string? FirstSource,
+    string? FirstCampaign,
+    string? FirstUtmSource,
+    string? FirstUtmMedium,
+    string? FirstUtmCampaign,
+    string? FirstUtmTerm,
+    string? FirstUtmContent,
     string? MetadataJson);
 
 public sealed class SiteStatisticsEventRequest
@@ -753,6 +1028,15 @@ public sealed class SiteStatisticsEventRequest
     public string? BrowserFamily { get; set; }
     public string? ReferrerDomain { get; set; }
     public string? Source { get; set; }
+    public string? LandingRoute { get; set; }
+    public string? FirstReferrerDomain { get; set; }
+    public string? FirstSource { get; set; }
+    public string? FirstCampaign { get; set; }
+    public string? FirstUtmSource { get; set; }
+    public string? FirstUtmMedium { get; set; }
+    public string? FirstUtmCampaign { get; set; }
+    public string? FirstUtmTerm { get; set; }
+    public string? FirstUtmContent { get; set; }
     public Dictionary<string, JsonElement>? Metadata { get; set; }
 }
 
@@ -798,4 +1082,13 @@ public sealed record SiteStatisticsDashboardEvent(
     string? BrowserFamily,
     string? ReferrerDomain,
     string? Source,
+    string? LandingRoute,
+    string? FirstReferrerDomain,
+    string? FirstSource,
+    string? FirstCampaign,
+    string? FirstUtmSource,
+    string? FirstUtmMedium,
+    string? FirstUtmCampaign,
+    string? FirstUtmTerm,
+    string? FirstUtmContent,
     IReadOnlyDictionary<string, string> Metadata);

--- a/LongevityWorldCup.Website/Business/SiteStatisticsService.cs
+++ b/LongevityWorldCup.Website/Business/SiteStatisticsService.cs
@@ -34,6 +34,21 @@ public sealed class SiteStatisticsService : IHostedService
         "token", "confirm", "stop", "accessToken", "stopToken", "invoiceId", "checkoutLink",
         "email", "accountEmail", "name", "displayName"
     ];
+    private static readonly HashSet<string> BioageCalculatorPaths = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "/pheno-age",
+        "/bortz-age",
+        "/onboarding/pheno-age.html",
+        "/onboarding/bortz-age.html"
+    };
+    private static readonly HashSet<string> BioagePrefillQueryKeys = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Year", "Month", "Day", "Date",
+        "AlbGL", "AlpUL", "CreatUmolL", "CrpMgL", "GluMmolL", "LymPc", "McvFL", "RdwPc",
+        "Wbc1000cellsuL", "NeutrophilPc", "MonocytePc", "Rbc10e12L", "MchPg", "AltUL", "GgtUL",
+        "UreaMmolL", "CystatinCMgL", "Hba1cMmolMol", "CholesterolMmolL", "ApoA1GL", "ShbgNmolL",
+        "VitaminDNmolL"
+    };
     private static readonly HashSet<string> SensitiveMetadataKeys = new(StringComparer.OrdinalIgnoreCase)
     {
         "email", "accountEmail", "name", "displayName", "accessToken", "stopToken", "token",
@@ -218,13 +233,24 @@ public sealed class SiteStatisticsService : IHostedService
         {
             var referrerDomain = ReadNullableString(reader, 13);
             var firstReferrerDomain = ReadNullableString(reader, 17);
+            var routeProjection = BuildRouteProjection(ReadNullableString(reader, 5));
+            var landingRouteProjection = BuildRouteProjection(ReadNullableString(reader, 16));
+            var metadata = ReadMetadata(ReadNullableString(reader, 15));
+            if (!string.IsNullOrWhiteSpace(routeProjection.EntryMode) && !metadata.ContainsKey("entryMode"))
+            {
+                metadata = new Dictionary<string, string>(metadata, StringComparer.OrdinalIgnoreCase)
+                {
+                    ["entryMode"] = routeProjection.EntryMode
+                };
+            }
+
             events.Add(new SiteStatisticsDashboardEvent(
                 OccurredAtUtc: RoundToMinute(ReadString(reader, 0)),
                 SessionHash: ReadString(reader, 1),
                 ActorHash: ReadNullableString(reader, 2),
                 EventName: ReadString(reader, 3),
                 Flow: ReadNullableString(reader, 4),
-                Route: ReadNullableString(reader, 5),
+                Route: routeProjection.Route,
                 Component: ReadNullableString(reader, 6),
                 Step: ReadNullableString(reader, 7),
                 Outcome: ReadNullableString(reader, 8),
@@ -234,7 +260,7 @@ public sealed class SiteStatisticsService : IHostedService
                 BrowserFamily: ReadNullableString(reader, 12),
                 ReferrerDomain: referrerDomain,
                 Source: NormalizeSource(ReadNullableString(reader, 14), referrerDomain),
-                LandingRoute: ReadNullableString(reader, 16),
+                LandingRoute: landingRouteProjection.Route,
                 FirstReferrerDomain: firstReferrerDomain,
                 FirstSource: NormalizeSource(ReadNullableString(reader, 18), firstReferrerDomain),
                 FirstCampaign: ReadNullableString(reader, 19),
@@ -243,7 +269,7 @@ public sealed class SiteStatisticsService : IHostedService
                 FirstUtmCampaign: ReadNullableString(reader, 22),
                 FirstUtmTerm: ReadNullableString(reader, 23),
                 FirstUtmContent: ReadNullableString(reader, 24),
-                Metadata: ReadMetadata(ReadNullableString(reader, 15))));
+                Metadata: metadata));
         }
 
         return events;
@@ -281,8 +307,14 @@ public sealed class SiteStatisticsService : IHostedService
             return null;
 
         var rawRoute = request.Route ?? ContextRoute(context) ?? string.Empty;
-        var route = SanitizeRoute(rawRoute);
+        var routeProjection = BuildRouteProjection(rawRoute);
+        var route = routeProjection.Route;
         var metadata = SanitizeMetadata(request.Metadata);
+        if (!string.IsNullOrWhiteSpace(routeProjection.EntryMode))
+        {
+            metadata["entryMode"] = routeProjection.EntryMode;
+        }
+
         var metadataJson = metadata.Count == 0 ? null : JsonSerializer.Serialize(metadata, JsonOptions);
         if (metadataJson is { Length: > MaxMetadataJsonLength })
         {
@@ -623,7 +655,7 @@ public sealed class SiteStatisticsService : IHostedService
         var landingRouteRaw = string.IsNullOrWhiteSpace(request.LandingRoute)
             ? rawRoute
             : request.LandingRoute!;
-        var landingRoute = SanitizeRoute(landingRouteRaw) ?? sanitizedRoute;
+        var landingRoute = BuildRouteProjection(landingRouteRaw).Route ?? sanitizedRoute;
         var firstReferrerDomain = SafeDomain(request.FirstReferrerDomain) ?? referrerDomain;
         var firstUtmSource = SafeCampaignValue(request.FirstUtmSource) ?? QueryValue(landingRouteRaw, "utm_source");
         var firstUtmMedium = SafeCampaignValue(request.FirstUtmMedium) ?? QueryValue(landingRouteRaw, "utm_medium");
@@ -687,6 +719,98 @@ public sealed class SiteStatisticsService : IHostedService
             return null;
         }
     }
+
+    private static RouteProjection BuildRouteProjection(string? route)
+    {
+        if (string.IsNullOrWhiteSpace(route))
+            return new RouteProjection(null, null);
+
+        if (!Uri.TryCreate(route, UriKind.RelativeOrAbsolute, out var uri))
+            return new RouteProjection(SafeToken(route.Split('?')[0], MaxTextLength), null);
+
+        var rawPath = uri.IsAbsoluteUri ? uri.AbsolutePath : route.Split('?')[0];
+        var path = SafeToken(CanonicalizeBioagePath(rawPath), MaxTextLength);
+        if (string.IsNullOrWhiteSpace(path))
+            return new RouteProjection(null, null);
+
+        if (!route.Contains('?'))
+            return new RouteProjection(path, null);
+
+        var query = route[(route.IndexOf('?') + 1)..];
+        if (IsBioageCalculatorPath(path))
+            return new RouteProjection(path, ResolveBioageEntryMode(query));
+
+        var pairs = new List<string>();
+        foreach (var part in query.Split('&', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var key = part.Split('=')[0];
+            if (SensitiveQueryKeys.Any(s => string.Equals(s, key, StringComparison.OrdinalIgnoreCase)))
+                continue;
+            var safeKey = SafeToken(key, 32);
+            if (!string.IsNullOrWhiteSpace(safeKey))
+                pairs.Add($"{safeKey}=redacted");
+        }
+
+        return new RouteProjection(pairs.Count == 0 ? path : $"{path}?{string.Join("&", pairs)}", null);
+    }
+
+    private static string CanonicalizeBioagePath(string path)
+    {
+        var normalized = path.TrimEnd('/');
+        if (string.IsNullOrWhiteSpace(normalized))
+            return "/";
+
+        return normalized.ToLowerInvariant() switch
+        {
+            "/pheno-age" => "/pheno-age",
+            "/bortz-age" => "/bortz-age",
+            "/onboarding/pheno-age.html" => "/pheno-age",
+            "/onboarding/bortz-age.html" => "/bortz-age",
+            _ => path
+        };
+    }
+
+    private static bool IsBioageCalculatorPath(string? path)
+        => !string.IsNullOrWhiteSpace(path) && BioageCalculatorPaths.Contains(path);
+
+    private static string? ResolveBioageEntryMode(string query)
+    {
+        try
+        {
+            var parsed = QueryHelpers.ParseQuery(query);
+            if (IsQueryFlagSet(parsed, "fake"))
+                return "fake";
+
+            if (IsQueryFlagSet(parsed, "update"))
+                return "update";
+
+            if (HasQueryKey(parsed, "discount") || HasQueryKey(parsed, "freepass"))
+                return "discount";
+
+            return parsed.Keys.Any(key => BioagePrefillQueryKeys.Contains(key)) ? "prefilled" : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static bool IsQueryFlagSet(IReadOnlyDictionary<string, Microsoft.Extensions.Primitives.StringValues> parsed, string key)
+    {
+        if (!parsed.TryGetValue(key, out var values))
+            return false;
+
+        if (values.Count == 0)
+            return true;
+
+        return values.Any(value =>
+            string.IsNullOrWhiteSpace(value) ||
+            (!string.Equals(value, "0", StringComparison.OrdinalIgnoreCase) &&
+             !string.Equals(value, "false", StringComparison.OrdinalIgnoreCase)));
+    }
+
+    private static bool HasQueryKey(IReadOnlyDictionary<string, Microsoft.Extensions.Primitives.StringValues> parsed, string key)
+        => parsed.TryGetValue(key, out var values) && values.Any(value => !string.IsNullOrWhiteSpace(value));
 
     private static Dictionary<string, string> SanitizeMetadata(IReadOnlyDictionary<string, JsonElement>? metadata)
     {
@@ -843,37 +967,6 @@ public sealed class SiteStatisticsService : IHostedService
         }
 
         return sb.ToString().Trim();
-    }
-
-    private static string? SanitizeRoute(string? route)
-    {
-        if (string.IsNullOrWhiteSpace(route))
-            return null;
-
-        if (!Uri.TryCreate(route, UriKind.RelativeOrAbsolute, out var uri))
-            return SafeToken(route.Split('?')[0], MaxTextLength);
-
-        var path = uri.IsAbsoluteUri ? uri.AbsolutePath : route.Split('?')[0];
-        path = SafeToken(path, MaxTextLength);
-        if (string.IsNullOrWhiteSpace(path))
-            return null;
-
-        if (!route.Contains('?'))
-            return path;
-
-        var query = route[(route.IndexOf('?') + 1)..];
-        var pairs = new List<string>();
-        foreach (var part in query.Split('&', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-        {
-            var key = part.Split('=')[0];
-            if (SensitiveQueryKeys.Any(s => string.Equals(s, key, StringComparison.OrdinalIgnoreCase)))
-                continue;
-            var safeKey = SafeToken(key, 32);
-            if (!string.IsNullOrWhiteSpace(safeKey))
-                pairs.Add($"{safeKey}=redacted");
-        }
-
-        return pairs.Count == 0 ? path : $"{path}?{string.Join("&", pairs)}";
     }
 
     private static string BuildHash(string prefix, string value)
@@ -1034,6 +1127,8 @@ internal sealed record SessionFirstTouch(
     string? FirstUtmCampaign,
     string? FirstUtmTerm,
     string? FirstUtmContent);
+
+internal sealed record RouteProjection(string? Route, string? EntryMode);
 
 internal sealed record QueuedSiteStatisticEvent(
     string Id,

--- a/LongevityWorldCup.Website/Business/SiteStatisticsService.cs
+++ b/LongevityWorldCup.Website/Business/SiteStatisticsService.cs
@@ -187,6 +187,18 @@ public sealed class SiteStatisticsService : IHostedService
               AND (@source = '' OR (
                     CASE
                         WHEN lower(coalesce(s.FirstReferrerDomain, e.ReferrerDomain, '')) IN ('longevityworldcup.com', 'www.longevityworldcup.com') THEN 'internal'
+                        WHEN lower(coalesce(s.FirstReferrerDomain, e.ReferrerDomain, '')) = 'com.google.android.gm'
+                          OR lower(coalesce(s.FirstReferrerDomain, e.ReferrerDomain, '')) LIKE 'mail.%'
+                          OR lower(coalesce(s.FirstReferrerDomain, e.ReferrerDomain, '')) LIKE '%.mail.%'
+                          OR lower(coalesce(s.FirstReferrerDomain, e.ReferrerDomain, '')) LIKE '%gmail%'
+                          OR lower(coalesce(s.FirstReferrerDomain, e.ReferrerDomain, '')) LIKE '%outlook%'
+                          OR lower(coalesce(s.FirstReferrerDomain, e.ReferrerDomain, '')) LIKE '%hotmail%'
+                          OR lower(coalesce(s.FirstReferrerDomain, e.ReferrerDomain, '')) LIKE '%protonmail%'
+                          OR lower(coalesce(s.FirstReferrerDomain, e.ReferrerDomain, '')) LIKE '%proton.me%'
+                          OR lower(coalesce(s.FirstReferrerDomain, e.ReferrerDomain, '')) LIKE '%fastmail%'
+                          OR lower(coalesce(s.FirstReferrerDomain, e.ReferrerDomain, '')) LIKE '%icloud%'
+                          OR lower(coalesce(s.FirstReferrerDomain, e.ReferrerDomain, '')) LIKE '%mail.yahoo%'
+                          OR lower(coalesce(s.FirstReferrerDomain, e.ReferrerDomain, '')) LIKE '%yahoomail%' THEN 'email'
                         ELSE coalesce(s.FirstSource, e.Source, 'direct')
                     END
                   ) = @source)
@@ -571,6 +583,18 @@ public sealed class SiteStatisticsService : IHostedService
                            e.ReferrerDomain,
                            CASE
                                WHEN lower(coalesce(e.ReferrerDomain, '')) IN ('longevityworldcup.com', 'www.longevityworldcup.com') THEN 'internal'
+                               WHEN lower(coalesce(e.ReferrerDomain, '')) = 'com.google.android.gm'
+                                 OR lower(coalesce(e.ReferrerDomain, '')) LIKE 'mail.%'
+                                 OR lower(coalesce(e.ReferrerDomain, '')) LIKE '%.mail.%'
+                                 OR lower(coalesce(e.ReferrerDomain, '')) LIKE '%gmail%'
+                                 OR lower(coalesce(e.ReferrerDomain, '')) LIKE '%outlook%'
+                                 OR lower(coalesce(e.ReferrerDomain, '')) LIKE '%hotmail%'
+                                 OR lower(coalesce(e.ReferrerDomain, '')) LIKE '%protonmail%'
+                                 OR lower(coalesce(e.ReferrerDomain, '')) LIKE '%proton.me%'
+                                 OR lower(coalesce(e.ReferrerDomain, '')) LIKE '%fastmail%'
+                                 OR lower(coalesce(e.ReferrerDomain, '')) LIKE '%icloud%'
+                                 OR lower(coalesce(e.ReferrerDomain, '')) LIKE '%mail.yahoo%'
+                                 OR lower(coalesce(e.ReferrerDomain, '')) LIKE '%yahoomail%' THEN 'email'
                                ELSE coalesce(e.Source, 'direct')
                            END
                     FROM SiteStatisticEvents e
@@ -878,6 +902,9 @@ public sealed class SiteStatisticsService : IHostedService
         if (IsInternalReferrerDomain(referrerDomain))
             return "internal";
 
+        if (IsEmailReferrerDomain(referrerDomain))
+            return "email";
+
         return SafeDisplayToken(source, MaxTextLength)
             ?? ClassifyExternalReferrer(referrerDomain)
             ?? "direct";
@@ -889,6 +916,9 @@ public sealed class SiteStatisticsService : IHostedService
             return null;
 
         var normalized = referrerDomain.Trim().ToLowerInvariant();
+        if (IsEmailReferrerDomain(normalized))
+            return "email";
+
         if (normalized.Contains("google", StringComparison.Ordinal) ||
             normalized.Contains("bing", StringComparison.Ordinal) ||
             normalized.Contains("duckduckgo", StringComparison.Ordinal) ||
@@ -913,6 +943,26 @@ public sealed class SiteStatisticsService : IHostedService
         }
 
         return "referral";
+    }
+
+    private static bool IsEmailReferrerDomain(string? referrerDomain)
+    {
+        if (string.IsNullOrWhiteSpace(referrerDomain))
+            return false;
+
+        var normalized = referrerDomain.Trim().ToLowerInvariant();
+        return string.Equals(normalized, "com.google.android.gm", StringComparison.Ordinal) ||
+               normalized.StartsWith("mail.", StringComparison.Ordinal) ||
+               normalized.Contains(".mail.", StringComparison.Ordinal) ||
+               normalized.Contains("gmail", StringComparison.Ordinal) ||
+               normalized.Contains("outlook", StringComparison.Ordinal) ||
+               normalized.Contains("hotmail", StringComparison.Ordinal) ||
+               normalized.Contains("protonmail", StringComparison.Ordinal) ||
+               normalized.Contains("proton.me", StringComparison.Ordinal) ||
+               normalized.Contains("fastmail", StringComparison.Ordinal) ||
+               normalized.Contains("icloud", StringComparison.Ordinal) ||
+               normalized.Contains("mail.yahoo", StringComparison.Ordinal) ||
+               normalized.Contains("yahoomail", StringComparison.Ordinal);
     }
 
     private static bool IsInternalReferrerDomain(string? referrerDomain)

--- a/LongevityWorldCup.Website/Business/SiteStatisticsService.cs
+++ b/LongevityWorldCup.Website/Business/SiteStatisticsService.cs
@@ -13,7 +13,9 @@ namespace LongevityWorldCup.Website.Business;
 
 public sealed class SiteStatisticsService : IHostedService
 {
+    private const string StatsSessionHeaderName = "X-LWC-Stats-Session";
     private const int MaxEventNameLength = 96;
+    private const int MaxSessionIdLength = 256;
     private const int MaxTextLength = 160;
     private const int MaxCampaignTextLength = 96;
     private const int MaxMetadataJsonLength = 4096;
@@ -124,12 +126,14 @@ public sealed class SiteStatisticsService : IHostedService
         string? outcome = null,
         string? errorCode = null,
         long? durationMs = null,
+        string? sessionId = null,
         IReadOnlyDictionary<string, object?>? metadata = null,
         CancellationToken ct = default)
     {
         var request = new SiteStatisticsEventRequest
         {
             EventName = eventName,
+            SessionId = RequestStatsSessionId(context) ?? SafeSessionId(sessionId),
             Flow = flow,
             Route = route,
             Component = component,
@@ -323,7 +327,8 @@ public sealed class SiteStatisticsService : IHostedService
 
         var referrerDomain = SafeDomain(request.ReferrerDomain) ?? SafeDomain(context?.Request.Headers.Referer.FirstOrDefault());
         var source = NormalizeSource(request.Source, referrerDomain);
-        var sessionHash = BuildHash("S", request.SessionId ?? ClientIdentifier.From(context ?? new DefaultHttpContext()));
+        var sessionIdentifier = SafeSessionId(request.SessionId) ?? ClientIdentifier.From(context ?? new DefaultHttpContext());
+        var sessionHash = BuildHash("S", sessionIdentifier);
         var firstTouch = BuildFirstTouch(request, rawRoute, route, referrerDomain, source);
 
         return new QueuedSiteStatisticEvent(
@@ -907,6 +912,12 @@ public sealed class SiteStatisticsService : IHostedService
         var token = SafeToken(value, maxLength);
         return LooksSensitiveValue(token) ? null : token;
     }
+
+    private static string? RequestStatsSessionId(HttpContext? context)
+        => SafeSessionId(context?.Request.Headers[StatsSessionHeaderName].FirstOrDefault());
+
+    private static string? SafeSessionId(string? value)
+        => SafeToken(value, MaxSessionIdLength);
 
     private static string? SafeCampaignValue(string? value)
     {

--- a/LongevityWorldCup.Website/Controllers/ApplicationController.cs
+++ b/LongevityWorldCup.Website/Controllers/ApplicationController.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 using MimeKit;
 using SixLabors.ImageSharp.Formats.Webp;
 using SixLabors.ImageSharp.Processing;
+using System.Diagnostics;
 using System.Globalization;
 using System.ComponentModel.DataAnnotations;
 using System.Net.Http.Headers;
@@ -23,12 +24,14 @@ namespace LongevityWorldCup.Website.Controllers
         IWebHostEnvironment environment,
         ILogger<HomeController> logger,
         DiscountSignupReportService? discountSignupReports = null,
-        IBtcpayInvoiceClient? btcpayInvoices = null) : ControllerBase
+        IBtcpayInvoiceClient? btcpayInvoices = null,
+        SiteStatisticsService? statistics = null) : ControllerBase
     {
         private readonly IWebHostEnvironment _environment = environment ?? throw new ArgumentNullException(nameof(environment));
         private readonly ILogger<HomeController> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         private readonly DiscountSignupReportService? _discountSignupReports = discountSignupReports;
         private readonly IBtcpayInvoiceClient? _btcpayInvoices = btcpayInvoices;
+        private readonly SiteStatisticsService? _statistics = statistics;
         private static readonly SemaphoreSlim PaidInvoiceNotificationFileLock = new(1, 1);
 
         private static readonly JsonSerializerOptions CachedJsonSerializerOptions = new()
@@ -172,19 +175,60 @@ namespace LongevityWorldCup.Website.Controllers
         [HttpPost("application")]
         public async Task<IActionResult> Application([FromBody] ApplicantData applicantData, CancellationToken ct)
         {
+            var startedAt = Stopwatch.GetTimestamp();
+            var submissionKind = "unknown";
+            bool? paymentRequiredForStats = null;
+
+            Task TrackSubmitFailedAsync(string errorCode)
+                => TrackApplicationSubmitEventAsync(
+                    outcome: "failed",
+                    submissionKind: submissionKind,
+                    paymentRequired: paymentRequiredForStats,
+                    errorCode: errorCode,
+                    durationMs: ElapsedMilliseconds(startedAt),
+                    metadata: null,
+                    ct: ct);
+
+            async Task<IActionResult> BadRequestWithStatsAsync(string errorCode, string message)
+            {
+                await TrackSubmitFailedAsync(errorCode).ConfigureAwait(false);
+                return BadRequest(message);
+            }
+
+            async Task<IActionResult> StatusCodeWithStatsAsync(int statusCode, string errorCode, string message)
+            {
+                await TrackSubmitFailedAsync(errorCode).ConfigureAwait(false);
+                return StatusCode(statusCode, message);
+            }
+
+            async Task<IActionResult> ProofBadRequestWithStatsAsync(string errorCode, string message, int? proofIndex = null)
+            {
+                await TrackApplicationProofEventAsync(
+                    outcome: "failed",
+                    submissionKind: submissionKind,
+                    proofCount: applicantData?.ProofPics?.Count ?? 0,
+                    errorCode: errorCode,
+                    proofIndex: proofIndex,
+                    durationMs: ElapsedMilliseconds(startedAt),
+                    ct: ct).ConfigureAwait(false);
+                await TrackSubmitFailedAsync(errorCode).ConfigureAwait(false);
+                return BadRequest(message);
+            }
+
             if (!ModelState.IsValid)
             {
+                await TrackSubmitFailedAsync("model_validation_failed").ConfigureAwait(false);
                 return ValidationProblem(ModelState);
             }
 
             if (applicantData == null)
             {
-                return BadRequest("Applicant data is null.");
+                return await BadRequestWithStatsAsync("missing_applicant_data", "Applicant data is null.").ConfigureAwait(false);
             }
 
             if (string.IsNullOrWhiteSpace(applicantData.Name))
             {
-                return BadRequest("Applicant name is required.");
+                return await BadRequestWithStatsAsync("missing_name", "Applicant name is required.").ConfigureAwait(false);
             }
 
             applicantData.ProofPics = applicantData.ProofPics?
@@ -193,7 +237,7 @@ namespace LongevityWorldCup.Website.Controllers
 
             if (applicantData.ProofPics?.Count > MaxProofImages)
             {
-                return BadRequest($"You can upload a maximum of {MaxProofImages} proof images.");
+                return await ProofBadRequestWithStatsAsync("too_many_proofs", $"You can upload a maximum of {MaxProofImages} proof images.").ConfigureAwait(false);
             }
 
             var hasSubmittedBiomarkers = applicantData.Biomarkers?.Any() is true;
@@ -220,6 +264,7 @@ namespace LongevityWorldCup.Website.Controllers
                 && applicantData.Biomarkers is null
                 && applicantData.ProofPics is null
                 && applicantData.DateOfBirth is null;
+            submissionKind = GetSubmissionKind(isResultSubmissionOnly, isEditSubmissionOnly);
 
             var submittedAccountEmail = applicantData.AccountEmail?.Trim();
             string? accountEmail = NormalizeOptionalAccountEmail(submittedAccountEmail);
@@ -227,19 +272,19 @@ namespace LongevityWorldCup.Website.Controllers
             string? chronoBortzDifference = applicantData.ChronoBortzDifference?.Trim();
             if (!isEditSubmissionOnly && !string.IsNullOrWhiteSpace(submittedAccountEmail) && accountEmail is null)
             {
-                return BadRequest("Account email is invalid.");
+                return await BadRequestWithStatsAsync("invalid_account_email", "Account email is invalid.").ConfigureAwait(false);
             }
 
             if (!isResultSubmissionOnly && hasOnlyResultSubmissionProfileFields && (hasSubmittedBiomarkers || hasSubmittedProofs))
             {
                 if (!hasSubmittedBiomarkers)
                 {
-                    return BadRequest("Biomarker data is required.");
+                    return await BadRequestWithStatsAsync("missing_biomarkers", "Biomarker data is required.").ConfigureAwait(false);
                 }
 
                 if (!hasSubmittedProofs)
                 {
-                    return BadRequest("Proof attachment is required.");
+                    return await ProofBadRequestWithStatsAsync("missing_proof", "Proof attachment is required.").ConfigureAwait(false);
                 }
             }
 
@@ -247,84 +292,84 @@ namespace LongevityWorldCup.Website.Controllers
             {
                 if (string.IsNullOrWhiteSpace(accountEmail))
                 {
-                    return BadRequest("Account email is required.");
+                    return await BadRequestWithStatsAsync("missing_account_email", "Account email is required.").ConfigureAwait(false);
                 }
 
                 if (applicantData.DateOfBirth is null)
                 {
-                    return BadRequest("Date of birth is required.");
+                    return await BadRequestWithStatsAsync("missing_date_of_birth", "Date of birth is required.").ConfigureAwait(false);
                 }
 
                 if (!IsValidDateOfBirth(applicantData.DateOfBirth))
                 {
                     if (IsFutureDateOfBirth(applicantData.DateOfBirth))
                     {
-                        return BadRequest("Date of birth cannot be in the future.");
+                        return await BadRequestWithStatsAsync("future_date_of_birth", "Date of birth cannot be in the future.").ConfigureAwait(false);
                     }
 
-                    return BadRequest("Date of birth is invalid.");
+                    return await BadRequestWithStatsAsync("invalid_date_of_birth", "Date of birth is invalid.").ConfigureAwait(false);
                 }
 
                 if (!hasSubmittedBiomarkers)
                 {
-                    return BadRequest("Biomarker data is required.");
+                    return await BadRequestWithStatsAsync("missing_biomarkers", "Biomarker data is required.").ConfigureAwait(false);
                 }
 
                 if (!hasSubmittedProofs)
                 {
-                    return BadRequest("Proof attachment is required.");
+                    return await ProofBadRequestWithStatsAsync("missing_proof", "Proof attachment is required.").ConfigureAwait(false);
                 }
 
                 if (string.IsNullOrWhiteSpace(applicantData.ProfilePic))
                 {
-                    return BadRequest("Profile picture is required.");
+                    return await BadRequestWithStatsAsync("missing_profile_picture", "Profile picture is required.").ConfigureAwait(false);
                 }
 
                 if (string.IsNullOrWhiteSpace(applicantData.Division))
                 {
-                    return BadRequest("Division is required.");
+                    return await BadRequestWithStatsAsync("missing_division", "Division is required.").ConfigureAwait(false);
                 }
 
                 if (string.IsNullOrWhiteSpace(applicantData.Flag))
                 {
-                    return BadRequest("Flag is required.");
+                    return await BadRequestWithStatsAsync("missing_flag", "Flag is required.").ConfigureAwait(false);
                 }
 
                 if (string.IsNullOrWhiteSpace(applicantData.Why))
                 {
-                    return BadRequest("Why is required.");
+                    return await BadRequestWithStatsAsync("missing_why", "Why is required.").ConfigureAwait(false);
                 }
 
                 if (string.IsNullOrWhiteSpace(applicantData.MediaContact))
                 {
-                    return BadRequest("Media contact is required.");
+                    return await BadRequestWithStatsAsync("missing_media_contact", "Media contact is required.").ConfigureAwait(false);
                 }
             }
 
             if (applicantData.Biomarkers?.Any() is true && !HasRequiredBiomarkerDates(applicantData.Biomarkers))
             {
-                return BadRequest("Biomarker date is required.");
+                return await BadRequestWithStatsAsync("missing_biomarker_date", "Biomarker date is required.").ConfigureAwait(false);
             }
 
             if (applicantData.Biomarkers?.Any() is true && !HasValidBiomarkerDates(applicantData.Biomarkers))
             {
                 if (HasFutureBiomarkerDates(applicantData.Biomarkers))
                 {
-                    return BadRequest("Biomarker date cannot be in the future.");
+                    return await BadRequestWithStatsAsync("future_biomarker_date", "Biomarker date cannot be in the future.").ConfigureAwait(false);
                 }
 
-                return BadRequest("Biomarker date is invalid.");
+                return await BadRequestWithStatsAsync("invalid_biomarker_date", "Biomarker date is invalid.").ConfigureAwait(false);
             }
 
             if (applicantData.Biomarkers?.Any() is true && !HasRequiredBiomarkerValues(applicantData.Biomarkers))
             {
-                return BadRequest("Biomarker result value is required.");
+                return await BadRequestWithStatsAsync("missing_biomarker_value", "Biomarker result value is required.").ConfigureAwait(false);
             }
 
             if (applicantData.Biomarkers?.Any() is true
                 && !HasCompleteSubmittedBiomarkerResults(applicantData.Biomarkers, chronoPhenoDifference, chronoBortzDifference, out var biomarkerResultError))
             {
-                return BadRequest(biomarkerResultError);
+                return await BadRequestWithStatsAsync("incomplete_biomarker_results", biomarkerResultError).ConfigureAwait(false);
             }
 
             // Load SMTP configuration
@@ -336,12 +381,11 @@ namespace LongevityWorldCup.Website.Controllers
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Application submission failed before processing because configuration could not be loaded.");
-                return StatusCode(500, $"Failed to load configuration: {ex.Message}");
+                return await StatusCodeWithStatsAsync(500, "config_load_failed", $"Failed to load configuration: {ex.Message}").ConfigureAwait(false);
             }
 
             var submissionId = NormalizeSubmissionId(applicantData.SubmissionId);
             applicantData.SubmissionId = submissionId;
-            var submissionKind = GetSubmissionKind(isResultSubmissionOnly, isEditSubmissionOnly);
             var proofLengths = GetDataUrlLengths(applicantData.ProofPics);
             var profilePicLength = GetDataUrlLength(applicantData.ProfilePic);
 
@@ -441,7 +485,7 @@ namespace LongevityWorldCup.Website.Controllers
                     submissionId,
                     submissionKind,
                     profilePicLength);
-                return BadRequest("The profile image could not be read. Please upload a smaller image and try again.");
+                return await BadRequestWithStatsAsync("invalid_profile_image", "The profile image could not be read. Please upload a smaller image and try again.").ConfigureAwait(false);
             }
 
             if (hasSubmittedProfileImage)
@@ -453,12 +497,12 @@ namespace LongevityWorldCup.Website.Controllers
                         "Application submission rejected because profile image could not be parsed. SubmissionId={SubmissionId} ProfilePicDataUrlLength={ProfilePicDataUrlLength}",
                         submissionId,
                         profilePicLength);
-                    return BadRequest("The profile image could not be read. Please upload a smaller image and try again.");
+                    return await BadRequestWithStatsAsync("profile_image_parse_failed", "The profile image could not be read. Please upload a smaller image and try again.").ConfigureAwait(false);
                 }
 
                 var profileImage = OptimizeProfileImage(parsedProfile, submissionId);
                 if (!profileImage.Success)
-                    return BadRequest(profileImage.ErrorMessage);
+                    return await BadRequestWithStatsAsync("profile_image_processing_failed", profileImage.ErrorMessage ?? "The profile image could not be processed.").ConfigureAwait(false);
 
                 await System.IO.File.WriteAllBytesAsync(Path.Combine(athleteFolder, $"{folderKey}.{profileImage.Extension}"), profileImage.Bytes!, ct);
             }
@@ -477,12 +521,12 @@ namespace LongevityWorldCup.Website.Controllers
                             submissionId,
                             idx,
                             b64?.Length ?? 0);
-                        return BadRequest($"Proof image {idx} could not be read. Please upload a smaller image or PDF page and try again.");
+                        return await ProofBadRequestWithStatsAsync("proof_parse_failed", $"Proof image {idx} could not be read. Please upload a smaller image or PDF page and try again.", idx).ConfigureAwait(false);
                     }
 
                     var proofImage = OptimizeProofImage(parsedProof, submissionId, idx);
                     if (!proofImage.Success)
-                        return BadRequest(proofImage.ErrorMessage);
+                        return await ProofBadRequestWithStatsAsync("proof_processing_failed", proofImage.ErrorMessage ?? "Proof image could not be processed.", idx).ConfigureAwait(false);
 
                     if (proofImage.Bytes != null)
                     {
@@ -491,6 +535,15 @@ namespace LongevityWorldCup.Website.Controllers
                         idx++;
                     }
                 }
+
+                await TrackApplicationProofEventAsync(
+                    outcome: "succeeded",
+                    submissionKind: submissionKind,
+                    proofCount: applicantData.ProofPics.Count,
+                    errorCode: null,
+                    proofIndex: null,
+                    durationMs: ElapsedMilliseconds(startedAt),
+                    ct: ct).ConfigureAwait(false);
             }
 
             // 2) Zip the folder
@@ -577,6 +630,7 @@ namespace LongevityWorldCup.Website.Controllers
 
             var requestedAmountUsd = hasFreePass ? 0m : applicantData.PaymentOffer?.AmountUsd ?? 0m;
             var paymentRequired = requestedAmountUsd > 0m;
+            paymentRequiredForStats = paymentRequired;
             string? archivedSubmissionPath = null;
             var auditEmailDelivered = false;
 
@@ -600,7 +654,7 @@ namespace LongevityWorldCup.Website.Controllers
                         "Application submission email failed and archive could not be saved. SubmissionId={SubmissionId} SubmissionKind={SubmissionKind}",
                         submissionId,
                         submissionKind);
-                    return StatusCode(500, "Internal server error: application could not be saved.");
+                    return await StatusCodeWithStatsAsync(500, "application_archive_failed", "Internal server error: application could not be saved.").ConfigureAwait(false);
                 }
 
                 _logger.LogError(
@@ -652,6 +706,20 @@ namespace LongevityWorldCup.Website.Controllers
                         auditEmailDelivered,
                         archivedSubmissionPath);
 
+                    await TrackApplicationSubmitEventAsync(
+                        outcome: "succeeded",
+                        submissionKind: submissionKind,
+                        paymentRequired: false,
+                        errorCode: null,
+                        durationMs: ElapsedMilliseconds(startedAt),
+                        metadata: new Dictionary<string, object?>
+                        {
+                            ["proofCount"] = applicantData.ProofPics?.Count ?? 0,
+                            ["auditEmailDelivered"] = auditEmailDelivered,
+                            ["archivedFallback"] = archivedSubmissionPath is not null
+                        },
+                        ct: ct).ConfigureAwait(false);
+
                     return Ok(new
                     {
                         success = true,
@@ -702,6 +770,30 @@ namespace LongevityWorldCup.Website.Controllers
                         paymentUnavailable: true,
                         ct: ct);
 
+                    await TrackApplicationPaymentEventAsync(
+                        eventName: "payment_unavailable",
+                        outcome: "failed",
+                        submissionKind: submissionKind,
+                        paymentRequired: true,
+                        errorCode: "invoice_create_failed",
+                        durationMs: ElapsedMilliseconds(startedAt),
+                        ct: ct).ConfigureAwait(false);
+
+                    await TrackApplicationSubmitEventAsync(
+                        outcome: "succeeded",
+                        submissionKind: submissionKind,
+                        paymentRequired: true,
+                        errorCode: null,
+                        durationMs: ElapsedMilliseconds(startedAt),
+                        metadata: new Dictionary<string, object?>
+                        {
+                            ["proofCount"] = applicantData.ProofPics?.Count ?? 0,
+                            ["auditEmailDelivered"] = auditEmailDelivered,
+                            ["archivedFallback"] = archivedSubmissionPath is not null,
+                            ["paymentState"] = "unavailable"
+                        },
+                        ct: ct).ConfigureAwait(false);
+
                     return Ok(new
                     {
                         success = true,
@@ -744,6 +836,30 @@ namespace LongevityWorldCup.Website.Controllers
                     auditEmailDelivered,
                     archivedSubmissionPath);
 
+                await TrackApplicationPaymentEventAsync(
+                    eventName: "checkout_redirect_started",
+                    outcome: "succeeded",
+                    submissionKind: submissionKind,
+                    paymentRequired: true,
+                    errorCode: null,
+                    durationMs: ElapsedMilliseconds(startedAt),
+                    ct: ct).ConfigureAwait(false);
+
+                await TrackApplicationSubmitEventAsync(
+                    outcome: "succeeded",
+                    submissionKind: submissionKind,
+                    paymentRequired: true,
+                    errorCode: null,
+                    durationMs: ElapsedMilliseconds(startedAt),
+                    metadata: new Dictionary<string, object?>
+                    {
+                        ["proofCount"] = applicantData.ProofPics?.Count ?? 0,
+                        ["auditEmailDelivered"] = auditEmailDelivered,
+                        ["archivedFallback"] = archivedSubmissionPath is not null,
+                        ["paymentState"] = "checkout_created"
+                    },
+                    ct: ct).ConfigureAwait(false);
+
                 return Ok(new
                 {
                     success = true,
@@ -763,9 +879,134 @@ namespace LongevityWorldCup.Website.Controllers
                     string.Join(",", proofLengths),
                     profilePicLength,
                     zipSizeBytes);
-                return StatusCode(500, $"Internal server error: {ex.Message}");
+                return await StatusCodeWithStatsAsync(500, "application_processing_failed", $"Internal server error: {ex.Message}").ConfigureAwait(false);
             }
         }
+
+        private Task TrackApplicationSubmitEventAsync(
+            string outcome,
+            string submissionKind,
+            bool? paymentRequired,
+            string? errorCode,
+            long? durationMs,
+            IReadOnlyDictionary<string, object?>? metadata,
+            CancellationToken ct)
+        {
+            var eventMetadata = BuildApplicationStatsMetadata(submissionKind, paymentRequired, metadata);
+            return TrackApplicationEventAsync(
+                "application_submit_" + outcome,
+                component: "application",
+                step: "submit",
+                outcome: outcome,
+                errorCode: errorCode,
+                durationMs: durationMs,
+                metadata: eventMetadata,
+                ct: ct);
+        }
+
+        private Task TrackApplicationProofEventAsync(
+            string outcome,
+            string submissionKind,
+            int proofCount,
+            string? errorCode,
+            int? proofIndex,
+            long? durationMs,
+            CancellationToken ct)
+        {
+            var metadata = BuildApplicationStatsMetadata(
+                submissionKind,
+                paymentRequired: null,
+                new Dictionary<string, object?>
+                {
+                    ["proofCount"] = proofCount,
+                    ["proofIndex"] = proofIndex
+                });
+
+            return TrackApplicationEventAsync(
+                "proof_processing_" + outcome,
+                component: "proof",
+                step: "process",
+                outcome: outcome,
+                errorCode: errorCode,
+                durationMs: durationMs,
+                metadata: metadata,
+                ct: ct);
+        }
+
+        private Task TrackApplicationPaymentEventAsync(
+            string eventName,
+            string outcome,
+            string submissionKind,
+            bool paymentRequired,
+            string? errorCode,
+            long? durationMs,
+            CancellationToken ct)
+        {
+            var metadata = BuildApplicationStatsMetadata(
+                submissionKind,
+                paymentRequired,
+                new Dictionary<string, object?>
+                {
+                    ["paymentProvider"] = "btcpay"
+                });
+
+            return TrackApplicationEventAsync(
+                eventName,
+                component: "payment",
+                step: "checkout",
+                outcome: outcome,
+                errorCode: errorCode,
+                durationMs: durationMs,
+                metadata: metadata,
+                ct: ct);
+        }
+
+        private Task TrackApplicationEventAsync(
+            string eventName,
+            string component,
+            string step,
+            string outcome,
+            string? errorCode,
+            long? durationMs,
+            IReadOnlyDictionary<string, object?>? metadata,
+            CancellationToken ct)
+            => _statistics?.RecordServerEventAsync(
+                eventName,
+                HttpContext,
+                flow: "application",
+                route: Request?.Path.Value,
+                component: component,
+                step: step,
+                outcome: outcome,
+                errorCode: errorCode,
+                durationMs: durationMs,
+                metadata: metadata,
+                ct: ct) ?? Task.CompletedTask;
+
+        private static Dictionary<string, object?> BuildApplicationStatsMetadata(
+            string submissionKind,
+            bool? paymentRequired,
+            IReadOnlyDictionary<string, object?>? extra)
+        {
+            var metadata = new Dictionary<string, object?>
+            {
+                ["submissionKind"] = string.IsNullOrWhiteSpace(submissionKind) ? "unknown" : submissionKind
+            };
+
+            if (paymentRequired.HasValue)
+                metadata["paymentRequired"] = paymentRequired.Value;
+
+            if (extra is not null)
+            {
+                foreach (var (key, value) in extra)
+                    metadata[key] = value;
+            }
+
+            return metadata;
+        }
+
+        private static long ElapsedMilliseconds(long startTimestamp)
+            => (long)Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
 
         private static async Task<string> PersistApplicationSubmissionArchiveAsync(
             string zipPath,

--- a/LongevityWorldCup.Website/Controllers/LongevitymaxxingController.cs
+++ b/LongevityWorldCup.Website/Controllers/LongevitymaxxingController.cs
@@ -22,7 +22,7 @@ public sealed class LongevitymaxxingController(LongevitymaxxingChallengeService 
     {
         try
         {
-            var result = await _challenge.SignupAsync(request, ct: ct).ConfigureAwait(false);
+            var result = await _challenge.SignupAsync(request, context: HttpContext, ct: ct).ConfigureAwait(false);
             return Ok(result);
         }
         catch (Exception ex) when (IsClientError(ex))
@@ -115,7 +115,7 @@ public sealed class LongevitymaxxingController(LongevitymaxxingChallengeService 
     {
         try
         {
-            return Ok(await _challenge.CreateCommitmentPaymentInvoiceAsync(request.AccessToken, ct: ct).ConfigureAwait(false));
+            return Ok(await _challenge.CreateCommitmentPaymentInvoiceAsync(request.AccessToken, context: HttpContext, ct: ct).ConfigureAwait(false));
         }
         catch (UnauthorizedAccessException ex)
         {
@@ -134,7 +134,7 @@ public sealed class LongevitymaxxingController(LongevitymaxxingChallengeService 
     {
         try
         {
-            return Ok(await _challenge.RefreshCommitmentPaymentStatusAsync(request.AccessToken, ct: ct).ConfigureAwait(false));
+            return Ok(await _challenge.RefreshCommitmentPaymentStatusAsync(request.AccessToken, context: HttpContext, ct: ct).ConfigureAwait(false));
         }
         catch (UnauthorizedAccessException ex)
         {
@@ -152,7 +152,7 @@ public sealed class LongevitymaxxingController(LongevitymaxxingChallengeService 
     {
         try
         {
-            return Ok(_challenge.SubmitCheckIn(request));
+            return Ok(_challenge.SubmitCheckIn(request, context: HttpContext));
         }
         catch (UnauthorizedAccessException ex)
         {
@@ -182,7 +182,7 @@ public sealed class LongevitymaxxingController(LongevitymaxxingChallengeService 
                 request.Nutrition,
                 request.Vices,
                 request.Note);
-            return Ok(await _challenge.SubmitCheckInAsync(checkIn, notePhotos, ct: ct).ConfigureAwait(false));
+            return Ok(await _challenge.SubmitCheckInAsync(checkIn, notePhotos, context: HttpContext, ct: ct).ConfigureAwait(false));
         }
         catch (UnauthorizedAccessException ex)
         {

--- a/LongevityWorldCup.Website/Middleware/HtmlInjectionMiddleware.cs
+++ b/LongevityWorldCup.Website/Middleware/HtmlInjectionMiddleware.cs
@@ -284,6 +284,11 @@ namespace LongevityWorldCup.Website.Middleware
                 sb.AppendLine("<script src=\"https://cdn.jsdelivr.net/npm/validator@13.9.0/validator.min.js\" crossorigin=\"anonymous\" defer></script>");
             }
 
+            if (config.IncludeSiteStatisticsTracking)
+            {
+                sb.AppendLine($"<script src=\"{_assetVersionProvider.AppendVersion("/js/site-statistics-tracking.js")}\" defer></script>");
+            }
+
             foreach (var path in config.BlockingScriptPaths ?? Array.Empty<string>())
             {
                 sb.AppendLine($"<script src=\"{_assetVersionProvider.AppendVersion(path)}\"></script>");
@@ -327,7 +332,8 @@ $@"<script type=""module"">
                         "/js/bortz-age.js",
                         "/js/badges.js",
                         "/js/age-visualization.js"
-                    ]);
+                    ],
+                    IncludeSiteStatisticsTracking: true);
             }
 
             return path.ToLowerInvariant() switch
@@ -343,7 +349,8 @@ $@"<script type=""module"">
                         "/js/bortz-age.js",
                         "/js/badges.js",
                         "/js/age-visualization.js"
-                    ]),
+                    ],
+                    IncludeSiteStatisticsTracking: true),
                 "/leaderboard/leaderboard.html" => new HeadAssetConfig(
                     IncludeValidator: false,
                     ModulePaths:
@@ -355,7 +362,8 @@ $@"<script type=""module"">
                         "/js/bortz-age.js",
                         "/js/badges.js",
                         "/js/age-visualization.js"
-                    ]),
+                    ],
+                    IncludeSiteStatisticsTracking: true),
                 "/event-board/event-board.html" => new HeadAssetConfig(
                     IncludeValidator: false,
                     ModulePaths:
@@ -364,7 +372,8 @@ $@"<script type=""module"">
                         "/js/flags.js",
                         "/js/leagueIcons.js",
                         "/js/badges.js"
-                    ]),
+                    ],
+                    IncludeSiteStatisticsTracking: true),
                 "/event-board-embed.html" => new HeadAssetConfig(
                     IncludeValidator: false,
                     ModulePaths:
@@ -1345,7 +1354,8 @@ $@"<script type=""module"">
         private sealed record HeadAssetConfig(
             bool IncludeValidator,
             IReadOnlyList<string> ModulePaths,
-            IReadOnlyList<string>? BlockingScriptPaths = null)
+            IReadOnlyList<string>? BlockingScriptPaths = null,
+            bool IncludeSiteStatisticsTracking = false)
         {
             public static readonly HeadAssetConfig Empty = new(false, Array.Empty<string>());
         }

--- a/LongevityWorldCup.Website/wwwroot/css/site-statistics.css
+++ b/LongevityWorldCup.Website/wwwroot/css/site-statistics.css
@@ -642,7 +642,7 @@ select:focus,
 
 .detail-sections {
     display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
     gap: 14px;
 }
 
@@ -652,6 +652,167 @@ select:focus,
     background: rgba(17, 22, 29, 0.9);
     padding: 13px;
     min-width: 0;
+}
+
+.source-visual-list,
+.field-visual-list {
+    display: grid;
+    gap: 8px;
+}
+
+.visual-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 10px;
+    align-items: center;
+    color: var(--dim);
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+}
+
+.visual-legend span {
+    display: inline-flex;
+    gap: 5px;
+    align-items: center;
+}
+
+.visual-legend i {
+    width: 8px;
+    height: 8px;
+    border-radius: 999px;
+    background: var(--dim);
+}
+
+.visual-legend i.manual,
+.stacked-bar .manual,
+.visual-meter-fill.manual,
+.source-pill.manual {
+    background: var(--cyan);
+}
+
+.visual-legend i.auto,
+.stacked-bar .auto,
+.visual-meter-fill.auto,
+.source-pill.auto {
+    background: var(--green);
+}
+
+.visual-legend i.late,
+.stacked-bar .late,
+.visual-meter-fill.late,
+.source-pill.late {
+    background: var(--amber);
+}
+
+.visual-legend i.legacy,
+.stacked-bar .legacy,
+.visual-meter-fill.legacy,
+.source-pill.legacy {
+    background: var(--blue);
+}
+
+.visual-legend i.failed,
+.stacked-bar .failed,
+.source-pill.failed {
+    background: var(--red);
+}
+
+.source-visual-row,
+.field-visual-row {
+    min-width: 0;
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.035);
+    padding: 8px;
+    display: grid;
+    gap: 8px;
+}
+
+.source-visual-row {
+    grid-template-columns: minmax(100px, 0.95fr) minmax(72px, 0.75fr) minmax(96px, 0.9fr);
+    align-items: center;
+}
+
+.source-identity,
+.field-visual-head {
+    display: grid;
+    gap: 5px;
+    min-width: 0;
+}
+
+.source-identity strong,
+.field-visual-head strong {
+    font-size: 12px;
+    line-height: 1.2;
+    overflow-wrap: anywhere;
+}
+
+.source-identity > span,
+.source-metrics,
+.field-metrics {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+    align-items: center;
+    min-width: 0;
+}
+
+.source-pill,
+.metric-chip {
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    min-height: 22px;
+    padding: 3px 7px;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    color: #080a0e;
+    font-size: 10px;
+    font-weight: 700;
+    line-height: 1;
+}
+
+.source-pill.entry,
+.source-pill.flow,
+.metric-chip {
+    color: var(--muted);
+    background: rgba(255, 255, 255, 0.05);
+}
+
+.metric-chip strong {
+    color: var(--text);
+}
+
+.visual-meter,
+.stacked-bar {
+    min-width: 0;
+    height: 12px;
+    border-radius: 999px;
+    overflow: hidden;
+    background: rgba(255, 255, 255, 0.08);
+}
+
+.visual-meter-fill,
+.stacked-bar span {
+    display: block;
+    flex: 0 1 auto;
+    height: 100%;
+    min-width: 2px;
+}
+
+.stacked-bar {
+    display: flex;
+}
+
+.field-visual-head {
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+}
+
+.field-visual-head span {
+    color: var(--dim);
+    font-size: 10px;
 }
 
 .compact-table {
@@ -1075,6 +1236,29 @@ select:focus,
         min-height: 64px;
         padding: 8px;
     }
+
+    .source-visual-list,
+    .field-visual-list {
+        gap: 6px;
+    }
+
+    .source-visual-row,
+    .field-visual-row {
+        gap: 6px;
+        padding: 7px;
+    }
+
+    .source-pill,
+    .metric-chip {
+        min-height: 19px;
+        padding: 2px 6px;
+        font-size: 9px;
+    }
+
+    .visual-meter,
+    .stacked-bar {
+        height: 10px;
+    }
 }
 
 @media (max-width: 1180px) {
@@ -1139,7 +1323,14 @@ select:focus,
     .decision-card,
     .decision-gridline,
     .segment-row,
-    .trend-row {
+    .trend-row,
+    .source-visual-row,
+    .field-visual-head {
         grid-template-columns: 1fr;
+    }
+
+    .source-metrics,
+    .field-metrics {
+        justify-content: flex-start;
     }
 }

--- a/LongevityWorldCup.Website/wwwroot/internal/site-statistics.html
+++ b/LongevityWorldCup.Website/wwwroot/internal/site-statistics.html
@@ -61,6 +61,7 @@
                     <select id="statsSource">
                         <option value="all">All</option>
                         <option value="direct">Direct</option>
+                        <option value="campaign">Campaign</option>
                         <option value="internal">Internal</option>
                         <option value="search">Search</option>
                         <option value="social">Social</option>

--- a/LongevityWorldCup.Website/wwwroot/internal/site-statistics.html
+++ b/LongevityWorldCup.Website/wwwroot/internal/site-statistics.html
@@ -62,6 +62,7 @@
                         <option value="all">All</option>
                         <option value="direct">Direct</option>
                         <option value="campaign">Campaign</option>
+                        <option value="email">Email</option>
                         <option value="internal">Internal</option>
                         <option value="search">Search</option>
                         <option value="social">Social</option>

--- a/LongevityWorldCup.Website/wwwroot/js/bioage-rank-preview.js
+++ b/LongevityWorldCup.Website/wwwroot/js/bioage-rank-preview.js
@@ -334,6 +334,16 @@
             '<div class="bioage-rank-neighbors">' + buildNearbyRows(rows, youIndex, clock) + '</div>';
     }
 
+    function trackRankPreview(eventName, clock, outcome) {
+        if (!window.LwcSiteStats || typeof window.LwcSiteStats.track !== 'function') return;
+        window.LwcSiteStats.track(eventName, {
+            component: 'rank_preview',
+            step: 'field_rank',
+            outcome: outcome,
+            metadata: { clock: clock }
+        });
+    }
+
     function render(targetId, options) {
         var target = document.getElementById(targetId);
         if (!target || !options) return Promise.resolve();
@@ -349,6 +359,7 @@
 
         target.hidden = false;
         target.innerHTML = '<div class="bioage-rank-loading">Calculating rank...</div>';
+        trackRankPreview('rank_preview_requested', clock, 'requested');
 
         return getSharedAthletes()
             .then(function (athletes) {
@@ -382,6 +393,7 @@
 
                 target.hidden = true;
                 target.innerHTML = '';
+                trackRankPreview('rank_preview_failed', clock, 'failed');
             });
     }
 

--- a/LongevityWorldCup.Website/wwwroot/js/proof-helpers.js
+++ b/LongevityWorldCup.Website/wwwroot/js/proof-helpers.js
@@ -146,6 +146,24 @@ function isSupportedProofFile(file) {
         || extension === 'heif';
 }
 
+function trackProofFileRejected(errorCode, files) {
+    const stats = window.LwcSiteStats;
+    if (!stats || typeof stats.track !== 'function') return;
+
+    const rejectedFiles = Array.from(files || []);
+    const first = rejectedFiles[0] || null;
+    stats.track('proof_file_rejected', {
+        component: 'proof_upload',
+        outcome: 'rejected',
+        errorCode: errorCode || 'client_rejected',
+        metadata: {
+            fileCountBucket: typeof stats.countBucket === 'function' ? stats.countBucket(rejectedFiles.length) : String(rejectedFiles.length),
+            fileTypeBucket: typeof stats.fileTypeBucket === 'function' ? stats.fileTypeBucket(first) : 'unknown',
+            fileSizeBucket: typeof stats.fileSizeBucket === 'function' ? stats.fileSizeBucket(first) : 'unknown'
+        }
+    });
+}
+
 window.setupProofUploadHTML = function (nextButton, uploadProofButton, proofPicInput, proofImageContainer, proofPics, biomarkerChecklistContainer, biomarkers, options) {
     nextButton.disabled = true;
     const cameraButton = options && options.cameraButton;
@@ -211,6 +229,7 @@ window.setupProofUploadHTML = function (nextButton, uploadProofButton, proofPicI
         const supportedFiles = selectedFiles.filter(file => isSupportedProofFile(file));
         if (supportedFiles.length === 0) {
             if (input) input.value = "";
+            trackProofFileRejected('unsupported_file_type', unsupportedFiles);
             customAlert('Proof files must be images or PDFs.')
                 .then(() => focusProofRetryButton(retryButton));
             return;
@@ -243,6 +262,7 @@ window.setupProofUploadHTML = function (nextButton, uploadProofButton, proofPicI
             };
 
             let failedFiles = 0;
+            const failedFileSamples = [];
             let hitImageLimit = false;
             // process one by one to preserve order
             for (const file of supportedFiles) {
@@ -294,9 +314,11 @@ window.setupProofUploadHTML = function (nextButton, uploadProofButton, proofPicI
                         nextButton.disabled = true;
                     } else {
                         failedFiles++;
+                        failedFileSamples.push(file);
                     }
                 } catch (_) {
                     failedFiles++;
+                    failedFileSamples.push(file);
                     if (proofPics.length > proofCountBeforeFile) {
                         updateProofImageContainer(proofImageContainer, nextButton, proofPics, uploadProofButton, cameraButton, biomarkerChecklistContainer);
                         checkProofImages(nextButton, proofPics, uploadProofButton, cameraButton, biomarkerChecklistContainer);
@@ -305,10 +327,12 @@ window.setupProofUploadHTML = function (nextButton, uploadProofButton, proofPicI
                 }
             }
             if (unsupportedFiles.length > 0) {
+                trackProofFileRejected('unsupported_file_type', unsupportedFiles);
                 customAlert('Some proof files were skipped because proof files must be images or PDFs.')
                     .then(() => focusProofRetryButton(retryButton));
             }
             if (failedFiles > 0) {
+                trackProofFileRejected('client_processing_failed', failedFileSamples);
                 customAlert('Some proof files could not be processed. Please try them again as images or PDFs.')
                     .then(() => focusProofRetryButton(retryButton));
             }
@@ -317,6 +341,7 @@ window.setupProofUploadHTML = function (nextButton, uploadProofButton, proofPicI
                 showProofUploadNotice('Only the first ' + maxProofImages + ' proof images were kept. Remove one to add another.');
             }
         } catch (error) {
+            trackProofFileRejected('proof_upload_failed', selectedFiles);
             customAlert('Proof upload failed. Please try again with an image or PDF file.')
                 .then(() => focusProofRetryButton(retryButton));
         } finally {

--- a/LongevityWorldCup.Website/wwwroot/js/site-statistics-tracking.js
+++ b/LongevityWorldCup.Website/wwwroot/js/site-statistics-tracking.js
@@ -3,6 +3,7 @@
 
     const endpoint = "/api/site-statistics/event";
     const sessionKey = "lwcSiteStatsSessionId";
+    const firstTouchKey = "lwcSiteStatsFirstTouch";
     const originalFetch = window.fetch ? window.fetch.bind(window) : null;
     const pageStartedAt = now();
     const sentOnce = new Set();
@@ -39,6 +40,15 @@
 
     function route() {
         return `${window.location.pathname}${window.location.search || ""}`;
+    }
+
+    function campaignValue(name) {
+        const value = safe(() => new URLSearchParams(window.location.search).get(name)) || "";
+        return safeToken(value, 96);
+    }
+
+    function hasCampaignParams() {
+        return !!(campaignValue("campaign") || campaignValue("utm_source") || campaignValue("utm_medium") || campaignValue("utm_campaign"));
     }
 
     function flowFromPath() {
@@ -82,16 +92,39 @@
 
     function source() {
         const host = referrerDomain();
-        if (!host) return "direct";
+        if (!host) return hasCampaignParams() ? "campaign" : "direct";
         if (isInternalReferrer(host)) return "internal";
         if (/google|bing|duckduckgo|yahoo|brave|search/i.test(host)) return "search";
         if (/x\.com|twitter|facebook|instagram|threads|youtube|linkedin|reddit|slack/i.test(host)) return "social";
         return "referral";
     }
 
+    function getFirstTouch() {
+        const existing = safe(() => sessionStorage.getItem(firstTouchKey));
+        if (existing) {
+            const parsed = safe(() => JSON.parse(existing));
+            if (parsed && typeof parsed === "object") return parsed;
+        }
+
+        const touch = {
+            landingRoute: route(),
+            firstReferrerDomain: referrerDomain(),
+            firstSource: source(),
+            firstCampaign: campaignValue("campaign") || campaignValue("utm_campaign"),
+            firstUtmSource: campaignValue("utm_source"),
+            firstUtmMedium: campaignValue("utm_medium"),
+            firstUtmCampaign: campaignValue("utm_campaign"),
+            firstUtmTerm: campaignValue("utm_term"),
+            firstUtmContent: campaignValue("utm_content")
+        };
+        safe(() => sessionStorage.setItem(firstTouchKey, JSON.stringify(touch)));
+        return touch;
+    }
+
     function track(eventName, options) {
         safe(() => {
             if (!eventName || !originalFetch) return;
+            const firstTouch = getFirstTouch();
             const payload = Object.assign({
                 eventName,
                 sessionId: getSessionId(),
@@ -101,7 +134,16 @@
                 deviceClass: deviceClass(),
                 browserFamily: browserFamily(),
                 referrerDomain: referrerDomain(),
-                source: source()
+                source: source(),
+                landingRoute: firstTouch.landingRoute,
+                firstReferrerDomain: firstTouch.firstReferrerDomain,
+                firstSource: firstTouch.firstSource,
+                firstCampaign: firstTouch.firstCampaign,
+                firstUtmSource: firstTouch.firstUtmSource,
+                firstUtmMedium: firstTouch.firstUtmMedium,
+                firstUtmCampaign: firstTouch.firstUtmCampaign,
+                firstUtmTerm: firstTouch.firstUtmTerm,
+                firstUtmContent: firstTouch.firstUtmContent
             }, options || {});
 
             const body = JSON.stringify(payload);
@@ -134,6 +176,16 @@
         const key = fieldKey(el);
         if (/email|name|token|note|why|media|link/i.test(key)) return "private_field";
         return key;
+    }
+
+    function safeToken(value, maxLength) {
+        value = String(value || "").trim();
+        if (!value) return "";
+        if (/@|https?:\/\/|data:|secret|bearer|password|token/i.test(value)) return "";
+        return value
+            .slice(0, maxLength || 96)
+            .replace(/[^\w./:$ -]/g, "")
+            .trim();
     }
 
     function fileTypeBucket(file) {

--- a/LongevityWorldCup.Website/wwwroot/js/site-statistics-tracking.js
+++ b/LongevityWorldCup.Website/wwwroot/js/site-statistics-tracking.js
@@ -425,7 +425,66 @@
         const form = document.getElementById("phenoAgeForm") || document.getElementById("bortzAgeForm");
         if (!form) return;
 
+        const required = Array.from(form.querySelectorAll("input[required], select[required], textarea[required]"));
+
+        function fieldHasRequiredValue(el) {
+            if (!el) return false;
+            if (el.type === "checkbox" || el.type === "radio") return !!el.checked;
+            return String(el.value || "").trim().length > 0;
+        }
+
+        function requiredProgressThreshold() {
+            const pct = required.length ? Math.floor((completedFields.size / required.length) * 100) : 0;
+            return pct >= 100 ? 100 : pct >= 75 ? 75 : pct >= 50 ? 50 : pct >= 25 ? 25 : 0;
+        }
+
+        function recordRequiredProgress(source) {
+            const threshold = requiredProgressThreshold();
+            if (threshold <= lastRequiredProgress) return;
+
+            lastRequiredProgress = threshold;
+            track("calculator_required_progress_changed", {
+                component: "calculator",
+                step: "required_fields",
+                outcome: "progress",
+                metadata: {
+                    progressBucket: String(threshold),
+                    completionSource: source
+                }
+            });
+            if (threshold === 100) {
+                track("calculator_all_required_fields_completed", {
+                    component: "calculator",
+                    outcome: "completed",
+                    metadata: { completionSource: source }
+                });
+            }
+        }
+
+        function recordFieldCompletion(el, source) {
+            const key = safeFieldKey(el);
+            if (!fieldHasRequiredValue(el) || completedFields.has(key)) return false;
+
+            completedFields.add(key);
+            track("calculator_field_completed", {
+                component: "calculator",
+                step: key,
+                outcome: "completed",
+                metadata: { completionSource: source }
+            });
+            return true;
+        }
+
+        function scanRequiredFields(source) {
+            let changed = false;
+            required.forEach(el => {
+                if (recordFieldCompletion(el, source)) changed = true;
+            });
+            if (changed || completedFields.size > 0) recordRequiredProgress(source);
+        }
+
         listen(form, "submit", () => {
+            scanRequiredFields("submit");
             track("calculator_started", { component: "calculator", outcome: "submitted" });
         }, true);
 
@@ -438,7 +497,13 @@
             });
         }, true);
 
-        const required = Array.from(form.querySelectorAll("input[required], select[required], textarea[required]"));
+        listen(form, "input", event => {
+            if (event && required.includes(event.target)) {
+                recordFieldCompletion(event.target, "input");
+                recordRequiredProgress("input");
+            }
+        }, true);
+
         required.forEach(el => {
             listen(el, "focus", () => {
                 const key = safeFieldKey(el);
@@ -448,27 +513,16 @@
             }, { passive: true });
 
             listen(el, "change", () => {
-                const key = safeFieldKey(el);
-                if (el.value && !completedFields.has(key)) {
-                    completedFields.add(key);
-                    track("calculator_field_completed", { component: "calculator", step: key, outcome: "completed" });
-                }
-                const pct = required.length ? Math.floor((completedFields.size / required.length) * 100) : 0;
-                const threshold = pct >= 100 ? 100 : pct >= 75 ? 75 : pct >= 50 ? 50 : pct >= 25 ? 25 : 0;
-                if (threshold > lastRequiredProgress) {
-                    lastRequiredProgress = threshold;
-                    track("calculator_required_progress_changed", {
-                        component: "calculator",
-                        step: "required_fields",
-                        outcome: "progress",
-                        metadata: { progressBucket: String(threshold) }
-                    });
-                    if (threshold === 100) {
-                        track("calculator_all_required_fields_completed", { component: "calculator", outcome: "completed" });
-                    }
-                }
+                recordFieldCompletion(el, "change");
+                recordRequiredProgress("change");
             }, { passive: true });
         });
+
+        scanRequiredFields("initial");
+        [250, 1000, 2500].forEach(delay => {
+            setTimeout(() => safe(() => scanRequiredFields("autofill")), delay);
+        });
+        listen(window, "pageshow", () => scanRequiredFields("pageshow"));
 
         const result = document.getElementById("phenoAgeResult") || document.getElementById("bortzAgeResult");
         const rank = document.getElementById("phenoAgeRankPreview") || document.getElementById("bortzAgeRankPreview");
@@ -487,6 +541,7 @@
             const observer = new MutationObserver(() => {
                 safe(() => {
                     if (!result.classList.contains("show")) return;
+                    scanRequiredFields("result");
                     const yearsText = document.getElementById("yearsText");
                     trackOnce(`result-${flowFromPath()}`, "calculator_result_generated", {
                         component: "calculator",

--- a/LongevityWorldCup.Website/wwwroot/js/site-statistics-tracking.js
+++ b/LongevityWorldCup.Website/wwwroot/js/site-statistics-tracking.js
@@ -4,6 +4,7 @@
     const endpoint = "/api/site-statistics/event";
     const sessionKey = "lwcSiteStatsSessionId";
     const firstTouchKey = "lwcSiteStatsFirstTouch";
+    const sessionHeader = "X-LWC-Stats-Session";
     const originalFetch = window.fetch ? window.fetch.bind(window) : null;
     const pageStartedAt = now();
     const sentOnce = new Set();
@@ -176,6 +177,26 @@
         if (sentOnce.has(key)) return;
         sentOnce.add(key);
         track(eventName, options);
+    }
+
+    function isSameOriginFetch(input) {
+        const raw = safe(() => input && input.url ? input.url : input) || "";
+        const parsed = safe(() => new URL(String(raw), window.location.href));
+        return !!parsed && parsed.origin === window.location.origin && parsed.pathname.indexOf("/api/") === 0;
+    }
+
+    function withStatsSessionHeader(args) {
+        if (!args || !args.length || typeof Headers === "undefined" || !isSameOriginFetch(args[0])) return args;
+        const init = args[1] ? Object.assign({}, args[1]) : {};
+        const headers = new Headers(init.headers || (typeof Request !== "undefined" && args[0] instanceof Request ? args[0].headers : undefined));
+        if (!headers.has(sessionHeader)) headers.set(sessionHeader, getSessionId());
+        init.headers = headers;
+
+        if (typeof Request !== "undefined" && args[0] instanceof Request) {
+            return [new Request(args[0], init)];
+        }
+
+        return [args[0], init];
     }
 
     function fieldKey(el) {
@@ -786,7 +807,7 @@
         if (!originalFetch) return;
 
         window.fetch = function () {
-            const args = arguments;
+            const args = withStatsSessionHeader(arguments);
             const url = safe(() => String(args[0] && args[0].url || args[0] || "")) || "";
             const started = now();
             const observed = safe(() => classifyFetch(url));
@@ -851,8 +872,8 @@
             return {
                 component: "application",
                 step: "submit",
-                successEvent: response => response.ok ? "application_submit_succeeded" : "application_submit_failed",
-                failureEvent: "application_submit_failed"
+                successEvent: response => response.ok ? null : "api_request_failed",
+                failureEvent: "api_request_failed"
             };
         }
         if (url.includes("/api/application/payment-status")) {
@@ -875,8 +896,8 @@
             return {
                 component: "signup",
                 step: "submit",
-                successEvent: response => response.ok ? "challenge_signup_succeeded" : "challenge_signup_failed",
-                failureEvent: "challenge_signup_failed"
+                successEvent: response => response.ok ? null : "api_request_failed",
+                failureEvent: "api_request_failed"
             };
         }
         if (url.includes("/api/longevitymaxxing/participant")) {
@@ -890,18 +911,16 @@
         if (url.includes("/api/longevitymaxxing/check-in")) {
             return {
                 component: "checkin",
-                step: "save",
-                successEvent: response => response.ok
-                    ? (lastCheckInKind === "practice" ? "challenge_practice_checkin_submitted" : "challenge_scored_checkin_submitted")
-                    : (lastCheckInKind === "practice" ? "challenge_practice_checkin_failed" : "challenge_scored_checkin_failed"),
-                failureEvent: lastCheckInKind === "practice" ? "challenge_practice_checkin_failed" : "challenge_scored_checkin_failed"
+                step: "submit",
+                successEvent: response => response.ok ? null : "api_request_failed",
+                failureEvent: "api_request_failed"
             };
         }
         if (url.includes("/api/longevitymaxxing/commitment-payment/status")) {
             return {
                 component: "commitment",
                 step: "status",
-                successEvent: response => response.ok ? "challenge_commitment_payment_status_checked" : "api_request_failed",
+                successEvent: response => response.ok ? null : "api_request_failed",
                 failureEvent: "api_request_failed"
             };
         }
@@ -909,7 +928,7 @@
             return {
                 component: "commitment",
                 step: "payment",
-                successEvent: () => "challenge_commitment_payment_opened",
+                successEvent: response => response.ok ? null : "api_request_failed",
                 failureEvent: "api_request_failed"
             };
         }

--- a/LongevityWorldCup.Website/wwwroot/js/site-statistics-tracking.js
+++ b/LongevityWorldCup.Website/wwwroot/js/site-statistics-tracking.js
@@ -248,6 +248,99 @@
         return "20_plus";
     }
 
+    function pathLower() {
+        return String(window.location.pathname || "/").toLowerCase();
+    }
+
+    function queryValue(name) {
+        return safe(() => new URLSearchParams(window.location.search || "").get(name)) || "";
+    }
+
+    function pathSegmentAfter(prefix) {
+        const path = pathLower();
+        if (!path.startsWith(prefix)) return "";
+        return safeToken(decodeURIComponent(path.slice(prefix.length).split("/")[0] || ""), 64);
+    }
+
+    function currentAthleteSlug() {
+        return pathSegmentAfter("/athlete/") || safeToken(queryValue("athlete"), 64);
+    }
+
+    function currentLeagueSlug() {
+        const routeSlug = pathSegmentAfter("/league/");
+        if (routeSlug) return routeSlug;
+        const view = safeToken(queryValue("view"), 64);
+        if (view) return view;
+        const filters = safeToken(queryValue("filters"), 128);
+        if (filters) return safeToken(filters.split(",")[0], 64);
+        return pathLower() === "/leaderboard" ? "ultimate" : "";
+    }
+
+    function isHomepagePath() {
+        const path = pathLower();
+        return path === "/" || path === "/index.html";
+    }
+
+    function isEventBoardPath() {
+        const path = pathLower();
+        return path === "/events" || path.includes("/event-board/");
+    }
+
+    function eventBoardClickMetadata(target) {
+        const link = target && target.closest ? target.closest("a[href]") : null;
+        const row = target && target.closest ? target.closest("tr.main-row") : null;
+        const href = link ? String(link.getAttribute("href") || "") : "";
+        let targetKind = "event";
+        if (link && link.classList.contains("view-all")) targetKind = "view_all";
+        else if (link && (link.classList.contains("event-athlete-link") || href.startsWith("/athlete/"))) targetKind = "athlete";
+        else if (href.startsWith("/league/") || href.includes("view=") || href.includes("filters=")) targetKind = "league";
+        else if (link) targetKind = "link";
+
+        const metadata = { targetKind };
+        if (row && row.dataset.eventTypeName) metadata.eventType = safeToken(row.dataset.eventTypeName, 64);
+        if (row && row.dataset.highlightSelection) metadata.highlightSelection = safeToken(row.dataset.highlightSelection, 64);
+        if (row && row.dataset.primarySlug) metadata.primarySlug = safeToken(row.dataset.primarySlug, 64);
+        return metadata;
+    }
+
+    function trackPublicPageViews() {
+        if (isHomepagePath() && !currentAthleteSlug()) {
+            const highlightsRoot = document.getElementById("events-root-index");
+            if (highlightsRoot) {
+                track("homepage_highlight_viewed", {
+                    component: "homepage",
+                    step: "highlights",
+                    outcome: "viewed"
+                });
+            }
+        }
+
+        if (isEventBoardPath()) {
+            track("event_viewed", {
+                component: "event_board",
+                outcome: "viewed"
+            });
+        }
+
+        const athleteSlug = currentAthleteSlug();
+        if (athleteSlug) {
+            track("athlete_profile_viewed", {
+                component: "athlete_profile",
+                outcome: "viewed",
+                metadata: { athleteSlug }
+            });
+        }
+
+        const leagueSlug = currentLeagueSlug();
+        if (leagueSlug) {
+            track("league_viewed", {
+                component: "leaderboard",
+                outcome: "viewed",
+                metadata: { league: leagueSlug }
+            });
+        }
+    }
+
     function setupPageViews() {
         const pageViewKey = `${window.location.pathname.toLowerCase()}${window.location.search || ""}`;
         if (trackedPageViews.has(pageViewKey)) return;
@@ -294,6 +387,7 @@
             return;
         }
 
+        trackPublicPageViews();
         track("site_page_viewed", { component: "site", outcome: "viewed" });
     }
 
@@ -546,6 +640,15 @@
         listen(document.getElementById("lmxSignupAthlete"), "input", () => {
             trackOnce("challenge-athlete-search-started", "challenge_athlete_search_started", { component: "signup", step: "athlete_search", outcome: "started" });
         }, { passive: true });
+        listen(document, "mousedown", event => {
+            const option = event.target && event.target.closest ? event.target.closest("#lmxSignupAthlete-autocomplete-list .lmx-athlete-option") : null;
+            if (!option) return;
+            track("challenge_athlete_search_result_selected", {
+                component: "signup",
+                step: "athlete_search",
+                outcome: "selected"
+            });
+        }, true);
         listen(document.getElementById("lmxSignupTimeZoneButton"), "click", () => {
             track("challenge_timezone_picker_opened", { component: "signup", step: "timezone", outcome: "opened" });
         }, { passive: true });
@@ -568,6 +671,59 @@
                 outcome: "started",
                 metadata: { checkinKind: practice ? "practice" : "scored" }
             });
+        }, true);
+
+        const commitmentPanel = document.getElementById("lmxCommitmentPanel");
+        if (commitmentPanel && typeof MutationObserver === "function") {
+            const trackCommitmentBlock = () => {
+                if (commitmentPanel.classList.contains("lmx-hidden")) return;
+                const card = commitmentPanel.querySelector(".lmx-commitment-card");
+                if (!card) return;
+                trackOnce("challenge-commitment-block-seen", "challenge_commitment_block_seen", {
+                    component: "commitment",
+                    step: "block",
+                    outcome: "viewed",
+                    metadata: { commitmentState: card.classList.contains("setup") ? "needs_amount" : "due" }
+                });
+            };
+            const observer = new MutationObserver(trackCommitmentBlock);
+            observer.observe(commitmentPanel, { childList: true, subtree: true, attributes: true, attributeFilter: ["class"] });
+            trackCommitmentBlock();
+        }
+    }
+
+    function setupPublicContentTracking() {
+        listen(document, "click", event => {
+            if (event.defaultPrevented) return;
+            if (event.button !== undefined && event.button !== 0) return;
+            if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+
+            const target = event.target;
+            if (!target || !target.closest) return;
+
+            const homepageRoot = target.closest("#events-root-index");
+            if (homepageRoot) {
+                const rowOrLink = target.closest("tr.main-row, a[href], button");
+                if (!rowOrLink) return;
+                track("homepage_highlight_clicked", {
+                    component: "homepage",
+                    step: "highlights",
+                    outcome: "clicked",
+                    metadata: eventBoardClickMetadata(target)
+                });
+                return;
+            }
+
+            const eventRoot = target.closest("#events-root, .event-board-page .events-board");
+            if (eventRoot) {
+                const link = target.closest("a[href]");
+                if (!link) return;
+                track("event_link_clicked", {
+                    component: "event_board",
+                    outcome: "clicked",
+                    metadata: eventBoardClickMetadata(target)
+                });
+            }
         }, true);
     }
 
@@ -721,6 +877,7 @@
         safe(setupCalculatorTracking);
         safe(setupProofTracking);
         safe(setupChallengeTracking);
+        safe(setupPublicContentTracking);
     });
     listen(window, "error", event => {
         track("client_error_observed", {

--- a/LongevityWorldCup.Website/wwwroot/js/site-statistics-tracking.js
+++ b/LongevityWorldCup.Website/wwwroot/js/site-statistics-tracking.js
@@ -6,6 +6,7 @@
     const originalFetch = window.fetch ? window.fetch.bind(window) : null;
     const pageStartedAt = now();
     const sentOnce = new Set();
+    const trackedPageViews = new Set();
     const completedFields = new Set();
     const touchedFields = new Set();
     let lastRequiredProgress = -1;
@@ -186,6 +187,10 @@
     }
 
     function setupPageViews() {
+        const pageViewKey = `${window.location.pathname.toLowerCase()}${window.location.search || ""}`;
+        if (trackedPageViews.has(pageViewKey)) return;
+        trackedPageViews.add(pageViewKey);
+
         const path = window.location.pathname.toLowerCase();
         if (flowFromPath() === "challenge") {
             track("challenge_page_viewed", { component: "challenge", outcome: "viewed" });
@@ -228,6 +233,36 @@
         }
 
         track("site_page_viewed", { component: "site", outcome: "viewed" });
+    }
+
+    function scheduleJoinPanelViewForCurrentRoute() {
+        const enqueue = typeof queueMicrotask === "function"
+            ? queueMicrotask
+            : callback => setTimeout(callback, 0);
+
+        enqueue(() => safe(trackJoinPanelViewForCurrentRoute));
+    }
+
+    function trackJoinPanelViewForCurrentRoute() {
+        if (window.location.pathname.toLowerCase() === "/join") {
+            setupPageViews();
+        }
+    }
+
+    function setupSpaRouteTracking() {
+        if (!window.history) return;
+
+        ["pushState", "replaceState"].forEach(method => {
+            const original = window.history[method];
+            if (typeof original !== "function") return;
+            window.history[method] = function () {
+                const result = original.apply(this, arguments);
+                scheduleJoinPanelViewForCurrentRoute();
+                return result;
+            };
+        });
+
+        listen(window, "popstate", scheduleJoinPanelViewForCurrentRoute);
     }
 
     function setupCalculatorTracking() {
@@ -617,6 +652,7 @@
     };
 
     setupFetchTracking();
+    setupSpaRouteTracking();
     listen(document, "DOMContentLoaded", () => {
         safe(setupPageViews);
         safe(setupJoinGameTracking);

--- a/LongevityWorldCup.Website/wwwroot/js/site-statistics-tracking.js
+++ b/LongevityWorldCup.Website/wwwroot/js/site-statistics-tracking.js
@@ -90,10 +90,20 @@
         return normalizedHost === currentHost || normalizedHost === "longevityworldcup.com";
     }
 
+    function isEmailReferrer(host) {
+        if (!host) return false;
+        const normalizedHost = String(host).toLowerCase();
+        return normalizedHost === "com.google.android.gm"
+            || /^mail\./i.test(normalizedHost)
+            || /\.mail\./i.test(normalizedHost)
+            || /gmail|outlook|hotmail|protonmail|proton\.me|fastmail|icloud|mail\.yahoo|yahoomail/i.test(normalizedHost);
+    }
+
     function source() {
         const host = referrerDomain();
         if (!host) return hasCampaignParams() ? "campaign" : "direct";
         if (isInternalReferrer(host)) return "internal";
+        if (isEmailReferrer(host)) return "email";
         if (/google|bing|duckduckgo|yahoo|brave|search/i.test(host)) return "search";
         if (/x\.com|twitter|facebook|instagram|threads|youtube|linkedin|reddit|slack/i.test(host)) return "social";
         return "referral";

--- a/LongevityWorldCup.Website/wwwroot/js/site-statistics.js
+++ b/LongevityWorldCup.Website/wwwroot/js/site-statistics.js
@@ -955,6 +955,7 @@
             return;
         }
         host.innerHTML = [
+            detailPanel("Calculator completion sources", calculatorCompletionSourceTable(events)),
             detailPanel("Calculator fields", fieldFrictionTable(events)),
             detailPanel("Proof upload", proofUploadTable(events)),
             detailPanel("Handoff integrity", handoffTable(events))
@@ -1408,17 +1409,199 @@
         return new Set(filtered.map(e => e.sessionHash)).size;
     }
 
+    function metadataValue(event, key) {
+        if (!event || !event.metadata || !Object.prototype.hasOwnProperty.call(event.metadata, key)) return "";
+        return String(event.metadata[key] || "");
+    }
+
+    function calculatorEntryMode(event) {
+        return metadataValue(event, "entryMode") || "standard";
+    }
+
+    function completionSource(event) {
+        return metadataValue(event, "completionSource") || "legacy";
+    }
+
+    function completionSourceLabel(source) {
+        const normalized = String(source || "legacy").toLowerCase();
+        if (normalized === "pageshow") return "page restore";
+        return normalized || "legacy";
+    }
+
+    function isAutomaticCompletion(event) {
+        const source = completionSource(event).toLowerCase();
+        return source === "initial" || source === "autofill" || source === "pageshow";
+    }
+
+    function isLateCompletion(event) {
+        const source = completionSource(event).toLowerCase();
+        return source === "submit" || source === "result";
+    }
+
+    function isManualCompletion(event) {
+        const source = completionSource(event).toLowerCase();
+        return source === "change" || source === "input";
+    }
+
+    function completionSourceClass(source) {
+        source = String(source || "legacy").toLowerCase();
+        if (source === "initial" || source === "autofill" || source === "pageshow" || source === "page restore") return "auto";
+        if (source === "submit" || source === "result") return "late";
+        if (source === "change" || source === "input") return "manual";
+        return "legacy";
+    }
+
+    function firstEntryMode(events) {
+        return events.map(calculatorEntryMode).find(mode => mode && mode !== "standard") || "standard";
+    }
+
+    function calculatorCompletionSourceTable(events) {
+        const completions = events.filter(e => e.eventName === "calculator_field_completed");
+        if (!completions.length) return empty("No calculator completion-source events yet.");
+
+        const eventsBySession = groupBy(events, e => e.sessionHash);
+        const sessions = Array.from(groupBy(completions, e => e.sessionHash).entries()).map(([sessionHash, items]) => {
+            const sessionEvents = eventsBySession.get(sessionHash) || items;
+            return {
+                entryMode: firstEntryMode(sessionEvents.concat(items)),
+                source: completionSourceLabel(mostCommon(items.map(completionSource))),
+                flow: mostCommon(sessionEvents.map(e => e.flow || "site")),
+                fields: items.length,
+                allFields: sessionEvents.some(e => e.eventName === "calculator_all_required_fields_completed"),
+                result: sessionEvents.some(e => e.eventName === "calculator_result_generated")
+            };
+        });
+
+        const rows = Array.from(groupBy(sessions, s => `${s.entryMode}|${s.source}`).entries())
+            .map(([key, items]) => {
+                const [entryMode, source] = key.split("|");
+                const fields = items.reduce((sum, item) => sum + item.fields, 0);
+                return {
+                    entryMode,
+                    source,
+                    sessions: items.length,
+                    fields,
+                    allFields: items.filter(item => item.allFields).length,
+                    results: items.filter(item => item.result).length,
+                    flow: flowLabel(mostCommon(items.map(item => item.flow)))
+                };
+            })
+            .sort((a, b) => b.results - a.results || b.sessions - a.sessions || b.fields - a.fields)
+            .slice(0, 12);
+
+        const maxFields = Math.max(1, ...rows.map(row => row.fields));
+        return `
+            <div class="source-visual-list">
+                ${completionLegend()}
+                ${rows.map(row => {
+                    const sourceClass = completionSourceClass(row.source);
+                    return `
+                        <div class="source-visual-row">
+                            <div class="source-identity">
+                                <strong>${esc(row.entryMode)} / ${esc(row.source)}</strong>
+                                <span>
+                                    <span class="source-pill entry">${esc(row.entryMode)}</span>
+                                    <span class="source-pill ${escAttr(sourceClass)}">${esc(row.source)}</span>
+                                    <span class="source-pill flow">${esc(row.flow)}</span>
+                                </span>
+                            </div>
+                            <div class="visual-meter" title="${escAttr(`${row.fields} completed required fields`)}">
+                                <span class="visual-meter-fill ${escAttr(sourceClass)}" style="width:${barWidth(row.fields, maxFields)}%"></span>
+                            </div>
+                            <div class="source-metrics">
+                                ${metricChip(row.sessions, "sessions")}
+                                ${metricChip(row.fields, "fields")}
+                                ${metricChip(row.allFields, "all")}
+                                ${metricChip(row.results, "results")}
+                            </div>
+                        </div>
+                    `;
+                }).join("")}
+            </div>
+        `;
+    }
+
     function fieldFrictionTable(events) {
         const relevant = events.filter(e => /^calculator_field_|calculator_validation_failed/.test(e.eventName));
         if (!relevant.length) return empty("No calculator field events yet.");
-        const rows = Array.from(groupBy(relevant, e => e.step || "unknown").entries()).map(([field, items]) => ({
-            field,
-            touched: countMatching(items, ["calculator_field_touched"]),
-            completed: countMatching(items, ["calculator_field_completed"]),
-            failed: countMatching(items, ["calculator_validation_failed"]),
-            topError: mostCommon(items.map(i => i.errorCode || i.outcome || "-"))
-        })).sort((a, b) => b.failed - a.failed || b.touched - a.touched).slice(0, 12);
-        return table(["Field", "Touched", "Done", "Failed", "Top error"], rows.map(r => [r.field, r.touched, r.completed, r.failed, r.topError]));
+        const rows = Array.from(groupBy(relevant, e => e.step || "unknown").entries()).map(([field, items]) => {
+            const completions = items.filter(e => e.eventName === "calculator_field_completed");
+            const auto = completions.filter(isAutomaticCompletion).length;
+            const late = completions.filter(isLateCompletion).length;
+            const manual = completions.filter(isManualCompletion).length;
+            const failed = countMatching(items, ["calculator_validation_failed"]);
+            return {
+                field,
+                touched: countMatching(items, ["calculator_field_touched"]),
+                completed: completions.length,
+                manual,
+                auto,
+                late,
+                legacy: Math.max(0, completions.length - manual - auto - late),
+                failed,
+                top: failed
+                    ? mostCommon(items.filter(i => i.eventName === "calculator_validation_failed").map(i => i.errorCode || i.outcome || "-"))
+                    : mostCommon(completions.map(e => completionSourceLabel(completionSource(e))))
+            };
+        }).sort((a, b) => b.failed - a.failed || b.late - a.late || b.auto - a.auto || b.touched - a.touched).slice(0, 12);
+        return `
+            <div class="field-visual-list">
+                ${completionLegend(true)}
+                ${rows.map(row => {
+                    const total = Math.max(1, row.manual + row.auto + row.late + row.legacy + row.failed);
+                    return `
+                        <div class="field-visual-row">
+                            <div class="field-visual-head">
+                                <strong>${esc(row.field)}</strong>
+                                <span>${esc(row.top)}</span>
+                            </div>
+                            <div class="stacked-bar" title="${escAttr(`${row.completed} completed, ${row.failed} failed`)}">
+                                ${barSegment(row.manual, total, "manual", "manual")}
+                                ${barSegment(row.auto, total, "auto", "auto")}
+                                ${barSegment(row.late, total, "late", "late")}
+                                ${barSegment(row.legacy, total, "legacy", "legacy")}
+                                ${barSegment(row.failed, total, "failed", "failed")}
+                            </div>
+                            <div class="field-metrics">
+                                ${metricChip(row.touched, "touch")}
+                                ${metricChip(row.completed, "done")}
+                                ${metricChip(row.auto, "auto")}
+                                ${metricChip(row.late, "late")}
+                                ${metricChip(row.failed, "fail")}
+                            </div>
+                        </div>
+                    `;
+                }).join("")}
+            </div>
+        `;
+    }
+
+    function completionLegend(includeFailed) {
+        const entries = [
+            ["manual", "Manual"],
+            ["auto", "Auto"],
+            ["late", "Late"],
+            ["legacy", "Legacy"]
+        ];
+        if (includeFailed) entries.push(["failed", "Failed"]);
+        return `<div class="visual-legend">${entries.map(([key, label]) => `<span><i class="${escAttr(key)}"></i>${esc(label)}</span>`).join("")}</div>`;
+    }
+
+    function metricChip(value, label) {
+        return `<span class="metric-chip"><strong>${esc(String(value))}</strong>${esc(label)}</span>`;
+    }
+
+    function barWidth(value, total) {
+        value = Number(value) || 0;
+        total = Math.max(1, Number(total) || 1);
+        if (value <= 0) return 0;
+        return Math.max(4, Math.round((value / total) * 100));
+    }
+
+    function barSegment(value, total, className, label) {
+        value = Number(value) || 0;
+        if (value <= 0) return "";
+        return `<span class="${escAttr(className)}" style="width:${barWidth(value, total)}%" title="${escAttr(`${value} ${label}`)}"></span>`;
     }
 
     function proofUploadTable(events) {

--- a/LongevityWorldCup.Website/wwwroot/js/site-statistics.js
+++ b/LongevityWorldCup.Website/wwwroot/js/site-statistics.js
@@ -7,7 +7,9 @@
         flow: "all",
         selectedFlow: "pheno",
         events: [],
+        defaultEvents: [],
         previousEvents: [],
+        previousDefaultEvents: [],
         decisionActions: [],
         selectedEventName: null,
         selectedSession: null,
@@ -198,11 +200,15 @@
             const payload = await response.json();
             state.events = Array.isArray(payload.events) ? payload.events.map(normalizeEvent) : [];
             state.previousEvents = Array.isArray(payload.previousEvents) ? payload.previousEvents.map(normalizeEvent) : [];
-            setStatus(`${uniqueSessions(state.events)} active sessions (${state.events.length} redacted events) and ${uniqueSessions(state.previousEvents)} comparison sessions loaded. Generated ${formatTime(payload.generatedAtUtc)}.`);
+            state.defaultEvents = collapseRepeatedPageViewBursts(state.events);
+            state.previousDefaultEvents = collapseRepeatedPageViewBursts(state.previousEvents);
+            setStatus(`${uniqueSessions(state.defaultEvents)} active sessions (${state.defaultEvents.length} default events from ${state.events.length} raw redacted events) and ${uniqueSessions(state.previousDefaultEvents)} comparison sessions loaded. Generated ${formatTime(payload.generatedAtUtc)}.`);
             renderAll();
         } catch (error) {
             state.events = [];
+            state.defaultEvents = [];
             state.previousEvents = [];
+            state.previousDefaultEvents = [];
             setStatus(`Dashboard data could not be loaded: ${error.message || "unknown error"}.`, true);
             renderAll();
         }
@@ -222,14 +228,16 @@
 
     function renderDataQuality() {
         const host = el("dataQualityStrip");
-        const active = decisionScopeEvents(state.events);
-        const previous = decisionScopeEvents(state.previousEvents);
-        const quality = dataQualityStats(active, previous);
+        const active = decisionScopeEvents(defaultEvents());
+        const previous = decisionScopeEvents(defaultPreviousEvents());
+        const rawActive = decisionScopeEvents(state.events);
+        const rawPrevious = decisionScopeEvents(state.previousEvents);
+        const quality = dataQualityStats(rawActive, rawPrevious);
         const cards = [
             {
                 label: "Sample size",
                 value: `${quality.sessions} sessions`,
-                detail: `${quality.events} redacted events`,
+                detail: `${active.length} default events from ${quality.events} raw`,
                 level: quality.sessions >= 10 ? "good" : quality.sessions >= 4 ? "warn" : ""
             },
             {
@@ -246,9 +254,9 @@
             },
             {
                 label: "Comparison baseline",
-                value: quality.previousSessions ? `${quality.previousSessions} sessions` : "pending",
-                detail: quality.previousSessions ? `${quality.previousEvents} previous events` : "trends should be read as sparse",
-                level: quality.previousSessions ? "good" : "warn"
+                value: uniqueSessions(previous) ? `${uniqueSessions(previous)} sessions` : "pending",
+                detail: uniqueSessions(previous) ? `${previous.length} default events from ${quality.previousEvents} raw` : "trends should be read as sparse",
+                level: uniqueSessions(previous) ? "good" : "warn"
             }
         ];
 
@@ -263,8 +271,8 @@
 
     function renderDecisionLayer() {
         state.decisionActions = [];
-        const active = decisionScopeEvents(state.events);
-        const previous = decisionScopeEvents(state.previousEvents);
+        const active = decisionScopeEvents(defaultEvents());
+        const previous = decisionScopeEvents(defaultPreviousEvents());
         const insights = buildDecisionInsights(active, previous).slice(0, 7);
         renderDecisionBrief(insights, active, previous);
         renderRecommendedInvestigations(insights, active);
@@ -708,7 +716,7 @@
         state.selectedEventName = null;
         state.selectedSession = null;
         state.selectedLabel = label || "Decision evidence";
-        renderDrilldown(events && events.length ? events : decisionScopeEvents(state.events));
+        renderDrilldown(events && events.length ? events : decisionScopeEvents(defaultEvents()));
         el("drilldownTitle").scrollIntoView({ block: "nearest" });
     }
 
@@ -807,7 +815,7 @@
         host.innerHTML = "";
         if (state.tab !== "Onboarding") return;
         ["pheno", "bortz", "application"].forEach(flow => {
-            const events = state.events.filter(e => e.flow === flow || (flow === "application" && e.flow === "application"));
+            const events = defaultEvents().filter(e => e.flow === flow || (flow === "application" && e.flow === "application"));
             const started = uniqueSessionsFor(events, flow === "application" ? ["proof_flow_opened"] : ["calculator_started"]);
             const completed = uniqueSessionsFor(events, flow === "application" ? ["application_submit_succeeded"] : ["calculator_result_generated"]);
             const failed = uniqueSessions(frictionEvents(events));
@@ -1040,6 +1048,14 @@
         return scopeEventsFor(events, state.tab, state.selectedFlow);
     }
 
+    function defaultEvents() {
+        return state.defaultEvents;
+    }
+
+    function defaultPreviousEvents() {
+        return state.previousDefaultEvents;
+    }
+
     function scopeEventsFor(events, tab, selectedFlow) {
         events = events.slice();
         if (tab === "Onboarding") {
@@ -1058,11 +1074,22 @@
     }
 
     function scopedEvents() {
+        return scopeEventsFor(defaultEvents(), state.tab, state.selectedFlow);
+    }
+
+    function rawScopedEvents() {
         return scopeEventsFor(state.events, state.tab, state.selectedFlow);
     }
 
     function selectedEvents() {
         let events = scopedEvents();
+        if (state.selectedEventName) events = events.filter(e => e.eventName === state.selectedEventName);
+        if (state.selectedSession) events = events.filter(e => e.sessionHash === state.selectedSession);
+        return events;
+    }
+
+    function selectedRawEvents() {
+        let events = rawScopedEvents();
         if (state.selectedEventName) events = events.filter(e => e.eventName === state.selectedEventName);
         if (state.selectedSession) events = events.filter(e => e.sessionHash === state.selectedSession);
         return events;
@@ -1117,6 +1144,58 @@
         return ["site_page_viewed", "onboarding_entry_viewed", "onboarding_page_viewed", "challenge_page_viewed"].includes(event.eventName);
     }
 
+    function collapseRepeatedPageViewBursts(events) {
+        const collapsed = [];
+        const pageViewsByRoute = new Map();
+        events.slice().sort((a, b) => a.time - b.time).forEach(event => {
+            if (!isPageViewEvent(event)) {
+                collapsed.push(event);
+                return;
+            }
+
+            const key = [event.sessionHash, event.route || ""].join("|");
+            const existing = pageViewsByRoute.get(key);
+            if (!existing) {
+                const copy = Object.assign({}, event, {
+                    collapsedCount: 1,
+                    collapsedFirstTime: event.time || 0,
+                    collapsedLastTime: event.time || 0,
+                    collapsedPageViewPriority: pageViewPriority(event)
+                });
+                pageViewsByRoute.set(key, copy);
+                collapsed.push(copy);
+                return;
+            }
+
+            existing.collapsedCount += 1;
+            if (pageViewPriority(event) > existing.collapsedPageViewPriority) {
+                existing.eventName = event.eventName;
+                existing.flow = event.flow;
+                existing.component = event.component;
+                existing.step = event.step;
+                existing.outcome = event.outcome;
+                existing.errorCode = event.errorCode;
+                existing.collapsedPageViewPriority = pageViewPriority(event);
+            }
+            if ((event.time || 0) >= existing.collapsedLastTime) {
+                existing.collapsedLastTime = event.time || 0;
+                existing.time = event.time;
+                existing.occurredAtUtc = event.occurredAtUtc;
+                existing.durationMs = event.durationMs;
+            }
+        });
+
+        return collapsed.sort((a, b) => b.time - a.time);
+    }
+
+    function pageViewPriority(event) {
+        if (event.eventName === "challenge_page_viewed") return 4;
+        if (event.eventName === "onboarding_entry_viewed") return 3;
+        if (event.eventName === "onboarding_page_viewed") return 3;
+        if (event.eventName === "site_page_viewed") return 1;
+        return 0;
+    }
+
     function collapseEventBursts(events, sequential) {
         const sorted = events.slice().sort((a, b) => a.time - b.time);
         if (sequential) {
@@ -1156,13 +1235,14 @@
     }
 
     function createBurst(key, event) {
+        const count = event.collapsedCount || 1;
         return {
             key,
-            count: 1,
+            count,
             first: event,
             last: event,
-            firstTime: event.time || 0,
-            lastTime: event.time || 0,
+            firstTime: event.collapsedFirstTime || event.time || 0,
+            lastTime: event.collapsedLastTime || event.time || 0,
             sessionHash: event.sessionHash,
             eventName: event.eventName,
             flow: event.flow,
@@ -1175,14 +1255,17 @@
     }
 
     function addToBurst(group, event) {
-        group.count += 1;
-        if ((event.time || 0) < group.firstTime) {
+        const count = event.collapsedCount || 1;
+        const firstTime = event.collapsedFirstTime || event.time || 0;
+        const lastTime = event.collapsedLastTime || event.time || 0;
+        group.count += count;
+        if (firstTime < group.firstTime) {
             group.first = event;
-            group.firstTime = event.time || 0;
+            group.firstTime = firstTime;
         }
-        if ((event.time || 0) >= group.lastTime) {
+        if (lastTime >= group.lastTime) {
             group.last = event;
-            group.lastTime = event.time || 0;
+            group.lastTime = lastTime;
         }
     }
 
@@ -1538,7 +1621,7 @@
     }
 
     function exportCsv() {
-        const events = selectedEvents();
+        const events = selectedRawEvents();
         const headers = ["occurredAtUtc", "sessionHash", "actorHash", "eventName", "flow", "route", "component", "step", "outcome", "errorCode", "durationMs", "deviceClass", "browserFamily", "referrerDomain", "source"];
         const lines = [headers.join(",")].concat(events.map(e => headers.map(h => csv(e[h])).join(",")));
         const blob = new Blob([lines.join("\n")], { type: "text/csv;charset=utf-8" });

--- a/LongevityWorldCup.Website/wwwroot/js/site-statistics.js
+++ b/LongevityWorldCup.Website/wwwroot/js/site-statistics.js
@@ -612,7 +612,7 @@
         const previousSessions = new Set(previous.map(e => e.sessionHash));
         const dimensions = [
             ["device", e => e.deviceClass || "unknown"],
-            ["source", e => e.source || "direct"],
+            ["source", acquisitionSource],
             ["flow", e => flowLabel(e.flow || "site")],
             ["session", e => previousSessions.has(e.sessionHash) ? "returning" : "new"]
         ];
@@ -923,9 +923,10 @@
         }
         if (state.tab === "Traffic") {
             host.innerHTML = [
-                detailPanel("Source quality", sourceQualityTable(events)),
+                detailPanel("Acquisition quality", sourceQualityTable(events)),
+                detailPanel("Campaigns", campaignTable(events)),
                 detailPanel("Device split", splitTable(events, e => e.deviceClass || "unknown")),
-                detailPanel("Referrers", splitTable(events, e => e.referrerDomain || e.source || "direct"))
+                detailPanel("First referrers", splitTable(events, e => e.firstReferrerDomain || e.referrerDomain || acquisitionSource(e)))
             ].join("");
             return;
         }
@@ -983,7 +984,7 @@
                 ${summaryItem("Sessions", sessions)}
                 ${summaryItem("Friction", failures)}
                 ${summaryItem("Median duration", median)}
-                ${summaryItem("Top source", mostCommon(events.map(e => e.source || "direct")))}
+                ${summaryItem("Top source", mostCommon(events.map(acquisitionSource)))}
                 ${summaryItem("Top device", mostCommon(events.map(e => e.deviceClass || "unknown")))}
                 ${summaryItem("Noisy sessions", quality.noisySessions)}
                 ${summaryItem("Burst groups", burstCount)}
@@ -1444,7 +1445,7 @@
     }
 
     function sourceQualityTable(events) {
-        const rows = Array.from(groupBy(events, e => e.source || "direct").entries()).map(([source, items]) => {
+        const rows = Array.from(groupBy(events, acquisitionSource).entries()).map(([source, items]) => {
             const results = uniqueSessionsFor(items, ["calculator_result_generated"]);
             const applications = uniqueSessionsFor(items, ["application_submit_succeeded"]);
             const challenge = uniqueSessionsFor(items, ["challenge_scored_checkin_submitted"]);
@@ -1452,6 +1453,21 @@
             return [source, uniqueSessions(items), results, applications, challenge, quality];
         }).sort((a, b) => b[5] - a[5]);
         return table(["Source", "Sessions", "Results", "Apps", "Challenge", "Quality"], rows.slice(0, 12));
+    }
+
+    function campaignTable(events) {
+        const rows = Array.from(groupBy(events, campaignLabel).entries())
+            .filter(([campaign]) => campaign !== "none")
+            .map(([campaign, items]) => [
+                campaign,
+                uniqueSessions(items),
+                mostCommon(items.map(acquisitionSource)),
+                uniqueSessionsFor(items, ["calculator_result_generated"]),
+                uniqueSessionsFor(items, ["application_submit_succeeded", "challenge_signup_succeeded"])
+            ])
+            .sort((a, b) => b[1] - a[1] || b[4] - a[4])
+            .slice(0, 12);
+        return rows.length ? table(["Campaign", "Sessions", "Top source", "Results", "Conversions"], rows) : empty("No campaign-tagged sessions yet.");
     }
 
     function slowStepTable(events) {
@@ -1474,7 +1490,7 @@
     function groupedTable(events, names) {
         const rows = names.map(name => {
             const items = events.filter(e => e.eventName === name);
-            return [name, items.length, new Set(items.map(i => i.sessionHash)).size, mostCommon(items.map(i => i.source || "direct"))];
+            return [name, items.length, new Set(items.map(i => i.sessionHash)).size, mostCommon(items.map(acquisitionSource))];
         }).filter(r => r[1] > 0);
         return rows.length ? table(["Event", "Events", "Sessions", "Top source"], rows) : empty("No matching events yet.");
     }
@@ -1506,6 +1522,15 @@
             sessionHash: event.sessionHash || "S-UNKNOWN",
             referrerDomain,
             source: effectiveSource(event.source, referrerDomain),
+            landingRoute: event.landingRoute || "",
+            firstReferrerDomain: event.firstReferrerDomain || "",
+            firstSource: effectiveSource(event.firstSource || event.source, event.firstReferrerDomain || referrerDomain),
+            firstCampaign: event.firstCampaign || "",
+            firstUtmSource: event.firstUtmSource || "",
+            firstUtmMedium: event.firstUtmMedium || "",
+            firstUtmCampaign: event.firstUtmCampaign || "",
+            firstUtmTerm: event.firstUtmTerm || "",
+            firstUtmContent: event.firstUtmContent || "",
             metadata: event.metadata || {},
             time: Date.parse(event.occurredAtUtc || "") || 0
         });
@@ -1514,6 +1539,17 @@
     function effectiveSource(source, referrerDomain) {
         if (isInternalReferrer(referrerDomain)) return "internal";
         return source || "direct";
+    }
+
+    function acquisitionSource(event) {
+        return event.firstSource || event.source || "direct";
+    }
+
+    function campaignLabel(event) {
+        return event.firstCampaign
+            || event.firstUtmCampaign
+            || event.firstUtmSource
+            || "none";
     }
 
     function isInternalReferrer(referrerDomain) {
@@ -1622,7 +1658,7 @@
 
     function exportCsv() {
         const events = selectedRawEvents();
-        const headers = ["occurredAtUtc", "sessionHash", "actorHash", "eventName", "flow", "route", "component", "step", "outcome", "errorCode", "durationMs", "deviceClass", "browserFamily", "referrerDomain", "source"];
+        const headers = ["occurredAtUtc", "sessionHash", "actorHash", "eventName", "flow", "route", "component", "step", "outcome", "errorCode", "durationMs", "deviceClass", "browserFamily", "referrerDomain", "source", "landingRoute", "firstReferrerDomain", "firstSource", "firstCampaign", "firstUtmSource", "firstUtmMedium", "firstUtmCampaign", "firstUtmTerm", "firstUtmContent"];
         const lines = [headers.join(",")].concat(events.map(e => headers.map(h => csv(e[h])).join(",")));
         const blob = new Blob([lines.join("\n")], { type: "text/csv;charset=utf-8" });
         const url = URL.createObjectURL(blob);


### PR DESCRIPTION
## Summary

- Fixes SPA `/join` page-view tracking and collapses noisy repeated page-view bursts in dashboard defaults while preserving raw events.
- Adds acquisition first-touch fields, email source classification, and canonical bioage calculator routes with entry-mode metadata.
- Adds server-side authoritative outcome stats for application, proof, checkout/payment, and Challenge flows.
- Fills dashboard-defined client events across public content, rank preview, proof upload, Challenge athlete selection, and commitment flows.
- Improves calculator progress tracking for prefilled/autofilled sessions and visualizes completion sources in the stats dashboard.

## Why

The builtin stats undercounted join views, treated later internal navigation as acquisition source, misclassified Gmail app traffic as search, and made successful prefilled calculator sessions look incomplete because field completion only came from change events. The dashboard also made the new calculator progress data hard to interpret as raw table counts.

## Validation

- `node --check LongevityWorldCup.Website\wwwroot\js\site-statistics.js`
- `node --check LongevityWorldCup.Website\wwwroot\js\site-statistics-tracking.js`
- `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --filter "FullyQualifiedName~SiteStatisticsDashboardPageTests"`
- `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --filter "FullyQualifiedName~SiteStatisticsDashboardBrowserTests"`
- Focused stats/service/application/challenge tests were run during the individual commits.

Note: one parallel local test run hit a transient Static Web Assets cache file lock; the same tests passed when rerun sequentially.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches analytics schema/migrations, payment and application submission paths, and broad client instrumentation; mistakes could mis-attribute traffic or add noise without breaking core user flows.
> 
> **Overview**
> **Builtin site statistics** get deeper acquisition modeling, authoritative server-side outcomes, broader client instrumentation, and dashboard views that make funnel data easier to read.
> 
> **Backend (`SiteStatisticsService`)** adds `SiteStatisticSessions` for session first-touch (landing route, UTM/campaign, referrer) and filters by that acquisition source (including **email** and **campaign**). Bio-age calculator routes are canonicalized with **entryMode** metadata; sensitive query params are redacted. Server events can align with browser sessions via `X-LWC-Stats-Session` or explicit `sessionId`.
> 
> **Application and challenge flows** record structured stats on submit, proof processing, payment/checkout, signup, check-ins (practice vs scored), and commitment payment/resolution—wired through controllers into `SiteStatisticsService`.
> 
> **Client tracking** extends the versioned tracker to more public pages (via HTML injection), SPA `/join` route changes, email referrer classification, prefilled calculator field completion (`completionSource`), and events for rank preview, proof rejections, challenge UI, and public content.
> 
> **Internal dashboard** adds calculator completion-source visuals (auto/late/manual), email source filter, and related CSS; tests cover service behavior, controllers, browser flows, and tracker/dashboard contracts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7888bc585857d4ec03df86e14c8e153bf667b0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->