### PR TITLE
Make longevitymaxxing pledge optional

### DIFF
--- a/LongevityWorldCup.Tests/LongevitymaxxingChallengePageTests.cs
+++ b/LongevityWorldCup.Tests/LongevitymaxxingChallengePageTests.cs
@@ -542,7 +542,7 @@ public sealed class LongevitymaxxingChallengePageTests
         Assert.Contains("const publicContentHidden = checkInOnly;", javascript);
         Assert.Contains("hero.classList.toggle(\"checkin-only\", publicContentHidden);", javascript);
         Assert.Contains("toggle(\"lmxBoardSection\", !publicContentHidden);", javascript);
-        Assert.Contains("toggle(\"lmxCommitmentPanel\", hasParticipant && commitmentBlocked);", javascript);
+        Assert.Contains("toggle(\"lmxCommitmentPanel\", hasParticipant && shouldShowCommitmentPanel(participantState, activeParticipantTab));", javascript);
         Assert.Contains("toggle(\"lmxParticipantTools\", hasParticipant && !commitmentBlocked && activeParticipantTab === \"home\");", javascript);
         Assert.Contains("toggle(\"lmxParticipantCalls\", hasParticipant && !commitmentBlocked && activeParticipantTab === \"home\");", javascript);
         Assert.Contains("toggle(\"lmxParticipantKicker\", !!kicker);", javascript);
@@ -593,7 +593,13 @@ public sealed class LongevitymaxxingChallengePageTests
         Assert.Contains("participantState.trendGuidance?.text", javascript);
         Assert.Contains("function renderCommitmentPanel", javascript);
         Assert.Contains("function payCommitment", javascript);
+        Assert.Contains("function shouldShowCommitmentPanel", javascript);
+        Assert.Contains("function shouldShowCheckInPledgePrompt", javascript);
+        Assert.Contains("Number(state.trendGuidance?.priorScoredDays || 0) >= 3", javascript);
         Assert.Contains("commitmentAmountUsd: parseCommitmentAmount", javascript);
+        Assert.Contains("commitmentAmountUsd: parseOptionalCommitmentAmount(\"lmxEditCommitmentAmount\")", javascript);
+        Assert.Contains("function parseOptionalCommitmentAmount", javascript);
+        Assert.DoesNotContain("lmxSignupCommitmentAmount", javascript);
         Assert.DoesNotContain("displayName: getIdentityDisplayName(\"edit\")", javascript);
         Assert.DoesNotContain("athleteLink: getIdentityAthletePayload(\"edit\")", javascript);
         Assert.Contains("renderCheckIns(orderedDays, containerId, recentRemarks);", javascript);
@@ -602,10 +608,13 @@ public sealed class LongevitymaxxingChallengePageTests
         Assert.Contains("setAttribute(\"aria-invalid\", \"true\")", javascript);
         Assert.Contains("Payment confirmed. You're unlocked.", javascript);
         Assert.Contains("Redeem yourself", javascript);
-        Assert.Contains(": \"Make a pledge to continue\";", javascript);
+        Assert.Contains(": \"Make a pledge\";", javascript);
+        Assert.DoesNotContain("Make a pledge to continue", javascript);
         Assert.Contains("<strong>Set a real stake</strong>", javascript);
         Assert.Contains("Fall below your recent average and either pay it or stop. Choose an amount that would hurt.", javascript);
         Assert.Contains("Make a pledge", javascript);
+        Assert.Contains("Fall below your recent average and either pay it or stop longevitymaxxing. You can keep checking in without a pledge.", javascript);
+        Assert.Contains("id=\"lmxPledgeCommitmentAmount\"", javascript);
         Assert.Contains("Check again", javascript);
         Assert.Contains("Waiting for payment confirmation...", javascript);
         Assert.Contains("Still waiting. This can take a minute.", javascript);
@@ -633,7 +642,8 @@ public sealed class LongevitymaxxingChallengePageTests
         Assert.Contains("<span aria-hidden=\"true\">$</span>", javascript);
         Assert.Contains("placeholder=\"300\"", javascript);
         var html = await client.GetStringAsync("/longevitymaxxing");
-        Assert.Contains("id=\"lmxSignupCommitmentAmount\"", html);
+        Assert.DoesNotContain("id=\"lmxSignupCommitmentAmount\"", html);
+        Assert.Contains("id=\"lmxEditCommitmentAmount\"", html);
         Assert.Contains("<span aria-hidden=\"true\">$</span>", html);
         Assert.Contains("placeholder=\"300\"", html);
         Assert.DoesNotContain("placeholder=\"$300\"", html);
@@ -791,7 +801,8 @@ public sealed class LongevitymaxxingChallengePageTests
         Assert.Contains("function chooseTimeZone", javascript);
         Assert.Contains("function timeZoneCountryLabel", javascript);
         Assert.Contains("new Intl.DisplayNames([\"en\"], { type: \"region\" })", javascript);
-        Assert.Contains("const TIME_ZONE_MATCH_LIMIT = 10;", javascript);
+        Assert.DoesNotContain("TIME_ZONE_MATCH_LIMIT", javascript);
+        Assert.DoesNotContain(".slice(0, TIME_ZONE_MATCH_LIMIT)", javascript);
         Assert.Contains("fillTimeZones(document.getElementById(\"lmxSignupTimeZone\"));", javascript);
         Assert.Contains("fillTimeZones(document.getElementById(\"lmxEditTimeZone\"));", javascript);
         Assert.Contains("initTimeZonePickers();", javascript);

--- a/LongevityWorldCup.Tests/LongevitymaxxingChallengeServiceTests.cs
+++ b/LongevityWorldCup.Tests/LongevitymaxxingChallengeServiceTests.cs
@@ -251,6 +251,55 @@ public sealed class LongevitymaxxingChallengeServiceTests
     }
 
     [Fact]
+    public async Task SignupWithoutCommitmentKeepsPledgeOptionalAfterConfirmation()
+    {
+        using var fixture = TestChallengeFixture.Create();
+        var now = DateTimeOffset.Parse("2026-06-07T12:00:00Z");
+
+        await fixture.Service.SignupAsync(new LongevitymaxxingSignupRequest(
+            "no-pledge@example.com",
+            "No Pledge Nell",
+            "UTC",
+            null), now);
+        var access = await fixture.Service.ConfirmAsync(
+            ReadQueryToken(fixture.Email.Confirmations.Last().Url, "confirm"),
+            now.AddMinutes(1));
+
+        Assert.Equal("deferred", access.State.Commitment.Status);
+        Assert.False(access.State.Commitment.BlocksParticipant);
+        Assert.True(access.State.Commitment.CanEditAmount);
+        Assert.Null(access.State.Participant.CommitmentAmountUsd);
+
+        var checkedIn = fixture.Service.SubmitCheckIn(
+            new LongevitymaxxingCheckInRequest(access.AccessToken, 1, 2, 2, 2, 2, null),
+            DateTimeOffset.Parse("2026-06-09T08:05:00Z"));
+        Assert.Equal("deferred", checkedIn.Commitment.Status);
+        Assert.Null(checkedIn.Participant.CommitmentAmountUsd);
+
+        fixture.Service.SubmitCheckIn(
+            new LongevitymaxxingCheckInRequest(access.AccessToken, 2, 2, 2, 2, 2, null),
+            DateTimeOffset.Parse("2026-06-10T08:05:00Z"));
+        fixture.Service.SubmitCheckIn(
+            new LongevitymaxxingCheckInRequest(access.AccessToken, 3, 2, 2, 2, 2, null),
+            DateTimeOffset.Parse("2026-06-11T08:05:00Z"));
+        var firstPledgeRelevantState = fixture.Service.SubmitCheckIn(
+            new LongevitymaxxingCheckInRequest(access.AccessToken, 4, 2, 2, 2, 2, null),
+            DateTimeOffset.Parse("2026-06-12T08:05:00Z"));
+        Assert.Equal(3, firstPledgeRelevantState.TrendGuidance.PriorScoredDays);
+        Assert.Equal("deferred", firstPledgeRelevantState.Commitment.Status);
+        Assert.False(firstPledgeRelevantState.Commitment.BlocksParticipant);
+
+        var configured = fixture.Service.EditParticipant(new LongevitymaxxingParticipantEditRequest(
+            access.AccessToken,
+            "UTC",
+            30m),
+            DateTimeOffset.Parse("2026-06-12T08:10:00Z"));
+
+        Assert.Equal("clear", configured.Commitment.Status);
+        Assert.Equal(30m, configured.Participant.CommitmentAmountUsd);
+    }
+
+    [Fact]
     public async Task SignupReservesAthleteNamesForSelectedAthleteProfiles()
     {
         using var fixture = TestChallengeFixture.Create();
@@ -1693,15 +1742,9 @@ public sealed class LongevitymaxxingChallengeServiceTests
     }
 
     [Fact]
-    public async Task SignupAndProfileRequireValidCommitmentAmountAfterOriginalCatchUp()
+    public async Task NoPledgeParticipantsCanContinuePastOriginalDuration()
     {
         using var fixture = TestChallengeFixture.Create();
-
-        await Assert.ThrowsAsync<InvalidOperationException>(() => fixture.Service.SignupAsync(new LongevitymaxxingSignupRequest(
-            "missing-commitment@example.com",
-            "Missing Commitment",
-            "UTC",
-            null)));
 
         await Assert.ThrowsAsync<InvalidOperationException>(() => fixture.Service.SignupAsync(new LongevitymaxxingSignupRequest(
             "small-commitment@example.com",
@@ -1714,7 +1757,7 @@ public sealed class LongevitymaxxingChallengeServiceTests
         var deferred = fixture.Service.GetParticipantState(access, DateTimeOffset.Parse("2026-06-09T08:05:00Z"));
         Assert.Equal("deferred", deferred.Commitment.Status);
         Assert.False(deferred.Commitment.BlocksParticipant);
-        Assert.False(deferred.Commitment.CanEditAmount);
+        Assert.True(deferred.Commitment.CanEditAmount);
         Assert.False(deferred.Commitment.CanPay);
 
         var checkedIn = fixture.Service.SubmitCheckIn(
@@ -1739,15 +1782,13 @@ public sealed class LongevitymaxxingChallengeServiceTests
             DateTimeOffset.Parse("2026-06-22T08:05:00Z"));
         Assert.Equal("deferred", day14.Commitment.Status);
 
-        var blocked = fixture.Service.GetParticipantState(access, DateTimeOffset.Parse("2026-06-23T08:05:00Z"));
-        Assert.Equal("needs-amount", blocked.Commitment.Status);
-        Assert.True(blocked.Commitment.BlocksParticipant);
-        Assert.True(blocked.Commitment.CanEditAmount);
-        Assert.False(blocked.Commitment.CanPay);
-        Assert.Contains("Configure an amount that'd hurt before continuing past Day 14.", blocked.Commitment.Message);
+        var continuing = fixture.Service.GetParticipantState(access, DateTimeOffset.Parse("2026-06-23T08:05:00Z"));
+        Assert.Equal("deferred", continuing.Commitment.Status);
+        Assert.False(continuing.Commitment.BlocksParticipant);
+
         var day15 = fixture.Service.SubmitCheckIn(
             new LongevitymaxxingCheckInRequest(access, 15, 2, 2, 2, 2, null),
-            DateTimeOffset.Parse("2026-06-23T08:05:00Z"));
+            DateTimeOffset.Parse("2026-06-23T08:15:00Z"));
         Assert.True(day15.Public.Leaderboard.Single().Cells.Single(cell => cell.ChallengeDay == 15).CheckedIn);
         Assert.Null(day15.Participant.CommitmentAmountUsd);
 
@@ -1755,7 +1796,7 @@ public sealed class LongevitymaxxingChallengeServiceTests
             access,
             "UTC",
             12.345m),
-            DateTimeOffset.Parse("2026-06-23T08:10:00Z"));
+            DateTimeOffset.Parse("2026-06-23T08:20:00Z"));
 
         Assert.Equal("clear", configured.Commitment.Status);
         Assert.Equal(12.35m, configured.Participant.CommitmentAmountUsd);
@@ -2100,7 +2141,7 @@ public sealed class LongevitymaxxingChallengeServiceTests
     }
 
     [Fact]
-    public async Task CommitmentBlocksProfilePictureUploadsUntilResolved()
+    public async Task CommitmentDueBlocksProfilePictureUploadsUntilResolved()
     {
         using var fixture = TestChallengeFixture.Create();
         var access = await CreateCommitmentDueParticipantAsync(fixture, "blocked-upload@example.com", "Blocked Bea");
@@ -2115,12 +2156,14 @@ public sealed class LongevitymaxxingChallengeServiceTests
         using var setupStream = CreatePngStream();
         var setupFile = CreatePngFormFile(setupStream);
 
-        var setupError = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            fixture.Service.UploadParticipantProfilePictureAsync(
-                setupAccess,
-                setupFile,
-                nowUtc: DateTimeOffset.Parse("2026-06-23T08:05:00Z")));
-        Assert.Contains("Configure your commitment amount", setupError.Message);
+        var setupState = await fixture.Service.UploadParticipantProfilePictureAsync(
+            setupAccess,
+            setupFile,
+            nowUtc: DateTimeOffset.Parse("2026-06-23T08:05:00Z"));
+
+        Assert.Equal("deferred", setupState.Commitment.Status);
+        Assert.False(setupState.Commitment.BlocksParticipant);
+        Assert.NotNull(setupState.Participant.ProfileImageUrl);
     }
 
     [Fact]

--- a/LongevityWorldCup.Website/Business/LongevitymaxxingChallengeService.cs
+++ b/LongevityWorldCup.Website/Business/LongevitymaxxingChallengeService.cs
@@ -166,14 +166,13 @@ public sealed class LongevitymaxxingChallengeService
         try
         {
             var now = EnsureUtc(nowUtc ?? DateTimeOffset.UtcNow);
-            var settings = BuildSettings(now);
 
             var email = NormalizeEmail(request.Email);
             var timeZoneId = NormalizeTimeZone(request.TimeZoneId);
             var athleteSlug = TryNormalizeAthleteSlug(request.AthleteLink);
             var athleteProfile = ResolveAthleteProfile(athleteSlug);
             var displayName = ResolveSignupDisplayName(request.DisplayName, athleteSlug, athleteProfile);
-            var commitmentAmountUsd = NormalizeCommitmentAmount(request.CommitmentAmountUsd);
+            var requestedCommitmentAmountUsd = NormalizeOptionalCommitmentAmount(request.CommitmentAmountUsd);
 
             var confirmationToken = CreateToken();
             var accessToken = CreateToken();
@@ -203,7 +202,7 @@ public sealed class LongevitymaxxingChallengeService
                     Add(insert, "@access", accessToken);
                     Add(insert, "@confirm", confirmationToken);
                     Add(insert, "@stop", stopToken);
-                    Add(insert, "@commitmentAmount", FormatDecimal(commitmentAmountUsd));
+                    Add(insert, "@commitmentAmount", FormatOptionalDecimal(requestedCommitmentAmountUsd));
                     Add(insert, "@created", now.ToString("o"));
                     Add(insert, "@updated", now.ToString("o"));
                     insert.ExecuteNonQuery();
@@ -218,6 +217,7 @@ public sealed class LongevitymaxxingChallengeService
                     if (HasActivePaymentObligation(sqlite, existing.Id))
                         return;
 
+                    var commitmentAmountUsd = requestedCommitmentAmountUsd ?? existing.CommitmentAmountUsd;
                     EnsureParticipantIdentityAvailable(sqlite, displayName, athleteSlug, existing.Id);
                     using var update = sqlite.CreateCommand();
                     update.CommandText =
@@ -233,7 +233,7 @@ public sealed class LongevitymaxxingChallengeService
                     Add(update, "@name", displayName);
                     Add(update, "@tz", timeZoneId);
                     Add(update, "@athlete", athleteSlug);
-                    Add(update, "@commitmentAmount", FormatDecimal(commitmentAmountUsd));
+                    Add(update, "@commitmentAmount", FormatOptionalDecimal(commitmentAmountUsd));
                     Add(update, "@updated", now.ToString("o"));
                     Add(update, "@id", participantId);
                     update.ExecuteNonQuery();
@@ -385,18 +385,14 @@ public sealed class LongevitymaxxingChallengeService
     public LongevitymaxxingParticipantState EditParticipant(LongevitymaxxingParticipantEditRequest request, DateTimeOffset? nowUtc = null)
     {
         var now = EnsureUtc(nowUtc ?? DateTimeOffset.UtcNow);
-        var settings = BuildSettings(now);
         var participant = RequireParticipantByAccessToken(request.AccessToken);
         var timeZoneId = NormalizeTimeZone(request.TimeZoneId);
-        var commitmentAmountUsd = request.CommitmentAmountUsd is null && !IsCommitmentSetupRequired(settings, participant, now)
+        var commitmentAmountUsd = request.CommitmentAmountUsd is null
             ? participant.CommitmentAmountUsd
             : NormalizeCommitmentAmount(request.CommitmentAmountUsd);
         if (GetActivePaymentObligation(participant.Id) is not null)
             throw new InvalidOperationException("Pay the commitment due or fix the triggering check-in before editing your profile.");
         EnsureParticipantIdentityUnchanged(participant, request);
-        var commitmentAmountParameter = commitmentAmountUsd.HasValue
-            ? FormatDecimal(commitmentAmountUsd.GetValueOrDefault())
-            : null;
 
         _db.Run(sqlite =>
         {
@@ -410,7 +406,7 @@ public sealed class LongevitymaxxingChallengeService
                 WHERE Id = @id;
                 """;
             Add(update, "@tz", timeZoneId);
-            Add(update, "@commitmentAmount", commitmentAmountParameter);
+            Add(update, "@commitmentAmount", FormatOptionalDecimal(commitmentAmountUsd));
             Add(update, "@updated", now.ToString("o"));
             Add(update, "@id", participant.Id);
             update.ExecuteNonQuery();
@@ -1969,33 +1965,9 @@ public sealed class LongevitymaxxingChallengeService
 
         if (participant.CommitmentAmountUsd is null)
         {
-            var hasOriginalDurationCatchUp = eligibleDays.Any(day =>
-                day.ChallengeDay <= settings.DurationDays &&
-                day.Existing is null);
-            var hasPendingContinuationCheckIn = eligibleDays.Any(day =>
-                day.ChallengeDay > settings.DurationDays &&
-                day.Existing is null);
-            if (!IsCommitmentSetupRequired(settings, participant, now) && !hasPendingContinuationCheckIn)
-            {
-                return new LongevitymaxxingCommitmentState(
-                    "deferred",
-                    false,
-                    false,
-                    false,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null);
-            }
-
             return new LongevitymaxxingCommitmentState(
-                "needs-amount",
-                !hasOriginalDurationCatchUp,
+                "deferred",
+                false,
                 true,
                 false,
                 null,
@@ -2006,7 +1978,7 @@ public sealed class LongevitymaxxingChallengeService
                 null,
                 null,
                 null,
-                "Configure an amount that'd hurt before continuing past Day 14.");
+                null);
         }
 
         return new LongevitymaxxingCommitmentState(
@@ -2037,6 +2009,16 @@ public sealed class LongevitymaxxingChallengeService
         var prior = GetPreviousScoredCheckIns(settings, participant, byDay, referenceDay)
             .Take(CommitmentAverageWindowDays)
             .ToList();
+        if (participant.CommitmentAmountUsd is null)
+        {
+            return new LongevitymaxxingCommitmentTrendGuidance(
+                false,
+                prior.Count,
+                null,
+                null,
+                "");
+        }
+
         if (prior.Count < CommitmentEnforcementPreviousScoredDays)
         {
             var remaining = CommitmentEnforcementPreviousScoredDays - prior.Count;
@@ -2487,9 +2469,6 @@ public sealed class LongevitymaxxingChallengeService
 
     private void EnsureParticipantNotCommitmentBlocked(ParticipantRecord participant, DateTimeOffset? nowUtc = null)
     {
-        var now = EnsureUtc(nowUtc ?? DateTimeOffset.UtcNow);
-        if (participant.CommitmentAmountUsd is null && IsCommitmentSetupRequired(BuildSettings(now), participant, now))
-            throw new InvalidOperationException("Configure your commitment amount before continuing.");
         if (GetActivePaymentObligation(participant.Id) is not null)
             throw new InvalidOperationException("Pay the commitment due or fix the triggering check-in before continuing.");
     }
@@ -2751,9 +2730,6 @@ public sealed class LongevitymaxxingChallengeService
         var localDate = DateOnly.FromDateTime(TimeZoneInfo.ConvertTime(now, ResolveTimeZone(participant.TimeZoneId)).DateTime);
         return localDate > settings.EndDate.AddDays(1);
     }
-
-    private static bool IsCommitmentAmountRequiredForCheckIn(ChallengeSettings settings, int challengeDay)
-        => challengeDay > settings.DurationDays;
 
     private static bool CountsForScore(
         ChallengeSettings settings,
@@ -3678,6 +3654,9 @@ public sealed class LongevitymaxxingChallengeService
         return rounded;
     }
 
+    private static decimal? NormalizeOptionalCommitmentAmount(decimal? amount)
+        => amount is null ? null : NormalizeCommitmentAmount(amount);
+
     private static string NormalizeToken(string token)
     {
         var normalized = (token ?? "").Trim();
@@ -4051,6 +4030,9 @@ public sealed class LongevitymaxxingChallengeService
 
     private static string FormatDecimal(decimal value)
         => value.ToString("0.####", CultureInfo.InvariantCulture);
+
+    private static string? FormatOptionalDecimal(decimal? value)
+        => value.HasValue ? FormatDecimal(value.Value) : null;
 
     private static decimal? ParseDecimal(string? value)
         => decimal.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out var parsed)

--- a/LongevityWorldCup.Website/wwwroot/js/longevitymaxxing.js
+++ b/LongevityWorldCup.Website/wwwroot/js/longevitymaxxing.js
@@ -14,7 +14,6 @@
     const NOTE_PHOTO_MAX_DIMENSION = 1600;
     const LEADERBOARD_SCORING_WINDOW_DAYS = 14;
     const COMMITMENT_PAYMENT_POLL_DELAYS_MS = [2500, 5000, 8000, 12000];
-    const TIME_ZONE_MATCH_LIMIT = 10;
     const QUESTIONS = [
         { key: "sleep", icon: "fa-moon", title: "Sleep", text: "Did you set yourself up for good sleep last night?" },
         { key: "exercise", icon: "fa-dumbbell", title: "Exercise", text: "Did you challenge or intentionally rest your body yesterday?" },
@@ -228,7 +227,6 @@
         const inactiveToggle = document.getElementById("lmxInactiveToggle");
         wireEmailValidityReset(signupEmailInput);
         wireEmailValidityReset(resendEmailInput);
-        wireCommitmentAmountValidation("lmxSignupCommitmentAmount");
         wireCommitmentAmountValidation("lmxEditCommitmentAmount");
 
         signupForm.addEventListener("submit", async event => {
@@ -242,15 +240,13 @@
                     email: signupEmail,
                     displayName: getIdentityDisplayName("signup"),
                     timeZoneId: document.getElementById("lmxSignupTimeZone").value,
-                    athleteLink: getIdentityAthletePayload("signup"),
-                    commitmentAmountUsd: parseCommitmentAmount("lmxSignupCommitmentAmount")
+                    athleteLink: getIdentityAthletePayload("signup")
                 };
                 const result = await postJson(`${API}/signup`, payload);
                 setStatus("lmxSignupStatus", result.message || "Check your email.", false);
                 signupForm.reset();
                 clearAthleteSelector("lmxSignupAthlete");
                 setIdentityMode("signup", "participant");
-                setCommitmentInputValue("lmxSignupCommitmentAmount", null);
                 setDefaultTimezone(document.getElementById("lmxSignupTimeZone"));
                 signupSubmitted = true;
                 renderAll();
@@ -300,11 +296,10 @@
             event.preventDefault();
             if (!accessToken) return;
             await withButton(editForm.querySelector("button[type='submit']"), async () => {
-                const showCommitment = shouldShowCommitmentAmountField(participantState);
                 const result = await postJson(`${API}/edit`, {
                     accessToken,
                     timeZoneId: document.getElementById("lmxEditTimeZone").value,
-                    commitmentAmountUsd: showCommitment ? parseCommitmentAmount("lmxEditCommitmentAmount") : null
+                    commitmentAmountUsd: parseOptionalCommitmentAmount("lmxEditCommitmentAmount")
                 });
                 participantState = result;
                 publicState = result.public;
@@ -897,7 +892,7 @@
         toggle("lmxMetrics", hasParticipant && dashboardMode && !participantGateOnly);
         toggle("lmxBoardSection", !publicContentHidden);
         toggle("lmxParticipantTabs", hasParticipant && !commitmentBlocked);
-        toggle("lmxCommitmentPanel", hasParticipant && commitmentBlocked);
+        toggle("lmxCommitmentPanel", hasParticipant && shouldShowCommitmentPanel(participantState, activeParticipantTab));
         toggle("lmxCheckinPanel", hasParticipant && !commitmentBlocked && activeParticipantTab === "checkin");
         toggle("lmxEditForm", hasParticipant && !commitmentBlocked && activeParticipantTab === "profile");
         toggle("lmxHomePanel", hasParticipant && !commitmentBlocked && activeParticipantTab === "home");
@@ -941,7 +936,7 @@
         setText("lmxParticipantKicker", kicker);
         toggle("lmxParticipantKicker", !!kicker);
         setText("lmxParticipantTitle", title);
-        renderCommitmentPanel(state);
+        renderCommitmentPanel(state, activeTab);
         renderParticipantNotice();
 
         renderProfileIdentity(participant);
@@ -952,7 +947,7 @@
         if (commitmentInput) {
             const showCommitment = shouldShowCommitmentAmountField(state);
             commitmentInput.disabled = !showCommitment || state.commitment?.canEditAmount === false;
-            commitmentInput.required = showCommitment;
+            commitmentInput.required = hasConfiguredCommitmentAmount(state);
         }
         renderProfilePictureControls(participant);
         renderParticipantCalls(state.calls || [], state.public.callSelectionClosesAtUtc);
@@ -966,7 +961,7 @@
         if (hasCommitmentBlock(participantState)) {
             return participantState.commitment?.status === "due"
                 ? `Commitment due, ${name}`
-                : "Make a pledge to continue";
+                : "Make a pledge";
         }
         if (activeTab === "profile") return `Profile, ${name}`;
         if (activeTab === "home") {
@@ -1156,11 +1151,42 @@
         return tab !== "checkin" && getPendingCheckInDays(state).length > 0;
     }
 
-    function renderCommitmentPanel(state) {
+    function renderCommitmentPanel(state, activeTab) {
         const panel = document.getElementById("lmxCommitmentPanel");
         if (!panel) return;
 
         const commitment = state.commitment || {};
+        if (shouldShowCheckInPledgePrompt(state, activeTab)) {
+            panel.innerHTML = `
+                <form id="lmxCommitmentAmountForm" class="lmx-commitment-card setup">
+                    <div class="lmx-commitment-main">
+                        <i class="fas fa-pen-nib" aria-hidden="true"></i>
+                        <div>
+                            <strong>Set a real stake</strong>
+                            <span id="lmxPledgeCommitmentHelp">Fall below your recent average and either pay it or stop longevitymaxxing. You can keep checking in without a pledge.</span>
+                        </div>
+                    </div>
+                    <div class="lmx-field">
+                        <label for="lmxPledgeCommitmentAmount">Pledge</label>
+                        <div class="lmx-money-input">
+                            <span aria-hidden="true">$</span>
+                            <input id="lmxPledgeCommitmentAmount" type="text" inputmode="decimal" required placeholder="300" aria-describedby="lmxPledgeCommitmentHelp">
+                        </div>
+                    </div>
+                    <button class="lmx-button secondary" type="submit">
+                        <i class="fas fa-pen-nib" aria-hidden="true"></i>
+                        Make a pledge
+                    </button>
+                    <div class="lmx-status" role="status" aria-live="polite" aria-atomic="true"></div>
+                </form>`;
+            panel.querySelector("form")?.addEventListener("submit", event => {
+                event.preventDefault();
+                saveCommitmentAmountFromPanel("lmxPledgeCommitmentAmount", panel.querySelector("button[type='submit']"), "Pledge saved.");
+            });
+            wireCommitmentAmountValidation("lmxPledgeCommitmentAmount");
+            return;
+        }
+
         if (!commitment.blocksParticipant) {
             panel.innerHTML = "";
             return;
@@ -1191,7 +1217,7 @@
                 </form>`;
             panel.querySelector("form")?.addEventListener("submit", event => {
                 event.preventDefault();
-                saveCommitmentAmountFromBlockedPanel(panel.querySelector("button[type='submit']"));
+                saveCommitmentAmountFromPanel("lmxBlockedCommitmentAmount", panel.querySelector("button[type='submit']"), "Commitment amount saved. You can continue.");
             });
             wireCommitmentAmountValidation("lmxBlockedCommitmentAmount");
             return;
@@ -1260,8 +1286,24 @@
         return !!(state && state.commitment && state.commitment.blocksParticipant);
     }
 
+    function shouldShowCommitmentPanel(state, activeTab) {
+        return !!(state && state.commitment && (state.commitment.blocksParticipant || shouldShowCheckInPledgePrompt(state, activeTab)));
+    }
+
+    function shouldShowCheckInPledgePrompt(state, activeTab) {
+        if (activeTab !== "checkin") return false;
+        if (state?.commitment?.status !== "deferred") return false;
+        const pendingScoredDays = getPendingCheckInDays(state).filter(day => day.countsForScore !== false);
+        if (!pendingScoredDays.length) return false;
+        return Number(state.trendGuidance?.priorScoredDays || 0) >= 3;
+    }
+
     function shouldShowCommitmentAmountField(state) {
-        return !!(state && state.commitment && state.commitment.status !== "deferred");
+        return !!(state && state.commitment);
+    }
+
+    function hasConfiguredCommitmentAmount(state) {
+        return Number(state?.participant?.commitmentAmountUsd ?? state?.commitment?.amountUsd ?? 0) >= 1;
     }
 
     function getCommitmentEditableDays(state) {
@@ -1270,7 +1312,7 @@
             .filter(day => day.existing && (!triggerDay || day.challengeDay === triggerDay));
     }
 
-    async function saveCommitmentAmountFromBlockedPanel(button) {
+    async function saveCommitmentAmountFromPanel(inputId, button, successMessage) {
         if (!accessToken || !participantState) return;
         await withButton(button, async () => {
             const participant = participantState.participant || {};
@@ -1279,12 +1321,12 @@
                 displayName: participant.displayName || "",
                 timeZoneId: participant.timeZoneId || Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
                 athleteLink: participant.athleteSlug || participant.athleteUrl || null,
-                commitmentAmountUsd: parseCommitmentAmount("lmxBlockedCommitmentAmount")
+                commitmentAmountUsd: parseCommitmentAmount(inputId)
             });
             participantState = result;
             publicState = result.public;
             if (!hasCommitmentBlock(result)) {
-                participantNotice = { message: "Commitment amount saved. You can continue.", isError: false };
+                participantNotice = { message: successMessage, isError: false };
                 participantActiveTab = null;
                 participantTabManual = false;
             }
@@ -2501,6 +2543,18 @@
 
         clearCommitmentAmountValidity(input);
         return Math.round(value * 100) / 100;
+    }
+
+    function parseOptionalCommitmentAmount(inputId) {
+        const input = document.getElementById(inputId);
+        if (input) sanitizeCommitmentAmountInput(input);
+        const raw = String(input?.value || "").trim();
+        if (!raw) {
+            clearCommitmentAmountValidity(input);
+            return null;
+        }
+
+        return parseCommitmentAmount(inputId);
     }
 
     function wireCommitmentAmountValidation(inputId) {
@@ -3817,8 +3871,7 @@
         const matches = zones
             .map(zone => ({ zone, score: timeZoneMatchScore(zone, terms, selected) }))
             .filter(item => item.score > 0)
-            .sort((a, b) => b.score - a.score || a.zone.localeCompare(b.zone))
-            .slice(0, TIME_ZONE_MATCH_LIMIT);
+            .sort((a, b) => b.score - a.score || a.zone.localeCompare(b.zone));
 
         list.innerHTML = matches.length
             ? matches.map((item, index) => timeZoneOptionHtml(item.zone, selected, index === 0)).join("")

--- a/LongevityWorldCup.Website/wwwroot/js/site-statistics-tracking.js
+++ b/LongevityWorldCup.Website/wwwroot/js/site-statistics-tracking.js
@@ -703,22 +703,11 @@
                 trackOnce("challenge-username-completed", "challenge_username_completed", { component: "signup", outcome: "completed" });
                 return;
             }
-            if (target.id === "lmxSignupCommitmentAmount") {
-                trackOnce("challenge-pledge-touched", "challenge_pledge_touched", { component: "signup", step: "pledge", outcome: "touched" });
-                if (target.value) {
-                    track("challenge_pledge_completed", {
-                        component: "signup",
-                        step: "pledge",
-                        outcome: "completed",
-                        metadata: { pledgeBucket: amountBucket(target.value) }
-                    });
-                }
-            }
         }, { passive: true });
 
         listen(signupForm, "invalid", event => {
             const key = safeFieldKey(event.target);
-            track(key === "lmxSignupCommitmentAmount" ? "challenge_pledge_validation_failed" : "challenge_email_validation_failed", {
+            track(key === "lmxSignupEmail" ? "challenge_email_validation_failed" : "challenge_signup_validation_failed", {
                 component: "signup",
                 step: key,
                 outcome: "failed",
@@ -740,6 +729,32 @@
                 });
             }, { passive: true });
         });
+
+        listen(document, "input", event => {
+            const target = event.target;
+            if (!target || (target.id !== "lmxPledgeCommitmentAmount" && target.id !== "lmxBlockedCommitmentAmount" && target.id !== "lmxEditCommitmentAmount")) return;
+            const component = target.id === "lmxEditCommitmentAmount" ? "profile" : "commitment";
+            trackOnce(`challenge-pledge-touched-${component}`, "challenge_pledge_touched", { component, step: "pledge", outcome: "touched" });
+            if (target.value) {
+                track("challenge_pledge_completed", {
+                    component,
+                    step: "pledge",
+                    outcome: "completed",
+                    metadata: { pledgeBucket: amountBucket(target.value) }
+                });
+            }
+        }, { passive: true });
+
+        listen(document, "invalid", event => {
+            const target = event.target;
+            if (!target || (target.id !== "lmxPledgeCommitmentAmount" && target.id !== "lmxBlockedCommitmentAmount" && target.id !== "lmxEditCommitmentAmount")) return;
+            track("challenge_pledge_validation_failed", {
+                component: target.id === "lmxEditCommitmentAmount" ? "profile" : "commitment",
+                step: safeFieldKey(target),
+                outcome: "failed",
+                errorCode: "browser_validation"
+            });
+        }, true);
 
         listen(document.getElementById("lmxSignupAthlete"), "input", () => {
             trackOnce("challenge-athlete-search-started", "challenge_athlete_search_started", { component: "signup", step: "athlete_search", outcome: "started" });

--- a/LongevityWorldCup.Website/wwwroot/longevitymaxxing/longevitymaxxing.html
+++ b/LongevityWorldCup.Website/wwwroot/longevitymaxxing/longevitymaxxing.html
@@ -130,14 +130,6 @@
                                 </div>
                             </fieldset>
                             <div class="lmx-field">
-                                <label for="lmxSignupCommitmentAmount">Pledge</label>
-                                <p id="lmxSignupCommitmentHelp" class="lmx-field-help lmx-commitment-help">Set a real stake. Fall below your recent average and either pay it or stop. Choose an amount that would hurt.</p>
-                                <div class="lmx-money-input">
-                                    <span aria-hidden="true">$</span>
-                                    <input id="lmxSignupCommitmentAmount" name="commitmentAmountUsd" type="text" inputmode="decimal" required placeholder="300" aria-describedby="lmxSignupCommitmentHelp">
-                                </div>
-                            </div>
-                            <div class="lmx-field">
                                 <span class="lmx-label" id="lmxSignupTimeZoneLabel">Timezone</span>
                                 <div class="lmx-timezone-picker" data-timezone-picker data-select-id="lmxSignupTimeZone" aria-labelledby="lmxSignupTimeZoneLabel">
                                     <button id="lmxSignupTimeZoneButton" class="lmx-timezone-button" type="button" aria-haspopup="listbox" aria-expanded="false">
@@ -166,7 +158,7 @@
                         <div class="lmx-card-head">
                             <span class="lmx-mini-label">email sent</span>
                             <h2>Check your email</h2>
-                            <p class="lmx-card-copy">Open the confirmation link in your email once. After that, this page becomes your check-in console. Your first check-in email arrives tomorrow morning at 7 AM; nothing else is due before then.</p>
+                            <p class="lmx-card-copy">Open the confirmation link in your email once. After that, this page becomes your check-in console. Your first check-in email arrives tomorrow morning at 7 AM.</p>
                         </div>
                         <button id="lmxSignupAgain" class="lmx-button secondary" type="button">
                             <i class="fas fa-rotate-left" aria-hidden="true"></i>

--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -16,7 +16,7 @@
 - **Social post** is generated copy for X, Threads, Facebook, Slack, or future integrations.
 - **Resting** means a Challenge participant is currently inactive for leaderboard grouping; saved check-ins and notes remain visible, and eligible catch-up check-ins can clear missed-day resting.
 - **Pledge buffer** is Challenge-only commitment slack: the pledge triggers only when a check-in is more than two raw habit points below the raw score needed to meet the recent average. It does not change leaderboard scoring or general slip scoring.
-- Legacy Challenge participants without a pledge may finish eligible original-duration catch-up check-ins. A pledge is required before Day 15+ continuation check-ins.
+- Challenge pledge is optional and is not collected on signup. Participants can set a pledge from the participant menu whenever profile editing is available. If no pledge is set, the check-in flow may prompt for one only when commitment enforcement is about to become relevant; no pledge means the participant continues normally and no Challenge commitment payment can trigger.
 
 ## Naming
 


### PR DESCRIPTION
## Summary
- make Longevitymaxxing Challenge signup work without collecting or requiring a pledge
- keep pledge setup available from the participant profile/menu and prompt during check-in only when enforcement is about to matter
- remove the timezone picker result cap so the full timezone list is available

## Validation
- dotnet test .\LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --filter FullyQualifiedName~LongevitymaxxingChallenge --logger "console;verbosity=minimal"
- dotnet test .\LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --no-build --filter FullyQualifiedName~SiteStatistics --logger "console;verbosity=minimal"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes commitment enforcement and signup/edit contracts in `LongevitymaxxingChallengeService` and participant UI; payment-due paths remain but behavior for no-pledge participants is materially different.
> 
> **Overview**
> Makes the Longevitymaxxing Challenge **pledge optional** end-to-end: signup no longer collects or requires a commitment amount, and the backend stops blocking check-ins, profile edits, or uploads when no pledge is set (including past Day 14).
> 
> **Backend** (`LongevitymaxxingChallengeService`): signup/edit use optional amount normalization; participants without a pledge stay in `deferred` with `CanEditAmount` instead of `needs-amount` / `BlocksParticipant`. Enforcement gates tied to post–Day 14 continuation and “configure amount before continuing” are removed; trend guidance stays empty until a pledge exists.
> 
> **Frontend**: pledge field removed from signup HTML; profile edit uses `parseOptionalCommitmentAmount`. A **non-blocking** check-in prompt (`shouldShowCheckInPledgePrompt`) appears on the check-in tab when status is `deferred`, there are pending scored days, and `priorScoredDays >= 3`. Commitment panel visibility follows `shouldShowCommitmentPanel` (blocked flow unchanged for payment due).
> 
> **Other**: timezone search shows all matches (drops `TIME_ZONE_MATCH_LIMIT`); pledge analytics move from signup to pledge/profile inputs; `UBIQUITOUS_LANGUAGE.md` documents optional pledges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9d7a4240caf25279f9ba07f6f22bb6e80566a57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->