### PR TITLE
Reduce application stat context noise

### DIFF
--- a/LongevityWorldCup.Tests/SiteStatisticsDashboardPageTests.cs
+++ b/LongevityWorldCup.Tests/SiteStatisticsDashboardPageTests.cs
@@ -206,6 +206,7 @@ public sealed class SiteStatisticsDashboardPageTests
         Assert.Contains("function isBenignMissingContextEvent(e)", dashboard);
         Assert.Contains("route === \"/apply\"", dashboard);
         Assert.Contains("route.includes(\"from=proof-upload\")", dashboard);
+        Assert.DoesNotContain("route.includes(\"from=redacted\")", dashboard);
         Assert.Contains("!isBenignMissingContextEvent(e)", dashboard);
     }
 

--- a/LongevityWorldCup.Tests/SiteStatisticsDashboardPageTests.cs
+++ b/LongevityWorldCup.Tests/SiteStatisticsDashboardPageTests.cs
@@ -83,6 +83,9 @@ public sealed class SiteStatisticsDashboardPageTests
         Assert.Contains("window.history[method] = function ()", tracker);
         Assert.Contains("function isIgnoredClientErrorMessage(message)", tracker);
         Assert.Contains("ResizeObserver loop completed with undelivered notifications", tracker);
+        Assert.Contains("function hasApplicationReviewContext()", tracker);
+        Assert.Contains("isReviewSource(params.get(\"from\"))", tracker);
+        Assert.Contains("isReviewSource(sessionStorage.getItem(\"came-from\"))", tracker);
         Assert.Contains("function isEmailReferrer(host)", tracker);
         const string emailSourceLine = "if (isEmailReferrer(host)) return \"email\";";
         const string searchSourceLine = "if (/google|bing|duckduckgo|yahoo|brave|search/i.test(host)) return \"search\";";
@@ -173,6 +176,37 @@ public sealed class SiteStatisticsDashboardPageTests
         Assert.Contains("stacked-bar", dashboard);
         Assert.Contains("\"Auto\"", dashboard);
         Assert.Contains("\"Late\"", dashboard);
+    }
+
+    [Fact]
+    public void SiteStatisticsTracker_DoesNotFlagValidApplicationEntryPagesAsMissingHandoff()
+    {
+        var repoRoot = FindRepoRoot();
+        var tracker = File.ReadAllText(Path.Combine(repoRoot, "LongevityWorldCup.Website", "wwwroot", "js", "site-statistics-tracking.js"));
+        var dashboard = File.ReadAllText(Path.Combine(repoRoot, "LongevityWorldCup.Website", "wwwroot", "js", "site-statistics.js"));
+
+        var pageViewTrackingStart = tracker.IndexOf("function setupPageViews()", StringComparison.Ordinal);
+        Assert.True(pageViewTrackingStart >= 0);
+
+        var applyBlockStart = tracker.IndexOf("if (path.includes(\"convergence\") || path === \"/apply\")", pageViewTrackingStart, StringComparison.Ordinal);
+        var proofsBlockStart = tracker.IndexOf("if (path.includes(\"proof-upload\") || path === \"/proofs\")", pageViewTrackingStart, StringComparison.Ordinal);
+        Assert.True(applyBlockStart >= 0);
+        Assert.True(proofsBlockStart > applyBlockStart);
+
+        var applyBlock = tracker[applyBlockStart..proofsBlockStart];
+        Assert.Contains("track(\"proof_flow_opened\"", applyBlock);
+        Assert.DoesNotContain("proof_flow_missing_handoff", applyBlock);
+
+        var calculatorBlockStart = tracker.IndexOf("if (flowFromPath() === \"pheno\"", proofsBlockStart, StringComparison.Ordinal);
+        Assert.True(calculatorBlockStart > proofsBlockStart);
+
+        var proofsBlock = tracker[proofsBlockStart..calculatorBlockStart];
+        Assert.Contains("proof_flow_missing_handoff", proofsBlock);
+
+        Assert.Contains("function isBenignMissingContextEvent(e)", dashboard);
+        Assert.Contains("route === \"/apply\"", dashboard);
+        Assert.Contains("route.includes(\"from=proof-upload\")", dashboard);
+        Assert.Contains("!isBenignMissingContextEvent(e)", dashboard);
     }
 
     [Fact]

--- a/LongevityWorldCup.Website/wwwroot/js/site-statistics-tracking.js
+++ b/LongevityWorldCup.Website/wwwroot/js/site-statistics-tracking.js
@@ -64,6 +64,22 @@
         return "site";
     }
 
+    function isReviewSource(value) {
+        return value === "proof-upload" || value === "edit-profile";
+    }
+
+    function hasApplicationReviewContext() {
+        return !!safe(() => {
+            const params = new URLSearchParams(window.location.search);
+            return sessionStorage.getItem("pendingPaymentInvoice") ||
+                localStorage.getItem("pendingPaymentInvoicePersistent") ||
+                isReviewSource(params.get("from")) ||
+                isReviewSource(sessionStorage.getItem("came-from")) ||
+                sessionStorage.getItem("contactEmail") ||
+                localStorage.getItem("contactEmail");
+        });
+    }
+
     function deviceClass() {
         const ua = navigator.userAgent || "";
         if (/ipad|tablet/i.test(ua)) return "tablet";
@@ -391,7 +407,7 @@
 
         if (path.includes("application-review") || path === "/review") {
             track("application_review_opened", { component: "application_review", outcome: "opened" });
-            const hasContext = !!safe(() => sessionStorage.getItem("pendingPaymentInvoice") || localStorage.getItem("pendingPaymentInvoicePersistent"));
+            const hasContext = hasApplicationReviewContext();
             track(hasContext ? "application_review_context_found" : "application_review_context_missing", {
                 component: "application_review",
                 outcome: hasContext ? "found" : "missing"
@@ -399,7 +415,12 @@
             return;
         }
 
-        if (path.includes("convergence") || path === "/apply" || path.includes("proof-upload") || path === "/proofs") {
+        if (path.includes("convergence") || path === "/apply") {
+            track("proof_flow_opened", { component: "application", outcome: "opened" });
+            return;
+        }
+
+        if (path.includes("proof-upload") || path === "/proofs") {
             track("proof_flow_opened", { component: "application", outcome: "opened" });
             const hasBiomarkerData = !!safe(() => sessionStorage.getItem("biomarkerData"));
             track(hasBiomarkerData ? "biomarker_handoff_found" : "proof_flow_missing_handoff", {

--- a/LongevityWorldCup.Website/wwwroot/js/site-statistics.js
+++ b/LongevityWorldCup.Website/wwwroot/js/site-statistics.js
@@ -757,10 +757,10 @@
             });
         }
 
-        const missingReview = active.filter(e => e.eventName === "application_review_context_missing");
+        const missingReview = active.filter(e => e.eventName === "application_review_context_missing" && !isBenignMissingContextEvent(e));
         if (missingReview.length > 0) {
             const affected = uniqueSessions(missingReview);
-            const previousAffected = uniqueSessions(previous.filter(e => e.eventName === "application_review_context_missing"));
+            const previousAffected = uniqueSessions(previous.filter(e => e.eventName === "application_review_context_missing" && !isBenignMissingContextEvent(e)));
             const trend = trendPhrase(affected, previousAffected || null, true);
             insights.push({
                 title: "Application review opens without stored context",
@@ -812,7 +812,7 @@
     }
 
     function addInvestigation(items, events, names, title, reason, sessionFilter) {
-        const filtered = events.filter(e => names.includes(e.eventName) && (!sessionFilter || sessionFilter.includes(e.sessionHash)));
+        const filtered = events.filter(e => names.includes(e.eventName) && !isBenignMissingContextEvent(e) && (!sessionFilter || sessionFilter.includes(e.sessionHash)));
         if (!filtered.length || items.some(item => item.title === title)) return;
         items.push({ title, reason, sessions: uniqueSessions(filtered), events: filtered });
     }
@@ -1326,9 +1326,22 @@
             errorCode === "ResizeObserver loop limit exceeded";
     }
 
+    function isBenignMissingContextEvent(e) {
+        if (!e) return false;
+        const route = String(e.route || "").toLowerCase();
+        if (e.eventName === "proof_flow_missing_handoff") {
+            return route === "/apply" || route.startsWith("/apply?") || route.includes("convergence");
+        }
+        if (e.eventName === "application_review_context_missing") {
+            return route.includes("from=proof-upload") || route.includes("from=edit-profile") || route.includes("from=redacted");
+        }
+        return false;
+    }
+
     function frictionEvents(events) {
         return events.filter(e =>
             !isIgnoredClientError(e) &&
+            !isBenignMissingContextEvent(e) &&
             (/failed|failure|missing|rejected|unavailable|invalid|error|blocked/.test(e.eventName) ||
                 /failed|missing|error|blocked/.test(e.outcome || "") ||
                 !!e.errorCode));

--- a/LongevityWorldCup.Website/wwwroot/js/site-statistics.js
+++ b/LongevityWorldCup.Website/wwwroot/js/site-statistics.js
@@ -1333,7 +1333,7 @@
             return route === "/apply" || route.startsWith("/apply?") || route.includes("convergence");
         }
         if (e.eventName === "application_review_context_missing") {
-            return route.includes("from=proof-upload") || route.includes("from=edit-profile") || route.includes("from=redacted");
+            return route.includes("from=proof-upload") || route.includes("from=edit-profile");
         }
         return false;
     }


### PR DESCRIPTION
## What changed

- Treat valid `/review` sources (`from=proof-upload`, `from=edit-profile`, `came-from`, contact email, or pending invoice) as application review context in the stats tracker.
- Stop treating `/apply` as a missing biomarker handoff; `/apply` is the valid application entry page, while `/proofs` still checks for `biomarkerData`.
- Filter clearly benign `/apply` missing-handoff rows from the site statistics dashboard friction and investigation logic.

## Why

After the ResizeObserver filter was deployed, production stats showed two noisy non-exception signals:

- `proof_flow_missing_handoff` only appeared on `/apply`, where no biomarker handoff is required.
- `application_review_context_missing` appeared on valid `/review?from=proof-upload` review pages after successful result uploads that do not require checkout.

The tracker fix stops future valid review pages from emitting missing-context events. The dashboard intentionally does not suppress redacted `/review?from=...` legacy rows, because the redacted route could also represent an unexpected source worth inspecting.

## Validation

- `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --filter "FullyQualifiedName~SiteStatisticsDashboard"`
- `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --filter "FullyQualifiedName~ApplicationReviewPageTests|FullyQualifiedName~ProofUploadPageTests|FullyQualifiedName~ApplicationOnboardingPageTests"`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side analytics and dashboard filtering only; no auth, payments, or submission logic changes.
> 
> **Overview**
> **Site statistics tracking** now treats more `/review` visits as having valid context (pending invoice, `from=proof-upload` / `from=edit-profile`, `came-from`, contact email) via `hasApplicationReviewContext()`, so fewer `application_review_context_missing` events are emitted on legitimate review flows.
> 
> **Page-view logic** splits `/apply` from `/proofs`: `/apply` only records `proof_flow_opened` and no longer fires `proof_flow_missing_handoff`; biomarker handoff checks stay on proof-upload routes only.
> 
> **The internal dashboard** adds `isBenignMissingContextEvent()` so expected `/apply` “missing handoff” and valid `/review?from=proof-upload|edit-profile` “missing context” rows are excluded from friction, decision insights, and recommended investigations (legacy redacted review routes are not blanket-suppressed).
> 
> **Tests** assert the tracker/dashboard behavior and extend tracker smoke checks for the new review-context helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e7e7bdb78936ebe8f076041baf06703f5e52186. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->