### PR TITLE
[codex] Fix first-touch stats attribution

### DIFF
--- a/LongevityWorldCup.Tests/PlayAthleteFlowBrowserTests.cs
+++ b/LongevityWorldCup.Tests/PlayAthleteFlowBrowserTests.cs
@@ -168,6 +168,7 @@ public sealed class PlayAthleteFlowBrowserTests
         await page.GetByRole(AriaRole.Button, new() { Name = "Edit profile" }).ClickAsync();
         await page.WaitForURLAsync("**/edit-profile");
         Assert.Equal("/edit-profile", new Uri(page.Url).AbsolutePath);
+        await page.WaitForFunctionAsync("() => document.querySelector('#character-title')?.textContent?.trim() === 'Browser Test Athlete'");
         Assert.Equal("Browser Test Athlete", await page.Locator("#character-title").InnerTextAsync());
         await page.WaitForFunctionAsync("() => document.querySelector('#divisionDisplaySelect')?.value === 'Open'");
         Assert.Equal("Open", await page.Locator("#divisionDisplaySelect").InputValueAsync());

--- a/LongevityWorldCup.Tests/SiteStatisticsServiceTests.cs
+++ b/LongevityWorldCup.Tests/SiteStatisticsServiceTests.cs
@@ -239,6 +239,120 @@ public sealed class SiteStatisticsServiceTests
     }
 
     [Fact]
+    public async Task Dashboard_AllowsExplicitFirstTouchToCorrectServerFallback()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), "LongevityWorldCup.Tests", $"{Guid.NewGuid():N}.db");
+        Directory.CreateDirectory(Path.GetDirectoryName(dbPath)!);
+        await using var cleanup = new TempDatabaseCleanup(dbPath);
+        using var database = new DatabaseManager(dbPath: dbPath);
+        var service = new SiteStatisticsService(database, NullLogger<SiteStatisticsService>.Instance);
+        var serverContext = new DefaultHttpContext();
+        serverContext.Request.Headers["X-LWC-Stats-Session"] = "race-session";
+        serverContext.Request.Headers.Referer = "https://www.longevityworldcup.com/join";
+        serverContext.Request.Path = "/api/application/application";
+
+        await service.RecordServerEventAsync(
+            "application_submit_accepted",
+            serverContext,
+            flow: "application",
+            route: "/api/application/application",
+            component: "application",
+            outcome: "accepted");
+
+        await service.RecordClientEventAsync(new SiteStatisticsEventRequest
+        {
+            EventName = "site_page_viewed",
+            SessionId = "race-session",
+            Flow = "onboarding",
+            Route = "/join?utm_source=google&utm_medium=cpc&utm_campaign=summer2026&campaign=summer-launch",
+            ReferrerDomain = "www.google.com",
+            Source = "search",
+            LandingRoute = "/join?utm_source=google&utm_medium=cpc&utm_campaign=summer2026&campaign=summer-launch",
+            FirstReferrerDomain = "www.google.com",
+            FirstSource = "search",
+            FirstCampaign = "summer-launch",
+            FirstUtmSource = "google",
+            FirstUtmMedium = "cpc",
+            FirstUtmCampaign = "summer2026"
+        }, new DefaultHttpContext());
+
+        var dashboard = await service.GetDashboardAsync(new SiteStatisticsDashboardQuery { Range = "30d" });
+        Assert.Equal(2, dashboard.Events.Count);
+        Assert.All(dashboard.Events, ev =>
+        {
+            Assert.Equal("search", ev.FirstSource);
+            Assert.Equal("www.google.com", ev.FirstReferrerDomain);
+            Assert.Equal("google", ev.FirstUtmSource);
+            Assert.Equal("cpc", ev.FirstUtmMedium);
+            Assert.Equal("summer2026", ev.FirstUtmCampaign);
+            Assert.Equal("summer-launch", ev.FirstCampaign);
+            Assert.Equal("/join?utm_source=redacted&utm_medium=redacted&utm_campaign=redacted&campaign=redacted", ev.LandingRoute);
+        });
+
+        var serverEvent = Assert.Single(dashboard.Events, ev => ev.EventName == "application_submit_accepted");
+        Assert.Equal("internal", serverEvent.Source);
+        Assert.Equal("search", serverEvent.FirstSource);
+
+        var searchOnly = await service.GetDashboardAsync(new SiteStatisticsDashboardQuery { Range = "30d", Source = "search" });
+        Assert.Equal(2, searchOnly.Events.Count);
+
+        var internalOnly = await service.GetDashboardAsync(new SiteStatisticsDashboardQuery { Range = "30d", Source = "internal" });
+        Assert.Empty(internalOnly.Events);
+    }
+
+    [Fact]
+    public async Task Dashboard_AllowsExplicitDirectFirstTouchToClearServerReferrerFallback()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), "LongevityWorldCup.Tests", $"{Guid.NewGuid():N}.db");
+        Directory.CreateDirectory(Path.GetDirectoryName(dbPath)!);
+        await using var cleanup = new TempDatabaseCleanup(dbPath);
+        using var database = new DatabaseManager(dbPath: dbPath);
+        var service = new SiteStatisticsService(database, NullLogger<SiteStatisticsService>.Instance);
+        var serverContext = new DefaultHttpContext();
+        serverContext.Request.Headers["X-LWC-Stats-Session"] = "direct-race-session";
+        serverContext.Request.Headers.Referer = "https://www.longevityworldcup.com/join";
+        serverContext.Request.Path = "/api/application/application";
+
+        await service.RecordServerEventAsync(
+            "application_submit_accepted",
+            serverContext,
+            flow: "application",
+            route: "/api/application/application",
+            component: "application",
+            outcome: "accepted");
+
+        await service.RecordClientEventAsync(new SiteStatisticsEventRequest
+        {
+            EventName = "site_page_viewed",
+            SessionId = "direct-race-session",
+            Flow = "onboarding",
+            Route = "/join",
+            Source = "direct",
+            LandingRoute = "/join",
+            FirstSource = "direct"
+        }, new DefaultHttpContext());
+
+        var dashboard = await service.GetDashboardAsync(new SiteStatisticsDashboardQuery { Range = "30d" });
+        Assert.Equal(2, dashboard.Events.Count);
+        Assert.All(dashboard.Events, ev =>
+        {
+            Assert.Equal("direct", ev.FirstSource);
+            Assert.Null(ev.FirstReferrerDomain);
+            Assert.Equal("/join", ev.LandingRoute);
+        });
+
+        var serverEvent = Assert.Single(dashboard.Events, ev => ev.EventName == "application_submit_accepted");
+        Assert.Equal("internal", serverEvent.Source);
+        Assert.Equal("direct", serverEvent.FirstSource);
+
+        var directOnly = await service.GetDashboardAsync(new SiteStatisticsDashboardQuery { Range = "30d", Source = "direct" });
+        Assert.Equal(2, directOnly.Events.Count);
+
+        var internalOnly = await service.GetDashboardAsync(new SiteStatisticsDashboardQuery { Range = "30d", Source = "internal" });
+        Assert.Empty(internalOnly.Events);
+    }
+
+    [Fact]
     public async Task Dashboard_ClassifiesCampaignTaggedDirectLandingAsCampaign()
     {
         var dbPath = Path.Combine(Path.GetTempPath(), "LongevityWorldCup.Tests", $"{Guid.NewGuid():N}.db");

--- a/LongevityWorldCup.Website/Business/SiteStatisticsService.cs
+++ b/LongevityWorldCup.Website/Business/SiteStatisticsService.cs
@@ -205,20 +205,34 @@ public sealed class SiteStatisticsService : IHostedService
               AND (@device = '' OR e.DeviceClass = @device)
               AND (@source = '' OR (
                     CASE
-                        WHEN lower(coalesce(s.FirstReferrerDomain, e.ReferrerDomain, '')) IN ('longevityworldcup.com', 'www.longevityworldcup.com') THEN 'internal'
-                        WHEN lower(coalesce(s.FirstReferrerDomain, e.ReferrerDomain, '')) = 'com.google.android.gm'
-                          OR lower(coalesce(s.FirstReferrerDomain, e.ReferrerDomain, '')) LIKE 'mail.%'
-                          OR lower(coalesce(s.FirstReferrerDomain, e.ReferrerDomain, '')) LIKE '%.mail.%'
-                          OR lower(coalesce(s.FirstReferrerDomain, e.ReferrerDomain, '')) LIKE '%gmail%'
-                          OR lower(coalesce(s.FirstReferrerDomain, e.ReferrerDomain, '')) LIKE '%outlook%'
-                          OR lower(coalesce(s.FirstReferrerDomain, e.ReferrerDomain, '')) LIKE '%hotmail%'
-                          OR lower(coalesce(s.FirstReferrerDomain, e.ReferrerDomain, '')) LIKE '%protonmail%'
-                          OR lower(coalesce(s.FirstReferrerDomain, e.ReferrerDomain, '')) LIKE '%proton.me%'
-                          OR lower(coalesce(s.FirstReferrerDomain, e.ReferrerDomain, '')) LIKE '%fastmail%'
-                          OR lower(coalesce(s.FirstReferrerDomain, e.ReferrerDomain, '')) LIKE '%icloud%'
-                          OR lower(coalesce(s.FirstReferrerDomain, e.ReferrerDomain, '')) LIKE '%mail.yahoo%'
-                          OR lower(coalesce(s.FirstReferrerDomain, e.ReferrerDomain, '')) LIKE '%yahoomail%' THEN 'email'
-                        ELSE coalesce(s.FirstSource, e.Source, 'direct')
+                        WHEN lower(coalesce(s.FirstReferrerDomain, '')) IN ('longevityworldcup.com', 'www.longevityworldcup.com') THEN 'internal'
+                        WHEN lower(coalesce(s.FirstReferrerDomain, '')) = 'com.google.android.gm'
+                          OR lower(coalesce(s.FirstReferrerDomain, '')) LIKE 'mail.%'
+                          OR lower(coalesce(s.FirstReferrerDomain, '')) LIKE '%.mail.%'
+                          OR lower(coalesce(s.FirstReferrerDomain, '')) LIKE '%gmail%'
+                          OR lower(coalesce(s.FirstReferrerDomain, '')) LIKE '%outlook%'
+                          OR lower(coalesce(s.FirstReferrerDomain, '')) LIKE '%hotmail%'
+                          OR lower(coalesce(s.FirstReferrerDomain, '')) LIKE '%protonmail%'
+                          OR lower(coalesce(s.FirstReferrerDomain, '')) LIKE '%proton.me%'
+                          OR lower(coalesce(s.FirstReferrerDomain, '')) LIKE '%fastmail%'
+                          OR lower(coalesce(s.FirstReferrerDomain, '')) LIKE '%icloud%'
+                          OR lower(coalesce(s.FirstReferrerDomain, '')) LIKE '%mail.yahoo%'
+                          OR lower(coalesce(s.FirstReferrerDomain, '')) LIKE '%yahoomail%' THEN 'email'
+                        WHEN s.FirstSource IS NOT NULL THEN s.FirstSource
+                        WHEN lower(coalesce(e.ReferrerDomain, '')) IN ('longevityworldcup.com', 'www.longevityworldcup.com') THEN 'internal'
+                        WHEN lower(coalesce(e.ReferrerDomain, '')) = 'com.google.android.gm'
+                          OR lower(coalesce(e.ReferrerDomain, '')) LIKE 'mail.%'
+                          OR lower(coalesce(e.ReferrerDomain, '')) LIKE '%.mail.%'
+                          OR lower(coalesce(e.ReferrerDomain, '')) LIKE '%gmail%'
+                          OR lower(coalesce(e.ReferrerDomain, '')) LIKE '%outlook%'
+                          OR lower(coalesce(e.ReferrerDomain, '')) LIKE '%hotmail%'
+                          OR lower(coalesce(e.ReferrerDomain, '')) LIKE '%protonmail%'
+                          OR lower(coalesce(e.ReferrerDomain, '')) LIKE '%proton.me%'
+                          OR lower(coalesce(e.ReferrerDomain, '')) LIKE '%fastmail%'
+                          OR lower(coalesce(e.ReferrerDomain, '')) LIKE '%icloud%'
+                          OR lower(coalesce(e.ReferrerDomain, '')) LIKE '%mail.yahoo%'
+                          OR lower(coalesce(e.ReferrerDomain, '')) LIKE '%yahoomail%' THEN 'email'
+                        ELSE coalesce(e.Source, 'direct')
                     END
                   ) = @source)
             ORDER BY e.OccurredAtUtc DESC
@@ -330,6 +344,7 @@ public sealed class SiteStatisticsService : IHostedService
         var sessionIdentifier = SafeSessionId(request.SessionId) ?? ClientIdentifier.From(context ?? new DefaultHttpContext());
         var sessionHash = BuildHash("S", sessionIdentifier);
         var firstTouch = BuildFirstTouch(request, rawRoute, route, referrerDomain, source);
+        var hasExplicitFirstTouch = HasExplicitFirstTouch(request);
 
         return new QueuedSiteStatisticEvent(
             Id: Guid.NewGuid().ToString("N"),
@@ -357,6 +372,7 @@ public sealed class SiteStatisticsService : IHostedService
             FirstUtmCampaign: firstTouch.FirstUtmCampaign,
             FirstUtmTerm: firstTouch.FirstUtmTerm,
             FirstUtmContent: firstTouch.FirstUtmContent,
+            HasExplicitFirstTouch: hasExplicitFirstTouch,
             MetadataJson: metadataJson);
     }
 
@@ -439,39 +455,56 @@ public sealed class SiteStatisticsService : IHostedService
                         ELSE SiteStatisticSessions.FirstSeenAtUtc
                     END,
                     LandingRoute = CASE
-                        WHEN excluded.FirstSeenAtUtc < SiteStatisticSessions.FirstSeenAtUtc OR SiteStatisticSessions.LandingRoute IS NULL THEN COALESCE(excluded.LandingRoute, SiteStatisticSessions.LandingRoute)
+                        WHEN excluded.FirstSeenAtUtc < SiteStatisticSessions.FirstSeenAtUtc
+                          OR SiteStatisticSessions.LandingRoute IS NULL
+                          OR (@hasExplicitFirstTouch = 1 AND lower(coalesce(SiteStatisticSessions.FirstSource, 'direct')) IN ('direct', 'internal')) THEN COALESCE(excluded.LandingRoute, SiteStatisticSessions.LandingRoute)
                         ELSE SiteStatisticSessions.LandingRoute
                     END,
                     FirstReferrerDomain = CASE
+                        WHEN @hasExplicitFirstTouch = 1 AND lower(coalesce(SiteStatisticSessions.FirstSource, 'direct')) IN ('direct', 'internal') THEN excluded.FirstReferrerDomain
                         WHEN excluded.FirstSeenAtUtc < SiteStatisticSessions.FirstSeenAtUtc OR SiteStatisticSessions.FirstReferrerDomain IS NULL THEN COALESCE(excluded.FirstReferrerDomain, SiteStatisticSessions.FirstReferrerDomain)
                         ELSE SiteStatisticSessions.FirstReferrerDomain
                     END,
                     FirstSource = CASE
-                        WHEN excluded.FirstSeenAtUtc < SiteStatisticSessions.FirstSeenAtUtc OR SiteStatisticSessions.FirstSource IS NULL THEN COALESCE(excluded.FirstSource, SiteStatisticSessions.FirstSource)
+                        WHEN excluded.FirstSeenAtUtc < SiteStatisticSessions.FirstSeenAtUtc
+                          OR SiteStatisticSessions.FirstSource IS NULL
+                          OR (@hasExplicitFirstTouch = 1 AND lower(coalesce(SiteStatisticSessions.FirstSource, 'direct')) IN ('direct', 'internal')) THEN COALESCE(excluded.FirstSource, SiteStatisticSessions.FirstSource)
                         ELSE SiteStatisticSessions.FirstSource
                     END,
                     FirstCampaign = CASE
-                        WHEN excluded.FirstSeenAtUtc < SiteStatisticSessions.FirstSeenAtUtc OR SiteStatisticSessions.FirstCampaign IS NULL THEN COALESCE(excluded.FirstCampaign, SiteStatisticSessions.FirstCampaign)
+                        WHEN excluded.FirstSeenAtUtc < SiteStatisticSessions.FirstSeenAtUtc
+                          OR SiteStatisticSessions.FirstCampaign IS NULL
+                          OR (@hasExplicitFirstTouch = 1 AND lower(coalesce(SiteStatisticSessions.FirstSource, 'direct')) IN ('direct', 'internal')) THEN COALESCE(excluded.FirstCampaign, SiteStatisticSessions.FirstCampaign)
                         ELSE SiteStatisticSessions.FirstCampaign
                     END,
                     FirstUtmSource = CASE
-                        WHEN excluded.FirstSeenAtUtc < SiteStatisticSessions.FirstSeenAtUtc OR SiteStatisticSessions.FirstUtmSource IS NULL THEN COALESCE(excluded.FirstUtmSource, SiteStatisticSessions.FirstUtmSource)
+                        WHEN excluded.FirstSeenAtUtc < SiteStatisticSessions.FirstSeenAtUtc
+                          OR SiteStatisticSessions.FirstUtmSource IS NULL
+                          OR (@hasExplicitFirstTouch = 1 AND lower(coalesce(SiteStatisticSessions.FirstSource, 'direct')) IN ('direct', 'internal')) THEN COALESCE(excluded.FirstUtmSource, SiteStatisticSessions.FirstUtmSource)
                         ELSE SiteStatisticSessions.FirstUtmSource
                     END,
                     FirstUtmMedium = CASE
-                        WHEN excluded.FirstSeenAtUtc < SiteStatisticSessions.FirstSeenAtUtc OR SiteStatisticSessions.FirstUtmMedium IS NULL THEN COALESCE(excluded.FirstUtmMedium, SiteStatisticSessions.FirstUtmMedium)
+                        WHEN excluded.FirstSeenAtUtc < SiteStatisticSessions.FirstSeenAtUtc
+                          OR SiteStatisticSessions.FirstUtmMedium IS NULL
+                          OR (@hasExplicitFirstTouch = 1 AND lower(coalesce(SiteStatisticSessions.FirstSource, 'direct')) IN ('direct', 'internal')) THEN COALESCE(excluded.FirstUtmMedium, SiteStatisticSessions.FirstUtmMedium)
                         ELSE SiteStatisticSessions.FirstUtmMedium
                     END,
                     FirstUtmCampaign = CASE
-                        WHEN excluded.FirstSeenAtUtc < SiteStatisticSessions.FirstSeenAtUtc OR SiteStatisticSessions.FirstUtmCampaign IS NULL THEN COALESCE(excluded.FirstUtmCampaign, SiteStatisticSessions.FirstUtmCampaign)
+                        WHEN excluded.FirstSeenAtUtc < SiteStatisticSessions.FirstSeenAtUtc
+                          OR SiteStatisticSessions.FirstUtmCampaign IS NULL
+                          OR (@hasExplicitFirstTouch = 1 AND lower(coalesce(SiteStatisticSessions.FirstSource, 'direct')) IN ('direct', 'internal')) THEN COALESCE(excluded.FirstUtmCampaign, SiteStatisticSessions.FirstUtmCampaign)
                         ELSE SiteStatisticSessions.FirstUtmCampaign
                     END,
                     FirstUtmTerm = CASE
-                        WHEN excluded.FirstSeenAtUtc < SiteStatisticSessions.FirstSeenAtUtc OR SiteStatisticSessions.FirstUtmTerm IS NULL THEN COALESCE(excluded.FirstUtmTerm, SiteStatisticSessions.FirstUtmTerm)
+                        WHEN excluded.FirstSeenAtUtc < SiteStatisticSessions.FirstSeenAtUtc
+                          OR SiteStatisticSessions.FirstUtmTerm IS NULL
+                          OR (@hasExplicitFirstTouch = 1 AND lower(coalesce(SiteStatisticSessions.FirstSource, 'direct')) IN ('direct', 'internal')) THEN COALESCE(excluded.FirstUtmTerm, SiteStatisticSessions.FirstUtmTerm)
                         ELSE SiteStatisticSessions.FirstUtmTerm
                     END,
                     FirstUtmContent = CASE
-                        WHEN excluded.FirstSeenAtUtc < SiteStatisticSessions.FirstSeenAtUtc OR SiteStatisticSessions.FirstUtmContent IS NULL THEN COALESCE(excluded.FirstUtmContent, SiteStatisticSessions.FirstUtmContent)
+                        WHEN excluded.FirstSeenAtUtc < SiteStatisticSessions.FirstSeenAtUtc
+                          OR SiteStatisticSessions.FirstUtmContent IS NULL
+                          OR (@hasExplicitFirstTouch = 1 AND lower(coalesce(SiteStatisticSessions.FirstSource, 'direct')) IN ('direct', 'internal')) THEN COALESCE(excluded.FirstUtmContent, SiteStatisticSessions.FirstUtmContent)
                         ELSE SiteStatisticSessions.FirstUtmContent
                     END;
                 """;
@@ -486,6 +519,7 @@ public sealed class SiteStatisticsService : IHostedService
             var firstUtmCampaignParam = sessionCmd.Parameters.Add("@firstUtmCampaign", SqliteType.Text);
             var firstUtmTermParam = sessionCmd.Parameters.Add("@firstUtmTerm", SqliteType.Text);
             var firstUtmContentParam = sessionCmd.Parameters.Add("@firstUtmContent", SqliteType.Text);
+            var hasExplicitFirstTouchParam = sessionCmd.Parameters.Add("@hasExplicitFirstTouch", SqliteType.Integer);
 
             using var cmd = sqlite.CreateCommand();
             cmd.Transaction = tx;
@@ -530,6 +564,7 @@ public sealed class SiteStatisticsService : IHostedService
                 firstUtmCampaignParam.Value = item.FirstUtmCampaign ?? (object)DBNull.Value;
                 firstUtmTermParam.Value = item.FirstUtmTerm ?? (object)DBNull.Value;
                 firstUtmContentParam.Value = item.FirstUtmContent ?? (object)DBNull.Value;
+                hasExplicitFirstTouchParam.Value = item.HasExplicitFirstTouch ? 1 : 0;
                 sessionCmd.ExecuteNonQuery();
 
                 id.Value = item.Id;
@@ -693,6 +728,17 @@ public sealed class SiteStatisticsService : IHostedService
             firstUtmTerm,
             firstUtmContent);
     }
+
+    private static bool HasExplicitFirstTouch(SiteStatisticsEventRequest request)
+        => !string.IsNullOrWhiteSpace(request.LandingRoute) ||
+           !string.IsNullOrWhiteSpace(request.FirstReferrerDomain) ||
+           !string.IsNullOrWhiteSpace(request.FirstSource) ||
+           !string.IsNullOrWhiteSpace(request.FirstCampaign) ||
+           !string.IsNullOrWhiteSpace(request.FirstUtmSource) ||
+           !string.IsNullOrWhiteSpace(request.FirstUtmMedium) ||
+           !string.IsNullOrWhiteSpace(request.FirstUtmCampaign) ||
+           !string.IsNullOrWhiteSpace(request.FirstUtmTerm) ||
+           !string.IsNullOrWhiteSpace(request.FirstUtmContent);
 
     private static string? ContextRoute(HttpContext? context)
     {
@@ -1167,6 +1213,7 @@ internal sealed record QueuedSiteStatisticEvent(
     string? FirstUtmCampaign,
     string? FirstUtmTerm,
     string? FirstUtmContent,
+    bool HasExplicitFirstTouch,
     string? MetadataJson);
 
 public sealed class SiteStatisticsEventRequest


### PR DESCRIPTION
Addresses the remaining Codex review feedback from #781.

## Summary
- Let explicit browser first-touch payloads correct direct/internal server fallback session rows.
- Add regression coverage for API/server stats arriving before the browser page-view event.

## Tests
- dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --no-restore --filter "FullyQualifiedName~SiteStatisticsServiceTests" --verbosity minimal
- dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --no-restore --filter "FullyQualifiedName~PlayAthleteFlowBrowserTests.ExistingAthleteNavigation_KeepsUrlPanelAndBackActionsInSync" --verbosity minimal
- dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --no-restore --verbosity minimal

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes analytics attribution and dashboard source-filter SQL; impact is limited to site statistics, with new tests covering the race scenarios.
> 
> **Overview**
> Fixes **first-touch / acquisition attribution** when a **server-side stats event** lands before the browser sends explicit first-touch data (e.g. API submit with same-site referer, then `site_page_viewed` with UTM/search fields).
> 
> **`SiteStatisticsService`** now treats client payloads that include `LandingRoute`, `FirstSource`, UTM fields, etc. as **explicit first touch**. On session upsert, if the stored session was only **`direct` or `internal`**, those fields are **overwritten** by the later explicit client event instead of staying stuck on server fallback.
> 
> Dashboard **source filtering** SQL was adjusted to **prefer session `FirstSource`** (and session first-referrer rules) before reclassifying from per-event referrers, so filtered views (e.g. `search`, `direct`) stay aligned with corrected session first touch.
> 
> Adds **regression tests** for server-then-client ordering (search correction and explicit direct clearing referrer). **`PlayAthleteFlowBrowserTests`** waits for `#character-title` on edit-profile to reduce flakes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd1cc15782f5219d9b4effc08acad2bf4a94eeee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->