### PR TITLE
Move longevitymaxxing entry point

### DIFF
--- a/LongevityWorldCup.Tests/LongevitymaxxingChallengePageTests.cs
+++ b/LongevityWorldCup.Tests/LongevitymaxxingChallengePageTests.cs
@@ -415,7 +415,7 @@ public sealed class LongevitymaxxingChallengePageTests
     }
 
     [Fact]
-    public async Task Homepage_AdvertisesLongevitymaxxingChallengeWhileSignupIsOpen()
+    public async Task Homepage_DoesNotAdvertiseLongevitymaxxingChallengeWhileSignupIsOpen()
     {
         using var factory = CreateFactory(new Config
         {
@@ -429,17 +429,17 @@ public sealed class LongevitymaxxingChallengePageTests
 
         var html = await client.GetStringAsync("/");
 
-        Assert.Contains("id=\"longevitymaxxingPromo\"", html);
-        Assert.Contains("Don't feel ready for the Longevity World Cup yet? Try longevitymaxxing first.", html);
-        Assert.Contains("Start longevitymaxxing", html);
-        Assert.Contains("href=\"/longevitymaxxing\"", html);
+        Assert.DoesNotContain("id=\"longevitymaxxingPromo\"", html);
+        Assert.DoesNotContain("Don't feel ready for the Longevity World Cup yet? Try longevitymaxxing first.", html);
+        Assert.DoesNotContain("Start longevitymaxxing", html);
+        Assert.DoesNotContain("href=\"/longevitymaxxing\"", html);
         Assert.DoesNotContain("Separate Lifestyle challenge", html);
         Assert.DoesNotContain("does not affect Ultimate League rankings", html);
         Assert.DoesNotContain("/api/longevitymaxxing/state", html);
     }
 
     [Fact]
-    public async Task Homepage_AdvertisesLongevitymaxxingChallengeWhileActiveSignupIsOpen()
+    public async Task Homepage_DoesNotAdvertiseLongevitymaxxingChallengeWhileActiveSignupIsOpen()
     {
         var now = DateTimeOffset.UtcNow;
         using var factory = CreateFactory(new Config
@@ -454,13 +454,13 @@ public sealed class LongevitymaxxingChallengePageTests
 
         var html = await client.GetStringAsync("/");
 
-        Assert.Contains("id=\"longevitymaxxingPromo\"", html);
-        Assert.Contains("Start longevitymaxxing", html);
+        Assert.DoesNotContain("id=\"longevitymaxxingPromo\"", html);
+        Assert.DoesNotContain("Start longevitymaxxing", html);
         Assert.DoesNotContain("Separate Lifestyle challenge", html);
     }
 
     [Fact]
-    public async Task Homepage_AdvertisesLongevitymaxxingChallengeBeforeStartAfterConfiguredSignupClose()
+    public async Task Homepage_DoesNotAdvertiseLongevitymaxxingChallengeBeforeStartAfterConfiguredSignupClose()
     {
         var now = DateTimeOffset.UtcNow;
         using var factory = CreateFactory(new Config
@@ -476,15 +476,15 @@ public sealed class LongevitymaxxingChallengePageTests
         var html = await client.GetStringAsync("/");
         var json = await client.GetStringAsync("/api/longevitymaxxing/state");
 
-        Assert.Contains("id=\"longevitymaxxingPromo\"", html);
-        Assert.Contains("Start longevitymaxxing", html);
+        Assert.DoesNotContain("id=\"longevitymaxxingPromo\"", html);
+        Assert.DoesNotContain("Start longevitymaxxing", html);
         Assert.DoesNotContain("Separate Lifestyle challenge", html);
         Assert.Contains("\"phase\":\"signup\"", json);
         Assert.Contains("\"signupOpen\":true", json);
     }
 
     [Fact]
-    public async Task Homepage_AdvertisesLongevitymaxxingChallengeAfterOriginalSignupClose()
+    public async Task Homepage_DoesNotAdvertiseLongevitymaxxingChallengeAfterOriginalSignupClose()
     {
         using var factory = CreateFactory(new Config
         {
@@ -498,9 +498,9 @@ public sealed class LongevitymaxxingChallengePageTests
 
         var html = await client.GetStringAsync("/");
 
-        Assert.Contains("id=\"longevitymaxxingPromo\"", html);
-        Assert.Contains("Don't feel ready for the Longevity World Cup yet? Try longevitymaxxing first.", html);
-        Assert.Contains("Start longevitymaxxing", html);
+        Assert.DoesNotContain("id=\"longevitymaxxingPromo\"", html);
+        Assert.DoesNotContain("Don't feel ready for the Longevity World Cup yet? Try longevitymaxxing first.", html);
+        Assert.DoesNotContain("Start longevitymaxxing", html);
         Assert.DoesNotContain("Separate Lifestyle challenge", html);
         Assert.DoesNotContain("does not affect Ultimate League rankings", html);
     }

--- a/LongevityWorldCup.Tests/PaymentOfferHandoffPageTests.cs
+++ b/LongevityWorldCup.Tests/PaymentOfferHandoffPageTests.cs
@@ -85,6 +85,7 @@ public sealed class PaymentOfferHandoffPageTests
         Assert.Contains("min-width: 44px;", html);
         Assert.Contains("height: 44px;", html);
         Assert.Contains(".pro-discount-box .pro-discount-breakdown .pro-discount-badge-slot:empty", html);
+        Assert.Contains(".pro-discount-box .pro-discount-breakdown.pro-discount-breakdown--with-badges .pro-discount-badge-slot:empty", html);
         Assert.Contains(".pro-discount-box .pro-discount-breakdown .pro-discount-text", html);
         Assert.Contains("overflow-wrap: anywhere;", html);
     }

--- a/LongevityWorldCup.Tests/PlayAthleteFlowBrowserTests.cs
+++ b/LongevityWorldCup.Tests/PlayAthleteFlowBrowserTests.cs
@@ -42,6 +42,7 @@ public sealed class PlayAthleteFlowBrowserTests
         Assert.Equal("/join", new Uri(page.Url).AbsolutePath);
         Assert.True(await page.GetByRole(AriaRole.Button, new() { Name = "Start amateur" }).IsVisibleAsync());
         Assert.True(await page.GetByRole(AriaRole.Button, new() { Name = "Go pro" }).IsVisibleAsync());
+        Assert.True(await page.GetByRole(AriaRole.Link, new() { Name = "Try our longevitymaxxing lifestyle challenge instead" }).IsVisibleAsync());
 
         await page.GoBackAsync();
         await page.WaitForURLAsync("**/play");
@@ -135,6 +136,7 @@ public sealed class PlayAthleteFlowBrowserTests
         Assert.Equal("/dashboard", new Uri(page.Url).AbsolutePath);
         Assert.Equal("Browser Test Athlete", await page.Locator("#athleteDashboardTitle").InnerTextAsync());
         await ExpectAthletePictureFallbackAsync(page, "#athleteDashboardPicture");
+        Assert.True(await page.GetByRole(AriaRole.Button, new() { Name = "Longevitymaxxing" }).IsVisibleAsync());
 
         await page.GoBackAsync();
         await page.WaitForURLAsync("**/select-athlete");

--- a/LongevityWorldCup.Tests/PlayMenuPageTests.cs
+++ b/LongevityWorldCup.Tests/PlayMenuPageTests.cs
@@ -75,6 +75,17 @@ public sealed class PlayMenuPageTests
         Assert.Contains("if (path === '/join') return 'join';", html);
         Assert.Contains("newBtn.addEventListener('click', () => showPlayPanel('join', { historyMode: 'push' }));", html);
         Assert.Contains("document.getElementById('joinTrackBackBtn').addEventListener('click', navigateToStartPanel);", html);
+        Assert.Contains("class=\"play-join-challenge-note\"", html);
+        Assert.Contains("id=\"joinStartChallengeLink\" href=\"/longevitymaxxing\"", html);
+        Assert.Contains("Not ready for a blood test yet?", html);
+        Assert.Contains("Try our longevitymaxxing lifestyle challenge instead", html);
+        Assert.Contains("<h1 class=\"play-join-title\">Choose your track</h1>", html);
+        Assert.Contains("To calculate your biological age, get a <strong>blood test</strong>.", html);
+        Assert.DoesNotContain("play-join-card--challenge", html);
+        Assert.DoesNotContain("play-join-secondary-actions", html);
+        Assert.DoesNotContain("<span class=\"track-name\">Longevitymaxxing</span>", html);
+        Assert.DoesNotContain("id=\"joinStartChallengeButton\"", html);
+        Assert.DoesNotContain("Start challenge</span>", html);
         Assert.DoesNotContain("onclick=\"window.location.href='/join'\"", html);
         Assert.Contains("flow.setPendingPaymentOffer({", html);
         Assert.Contains("source: 'join-game'", html);
@@ -100,6 +111,11 @@ public sealed class PlayMenuPageTests
         Assert.Contains("removeLocalItem(\"contactEmail\");", flow);
         Assert.Contains("\"/pheno-age?update=1\"", flow);
         Assert.Contains("\"/bortz-age?update=1\"", flow);
+        Assert.Contains("\"/longevitymaxxing\"", flow);
+        Assert.Contains("dynamicActions.append(challengeButton, submitButton, goProButton);", flow);
+        Assert.Contains("dynamicActions.append(challengeButton, phenoButton, bortzButton);", flow);
+        Assert.Contains("Longevitymaxxing</span>", flow);
+        Assert.DoesNotContain("Longevitymaxxing Challenge</span>", flow);
     }
 
     [Fact]
@@ -245,12 +261,15 @@ public sealed class PlayMenuPageTests
         using var client = factory.CreateClient();
 
         var html = await client.GetStringAsync("/play/menu.html");
+        var flow = await client.GetStringAsync("/js/play-athlete-flow.js");
 
         Assert.Contains(".pro-discount-badge-slot {\n            width: 44px;", html);
         Assert.Contains("min-width: 44px;", html);
         Assert.Contains("height: 44px;", html);
         Assert.Contains(".pro-discount-badge-slot:empty", html);
+        Assert.Contains(".pro-discount-breakdown.pro-discount-breakdown--with-badges .pro-discount-badge-slot:empty", html);
         Assert.Contains(".pro-discount-text", html);
         Assert.Contains("overflow-wrap: anywhere;", html);
+        Assert.Contains("pro-discount-breakdown--with-badges", flow);
     }
 }

--- a/LongevityWorldCup.Tests/SiteStatisticsDashboardPageTests.cs
+++ b/LongevityWorldCup.Tests/SiteStatisticsDashboardPageTests.cs
@@ -54,9 +54,12 @@ public sealed class SiteStatisticsDashboardPageTests
 
         Assert.Contains("id=\"joinStartAmateurBtn\"", menu);
         Assert.Contains("id=\"joinGoProButton\"", menu);
+        Assert.Contains("id=\"joinStartChallengeLink\"", menu);
         Assert.Contains("play-join-biomarkers", menu);
         Assert.Contains("joinStartAmateurBtn", tracker);
         Assert.Contains("joinGoProButton", tracker);
+        Assert.Contains("joinStartChallengeLink", tracker);
+        Assert.Contains("onboarding_challenge_selected", tracker);
         Assert.Contains(".play-join-biomarkers details", tracker);
         Assert.Contains(".play-join-card--pro", tracker);
         Assert.Contains("return \"internal\";", tracker);

--- a/LongevityWorldCup.Website/wwwroot/js/play-athlete-flow.js
+++ b/LongevityWorldCup.Website/wwwroot/js/play-athlete-flow.js
@@ -702,6 +702,9 @@ function createGoProDiscountSummary(result) {
 
     const breakdownLine = document.createElement("p");
     breakdownLine.className = "pro-discount-breakdown";
+    if (Array.isArray(result.components) && result.components.some(component => component && component.isBadge)) {
+        breakdownLine.classList.add("pro-discount-breakdown--with-badges");
+    }
     if (typeof window.proDiscounts.createBreakdownHtml === "function") {
         breakdownLine.innerHTML = window.proDiscounts.createBreakdownHtml(result);
     } else {
@@ -728,6 +731,12 @@ function renderDashboardActions(athlete, options) {
 
         const isDemoPro = Boolean(options.demoPro);
         const isPro = isDemoPro || (window.isAthletePro ? window.isAthletePro(athlete) : false);
+        const challengeButton = createDashboardButton(
+            "<span class=\"dashboard-action-label flow-action__label\">Longevitymaxxing</span><i class=\"fas fa-calendar-check\" aria-hidden=\"true\"></i>",
+            "option-button grey flow-action flow-action--secondary",
+            "/longevitymaxxing",
+            () => clearPendingPaymentOffer()
+        );
 
         if (isPro) {
             const phenoButton = createDashboardButton(
@@ -742,7 +751,7 @@ function renderDashboardActions(athlete, options) {
                 "/bortz-age?update=1",
                 () => clearPendingPaymentOffer()
             );
-            dynamicActions.append(phenoButton, bortzButton);
+            dynamicActions.append(challengeButton, phenoButton, bortzButton);
             return;
         }
 
@@ -782,7 +791,7 @@ function renderDashboardActions(athlete, options) {
             }
         );
 
-        dynamicActions.append(submitButton, goProButton);
+        dynamicActions.append(challengeButton, submitButton, goProButton);
         const goProDiscountSummary = goProDiscountResult ? createGoProDiscountSummary(goProDiscountResult) : null;
         if (goProDiscountSummary) {
             dynamicActions.append(goProDiscountSummary);

--- a/LongevityWorldCup.Website/wwwroot/js/site-statistics-tracking.js
+++ b/LongevityWorldCup.Website/wwwroot/js/site-statistics-tracking.js
@@ -359,6 +359,7 @@
     function setupJoinGameTracking() {
         const amateur = document.getElementById("joinStartAmateurBtn") || document.querySelector("[onclick*='startAmateurApplication']");
         const pro = document.getElementById("joinGoProButton") || document.querySelector("[onclick*='startProApplication']");
+        const challenge = document.getElementById("joinStartChallengeLink");
         listen(amateur, "click", () => {
             track("onboarding_clock_selected", {
                 flow: "pheno",
@@ -375,6 +376,15 @@
                 step: "pro",
                 outcome: "selected",
                 metadata: { track: "pro" }
+            });
+        }, { passive: true });
+        listen(challenge, "click", () => {
+            track("onboarding_challenge_selected", {
+                flow: "challenge",
+                component: "join_game",
+                step: "challenge",
+                outcome: "selected",
+                metadata: { track: "challenge" }
             });
         }, { passive: true });
 

--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -506,34 +506,6 @@
     }
     .ranking-explanation.is-visible{ display:block; }
     .ranking-explanation strong{ color:var(--primary-color); }
-    .longevitymaxxing-promo{
-        display:flex; align-items:center; justify-content:space-between; gap:1rem; margin:0 0 1rem; padding:.9rem 1rem;
-        border:1px solid rgba(15,23,42,.08); border-radius:8px;
-        background:rgba(255,255,255,.88);
-        box-shadow:0 8px 20px rgba(15,23,42,.08); box-sizing:border-box;
-    }
-    .longevitymaxxing-promo p{
-        margin:0; color:#2f3f49; font-size:.98rem; line-height:1.4;
-    }
-    .longevitymaxxing-promo p strong{
-        color:#0f172a; font-weight:850;
-    }
-    .longevitymaxxing-promo-action{
-        display:inline-flex; align-items:center; justify-content:center; min-height:44px; white-space:nowrap;
-        padding:.68rem 1.05rem; border:1px solid rgba(15,23,42,.08); border-radius:8px;
-        background:#0797a9; color:#fff; font-weight:800; text-decoration:none;
-        box-shadow:0 7px 16px rgba(0,151,169,.22), inset 0 1px 0 rgba(255,255,255,.22);
-        transition:background-color .18s ease, border-color .18s ease, box-shadow .18s ease, transform .18s ease;
-    }
-    .longevitymaxxing-promo-action:hover,
-    .longevitymaxxing-promo-action:focus-visible{
-        color:#fff; border-color:rgba(15,23,42,.14); background:#067f8f; outline:none;
-        box-shadow:0 9px 18px rgba(0,127,143,.24), inset 0 1px 0 rgba(255,255,255,.18);
-        transform:translateY(-1px);
-    }
-    .longevitymaxxing-promo-action:focus-visible{
-        box-shadow:0 0 0 3px rgba(255,64,129,.20), 0 9px 18px rgba(0,127,143,.24);
-    }
     .search-wrapper{ display:flex; justify-content:flex-end; margin-bottom:1rem; }
     .search-container{ position:relative; max-width:250px; width:100%; min-height:44px; margin-right:.5rem; }
     #athleteSearch{
@@ -1758,12 +1730,6 @@
             margin-left:auto;
             margin-right:auto;
         }
-        .longevitymaxxing-promo{
-            flex-direction:column; align-items:stretch; gap:.75rem; margin:1.15rem 0 1.25rem; padding:.95rem;
-        }
-        .longevitymaxxing-promo-action{
-            width:100%; box-sizing:border-box;
-        }
         body.sidebar-drawer-open{
             overflow:hidden;
         }
@@ -2369,21 +2335,6 @@
             margin-bottom:.55rem;
         }
 
-        .longevitymaxxing-promo{
-            flex-direction:row;
-            align-items:center;
-            margin:0 0 .6rem;
-            padding:.75rem .85rem;
-        }
-
-        .longevitymaxxing-promo p{
-            font-size:.92rem;
-        }
-
-        .longevitymaxxing-promo-action{
-            width:auto;
-        }
-
         .leaderboard-view-switcher{
             width:auto;
             min-width:0;
@@ -2545,11 +2496,6 @@
                 <div class="podium-skeleton-line skeleton-shimmer"></div>
             </div>
         </div>
-
-        <section class="longevitymaxxing-promo" id="longevitymaxxingPromo" aria-label="Longevitymaxxing">
-            <p>Don't feel ready for the Longevity World Cup yet? Try longevitymaxxing first.</p>
-            <a class="longevitymaxxing-promo-action" href="/longevitymaxxing">Start longevitymaxxing</a>
-        </section>
 
         <div class="leaderboard-toolbar">
             <div class="leaderboard-view-switcher" role="radiogroup" aria-labelledby="leaderboardViewLabel">

--- a/LongevityWorldCup.Website/wwwroot/play/menu.html
+++ b/LongevityWorldCup.Website/wwwroot/play/menu.html
@@ -324,6 +324,22 @@
             color: #14532d;
         }
 
+        .play-join-challenge-note {
+            width: min(100%, 760px);
+            margin: 1rem auto 0;
+            color: #526d7a;
+            font-size: 0.95rem;
+            line-height: 1.35;
+            text-align: center;
+        }
+
+        .play-join-challenge-note a {
+            color: #0f6d7a;
+            font-weight: 700;
+            text-decoration: underline;
+            text-underline-offset: 0.16em;
+        }
+
         .play-join-back {
             margin-top: 1.35rem;
         }
@@ -514,6 +530,10 @@
 
         .pro-discount-box .pro-discount-breakdown .pro-discount-badge-slot:empty {
             display: none;
+        }
+
+        .pro-discount-box .pro-discount-breakdown.pro-discount-breakdown--with-badges .pro-discount-badge-slot:empty {
+            display: inline-flex;
         }
 
         .pro-discount-box .pro-discount-breakdown .pro-discount-text {
@@ -876,7 +896,12 @@
                         </div>
                     </div>
                 </article>
+
             </div>
+
+            <p class="play-join-challenge-note">
+                Not ready for a blood test yet? <a id="joinStartChallengeLink" href="/longevitymaxxing">Try our longevitymaxxing lifestyle challenge instead</a>
+            </p>
 
             <div class="options-container play-join-back flow-action-stack">
                 <button id="joinTrackBackBtn" type="button" class="option-button back-button flow-action flow-action--secondary flow-action--icon-left">
@@ -1271,6 +1296,7 @@
                 if (amateurPrice) amateurPrice.textContent = 'free';
                 if (proEntryPrice) proEntryPrice.innerHTML = '<span class="pro-new-price">free</span>';
                 if (breakdown) breakdown.textContent = '';
+                if (breakdown) breakdown.classList.remove('pro-discount-breakdown--with-badges');
                 if (note) note.style.display = 'none';
                 return true;
             }
@@ -1284,6 +1310,10 @@
                 const breakdown = document.getElementById('joinProDiscountBreakdown');
                 const proEntryPrice = document.getElementById('joinProEntryPrice');
                 if (!note || !breakdown || !proEntryPrice) return;
+                breakdown.classList.toggle(
+                    'pro-discount-breakdown--with-badges',
+                    Array.isArray(result.components) && result.components.some(component => component && component.isBadge)
+                );
 
                 proEntryPrice.innerHTML = typeof window.proDiscounts.createPriceHtml === 'function'
                     ? window.proDiscounts.createPriceHtml(result)
@@ -1291,6 +1321,7 @@
 
                 if (!Array.isArray(result.components) || result.components.length === 0) {
                     breakdown.textContent = '';
+                    breakdown.classList.remove('pro-discount-breakdown--with-badges');
                     note.style.display = 'none';
                     return;
                 }


### PR DESCRIPTION
## What changed
- Removed the Longevitymaxxing Challenge promo from the homepage leaderboard content.
- Added Longevitymaxxing as a low-prominence text link under the existing `/join` Amateur/Professional track choice, preserving the master layout.
- Added Longevitymaxxing as a normal athlete dashboard action directly under Edit profile.
- Kept discount badge text alignment stable when a badge-backed discount row is present.
- Added tracking/test coverage for the new join link and dashboard action.

## Why
The challenge should be discoverable without competing with the biological-age athlete track decision or appearing as a homepage advertisement.

## Impact
New athletes still see the original two-track Amateur/Professional flow. Users who are not ready for blood testing can follow the small Longevitymaxxing lifestyle challenge link instead. Existing athletes can access Longevitymaxxing from their dashboard.

## Validation
- `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --filter "FullyQualifiedName~LongevitymaxxingChallengePageTests|FullyQualifiedName~PaymentOfferHandoffPageTests|FullyQualifiedName~PlayAthleteFlowBrowserTests|FullyQualifiedName~PlayMenuPageTests|FullyQualifiedName~SiteStatisticsDashboardPageTests" --logger "console;verbosity=normal"`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Front-end routing, copy, and analytics only; no auth, payments, or API behavior changes beyond new click tracking.
> 
> **Overview**
> **Longevitymaxxing** is no longer promoted on the homepage leaderboard—the `#longevitymaxxingPromo` section and its styles are removed.
> 
> Discovery moves into the play flow instead: `/join` keeps the Amateur/Pro track choice and adds a low-key text link (`joinStartChallengeLink`) to `/longevitymaxxing` for users not ready for blood testing. Returning athletes get a **Longevitymaxxing** secondary dashboard action (alongside submit/go pro) via `renderDashboardActions` in `play-athlete-flow.js`.
> 
> Join clicks on that link emit `onboarding_challenge_selected` in site statistics. Pro discount rows with badge components use `pro-discount-breakdown--with-badges` so empty badge slots stay visible and alignment stays stable on join and dashboard pricing.
> 
> Tests and browser checks were updated for the new placements and the absence of homepage promo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e2881f6d55a75455457dd7cb7548fef4c7ace22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->