### PR TITLE
Reduce ResizeObserver stat noise

### DIFF
--- a/LongevityWorldCup.Tests/SiteStatisticsDashboardBrowserTests.cs
+++ b/LongevityWorldCup.Tests/SiteStatisticsDashboardBrowserTests.cs
@@ -75,6 +75,7 @@ public sealed class SiteStatisticsDashboardBrowserTests
         Assert.Contains("AUTO", onboardingDetailText);
         Assert.Contains("baseline pending", visibleText);
         Assert.Contains("S-", visibleText);
+        Assert.DoesNotContain("ResizeObserver loop completed", visibleText);
         Assert.DoesNotContain("raw-browser-session", visibleText);
         Assert.DoesNotContain("private-token", visibleText);
         Assert.DoesNotContain("athlete@example.test", visibleText);
@@ -181,6 +182,15 @@ public sealed class SiteStatisticsDashboardBrowserTests
             {
                 ["checkInKind"] = JsonSerializer.SerializeToElement("practice")
             });
+        await PostEventAsync(
+            client,
+            "client_error_observed",
+            "site",
+            "resize-observer-noise",
+            "/athlete/siim-land",
+            "client",
+            "failed",
+            errorCode: "ResizeObserver loop completed with undelivered notifications.");
     }
 
     private static async Task SeedNoisyJoinEventsAsync(HttpClient client)
@@ -205,7 +215,8 @@ public sealed class SiteStatisticsDashboardBrowserTests
         string route,
         string component,
         string outcome,
-        Dictionary<string, JsonElement>? metadata = null)
+        Dictionary<string, JsonElement>? metadata = null,
+        string? errorCode = null)
     {
         using var response = await client.PostAsync(
             "/api/site-statistics/event",
@@ -217,6 +228,7 @@ public sealed class SiteStatisticsDashboardBrowserTests
                 Route = route,
                 Component = component,
                 Outcome = outcome,
+                ErrorCode = errorCode,
                 DeviceClass = "desktop",
                 BrowserFamily = "Chromium",
                 Source = "direct",

--- a/LongevityWorldCup.Tests/SiteStatisticsDashboardPageTests.cs
+++ b/LongevityWorldCup.Tests/SiteStatisticsDashboardPageTests.cs
@@ -81,6 +81,8 @@ public sealed class SiteStatisticsDashboardPageTests
         Assert.Contains("function setupSpaRouteTracking()", tracker);
         Assert.Contains("trackJoinPanelViewForCurrentRoute", tracker);
         Assert.Contains("window.history[method] = function ()", tracker);
+        Assert.Contains("function isIgnoredClientErrorMessage(message)", tracker);
+        Assert.Contains("ResizeObserver loop completed with undelivered notifications", tracker);
         Assert.Contains("function isEmailReferrer(host)", tracker);
         const string emailSourceLine = "if (isEmailReferrer(host)) return \"email\";";
         const string searchSourceLine = "if (/google|bing|duckduckgo|yahoo|brave|search/i.test(host)) return \"search\";";
@@ -133,6 +135,7 @@ public sealed class SiteStatisticsDashboardPageTests
         Assert.Contains("lmxCommitmentPanel", tracker);
         Assert.Contains("setupPublicContentTracking", tracker);
         Assert.Contains("trackPublicPageViews", tracker);
+        Assert.Contains("function isIgnoredClientError(e)", dashboard);
     }
 
     [Fact]

--- a/LongevityWorldCup.Website/wwwroot/event-board-embed.html
+++ b/LongevityWorldCup.Website/wwwroot/event-board-embed.html
@@ -491,10 +491,24 @@
         function ready(fn){if(document.readyState!=='loading')fn();else document.addEventListener('DOMContentLoaded',fn)}
         ready(function(){
             var root=document.getElementById('events-embed-root');
-            function post(){if(window.parent&&window.parent!==window){var h=Math.ceil(root.getBoundingClientRect().height);window.parent.postMessage({type:'events-embed-height',h:h},'*')}}
-            var ro=new ResizeObserver(post);if(root)ro.observe(root);
-            var mo=new MutationObserver(function(){requestAnimationFrame(post)});if(root)mo.observe(root,{childList:true,subtree:true});
-            window.addEventListener('load',post);
+            var lastHeight=-1;
+            var postFrame=0;
+            function post(){
+                postFrame=0;
+                if(!root||!window.parent||window.parent===window)return;
+                var h=Math.ceil(root.getBoundingClientRect().height);
+                if(h===lastHeight)return;
+                lastHeight=h;
+                window.parent.postMessage({type:'events-embed-height',h:h},'*');
+            }
+            function schedulePost(){
+                if(postFrame)return;
+                var requestFrame=window.requestAnimationFrame||function(callback){return window.setTimeout(callback,0)};
+                postFrame=requestFrame(post);
+            }
+            var ro=root&&'ResizeObserver'in window?new ResizeObserver(schedulePost):null;if(ro)ro.observe(root);
+            var mo=new MutationObserver(schedulePost);if(root)mo.observe(root,{childList:true,subtree:true});
+            window.addEventListener('load',schedulePost);
             var q=new URLSearchParams(window.location.search);
             var rawRows=(q.get('rows')||'5').trim();
             var rows=/^(all|full|0)$/i.test(rawRows)?null:parseInt(rawRows,10);
@@ -504,7 +518,7 @@
             var ln=q.get('linkNames');
             var linkNames=ln==null?true:!(ln==='false'||ln==='0');
             function safeLoad(){
-                if(typeof window.loadEventsTable==='function'){window.loadEventsTable(rows,viewAll,athlete,linkNames);post();return true}
+                if(typeof window.loadEventsTable==='function'){window.loadEventsTable(rows,viewAll,athlete,linkNames);schedulePost();return true}
                 return false
             }
             if(!safeLoad()){

--- a/LongevityWorldCup.Website/wwwroot/js/age-visualization.js
+++ b/LongevityWorldCup.Website/wwwroot/js/age-visualization.js
@@ -204,8 +204,26 @@
 
     var radarChartInstance = null;
     var radarResizeObserver = null;
+    var radarResizeFrame = 0;
+
+    function scheduleRadarResize() {
+        if (radarResizeFrame) return;
+        var requestFrame = window.requestAnimationFrame || function (callback) { return window.setTimeout(callback, 0); };
+        radarResizeFrame = requestFrame(function () {
+            radarResizeFrame = 0;
+            if (radarChartInstance) radarChartInstance.resize();
+        });
+    }
+
+    function cancelRadarResize() {
+        if (!radarResizeFrame) return;
+        if (window.cancelAnimationFrame) window.cancelAnimationFrame(radarResizeFrame);
+        else window.clearTimeout(radarResizeFrame);
+        radarResizeFrame = 0;
+    }
 
     function destroyRadarChart() {
+        cancelRadarResize();
         if (radarResizeObserver) {
             var wrapper = document.getElementById('ageRadarWrapper');
             if (wrapper) radarResizeObserver.disconnect();
@@ -419,10 +437,10 @@
         });
         radarChartInstance._radarTooltipContributors = contributors;
         if (radarResizeObserver && wrapper) radarResizeObserver.disconnect();
-        radarResizeObserver = new ResizeObserver(function () {
-            if (radarChartInstance) radarChartInstance.resize();
-        });
-        radarResizeObserver.observe(wrapper);
+        if ('ResizeObserver' in window) {
+            radarResizeObserver = new ResizeObserver(scheduleRadarResize);
+            radarResizeObserver.observe(wrapper);
+        }
 
         function selectClock(bortz) {
             var payload = bortz ? currentClockState.bortz : currentClockState.pheno;

--- a/LongevityWorldCup.Website/wwwroot/js/site-statistics-tracking.js
+++ b/LongevityWorldCup.Website/wwwroot/js/site-statistics-tracking.js
@@ -179,6 +179,13 @@
         track(eventName, options);
     }
 
+    function isIgnoredClientErrorMessage(message) {
+        message = String(message || "").trim();
+        return message === "ResizeObserver loop completed with undelivered notifications." ||
+            message === "ResizeObserver loop completed with undelivered notifications" ||
+            message === "ResizeObserver loop limit exceeded";
+    }
+
     function isSameOriginFetch(input) {
         const raw = safe(() => input && input.url ? input.url : input) || "";
         const parsed = safe(() => new URL(String(raw), window.location.href));
@@ -954,10 +961,12 @@
         safe(setupPublicContentTracking);
     });
     listen(window, "error", event => {
+        const message = event && event.message ? String(event.message) : "";
+        if (isIgnoredClientErrorMessage(message)) return;
         track("client_error_observed", {
             component: "client",
             outcome: "failed",
-            errorCode: event && event.message ? String(event.message).slice(0, 80) : "error"
+            errorCode: message ? message.slice(0, 80) : "error"
         });
     });
 })();

--- a/LongevityWorldCup.Website/wwwroot/js/site-statistics.js
+++ b/LongevityWorldCup.Website/wwwroot/js/site-statistics.js
@@ -1304,11 +1304,20 @@
         updateUrl();
     }
 
+    function isIgnoredClientError(e) {
+        if (!e || e.eventName !== "client_error_observed") return false;
+        const errorCode = String(e.errorCode || "").trim();
+        return errorCode === "ResizeObserver loop completed with undelivered notifications." ||
+            errorCode === "ResizeObserver loop completed with undelivered notifications" ||
+            errorCode === "ResizeObserver loop limit exceeded";
+    }
+
     function frictionEvents(events) {
         return events.filter(e =>
-            /failed|failure|missing|rejected|unavailable|invalid|error|blocked/.test(e.eventName) ||
-            /failed|missing|error|blocked/.test(e.outcome || "") ||
-            !!e.errorCode);
+            !isIgnoredClientError(e) &&
+            (/failed|failure|missing|rejected|unavailable|invalid|error|blocked/.test(e.eventName) ||
+                /failed|missing|error|blocked/.test(e.outcome || "") ||
+                !!e.errorCode));
     }
 
     function dataQualityStats(events, previous) {

--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -4989,6 +4989,22 @@
         return freshFrame;
     }
 
+    function scheduleBiomarkerChartResize() {
+        if (window.biomarkerChartResizeFrame) return;
+        const requestFrame = window.requestAnimationFrame || function(callback) { return window.setTimeout(callback, 0); };
+        window.biomarkerChartResizeFrame = requestFrame(function() {
+            window.biomarkerChartResizeFrame = 0;
+            if (window.biomarkerChartInstance) window.biomarkerChartInstance.resize();
+        });
+    }
+
+    function cancelBiomarkerChartResize() {
+        if (!window.biomarkerChartResizeFrame) return;
+        if (window.cancelAnimationFrame) window.cancelAnimationFrame(window.biomarkerChartResizeFrame);
+        else window.clearTimeout(window.biomarkerChartResizeFrame);
+        window.biomarkerChartResizeFrame = 0;
+    }
+
     function resetModalForLoading(athleteSlug) {
         ensureAthleteModalDeferredSections();
         closeAthleteShareMenu();
@@ -5036,6 +5052,7 @@
             window.biomarkerChartInstance.destroy();
             window.biomarkerChartInstance = null;
         }
+        cancelBiomarkerChartResize();
         if (typeof window.destroyAgeRadarChart === 'function') {
             window.destroyAgeRadarChart();
         }
@@ -5296,6 +5313,7 @@
             window.biomarkerChartResizeObserver.disconnect();
             window.biomarkerChartResizeObserver = null;
         }
+        cancelBiomarkerChartResize();
         if (typeof window.destroyAgeRadarChart === 'function') {
             window.destroyAgeRadarChart();
         }
@@ -6971,16 +6989,16 @@
                         // Force Chart.js to re-measure after layout; hover triggers this internally, so do it explicitly (second rAF + ResizeObserver fallback).
                         requestAnimationFrame(function() {
                             if (requestId !== currentAthleteModalRequestId) return;
-                            if (window.biomarkerChartInstance) window.biomarkerChartInstance.resize();
+                            scheduleBiomarkerChartResize();
                         });
 
                         var chartContainer = document.getElementById('athlete-biomarkers');
                         if (chartContainer && window.biomarkerChartInstance) {
                             if (window.biomarkerChartResizeObserver) window.biomarkerChartResizeObserver.disconnect();
-                            window.biomarkerChartResizeObserver = new ResizeObserver(function() {
-                                if (window.biomarkerChartInstance) window.biomarkerChartInstance.resize();
-                            });
-                            window.biomarkerChartResizeObserver.observe(chartContainer);
+                            if ('ResizeObserver' in window) {
+                                window.biomarkerChartResizeObserver = new ResizeObserver(scheduleBiomarkerChartResize);
+                                window.biomarkerChartResizeObserver.observe(chartContainer);
+                            }
                         }
                     });
                 });


### PR DESCRIPTION
## Summary

This PR reduces the ResizeObserver client-error noise that was dominating the internal site statistics dashboard.

## What was happening

Production statistics showed that `ResizeObserver loop completed with undelivered notifications` accounted for nearly all recent client errors: 649 events across 287 sessions in the last 30 days, first seen on July 4, 2026 UTC. The events were concentrated on public athlete profile routes such as `/athlete/siim-land`, `/athlete/martin-helstab`, and `/athlete/wen-z`.

Session timelines showed users landing on the homepage or leaderboard, then opening multiple athlete profiles in the modal. That points at profile-modal rendering rather than an onboarding, challenge, or server-side issue.

## Changes

- Defers Chart.js resize calls from athlete profile `ResizeObserver` callbacks through `requestAnimationFrame`.
- Defers event-board iframe height messages and skips duplicate height posts.
- Ignores the known benign browser ResizeObserver loop messages in the client tracker.
- Filters already-stored ResizeObserver loop messages out of dashboard friction calculations so historical rows stop dominating investigations after deploy.
- Adds dashboard tests for the ignored ResizeObserver noise path.

## Validation

- `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --filter "FullyQualifiedName~SiteStatisticsDashboard"`
- `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --filter "FullyQualifiedName~EventBoardBrowserTests"`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Front-end analytics and layout timing only; no auth, API contracts, or data persistence changes beyond how events are recorded and displayed.
> 
> **Overview**
> Cuts down benign **ResizeObserver** loop messages that were flooding site statistics and obscuring real client friction.
> 
> **Runtime:** `ResizeObserver` callbacks now schedule Chart.js resizes and iframe height posts via `requestAnimationFrame`, with deduped height reporting in the events embed and cleanup when athlete modals tear down charts.
> 
> **Telemetry & dashboard:** The client tracker skips known ResizeObserver error strings; the internal dashboard excludes matching `client_error_observed` rows from friction views so historical data stops dominating after deploy.
> 
> **Tests:** Browser and static tests seed a ResizeObserver-style error and assert it does not appear on the dashboard UI; tracker/dashboard source tests assert the ignore helpers exist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80d7491373cd48bf1cda4246433214402f5dfe13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->