### PR TITLE
UI/UX bug fixes

### DIFF
--- a/LongevityWorldCup.Documentation/Ruleset.md
+++ b/LongevityWorldCup.Documentation/Ruleset.md
@@ -6,7 +6,7 @@ The Longevity World Cup is a competition between longevity athletes. The goal is
 - Seasonal clocks typically start and end around mid-January, and **only accept results from the given calendar year** (January 1 to December 31). At **season close**, final rankings lock for that season.
 - Some clocks may run as **all-time competitions** instead of seasonal competitions. **The all-time competition currently uses [pheno age](https://pmc.ncbi.nlm.nih.gov/articles/PMC5940111/pdf/aging-10-101414.pdf)**.
 
-![image](https://github.com/user-attachments/assets/337ab8a6-935b-4986-8e63-28aa6f494582)
+![Season duration defines the competition cycle, while test validity defines test acceptance](https://github.com/user-attachments/assets/337ab8a6-935b-4986-8e63-28aa6f494582)
 
 ## Tracks
 The Longevity World Cup has multiple tracks: **Amateur** and **Professional**. These use different clocks and rules.
@@ -22,14 +22,14 @@ The Longevity World Cup has multiple tracks: **Amateur** and **Professional**. T
   - **Partial or non-same-day submissions are not allowed for a given clock**. Required biomarkers must come from the same blood draw or report date.
 - The competition also uses **leagues** (for example generation-based or other category-based rankings). You can rank globally and still compete within your generation league.
 
-![image](https://github.com/user-attachments/assets/968fc0b2-3389-40a3-93e9-4a415f565b11)
+![Multiple submissions may improve ranking at higher cost, while one strategic submission is cheaper but may miss the optimum](https://github.com/user-attachments/assets/968fc0b2-3389-40a3-93e9-4a415f565b11)
 ## Prizes and payouts
 - Prize money is awarded to the top three athletes in the Ultimate League.
 - Bitcoin donations fund the prize money pool.
 - 10% of donations covers operating costs, and 90% funds the prize money pool.
 - Payouts are made in Bitcoin in mid-January. If you need a Bitcoin wallet, we'll help you set one up. We recommend [Green Wallet](https://blockstream.com/green/) for mobile or [Wasabi Wallet](https://wasabiwallet.io/) for desktop. Fun fact: Wasabi Wallet and the Longevity World Cup share the same creator.
 
-![image](https://github.com/user-attachments/assets/9a41f400-92a1-496d-8553-b727186580b2)
+![Prize money timeline from Bitcoin donations through allocation, funding, costs, wallet setup, and January payouts](https://github.com/user-attachments/assets/9a41f400-92a1-496d-8553-b727186580b2)
 
 ## FAQ
 
@@ -40,7 +40,7 @@ Anyone interested in longevity and capable of submitting valid test results can 
 #### How do I register for the competition?
 Apply through the [Longevity World Cup website](https://www.longevityworldcup.com/).
 
-![image](https://github.com/user-attachments/assets/38c545e9-13e5-4ba2-b2e0-d52bbf149207)
+![Registration process: visit the website, then follow the instructions](https://github.com/user-attachments/assets/38c545e9-13e5-4ba2-b2e0-d52bbf149207)
 
 Need help with your application? Watch [this seven-minute video tutorial](https://www.youtube.com/watch?v=0mCIbqgfqq8) or [this one-minute video tutorial](https://www.youtube.com/shorts/yhMFZMPAoKQ).
 
@@ -88,7 +88,7 @@ Yes. Email `hi@longevityworldcup.com`.
 - Mean Corpuscular Hemoglobin (MCH)
 - Apolipoprotein A1 (ApoA1)
 
-![image](https://github.com/user-attachments/assets/4770485d-440c-4ce6-be6a-b547798696c3)
+![Biomarkers used in pheno age calculation and their common laboratory names](https://github.com/user-attachments/assets/4770485d-440c-4ce6-be6a-b547798696c3)
 
 #### Can I use any laboratory for my tests?
 Yes, as long as the lab provides the biomarkers required for that clock.
@@ -106,7 +106,7 @@ Each season closes in mid-January, giving your lab enough time to process a test
 #### What if there's a tie?
 Ties break by older chronological age, then username alphabetically.
 
-![image](https://github.com/user-attachments/assets/a13ec2f2-346e-4024-aba5-dd32e807a34e)
+![Tie-break order: pheno age, chronological age, then alphabetical order](https://github.com/user-attachments/assets/a13ec2f2-346e-4024-aba5-dd32e807a34e)
 
 #### How is my score calculated if I submit multiple results?
 If you submit multiple test results, the **best** result is used for your season standing for the relevant clock. This encourages incremental updates and fair comparisons between strategic and transparent participants.
@@ -128,7 +128,7 @@ You can't.
 #### How much can I edit my profile picture?
 Your profile picture must show you facing the camera, but you can edit it freely, including as a drawing or AI-generated version. Choose a picture that represents you well and works for age estimation from a photo.
 
-![image](https://github.com/user-attachments/assets/613afebb-4ec7-4b0d-a961-8a09e26391ab)
+![Profile picture compliance balances editing freedom with use of a personal image](https://github.com/user-attachments/assets/613afebb-4ec7-4b0d-a961-8a09e26391ab)
 
 #### I'm already an athlete. How can I make changes?
 Through the [Athlete Dashboard](https://www.longevityworldcup.com/select-athlete) or by sending us an email to `hi@longevityworldcup.com`.

--- a/LongevityWorldCup.Documentation/Ruleset.md
+++ b/LongevityWorldCup.Documentation/Ruleset.md
@@ -106,7 +106,7 @@ Each season closes in mid-January, giving your lab enough time to process a test
 #### What if there's a tie?
 Ties break by older chronological age, then username alphabetically.
 
-![Tie-break order: pheno age, chronological age, then alphabetical order](https://github.com/user-attachments/assets/a13ec2f2-346e-4024-aba5-dd32e807a34e)
+![Ranking flow: compare pheno age, then break ties by older chronological age and, if still tied, username alphabetically](https://github.com/user-attachments/assets/a13ec2f2-346e-4024-aba5-dd32e807a34e)
 
 #### How is my score calculated if I submit multiple results?
 If you submit multiple test results, the **best** result is used for your season standing for the relevant clock. This encourages incremental updates and fair comparisons between strategic and transparent participants.

--- a/LongevityWorldCup.Tests/ApplicationOnboardingPageTests.cs
+++ b/LongevityWorldCup.Tests/ApplicationOnboardingPageTests.cs
@@ -7,6 +7,19 @@ namespace LongevityWorldCup.Tests;
 public sealed class ApplicationOnboardingPageTests
 {
     [Fact]
+    public async Task ApplicationContactEmail_UsesARealInputLabel()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var html = await client.GetStringAsync("/onboarding/convergence.html");
+
+        Assert.Contains("<legend>Contact email</legend>", html);
+        Assert.Contains("<label for=\"accountEmail\" class=\"visually-hidden\">Email address</label>", html);
+        Assert.DoesNotContain("<legend for=\"accountEmail\">", html);
+    }
+
+    [Fact]
     public async Task ApplicationRetry_ReenablesEmailFieldAfterSubmissionFailure()
     {
         using var factory = new TestWebApplicationFactory();

--- a/LongevityWorldCup.Tests/ApplicationOnboardingPageTests.cs
+++ b/LongevityWorldCup.Tests/ApplicationOnboardingPageTests.cs
@@ -7,18 +7,18 @@ namespace LongevityWorldCup.Tests;
 public sealed class ApplicationOnboardingPageTests
 {
     [Fact]
-    public async Task ProfilePictureIllustration_IsKeyboardAccessibleWhenClickable()
+    public async Task ProfilePictureUpload_UsesNativeButtonsWithoutADuplicateImageTabStop()
     {
         using var factory = new TestWebApplicationFactory();
         using var client = factory.CreateClient();
 
         var html = await client.GetStringAsync("/onboarding/convergence.html");
 
-        Assert.Contains("illustrationImage.setAttribute('role', 'button');", html);
-        Assert.Contains("illustrationImage.setAttribute('tabindex', '0');", html);
-        Assert.Contains("illustrationImage.setAttribute('aria-label', 'Choose a profile picture');", html);
-        Assert.Contains("illustrationImage.addEventListener('keydown'", html);
-        Assert.Contains(".clickable:focus-visible", html);
+        Assert.Contains("<button type=\"button\" id=\"takeProfileSelfieButton\"", html);
+        Assert.Contains("<button type=\"button\" id=\"uploadButton\"", html);
+        Assert.DoesNotContain("illustrationImage.setAttribute('role', 'button');", html);
+        Assert.DoesNotContain("illustrationImage.setAttribute('tabindex', '0');", html);
+        Assert.DoesNotContain("illustrationImage.addEventListener('keydown'", html);
     }
 
     [Fact]

--- a/LongevityWorldCup.Tests/ApplicationOnboardingPageTests.cs
+++ b/LongevityWorldCup.Tests/ApplicationOnboardingPageTests.cs
@@ -7,6 +7,21 @@ namespace LongevityWorldCup.Tests;
 public sealed class ApplicationOnboardingPageTests
 {
     [Fact]
+    public async Task ProfilePictureIllustration_IsKeyboardAccessibleWhenClickable()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var html = await client.GetStringAsync("/onboarding/convergence.html");
+
+        Assert.Contains("illustrationImage.setAttribute('role', 'button');", html);
+        Assert.Contains("illustrationImage.setAttribute('tabindex', '0');", html);
+        Assert.Contains("illustrationImage.setAttribute('aria-label', 'Choose a profile picture');", html);
+        Assert.Contains("illustrationImage.addEventListener('keydown'", html);
+        Assert.Contains(".clickable:focus-visible", html);
+    }
+
+    [Fact]
     public async Task ApplicationContactEmail_UsesARealInputLabel()
     {
         using var factory = new TestWebApplicationFactory();

--- a/LongevityWorldCup.Tests/BadgeNavigationAccessibilityTests.cs
+++ b/LongevityWorldCup.Tests/BadgeNavigationAccessibilityTests.cs
@@ -1,0 +1,34 @@
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class BadgeNavigationAccessibilityTests
+{
+    [Fact]
+    public void ClickableBadges_UseNativeLinksInsteadOfPointerOnlySpans()
+    {
+        var badges = File.ReadAllText(GetWebRootFile("js", "badges.js"));
+        var eventBoard = File.ReadAllText(GetWebRootFile("partials", "event-board-content.html"));
+
+        Assert.Contains("<a class=\"${className} badge-clickable\" href=\"${escapeAttr(url)}\" aria-label=\"Open league\"", badges);
+        Assert.Contains("aria-label=\"Open personal page\"", badges);
+        Assert.DoesNotContain("onclick=\"window.location.href='${url}';\"", badges);
+
+        Assert.Contains("<a class=\"badge-class ${familyClass} badge-clickable\" href=\"${esc(url)}\" aria-label=\"Open league\"", eventBoard);
+        Assert.DoesNotContain("role=\"button\" tabindex=\"0\" onclick=\"window.location.href='${url}'\"", eventBoard);
+    }
+
+    private static string GetWebRootFile(string folder, string fileName, [CallerFilePath] string sourceFilePath = "")
+    {
+        var testsDirectory = Path.GetDirectoryName(sourceFilePath)
+            ?? throw new InvalidOperationException("Could not locate the tests directory.");
+        return Path.GetFullPath(Path.Combine(
+            testsDirectory,
+            "..",
+            "LongevityWorldCup.Website",
+            "wwwroot",
+            folder,
+            fileName));
+    }
+}

--- a/LongevityWorldCup.Tests/BadgeNavigationAccessibilityTests.cs
+++ b/LongevityWorldCup.Tests/BadgeNavigationAccessibilityTests.cs
@@ -15,7 +15,10 @@ public sealed class BadgeNavigationAccessibilityTests
         Assert.Contains("aria-label=\"Open personal page\"", badges);
         Assert.DoesNotContain("onclick=\"window.location.href='${url}';\"", badges);
 
-        Assert.Contains("<a class=\"badge-class ${familyClass} badge-clickable\" href=\"${esc(url)}\" aria-label=\"Open league\"", eventBoard);
+        Assert.Contains("const isPodcast=String(label||'').trim().toLowerCase()==='podcast';", eventBoard);
+        Assert.Contains("const targetAttrs=isPodcast?' target=\"_blank\" rel=\"noopener\"':'';", eventBoard);
+        Assert.Contains("const accessibleLabel=isPodcast?'Open podcast':'Open league';", eventBoard);
+        Assert.Contains("href=\"${esc(url)}\"${targetAttrs} aria-label=\"${accessibleLabel}\"", eventBoard);
         Assert.DoesNotContain("role=\"button\" tabindex=\"0\" onclick=\"window.location.href='${url}'\"", eventBoard);
     }
 

--- a/LongevityWorldCup.Tests/BioageStoredBiomarkerTests.cs
+++ b/LongevityWorldCup.Tests/BioageStoredBiomarkerTests.cs
@@ -9,6 +9,23 @@ public sealed class BioageStoredBiomarkerTests
     [Theory]
     [InlineData("pheno-age.html")]
     [InlineData("bortz-age.html")]
+    public void BiomarkerCards_AreKeyboardOperableAndShowFocus(string fileName)
+    {
+        var html = File.ReadAllText(GetPagePath(fileName));
+
+        Assert.Contains("header.setAttribute('role', 'button');", html);
+        Assert.Contains("header.setAttribute('tabindex', '0');", html);
+        Assert.Contains("header.querySelector('.toggle-icon')?.setAttribute('aria-hidden', 'true');", html);
+        Assert.Contains("header.addEventListener('keydown', event => {", html);
+        Assert.Contains("if (event.key !== 'Enter' && event.key !== ' ') return;", html);
+        Assert.Contains(".biomarker-card-header:focus-visible", html);
+        Assert.Contains("header.setAttribute('aria-disabled', 'true');", html);
+        Assert.Contains("header.setAttribute('tabindex', '-1');", html);
+    }
+
+    [Theory]
+    [InlineData("pheno-age.html")]
+    [InlineData("bortz-age.html")]
     public void BioageInputs_HavePersistentAccessibleNames(string fileName)
     {
         var html = File.ReadAllText(GetPagePath(fileName));

--- a/LongevityWorldCup.Tests/BioageStoredBiomarkerTests.cs
+++ b/LongevityWorldCup.Tests/BioageStoredBiomarkerTests.cs
@@ -1,10 +1,68 @@
 using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 using Xunit;
 
 namespace LongevityWorldCup.Tests;
 
 public sealed class BioageStoredBiomarkerTests
 {
+    [Theory]
+    [InlineData("pheno-age.html")]
+    [InlineData("bortz-age.html")]
+    public void BioageInputs_HavePersistentAccessibleNames(string fileName)
+    {
+        var html = File.ReadAllText(GetPagePath(fileName));
+        var expectedLabels = fileName == "pheno-age.html"
+            ? new Dictionary<string, string>
+            {
+                ["blood-draw-date"] = "Blood draw date",
+                ["wbc"] = "White blood cell count (WBC)",
+                ["lymphocyte"] = "Lymphocytes",
+                ["mcv"] = "Mean corpuscular volume (MCV)",
+                ["rcdw"] = "Red cell distribution width (RDW, RDW-CV)",
+                ["albumin"] = "Albumin",
+                ["ap"] = "Alkaline phosphatase (ALP)",
+                ["creatinine"] = "Creatinine",
+                ["glucose"] = "Glucose",
+                ["crp-negative"] = "Set CRP as below the detection limit",
+                ["crp"] = "C-reactive protein (CRP)"
+            }
+            : new Dictionary<string, string>
+            {
+                ["blood-draw-date"] = "Blood draw date",
+                ["wbc"] = "White blood cell count (WBC)",
+                ["lymphocyte_percentage"] = "Lymphocytes",
+                ["neutrophil_percentage"] = "Neutrophils",
+                ["monocyte_percentage"] = "Monocytes",
+                ["rbc"] = "Red blood cell count (RBC)",
+                ["mcv"] = "Mean corpuscular volume (MCV)",
+                ["mch"] = "Mean corpuscular hemoglobin (MCH)",
+                ["rdw"] = "Red cell distribution width (RDW, RDW-CV)",
+                ["albumin"] = "Albumin",
+                ["alt"] = "Alanine aminotransferase (ALT, ALAT)",
+                ["alp"] = "Alkaline phosphatase (ALP)",
+                ["ggt"] = "Gamma-glutamyl transferase (GGT)",
+                ["urea"] = "Urea or blood urea nitrogen (BUN)",
+                ["creatinine"] = "Creatinine",
+                ["cystatin_c"] = "Cystatin C",
+                ["glucose"] = "Glucose",
+                ["hba1c"] = "Hemoglobin A1c (HbA1c)",
+                ["cholesterol"] = "Total cholesterol",
+                ["apoa1"] = "Apolipoprotein A1 (ApoA1)",
+                ["crp-negative"] = "Set CRP as below the detection limit",
+                ["crp"] = "C-reactive protein (CRP)",
+                ["shbg"] = "Sex hormone-binding globulin (SHBG)",
+                ["vitamin_d"] = "Vitamin D (25-OH)"
+            };
+
+        foreach (var (id, label) in expectedLabels)
+        {
+            Assert.Matches(
+                $"<input(?=[^>]*\\bid=\\\"{Regex.Escape(id)}\\\")(?=[^>]*\\baria-label=\\\"{Regex.Escape(label)}\\\")[^>]*>",
+                html);
+        }
+    }
+
     [Theory]
     [InlineData("pheno-age.html")]
     [InlineData("bortz-age.html")]

--- a/LongevityWorldCup.Tests/BioageStoredBiomarkerTests.cs
+++ b/LongevityWorldCup.Tests/BioageStoredBiomarkerTests.cs
@@ -324,6 +324,19 @@ public sealed class BioageStoredBiomarkerTests
     [Theory]
     [InlineData("pheno-age.html")]
     [InlineData("bortz-age.html")]
+    public void BioageWizardDots_AreExposedWithTheirAccessibleNames(string fileName)
+    {
+        var html = File.ReadAllText(GetPagePath(fileName));
+
+        Assert.Contains("<div class=\"lwc-wizard-nav\">", html);
+        Assert.Contains("role=\"button\" tabindex=\"0\" aria-label=\"Go to Step 1\"", html);
+        Assert.Contains("role=\"button\" tabindex=\"0\" aria-label=\"Go to Step 2\"", html);
+        Assert.DoesNotContain("<div class=\"lwc-wizard-nav\" aria-hidden=\"true\">", html);
+    }
+
+    [Theory]
+    [InlineData("pheno-age.html")]
+    [InlineData("bortz-age.html")]
     public void BioageUpdatePages_HideWizardNavigationAndForceBiomarkerStep(string fileName)
     {
         var html = File.ReadAllText(GetPagePath(fileName));

--- a/LongevityWorldCup.Tests/CharacterSelectionPageTests.cs
+++ b/LongevityWorldCup.Tests/CharacterSelectionPageTests.cs
@@ -14,6 +14,7 @@ public sealed class CharacterSelectionPageTests
 
         Assert.Contains("id=\"athleteSelectionPanel\"", html);
         Assert.Contains("id=\"athleteSelectionPicture\" class=\"athlete-picture-frame\"", html);
+        Assert.Contains("<label for=\"playAthleteInput\" class=\"visually-hidden\">Athlete name</label>", html);
         Assert.Contains("id=\"playAthleteInput\"", html);
         Assert.Contains("id=\"playConfirmAthleteBtn\"", html);
         Assert.Contains("function navigateToStartPanel()", html);

--- a/LongevityWorldCup.Tests/CustomEventDesignerAccessibilityTests.cs
+++ b/LongevityWorldCup.Tests/CustomEventDesignerAccessibilityTests.cs
@@ -1,0 +1,19 @@
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class CustomEventDesignerAccessibilityTests
+{
+    [Fact]
+    public async Task GeneratedOutputs_HaveAccessibleNames()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var html = await client.GetStringAsync("/internal/custom-event-designer.html");
+
+        Assert.Contains("id=\"secretHashOutput\" class=\"token\" aria-label=\"Generated configuration hash\"", html);
+        Assert.Contains("id=\"cleanupCommandOutput\" class=\"token\" aria-label=\"Generated cleanup SQL\"", html);
+        Assert.Contains("id=\"commandOutput\" class=\"token\" aria-label=\"Generated server command\"", html);
+    }
+}

--- a/LongevityWorldCup.Tests/EditProfilePageTests.cs
+++ b/LongevityWorldCup.Tests/EditProfilePageTests.cs
@@ -5,6 +5,21 @@ namespace LongevityWorldCup.Tests;
 public sealed class EditProfilePageTests
 {
     [Fact]
+    public async Task EditProfileFields_HavePersistentLabels()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var html = await client.GetStringAsync("/play/edit-profile.html");
+
+        Assert.Contains("<label for=\"divisionDisplaySelect\" class=\"visually-hidden\">Division</label>", html);
+        Assert.Contains("<label for=\"flagDisplayInput\" class=\"visually-hidden\">Flag</label>", html);
+        Assert.Contains("<label for=\"personalLinkInput\" class=\"visually-hidden\">Personal link</label>", html);
+        Assert.Contains("<label for=\"mediaContactInput\" class=\"visually-hidden\">Media contact</label>", html);
+        Assert.Contains("<label for=\"whyDisplayInput\" class=\"visually-hidden\">Your why</label>", html);
+    }
+
+    [Fact]
     public async Task EditProfile_BackButtonReturnsToDashboardWithoutHistoryFallback()
     {
         using var factory = new TestWebApplicationFactory();

--- a/LongevityWorldCup.Tests/EditProfilePageTests.cs
+++ b/LongevityWorldCup.Tests/EditProfilePageTests.cs
@@ -20,6 +20,18 @@ public sealed class EditProfilePageTests
     }
 
     [Fact]
+    public async Task EditProfileOptions_UseTheConfiguredEntranceAnimation()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var html = await client.GetStringAsync("/play/edit-profile.html");
+
+        Assert.Contains("id=\"editOptionsGroup\" data-aos=\"fade\"", html);
+        Assert.DoesNotContain("cdata-aos", html);
+    }
+
+    [Fact]
     public async Task EditProfile_BackButtonReturnsToDashboardWithoutHistoryFallback()
     {
         using var factory = new TestWebApplicationFactory();

--- a/LongevityWorldCup.Tests/EventBoardInteractionAccessibilityTests.cs
+++ b/LongevityWorldCup.Tests/EventBoardInteractionAccessibilityTests.cs
@@ -1,0 +1,18 @@
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class EventBoardInteractionAccessibilityTests
+{
+    [Fact]
+    public async Task CustomEventExpander_HasVisibleKeyboardFocus()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var html = await client.GetStringAsync("/events");
+
+        Assert.Contains(".custom-event-expander:focus-visible{", html);
+        Assert.Contains("box-shadow:0 0 0 3px rgba(0,188,212,.28) !important;", html);
+    }
+}

--- a/LongevityWorldCup.Tests/HomepageLinkAccessibilityTests.cs
+++ b/LongevityWorldCup.Tests/HomepageLinkAccessibilityTests.cs
@@ -27,4 +27,16 @@ public sealed class HomepageLinkAccessibilityTests
         Assert.Contains("<a href=\"/ruleset#faq\"><i class=\"fas fa-circle-question\" aria-hidden=\"true\"></i> Extended FAQ</a>", html);
         Assert.DoesNotContain("homepage-faq-icon-link", html);
     }
+
+    [Fact]
+    public async Task MerchCarousel_OnlyTabsToTheVisibleSlide()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var html = await client.GetStringAsync("/");
+
+        Assert.Contains("slide.setAttribute('aria-hidden', String(!isActive));", html);
+        Assert.Contains("slide.tabIndex = isActive ? 0 : -1;", html);
+    }
 }

--- a/LongevityWorldCup.Tests/HomepageLinkAccessibilityTests.cs
+++ b/LongevityWorldCup.Tests/HomepageLinkAccessibilityTests.cs
@@ -15,4 +15,16 @@ public sealed class HomepageLinkAccessibilityTests
         Assert.Contains("<i class=\"fas fa-book-open\" aria-hidden=\"true\"></i> History of longevity as a sport", html);
         Assert.DoesNotContain("text-decoration: none;\"><i class=\"fas fa-book-open\"", html);
     }
+
+    [Fact]
+    public async Task ExtendedFaqCallToAction_IsOneNamedLink()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var html = await client.GetStringAsync("/");
+
+        Assert.Contains("<a href=\"/ruleset#faq\"><i class=\"fas fa-circle-question\" aria-hidden=\"true\"></i> Extended FAQ</a>", html);
+        Assert.DoesNotContain("homepage-faq-icon-link", html);
+    }
 }

--- a/LongevityWorldCup.Tests/HomepageLinkAccessibilityTests.cs
+++ b/LongevityWorldCup.Tests/HomepageLinkAccessibilityTests.cs
@@ -1,0 +1,18 @@
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class HomepageLinkAccessibilityTests
+{
+    [Fact]
+    public async Task HistoryCallToAction_IsOneNamedLink()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var html = await client.GetStringAsync("/");
+
+        Assert.Contains("<i class=\"fas fa-book-open\" aria-hidden=\"true\"></i> History of longevity as a sport", html);
+        Assert.DoesNotContain("text-decoration: none;\"><i class=\"fas fa-book-open\"", html);
+    }
+}

--- a/LongevityWorldCup.Tests/HomepageNewsletterModalTests.cs
+++ b/LongevityWorldCup.Tests/HomepageNewsletterModalTests.cs
@@ -6,6 +6,19 @@ namespace LongevityWorldCup.Tests;
 public sealed class HomepageNewsletterModalTests
 {
     [Fact]
+    public void NewsletterEmailInput_HasPersistentAccessibleLabelAndAutocomplete()
+    {
+        var indexHtml = File.ReadAllText(Path.Combine(
+            FindRepoRoot(),
+            "LongevityWorldCup.Website",
+            "wwwroot",
+            "index.html"));
+
+        Assert.Contains("<label for=\"emailInput\" class=\"visually-hidden\">Email address</label>", indexHtml);
+        Assert.Contains("id=\"emailInput\" class=\"shared-email-input\" placeholder=\"athlete@example.com\" autocomplete=\"email\"", indexHtml);
+    }
+
+    [Fact]
     public void NewsletterSuccessDialog_AllowsLongEmailToWrap()
     {
         var indexHtml = File.ReadAllText(Path.Combine(

--- a/LongevityWorldCup.Tests/LeaderboardInteractionAccessibilityTests.cs
+++ b/LongevityWorldCup.Tests/LeaderboardInteractionAccessibilityTests.cs
@@ -45,6 +45,15 @@ public sealed class LeaderboardInteractionAccessibilityTests
         Assert.DoesNotContain("<span id=\"closeAthleteDetailsModal\"", html);
     }
 
+    [Fact]
+    public void PodiumPrizePanels_AreNativeDonationLinks()
+    {
+        var html = File.ReadAllText(GetLeaderboardPartialPath());
+
+        Assert.Contains("<a class=\"podium-item-lower\" href=\"#donation-section\" aria-label=\"Donate to the prize pool\">", html);
+        Assert.DoesNotContain("function subscribeLowerPodiumClick()", html);
+    }
+
     private static string GetLeaderboardPartialPath([CallerFilePath] string sourceFilePath = "")
     {
         var testsDirectory = Path.GetDirectoryName(sourceFilePath)

--- a/LongevityWorldCup.Tests/LeaderboardInteractionAccessibilityTests.cs
+++ b/LongevityWorldCup.Tests/LeaderboardInteractionAccessibilityTests.cs
@@ -35,6 +35,16 @@ public sealed class LeaderboardInteractionAccessibilityTests
         Assert.Contains(".enlarged-portrait .close-btn:focus-visible", html);
     }
 
+    [Fact]
+    public void AthleteDetailsModal_UsesNativeCloseButtons()
+    {
+        var html = File.ReadAllText(GetLeaderboardPartialPath());
+
+        Assert.Contains("<button type=\"button\" id=\"closeAthleteDetailsModal\" class=\"close\" aria-label=\"Close athlete details\">", html);
+        Assert.Contains("<button class=\"sticky-close-btn\" id=\"stickyCloseBtn\" aria-label=\"Close athlete details\">", html);
+        Assert.DoesNotContain("<span id=\"closeAthleteDetailsModal\"", html);
+    }
+
     private static string GetLeaderboardPartialPath([CallerFilePath] string sourceFilePath = "")
     {
         var testsDirectory = Path.GetDirectoryName(sourceFilePath)

--- a/LongevityWorldCup.Tests/LeaderboardInteractionAccessibilityTests.cs
+++ b/LongevityWorldCup.Tests/LeaderboardInteractionAccessibilityTests.cs
@@ -19,6 +19,22 @@ public sealed class LeaderboardInteractionAccessibilityTests
         Assert.Contains("event.stopPropagation();", html);
     }
 
+    [Fact]
+    public void ImageViewer_UsesKeyboardControlsAndRestoresFocus()
+    {
+        var html = File.ReadAllText(GetLeaderboardPartialPath());
+
+        Assert.Contains("role=\"dialog\" aria-modal=\"true\" aria-label=\"Enlarged image\"", html);
+        Assert.Contains("<button type=\"button\" class=\"close-btn\" aria-label=\"Close enlarged image\">", html);
+        Assert.Contains("closeButton.focus();", html);
+        Assert.Contains("returnFocusTo.focus();", html);
+        Assert.Contains("img.setAttribute('role', 'button');", html);
+        Assert.Contains("img.setAttribute('tabindex', '0');", html);
+        Assert.Contains("img.addEventListener('keydown', event => {", html);
+        Assert.Contains(".proof-item img:focus-visible", html);
+        Assert.Contains(".enlarged-portrait .close-btn:focus-visible", html);
+    }
+
     private static string GetLeaderboardPartialPath([CallerFilePath] string sourceFilePath = "")
     {
         var testsDirectory = Path.GetDirectoryName(sourceFilePath)

--- a/LongevityWorldCup.Tests/LeaderboardInteractionAccessibilityTests.cs
+++ b/LongevityWorldCup.Tests/LeaderboardInteractionAccessibilityTests.cs
@@ -1,0 +1,34 @@
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class LeaderboardInteractionAccessibilityTests
+{
+    [Fact]
+    public void AthleteNames_AreNamedKeyboardControlsWithVisibleFocus()
+    {
+        var html = File.ReadAllText(GetLeaderboardPartialPath());
+
+        Assert.Contains(".athlete-name:focus-visible", html);
+        Assert.Contains("athleteNameElement.setAttribute('role', 'button');", html);
+        Assert.Contains("athleteNameElement.setAttribute('tabindex', '0');", html);
+        Assert.Contains("athleteNameElement.setAttribute('aria-label'", html);
+        Assert.Contains("athleteNameElement.addEventListener('keydown', handleAthleteNameKeydown);", html);
+        Assert.Contains("if (event.key !== 'Enter' && event.key !== ' ') return;", html);
+        Assert.Contains("event.stopPropagation();", html);
+    }
+
+    private static string GetLeaderboardPartialPath([CallerFilePath] string sourceFilePath = "")
+    {
+        var testsDirectory = Path.GetDirectoryName(sourceFilePath)
+            ?? throw new InvalidOperationException("Could not locate the tests directory.");
+        return Path.GetFullPath(Path.Combine(
+            testsDirectory,
+            "..",
+            "LongevityWorldCup.Website",
+            "wwwroot",
+            "partials",
+            "leaderboard-content.html"));
+    }
+}

--- a/LongevityWorldCup.Tests/LeaderboardInteractionAccessibilityTests.cs
+++ b/LongevityWorldCup.Tests/LeaderboardInteractionAccessibilityTests.cs
@@ -14,6 +14,7 @@ public sealed class LeaderboardInteractionAccessibilityTests
         Assert.Contains("athleteNameElement.setAttribute('role', 'button');", html);
         Assert.Contains("athleteNameElement.setAttribute('tabindex', '0');", html);
         Assert.Contains("athleteNameElement.setAttribute('aria-label'", html);
+        Assert.Contains("if (!athleteName) return;", html);
         Assert.Contains("athleteNameElement.addEventListener('keydown', handleAthleteNameKeydown);", html);
         Assert.Contains("if (event.key !== 'Enter' && event.key !== ' ') return;", html);
         Assert.Contains("event.stopPropagation();", html);
@@ -31,6 +32,10 @@ public sealed class LeaderboardInteractionAccessibilityTests
         Assert.Contains("img.setAttribute('role', 'button');", html);
         Assert.Contains("img.setAttribute('tabindex', '0');", html);
         Assert.Contains("img.addEventListener('keydown', event => {", html);
+        Assert.Contains("if (typeof accessibleLabel === 'function')", html);
+        Assert.Contains("addClickListenerToImages('.portrait, .podium-portrait', handleAthleteNameClick);", html);
+        Assert.DoesNotContain(".portrait:focus-visible", html);
+        Assert.DoesNotContain(".podium-portrait:focus-visible", html);
         Assert.Contains(".proof-item img:focus-visible", html);
         Assert.Contains(".enlarged-portrait .close-btn:focus-visible", html);
     }

--- a/LongevityWorldCup.Tests/LongevitymaxxingChallengePageTests.cs
+++ b/LongevityWorldCup.Tests/LongevitymaxxingChallengePageTests.cs
@@ -301,8 +301,8 @@ public sealed class LongevitymaxxingChallengePageTests
         Assert.Contains("id=\"lmxProfilePictureInput\" type=\"file\" accept=\"image/*\"", html);
         Assert.Contains("id=\"lmxSignupTimeZoneLabel\">Timezone</span>", html);
         Assert.Contains("class=\"lmx-timezone-picker\" data-timezone-picker data-select-id=\"lmxSignupTimeZone\"", html);
-        Assert.Contains("<input id=\"lmxSignupTimeZoneSearch\" type=\"search\" autocomplete=\"off\" autocapitalize=\"none\" spellcheck=\"false\" placeholder=\"Search city or timezone\" aria-controls=\"lmxSignupTimeZoneList\">", html);
-        Assert.Contains("<input id=\"lmxEditTimeZoneSearch\" type=\"search\" autocomplete=\"off\" autocapitalize=\"none\" spellcheck=\"false\" placeholder=\"Search city or timezone\" aria-controls=\"lmxEditTimeZoneList\">", html);
+        Assert.Contains("<input id=\"lmxSignupTimeZoneSearch\" type=\"search\" autocomplete=\"off\" autocapitalize=\"none\" spellcheck=\"false\" placeholder=\"Search city or timezone\" aria-label=\"Search city or timezone\" aria-controls=\"lmxSignupTimeZoneList\">", html);
+        Assert.Contains("<input id=\"lmxEditTimeZoneSearch\" type=\"search\" autocomplete=\"off\" autocapitalize=\"none\" spellcheck=\"false\" placeholder=\"Search city or timezone\" aria-label=\"Search city or timezone\" aria-controls=\"lmxEditTimeZoneList\">", html);
         Assert.Contains("id=\"lmxSignupTimeZone\" class=\"lmx-timezone-native\" name=\"timeZoneId\" required", html);
         Assert.Contains("id=\"lmxEditTimeZone\" class=\"lmx-timezone-native\" required", html);
         Assert.DoesNotContain("Extra details", html);

--- a/LongevityWorldCup.Tests/PageDocumentTitleTests.cs
+++ b/LongevityWorldCup.Tests/PageDocumentTitleTests.cs
@@ -1,0 +1,37 @@
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class PageDocumentTitleTests
+{
+    [Theory]
+    [InlineData("/privacy", "Privacy Policy | Longevity World Cup", false)]
+    [InlineData("/pheno-age", "Pheno Age Calculator | Longevity World Cup", true)]
+    [InlineData("/bortz-age", "Bortz Age Calculator | Longevity World Cup", true)]
+    [InlineData("/play", "Game Menu | Longevity World Cup", true)]
+    [InlineData("/join", "Join Longevity World Cup", true)]
+    [InlineData("/apply", "Athlete Application | Longevity World Cup", true)]
+    [InlineData("/review", "Application Review | Longevity World Cup", true)]
+    [InlineData("/proofs", "Proof Upload | Longevity World Cup", true)]
+    [InlineData("/select-athlete", "Athlete Selection | Longevity World Cup", true)]
+    [InlineData("/dashboard", "Athlete Dashboard | Longevity World Cup", true)]
+    [InlineData("/edit-profile", "Edit Profile | Longevity World Cup", true)]
+    [InlineData("/unsubscribe", "Unsubscribe | Longevity World Cup", true)]
+    public async Task UtilityPages_KeepSpecificBrowserTabTitles(string path, string expectedTitle, bool expectsNoIndex)
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var html = await client.GetStringAsync(path);
+
+        Assert.Contains($"<title>{expectedTitle}</title>", html);
+        if (expectsNoIndex)
+        {
+            Assert.Contains("<meta name=\"robots\" content=\"noindex, nofollow\"", html);
+        }
+        else
+        {
+            Assert.DoesNotContain("<meta name=\"robots\" content=\"noindex, nofollow\"", html);
+        }
+    }
+}

--- a/LongevityWorldCup.Tests/RulesetImageAccessibilityTests.cs
+++ b/LongevityWorldCup.Tests/RulesetImageAccessibilityTests.cs
@@ -18,7 +18,7 @@ public sealed class RulesetImageAccessibilityTests
         Assert.Contains("alt=\"Prize money timeline from Bitcoin donations through allocation, funding, costs, wallet setup, and January payouts\"", html);
         Assert.Contains("alt=\"Registration process: visit the website, then follow the instructions\"", html);
         Assert.Contains("alt=\"Biomarkers used in pheno age calculation and their common laboratory names\"", html);
-        Assert.Contains("alt=\"Tie-break order: pheno age, chronological age, then alphabetical order\"", html);
+        Assert.Contains("alt=\"Ranking flow: compare pheno age, then break ties by older chronological age and, if still tied, username alphabetically\"", html);
         Assert.Contains("alt=\"Profile picture compliance balances editing freedom with use of a personal image\"", html);
     }
 }

--- a/LongevityWorldCup.Tests/RulesetImageAccessibilityTests.cs
+++ b/LongevityWorldCup.Tests/RulesetImageAccessibilityTests.cs
@@ -1,0 +1,24 @@
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class RulesetImageAccessibilityTests
+{
+    [Fact]
+    public async Task RulesetDiagrams_HaveDescriptiveAlternativeText()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var html = await client.GetStringAsync("/ruleset");
+
+        Assert.DoesNotContain("alt=\"image\"", html);
+        Assert.Contains("alt=\"Season duration defines the competition cycle, while test validity defines test acceptance\"", html);
+        Assert.Contains("alt=\"Multiple submissions may improve ranking at higher cost, while one strategic submission is cheaper but may miss the optimum\"", html);
+        Assert.Contains("alt=\"Prize money timeline from Bitcoin donations through allocation, funding, costs, wallet setup, and January payouts\"", html);
+        Assert.Contains("alt=\"Registration process: visit the website, then follow the instructions\"", html);
+        Assert.Contains("alt=\"Biomarkers used in pheno age calculation and their common laboratory names\"", html);
+        Assert.Contains("alt=\"Tie-break order: pheno age, chronological age, then alphabetical order\"", html);
+        Assert.Contains("alt=\"Profile picture compliance balances editing freedom with use of a personal image\"", html);
+    }
+}

--- a/LongevityWorldCup.Tests/SubmitButtonFallbackAccessibilityTests.cs
+++ b/LongevityWorldCup.Tests/SubmitButtonFallbackAccessibilityTests.cs
@@ -1,0 +1,20 @@
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class SubmitButtonFallbackAccessibilityTests
+{
+    [Theory]
+    [InlineData("/play/edit-profile.html", "Submit change request")]
+    [InlineData("/play/proof-upload.html", "Submit new results")]
+    public async Task SubmitButtons_HaveNamesBeforeScriptsRun(string path, string label)
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var html = await client.GetStringAsync(path);
+
+        Assert.Contains($"id=\"submitButton\" type=\"submit\"", html);
+        Assert.Contains($"<span class=\"flow-action__label\">{label}</span><i class=\"fa fa-rocket\" aria-hidden=\"true\"></i></button>", html);
+    }
+}

--- a/LongevityWorldCup.Website/Middleware/HtmlInjectionMiddleware.cs
+++ b/LongevityWorldCup.Website/Middleware/HtmlInjectionMiddleware.cs
@@ -54,6 +54,22 @@ namespace LongevityWorldCup.Website.Middleware
                     "Crowd Age Leaderboard | Longevity World Cup",
                     "Crowd Age rankings from accepted guesses.")
             };
+        private static readonly IReadOnlyDictionary<string, string> NonIndexablePageTitles =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["/privacy"] = "Privacy Policy | Longevity World Cup",
+                ["/pheno-age"] = "Pheno Age Calculator | Longevity World Cup",
+                ["/bortz-age"] = "Bortz Age Calculator | Longevity World Cup",
+                ["/play"] = "Game Menu | Longevity World Cup",
+                ["/join"] = "Join Longevity World Cup",
+                ["/apply"] = "Athlete Application | Longevity World Cup",
+                ["/review"] = "Application Review | Longevity World Cup",
+                ["/proofs"] = "Proof Upload | Longevity World Cup",
+                ["/select-athlete"] = "Athlete Selection | Longevity World Cup",
+                ["/dashboard"] = "Athlete Dashboard | Longevity World Cup",
+                ["/edit-profile"] = "Edit Profile | Longevity World Cup",
+                ["/unsubscribe"] = "Unsubscribe | Longevity World Cup"
+            };
 
         public async Task Invoke(HttpContext context)
         {
@@ -659,8 +675,8 @@ $@"<script type=""module"">
                     "Longevity World Cup member page.",
                     "noindex, nofollow",
                     canonicalUrl,
-                    "Longevity World Cup",
-                    "Longevity World Cup",
+                    GetNonIndexablePageTitle(canonicalPath),
+                    GetNonIndexablePageTitle(canonicalPath),
                     noCardDescription,
                     defaultOgImage
                 ),
@@ -675,6 +691,13 @@ $@"<script type=""module"">
                     defaultOgImage
                 )
             };
+        }
+
+        private static string GetNonIndexablePageTitle(string canonicalPath)
+        {
+            return NonIndexablePageTitles.TryGetValue(canonicalPath, out var title)
+                ? title
+                : "Longevity World Cup";
         }
 
         private static string GetRequestCanonicalPath(HttpContext context)

--- a/LongevityWorldCup.Website/wwwroot/index.html
+++ b/LongevityWorldCup.Website/wwwroot/index.html
@@ -1967,7 +1967,8 @@
             </p>
 
             <form id="newsletter-form">
-                <input type="email" id="emailInput" class="shared-email-input" placeholder="athlete@example.com" required>
+                <label for="emailInput" class="visually-hidden">Email address</label>
+                <input type="email" id="emailInput" class="shared-email-input" placeholder="athlete@example.com" autocomplete="email" required>
                 <button type="submit" class="enhanced-subscribe-btn shared-email-button" aria-label="Subscribe to the Longevity World&nbsp;Cup newsletter">
                     <i class="fas fa-paper-plane"></i> Subscribe
                 </button>

--- a/LongevityWorldCup.Website/wwwroot/index.html
+++ b/LongevityWorldCup.Website/wwwroot/index.html
@@ -272,10 +272,6 @@
                 text-decoration: underline;
             }
 
-            .homepage-faq-more .homepage-faq-icon-link {
-                text-decoration: none;
-            }
-
             /* Input field style */
             .section-container input[type="email"] {
                 padding: 0.6rem 1rem;
@@ -1914,8 +1910,7 @@
                 </div>
             </div>
             <p class="homepage-faq-more">
-                <a href="/ruleset#faq" class="homepage-faq-icon-link" aria-hidden="true" tabindex="-1"><i class="fas fa-circle-question"></i> </a>
-                <a href="/ruleset#faq">Extended FAQ</a>
+                <a href="/ruleset#faq"><i class="fas fa-circle-question" aria-hidden="true"></i> Extended FAQ</a>
             </p>
         </section>
 

--- a/LongevityWorldCup.Website/wwwroot/index.html
+++ b/LongevityWorldCup.Website/wwwroot/index.html
@@ -2209,6 +2209,7 @@
                     const isActive = slideIndex === activeIndex;
                     slide.classList.toggle('is-active', isActive);
                     slide.setAttribute('aria-hidden', String(!isActive));
+                    slide.tabIndex = isActive ? 0 : -1;
                 });
 
                 dots.forEach((dot, dotIndex) => {

--- a/LongevityWorldCup.Website/wwwroot/index.html
+++ b/LongevityWorldCup.Website/wwwroot/index.html
@@ -1889,8 +1889,7 @@
                 </div>
             </div>
             <p style="margin-top: 1.5rem; font-size: 1rem; color: var(--dark-text-color);">
-                <a href="/history" style="color: var(--primary-color); text-decoration: none;"><i class="fas fa-book-open"></i> </a>
-                <a href="/history" style="color: var(--primary-color); text-decoration: underline;">History of longevity as a sport</a>
+                <a href="/history" style="color: var(--primary-color); text-decoration: underline;"><i class="fas fa-book-open" aria-hidden="true"></i> History of longevity as a sport</a>
             </p>
         </div>
 

--- a/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
+++ b/LongevityWorldCup.Website/wwwroot/internal/custom-event-designer.html
@@ -909,13 +909,13 @@
                     <button id="copySecretHashBtn" class="secondary" type="button" disabled>Copy Hash</button>
                     <div id="secretHashState" class="post-status" aria-live="polite"></div>
                 </div>
-                <textarea id="secretHashOutput" class="token" readonly hidden></textarea>
+                <textarea id="secretHashOutput" class="token" aria-label="Generated configuration hash" readonly hidden></textarea>
                 <div class="payload-actions">
                     <button id="postEventBtn" type="button">Queue Event</button>
                     <button id="copyCleanupCommandBtn" class="secondary" type="button" disabled hidden>Copy Cleanup SQL</button>
                     <div id="directPostStatus" class="post-status" aria-live="polite"></div>
                 </div>
-                <textarea id="cleanupCommandOutput" class="token" readonly hidden></textarea>
+                <textarea id="cleanupCommandOutput" class="token" aria-label="Generated cleanup SQL" readonly hidden></textarea>
                 <div id="postValidationHint" class="validation-hint" hidden>Title and at least one destination are required before queueing.</div>
             </div>
 
@@ -932,7 +932,7 @@
 
             <details class="payload-box">
                 <summary>Manual server command fallback</summary>
-                <textarea id="commandOutput" class="token" readonly></textarea>
+                <textarea id="commandOutput" class="token" aria-label="Generated server command" readonly></textarea>
                 <div class="payload-actions">
                     <button id="copyCommandBtn" class="secondary" type="button">Copy Command</button>
                     <div id="copyState" style="font-size:12px;color:var(--muted);"></div>

--- a/LongevityWorldCup.Website/wwwroot/js/badges.js
+++ b/LongevityWorldCup.Website/wwwroot/js/badges.js
@@ -13,11 +13,6 @@
 */
 
 /* =========================
-   Shared UI helpers
-   ========================= */
-const spanA11y = 'role="button" tabindex="0" aria-label="Open league"';
-
-/* =========================
    Legacy visuals (backgrounds)
    ========================= */
 const LEGACY_BG = {
@@ -713,14 +708,12 @@ function buildServerBadgeHtml(b, athlete) {
         };
     }
 
-    const clickableAttrs = url
-        ? `class="${className} badge-clickable" ${spanA11y} onclick="window.location.href='${url}';"`
-        : `class="${className}"`;
-
     return {
         order,
         searchText: tooltip,
-        html: `<span ${clickableAttrs} title="${tooltip}" style="${styleWithBadgeVars(style)}"><i class="fa ${icon}"></i></span>`
+        html: url
+            ? `<a class="${className} badge-clickable" href="${escapeAttr(url)}" aria-label="Open league" title="${tooltip}" style="${styleWithBadgeVars(style)}"><i class="fa ${icon}"></i></a>`
+            : `<span class="${className}" title="${tooltip}" style="${styleWithBadgeVars(style)}"><i class="fa ${icon}"></i></span>`
     };
 }
 
@@ -744,7 +737,7 @@ window.setBadges = function (athlete, athleteCell) {
         items.push({
             order: 0,
             searchText: 'Personal page',
-            html: `<a class="badge-class badge-family-utility badge-clickable" ${spanA11y} href="${href}" target="_blank" rel="noopener"
+            html: `<a class="badge-class badge-family-utility badge-clickable" href="${escapeAttr(href)}" target="_blank" rel="noopener" aria-label="Open personal page"
                title="Personal page" style="${LEGACY_BG.personal}">
                <i class="fa fa-link"></i>
              </a>`
@@ -851,5 +844,4 @@ window.makeTooltipFromServerBadge = makeTooltipFromServerBadge;
 window.pickClickUrl = pickClickUrl;
 window.getBadgeFamilyClass = getBadgeFamilyClass;
 window.styleWithBadgeVars = styleWithBadgeVars;
-
 

--- a/LongevityWorldCup.Website/wwwroot/longevitymaxxing/longevitymaxxing.html
+++ b/LongevityWorldCup.Website/wwwroot/longevitymaxxing/longevitymaxxing.html
@@ -140,7 +140,7 @@
                                     <div class="lmx-timezone-popover" hidden>
                                         <div class="lmx-timezone-search">
                                             <i class="fas fa-magnifying-glass" aria-hidden="true"></i>
-                                            <input id="lmxSignupTimeZoneSearch" type="search" autocomplete="off" autocapitalize="none" spellcheck="false" placeholder="Search city or timezone" aria-controls="lmxSignupTimeZoneList">
+                                            <input id="lmxSignupTimeZoneSearch" type="search" autocomplete="off" autocapitalize="none" spellcheck="false" placeholder="Search city or timezone" aria-label="Search city or timezone" aria-controls="lmxSignupTimeZoneList">
                                         </div>
                                         <div id="lmxSignupTimeZoneList" class="lmx-timezone-list" role="listbox" aria-label="Timezones"></div>
                                     </div>
@@ -229,7 +229,7 @@
                                 <div class="lmx-timezone-popover" hidden>
                                     <div class="lmx-timezone-search">
                                         <i class="fas fa-magnifying-glass" aria-hidden="true"></i>
-                                        <input id="lmxEditTimeZoneSearch" type="search" autocomplete="off" autocapitalize="none" spellcheck="false" placeholder="Search city or timezone" aria-controls="lmxEditTimeZoneList">
+                                        <input id="lmxEditTimeZoneSearch" type="search" autocomplete="off" autocapitalize="none" spellcheck="false" placeholder="Search city or timezone" aria-label="Search city or timezone" aria-controls="lmxEditTimeZoneList">
                                     </div>
                                     <div id="lmxEditTimeZoneList" class="lmx-timezone-list" role="listbox" aria-label="Timezones"></div>
                                 </div>

--- a/LongevityWorldCup.Website/wwwroot/misc-pages/ruleset.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/ruleset.html
@@ -385,7 +385,7 @@
 <li>Seasonal clocks typically start and end around mid-January, and <strong>only accept results from the given calendar year</strong> (January 1 to December 31). At <strong>season close</strong>, final rankings lock for that season.</li>
 <li>Some clocks may run as <strong>all-time competitions</strong> instead of seasonal competitions. <strong>The all-time competition currently uses <a href="https://pmc.ncbi.nlm.nih.gov/articles/PMC5940111/pdf/aging-10-101414.pdf" target="_blank" rel="noopener noreferrer">pheno age</a></strong>.</li>
 </ul>
-<p><img src="https://github.com/user-attachments/assets/337ab8a6-935b-4986-8e63-28aa6f494582" alt="image" /></p>
+<p><img src="https://github.com/user-attachments/assets/337ab8a6-935b-4986-8e63-28aa6f494582" alt="Season duration defines the competition cycle, while test validity defines test acceptance" /></p>
 <h2 id="tracks">Tracks</h2>
 <p>The Longevity World Cup has multiple tracks: <strong>Amateur</strong> and <strong>Professional</strong>. These use different clocks and rules.</p>
 <ul>
@@ -404,7 +404,7 @@
 </li>
 <li>The competition also uses <strong>leagues</strong> (for example generation-based or other category-based rankings). You can rank globally and still compete within your generation league.</li>
 </ul>
-<p><img src="https://github.com/user-attachments/assets/968fc0b2-3389-40a3-93e9-4a415f565b11" alt="image" /></p>
+<p><img src="https://github.com/user-attachments/assets/968fc0b2-3389-40a3-93e9-4a415f565b11" alt="Multiple submissions may improve ranking at higher cost, while one strategic submission is cheaper but may miss the optimum" /></p>
 <h2 id="prizes-and-payouts">Prizes and payouts</h2>
 <ul>
 <li>Prize money is awarded to the top three athletes in the Ultimate League.</li>
@@ -412,14 +412,14 @@
 <li>10% of donations covers operating costs, and 90% funds the prize money pool.</li>
 <li>Payouts are made in Bitcoin in mid-January. If you need a Bitcoin wallet, we'll help you set one up. We recommend <a href="https://blockstream.com/green/" target="_blank" rel="noopener noreferrer">Green Wallet</a> for mobile or <a href="https://wasabiwallet.io/" target="_blank" rel="noopener noreferrer">Wasabi Wallet</a> for desktop. Fun fact: Wasabi Wallet and the Longevity World Cup share the same creator.</li>
 </ul>
-<p><img src="https://github.com/user-attachments/assets/9a41f400-92a1-496d-8553-b727186580b2" alt="image" /></p>
+<p><img src="https://github.com/user-attachments/assets/9a41f400-92a1-496d-8553-b727186580b2" alt="Prize money timeline from Bitcoin donations through allocation, funding, costs, wallet setup, and January payouts" /></p>
 <h2 id="faq">FAQ</h2>
 <h3 id="general-questions">General questions</h3>
 <h4 id="who-can-participate-in-the-longevity-world-cup">Who can participate in the Longevity World Cup?</h4>
 <p>Anyone interested in longevity and capable of submitting valid test results can participate.</p>
 <h4 id="how-do-i-register-for-the-competition">How do I register for the competition?</h4>
 <p>Apply through the <a href="https://www.longevityworldcup.com/" target="_blank" rel="noopener noreferrer">Longevity World Cup website</a>.</p>
-<p><img src="https://github.com/user-attachments/assets/38c545e9-13e5-4ba2-b2e0-d52bbf149207" alt="image" /></p>
+<p><img src="https://github.com/user-attachments/assets/38c545e9-13e5-4ba2-b2e0-d52bbf149207" alt="Registration process: visit the website, then follow the instructions" /></p>
 <p>Need help with your application? Watch <a href="https://www.youtube.com/watch?v=0mCIbqgfqq8" target="_blank" rel="noopener noreferrer">this seven-minute video tutorial</a> or <a href="https://www.youtube.com/shorts/yhMFZMPAoKQ" target="_blank" rel="noopener noreferrer">this one-minute video tutorial</a>.</p>
 <h4 id="can-i-withdraw-from-the-competition">Can I withdraw from the competition?</h4>
 <p>Yes. Email <code>hi@longevityworldcup.com</code>.</p>
@@ -464,7 +464,7 @@
 <li>Mean Corpuscular Hemoglobin (MCH)</li>
 <li>Apolipoprotein A1 (ApoA1)</li>
 </ul>
-<p><img src="https://github.com/user-attachments/assets/4770485d-440c-4ce6-be6a-b547798696c3" alt="image" /></p>
+<p><img src="https://github.com/user-attachments/assets/4770485d-440c-4ce6-be6a-b547798696c3" alt="Biomarkers used in pheno age calculation and their common laboratory names" /></p>
 <h4 id="can-i-use-any-laboratory-for-my-tests">Can I use any laboratory for my tests?</h4>
 <p>Yes, as long as the lab provides the biomarkers required for that clock.</p>
 <h4 id="why-does-my-pheno-age-result-differ-from-other-calculators">Why does my <a href="https://pmc.ncbi.nlm.nih.gov/articles/PMC5940111/pdf/aging-10-101414.pdf" target="_blank" rel="noopener noreferrer">pheno age</a> result differ from other calculators?</h4>
@@ -476,7 +476,7 @@
 <p>Each season closes in mid-January, giving your lab enough time to process a test from December 31.</p>
 <h4 id="what-if-theres-a-tie">What if there's a tie?</h4>
 <p>Ties break by older chronological age, then username alphabetically.</p>
-<p><img src="https://github.com/user-attachments/assets/a13ec2f2-346e-4024-aba5-dd32e807a34e" alt="image" /></p>
+<p><img src="https://github.com/user-attachments/assets/a13ec2f2-346e-4024-aba5-dd32e807a34e" alt="Tie-break order: pheno age, chronological age, then alphabetical order" /></p>
 <h4 id="how-is-my-score-calculated-if-i-submit-multiple-results">How is my score calculated if I submit multiple results?</h4>
 <p>If you submit multiple test results, the <strong>best</strong> result is used for your season standing for the relevant clock. This encourages incremental updates and fair comparisons between strategic and transparent participants.</p>
 <h4 id="how-are-lab-detection-limits-handled-in-the-competition">How are lab detection limits handled in the competition?</h4>
@@ -494,7 +494,7 @@
 <h3 id="practical-matters">Practical matters</h3>
 <h4 id="how-much-can-i-edit-my-profile-picture">How much can I edit my profile picture?</h4>
 <p>Your profile picture must show you facing the camera, but you can edit it freely, including as a drawing or AI-generated version. Choose a picture that represents you well and works for age estimation from a photo.</p>
-<p><img src="https://github.com/user-attachments/assets/613afebb-4ec7-4b0d-a961-8a09e26391ab" alt="image" /></p>
+<p><img src="https://github.com/user-attachments/assets/613afebb-4ec7-4b0d-a961-8a09e26391ab" alt="Profile picture compliance balances editing freedom with use of a personal image" /></p>
 <h4 id="im-already-an-athlete-how-can-i-make-changes">I'm already an athlete. How can I make changes?</h4>
 <p>Through the <a href="https://www.longevityworldcup.com/select-athlete" target="_blank" rel="noopener noreferrer">Athlete Dashboard</a> or by sending us an email to <code>hi@longevityworldcup.com</code>.</p>
 <h4 id="what-will-sponsorships-include">What will sponsorships include?</h4>

--- a/LongevityWorldCup.Website/wwwroot/misc-pages/ruleset.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/ruleset.html
@@ -476,7 +476,7 @@
 <p>Each season closes in mid-January, giving your lab enough time to process a test from December 31.</p>
 <h4 id="what-if-theres-a-tie">What if there's a tie?</h4>
 <p>Ties break by older chronological age, then username alphabetically.</p>
-<p><img src="https://github.com/user-attachments/assets/a13ec2f2-346e-4024-aba5-dd32e807a34e" alt="Tie-break order: pheno age, chronological age, then alphabetical order" /></p>
+<p><img src="https://github.com/user-attachments/assets/a13ec2f2-346e-4024-aba5-dd32e807a34e" alt="Ranking flow: compare pheno age, then break ties by older chronological age and, if still tied, username alphabetically" /></p>
 <h4 id="how-is-my-score-calculated-if-i-submit-multiple-results">How is my score calculated if I submit multiple results?</h4>
 <p>If you submit multiple test results, the <strong>best</strong> result is used for your season standing for the relevant clock. This encourages incremental updates and fair comparisons between strategic and transparent participants.</p>
 <h4 id="how-are-lab-detection-limits-handled-in-the-competition">How are lab detection limits handled in the competition?</h4>

--- a/LongevityWorldCup.Website/wwwroot/onboarding/bortz-age.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/bortz-age.html
@@ -1019,7 +1019,7 @@
                         <legend>Blood draw date:</legend>
                         <p class="privacy-note">When did you get your blood test done?</p>
                         <div class="input-group lwc-date-flex">
-                            <input type="date" id="blood-draw-date" name="blood-draw-date" required aria-required="true" max="" onchange="calculateResultIfResultAlreadyCalculated()" autocomplete="off">
+                            <input type="date" id="blood-draw-date" name="blood-draw-date" required aria-required="true" aria-label="Blood draw date" max="" onchange="calculateResultIfResultAlreadyCalculated()" autocomplete="off">
                         </div>
                     </fieldset>
                     <div class="lwc-step-actions flow-action-stack">
@@ -1048,7 +1048,7 @@
                             </div>
                             <div class="biomarker-card-content">
                                 <div class="input-group">
-                                    <input type="number" id="wbc" name="wbc" step="any" required aria-required="true" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
+                                    <input type="number" id="wbc" name="wbc" step="any" required aria-required="true" aria-label="White blood cell count (WBC)" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
                                     <label for="wbcUnit" class="visually-hidden">Select unit for White Blood Cell Count</label>
                                     <select id="wbcUnit" name="wbcUnit" aria-label="WBC unit" onchange="calculateResultIfResultAlreadyCalculated()">
                                         <option value="1">10⁹/L</option>
@@ -1062,7 +1062,7 @@
                             <div class="biomarker-card-header" aria-expanded="false">Lymphocytes <span class="toggle-icon">+</span></div>
                             <div class="biomarker-card-content">
                                 <div class="input-group">
-                                    <input type="number" id="lymphocyte_percentage" name="lymphocyte_percentage" step="any" required aria-required="true" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
+                                    <input type="number" id="lymphocyte_percentage" name="lymphocyte_percentage" step="any" required aria-required="true" aria-label="Lymphocytes" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
                                     <label for="lymphocyte_percentageUnit" class="visually-hidden">Select unit for Lymphocytes</label>
                                     <select id="lymphocyte_percentageUnit" aria-label="Lymphocyte unit" onchange="calculateResultIfResultAlreadyCalculated()">
                                         <option value="1">%</option>
@@ -1077,7 +1077,7 @@
                             <div class="biomarker-card-header" aria-expanded="false">Neutrophils <span class="toggle-icon">+</span></div>
                             <div class="biomarker-card-content">
                                 <div class="input-group">
-                                    <input type="number" id="neutrophil_percentage" name="neutrophil_percentage" step="any" required aria-required="true" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
+                                    <input type="number" id="neutrophil_percentage" name="neutrophil_percentage" step="any" required aria-required="true" aria-label="Neutrophils" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
                                     <label for="neutrophil_percentageUnit" class="visually-hidden">Neutrophils unit</label>
                                     <select id="neutrophil_percentageUnit" aria-label="Neutrophils unit" onchange="calculateResultIfResultAlreadyCalculated()">
                                         <option value="1">%</option>
@@ -1092,7 +1092,7 @@
                             <div class="biomarker-card-header" aria-expanded="false">Monocytes <span class="toggle-icon">+</span></div>
                             <div class="biomarker-card-content">
                                 <div class="input-group">
-                                    <input type="number" id="monocyte_percentage" name="monocyte_percentage" step="any" required aria-required="true" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
+                                    <input type="number" id="monocyte_percentage" name="monocyte_percentage" step="any" required aria-required="true" aria-label="Monocytes" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
                                     <label for="monocyte_percentageUnit" class="visually-hidden">Monocytes unit</label>
                                     <select id="monocyte_percentageUnit" aria-label="Monocytes unit" onchange="calculateResultIfResultAlreadyCalculated()">
                                         <option value="1">%</option>
@@ -1107,7 +1107,7 @@
                             <div class="biomarker-card-header" aria-expanded="false">Red blood cell count (RBC) <span class="toggle-icon">+</span></div>
                             <div class="biomarker-card-content">
                                 <div class="input-group">
-                                    <input type="number" id="rbc" name="rbc" step="any" required aria-required="true" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
+                                    <input type="number" id="rbc" name="rbc" step="any" required aria-required="true" aria-label="Red blood cell count (RBC)" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
                                     <label for="rbcUnit" class="visually-hidden">RBC unit</label>
                                     <select id="rbcUnit" aria-label="RBC unit" onchange="calculateResultIfResultAlreadyCalculated()">
                                         <option value="1">10¹²/L</option>
@@ -1121,7 +1121,7 @@
                             <div class="biomarker-card-header" aria-expanded="false">Mean corpuscular volume (MCV) <span class="toggle-icon">+</span></div>
                             <div class="biomarker-card-content">
                                 <div class="input-group">
-                                    <input type="number" id="mcv" name="mcv" step="any" required aria-required="true" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
+                                    <input type="number" id="mcv" name="mcv" step="any" required aria-required="true" aria-label="Mean corpuscular volume (MCV)" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
                                     <label for="mcvUnit" class="visually-hidden">MCV unit</label>
                                     <select id="mcvUnit" aria-label="MCV unit" onchange="calculateResultIfResultAlreadyCalculated()">
                                         <option value="1">fL</option>
@@ -1134,7 +1134,7 @@
                             <div class="biomarker-card-header" aria-expanded="false">Mean corpuscular hemoglobin (MCH) <span class="toggle-icon">+</span></div>
                             <div class="biomarker-card-content">
                                 <div class="input-group">
-                                    <input type="number" id="mch" name="mch" step="any" required aria-required="true" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
+                                    <input type="number" id="mch" name="mch" step="any" required aria-required="true" aria-label="Mean corpuscular hemoglobin (MCH)" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
                                     <label for="mchUnit" class="visually-hidden">MCH unit</label>
                                     <select id="mchUnit" aria-label="MCH unit" onchange="calculateResultIfResultAlreadyCalculated()">
                                         <option value="1">pg</option>
@@ -1147,7 +1147,7 @@
                             <div class="biomarker-card-header" aria-expanded="false">Red cell distribution width (RDW, RDW-CV) <span class="toggle-icon">+</span></div>
                             <div class="biomarker-card-content">
                                 <div class="input-group">
-                                    <input type="number" id="rdw" name="rdw" step="any" required aria-required="true" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
+                                    <input type="number" id="rdw" name="rdw" step="any" required aria-required="true" aria-label="Red cell distribution width (RDW, RDW-CV)" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
                                     <label for="rdwUnit" class="visually-hidden">RDW unit</label>
                                     <select id="rdwUnit" aria-label="RDW unit" onchange="calculateResultIfResultAlreadyCalculated()">
                                         <option value="1">%</option>
@@ -1163,7 +1163,7 @@
                             <div class="biomarker-card-header" aria-expanded="false">Albumin <span class="toggle-icon">+</span></div>
                             <div class="biomarker-card-content">
                                 <div class="input-group">
-                                    <input type="number" id="albumin" name="albumin" step="any" required aria-required="true" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
+                                    <input type="number" id="albumin" name="albumin" step="any" required aria-required="true" aria-label="Albumin" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
                                     <label for="albuminUnit" class="visually-hidden">Albumin unit</label>
                                     <select id="albuminUnit" aria-label="Albumin unit" onchange="calculateResultIfResultAlreadyCalculated()">
                                         <option value="1">g/L</option>
@@ -1177,7 +1177,7 @@
                             <div class="biomarker-card-header" aria-expanded="false">Alanine aminotransferase (ALT, ALAT) <span class="toggle-icon">+</span></div>
                             <div class="biomarker-card-content">
                                 <div class="input-group">
-                                    <input type="number" id="alt" name="alt" step="any" required aria-required="true" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
+                                    <input type="number" id="alt" name="alt" step="any" required aria-required="true" aria-label="Alanine aminotransferase (ALT, ALAT)" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
                                     <label for="altUnit" class="visually-hidden">ALT unit</label>
                                     <select id="altUnit" aria-label="ALT unit" onchange="calculateResultIfResultAlreadyCalculated()">
                                         <option value="1">U/L</option>
@@ -1191,7 +1191,7 @@
                             <div class="biomarker-card-header" aria-expanded="false">Alkaline phosphatase (ALP) <span class="toggle-icon">+</span></div>
                             <div class="biomarker-card-content">
                                 <div class="input-group">
-                                    <input type="number" id="alp" name="alp" step="any" required aria-required="true" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
+                                    <input type="number" id="alp" name="alp" step="any" required aria-required="true" aria-label="Alkaline phosphatase (ALP)" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
                                     <label for="alpUnit" class="visually-hidden">ALP unit</label>
                                     <select id="alpUnit" aria-label="ALP unit" onchange="calculateResultIfResultAlreadyCalculated()">
                                         <option value="1">U/L</option>
@@ -1205,7 +1205,7 @@
                             <div class="biomarker-card-header" aria-expanded="false">Gamma-glutamyl transferase (GGT) <span class="toggle-icon">+</span></div>
                             <div class="biomarker-card-content">
                                 <div class="input-group">
-                                    <input type="number" id="ggt" name="ggt" step="any" required aria-required="true" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
+                                    <input type="number" id="ggt" name="ggt" step="any" required aria-required="true" aria-label="Gamma-glutamyl transferase (GGT)" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
                                     <label for="ggtUnit" class="visually-hidden">GGT unit</label>
                                     <select id="ggtUnit" aria-label="GGT unit" onchange="calculateResultIfResultAlreadyCalculated()">
                                         <option value="1">U/L</option>
@@ -1222,7 +1222,7 @@
                             <div class="biomarker-card-header" aria-expanded="false">Urea/BUN <span class="toggle-icon">+</span></div>
                             <div class="biomarker-card-content">
                                 <div class="input-group">
-                                    <input type="number" id="urea" name="urea" step="any" required aria-required="true" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
+                                    <input type="number" id="urea" name="urea" step="any" required aria-required="true" aria-label="Urea or blood urea nitrogen (BUN)" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
                                     <label for="ureaUnit" class="visually-hidden">Urea/BUN unit</label>
                                     <select id="ureaUnit" aria-label="Urea/BUN unit" onchange="calculateResultIfResultAlreadyCalculated()">
                                         <option value="1">Urea (mmol/L)</option>
@@ -1237,7 +1237,7 @@
                             <div class="biomarker-card-header" aria-expanded="false">Creatinine <span class="toggle-icon">+</span></div>
                             <div class="biomarker-card-content">
                                 <div class="input-group">
-                                    <input type="number" id="creatinine" name="creatinine" step="any" required aria-required="true" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
+                                    <input type="number" id="creatinine" name="creatinine" step="any" required aria-required="true" aria-label="Creatinine" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
                                     <label for="creatinineUnit" class="visually-hidden">Creatinine unit</label>
                                     <select id="creatinineUnit" aria-label="Creatinine unit" onchange="calculateResultIfResultAlreadyCalculated()">
                                         <option value="1">µmol/L</option>
@@ -1251,7 +1251,7 @@
                             <div class="biomarker-card-header" aria-expanded="false">Cystatin C <span class="toggle-icon">+</span></div>
                             <div class="biomarker-card-content">
                                 <div class="input-group">
-                                    <input type="number" id="cystatin_c" name="cystatin_c" step="any" required aria-required="true" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
+                                    <input type="number" id="cystatin_c" name="cystatin_c" step="any" required aria-required="true" aria-label="Cystatin C" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
                                     <label for="cystatin_cUnit" class="visually-hidden">Cystatin C unit</label>
                                     <select id="cystatin_cUnit" aria-label="Cystatin C unit" onchange="calculateResultIfResultAlreadyCalculated()">
                                         <option value="1">mg/L</option>
@@ -1268,7 +1268,7 @@
                             <div class="biomarker-card-header" aria-expanded="false">Glucose <span class="toggle-icon">+</span></div>
                             <div class="biomarker-card-content">
                                 <div class="input-group">
-                                    <input type="number" id="glucose" name="glucose" step="any" required aria-required="true" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
+                                    <input type="number" id="glucose" name="glucose" step="any" required aria-required="true" aria-label="Glucose" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
                                     <label for="glucoseUnit" class="visually-hidden">Glucose unit</label>
                                     <select id="glucoseUnit" aria-label="Glucose unit" onchange="calculateResultIfResultAlreadyCalculated()">
                                         <option value="1">mmol/L</option>
@@ -1282,7 +1282,7 @@
                             <div class="biomarker-card-header" aria-expanded="false">Hemoglobin A1c (HbA1c) <span class="toggle-icon">+</span></div>
                             <div class="biomarker-card-content">
                                 <div class="input-group">
-                                    <input type="number" id="hba1c" name="hba1c" step="any" required aria-required="true" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
+                                    <input type="number" id="hba1c" name="hba1c" step="any" required aria-required="true" aria-label="Hemoglobin A1c (HbA1c)" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
                                     <label for="hba1cUnit" class="visually-hidden">HbA1c unit</label>
                                     <select id="hba1cUnit" aria-label="HbA1c unit" onchange="calculateResultIfResultAlreadyCalculated()">
                                         <option value="1">mmol/mol (IFCC)</option>
@@ -1298,7 +1298,7 @@
                             <div class="biomarker-card-header" aria-expanded="false">Total cholesterol <span class="toggle-icon">+</span></div>
                             <div class="biomarker-card-content">
                                 <div class="input-group">
-                                    <input type="number" id="cholesterol" name="cholesterol" step="any" required aria-required="true" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
+                                    <input type="number" id="cholesterol" name="cholesterol" step="any" required aria-required="true" aria-label="Total cholesterol" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
                                     <label for="cholesterolUnit" class="visually-hidden">Cholesterol unit</label>
                                     <select id="cholesterolUnit" aria-label="Cholesterol unit" onchange="calculateResultIfResultAlreadyCalculated()">
                                         <option value="1">mmol/L</option>
@@ -1312,7 +1312,7 @@
                             <div class="biomarker-card-header" aria-expanded="false">Apolipoprotein A1 (ApoA1) <span class="toggle-icon">+</span></div>
                             <div class="biomarker-card-content">
                                 <div class="input-group">
-                                    <input type="number" id="apoa1" name="apoa1" step="any" required aria-required="true" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
+                                    <input type="number" id="apoa1" name="apoa1" step="any" required aria-required="true" aria-label="Apolipoprotein A1 (ApoA1)" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
                                     <label for="apoa1Unit" class="visually-hidden">ApoA1 unit</label>
                                     <select id="apoa1Unit" aria-label="ApoA1 unit" onchange="calculateResultIfResultAlreadyCalculated()">
                                         <option value="1">g/L</option>
@@ -1333,13 +1333,13 @@
                                         <span class="bioageform-toggle-text">Set if negative:</span>
                                         <div class="negative-toggle">
                                             <label for="crp-negative" class="toggle-label">
-                                                <input type="checkbox" id="crp-negative" onchange="toggleCRPInput()">
+                                                <input type="checkbox" id="crp-negative" aria-label="Set CRP as below the detection limit" onchange="toggleCRPInput()">
                                                 <span class="slider"></span>
                                             </label>
                                         </div>
                                     </div>
                                     <div class="input-group">
-                                        <input type="number" id="crp" name="crp" step="any" required aria-required="true" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
+                                        <input type="number" id="crp" name="crp" step="any" required aria-required="true" aria-label="C-reactive protein (CRP)" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
                                         <label for="crpUnit" class="visually-hidden">CRP unit</label>
                                         <select id="crpUnit" aria-label="CRP unit" onchange="calculateResultIfResultAlreadyCalculated()">
                                             <option value="1">mg/L</option>
@@ -1357,7 +1357,7 @@
                             <div class="biomarker-card-header" aria-expanded="false">Sex hormone-binding globulin (SHBG) <span class="toggle-icon">+</span></div>
                             <div class="biomarker-card-content">
                                 <div class="input-group">
-                                    <input type="number" id="shbg" name="shbg" step="any" required aria-required="true" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
+                                    <input type="number" id="shbg" name="shbg" step="any" required aria-required="true" aria-label="Sex hormone-binding globulin (SHBG)" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
                                     <label for="shbgUnit" class="visually-hidden">SHBG unit</label>
                                     <select id="shbgUnit" aria-label="SHBG unit" onchange="calculateResultIfResultAlreadyCalculated()">
                                         <option value="1">nmol/L</option>
@@ -1371,7 +1371,7 @@
                             <div class="biomarker-card-header" aria-expanded="false">Vitamin D (25-OH) <span class="toggle-icon">+</span></div>
                             <div class="biomarker-card-content">
                                 <div class="input-group">
-                                    <input type="number" id="vitamin_d" name="vitamin_d" step="any" required aria-required="true" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
+                                    <input type="number" id="vitamin_d" name="vitamin_d" step="any" required aria-required="true" aria-label="Vitamin D (25-OH)" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
                                     <label for="vitamin_dUnit" class="visually-hidden">Vitamin D unit</label>
                                     <select id="vitamin_dUnit" aria-label="Vitamin D unit" onchange="calculateResultIfResultAlreadyCalculated()">
                                         <option value="1">nmol/L</option>

--- a/LongevityWorldCup.Website/wwwroot/onboarding/bortz-age.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/bortz-age.html
@@ -969,7 +969,7 @@
                 </a>
             </section>
             <form id="bortzAgeForm" class="bioageform" data-aos="fade" data-aos-duration="700" data-aos-delay="350">
-                <div class="lwc-wizard-nav" aria-hidden="true">
+                <div class="lwc-wizard-nav">
                     <div class="lwc-dot lwc-dot--on" id="lwcDot1" role="button" tabindex="0" aria-label="Go to Step 1"></div>
                     <div class="lwc-dot" id="lwcDot2" role="button" tabindex="0" aria-label="Go to Step 2"></div>
                 </div>

--- a/LongevityWorldCup.Website/wwwroot/onboarding/bortz-age.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/bortz-age.html
@@ -713,6 +713,11 @@
                 background: #f1f5f9;
             }
 
+            .biomarker-card-header:focus-visible {
+                outline: 3px solid rgba(0, 188, 212, 0.45);
+                outline-offset: -3px;
+            }
+
             .biomarker-card.active .biomarker-card-header {
                 background: #f8feff;
                 color: #1f2937;
@@ -3633,7 +3638,11 @@
 
         // Wire up all biomarker‐card headers
         document.querySelectorAll('.biomarker-card-header').forEach(header => {
-            header.addEventListener('click', function handler() {
+            header.setAttribute('role', 'button');
+            header.setAttribute('tabindex', '0');
+            header.querySelector('.toggle-icon')?.setAttribute('aria-hidden', 'true');
+
+            const toggleCard = function () {
                 const card = header.parentNode;
                 const content = card.querySelector('.biomarker-card-content');
                 const icon = header.querySelector('.toggle-icon');
@@ -3648,6 +3657,8 @@
                         content.style.paddingBottom = '0.75rem';
                         header.style.pointerEvents = 'none';
                         header.style.cursor = 'default';
+                        header.setAttribute('aria-disabled', 'true');
+                        header.setAttribute('tabindex', '-1');
                         icon.style.display = 'none';
                     }
                     return;
@@ -3668,6 +3679,13 @@
                     content.style.paddingTop = '0';
                     content.style.paddingBottom = '0';
                 }
+            };
+
+            header.addEventListener('click', toggleCard);
+            header.addEventListener('keydown', event => {
+                if (event.key !== 'Enter' && event.key !== ' ') return;
+                event.preventDefault();
+                toggleCard();
             });
         });
 
@@ -3709,6 +3727,8 @@
                     if (header) {
                         header.style.pointerEvents = 'none';
                         header.style.cursor = 'default';
+                        header.setAttribute('aria-disabled', 'true');
+                        header.setAttribute('tabindex', '-1');
                     }
                 } else {
                     // In update mode: show a minus icon

--- a/LongevityWorldCup.Website/wwwroot/onboarding/convergence.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/convergence.html
@@ -141,6 +141,11 @@
             cursor: pointer;
         }
 
+        .clickable:focus-visible {
+            outline: 3px solid var(--primary-color);
+            outline-offset: 4px;
+        }
+
         .convergence-upload-guidance {
             width: min(100%, 408px);
             margin: 0.75rem auto 1.2rem;
@@ -1355,6 +1360,9 @@
 
             // Remove 'clickable' class initially
             illustrationImage.classList.remove('clickable');
+            illustrationImage.removeAttribute('role');
+            illustrationImage.removeAttribute('tabindex');
+            illustrationImage.removeAttribute('aria-label');
 
             switch (stage) {
                 case 1:
@@ -1465,6 +1473,9 @@
                     document.getElementById('profileUploadSection').style.display = '';
 
                     illustrationImage.classList.add('clickable');
+                    illustrationImage.setAttribute('role', 'button');
+                    illustrationImage.setAttribute('tabindex', '0');
+                    illustrationImage.setAttribute('aria-label', 'Choose a profile picture');
                     nextButton.innerHTML = '<span class="flow-action__label">Next</span><i class="fas fa-arrow-right" aria-hidden="true"></i>';
                     updateSubProgress(4);
 
@@ -2035,6 +2046,11 @@
             const illustrationImage = document.getElementById('illustrationImage');
             if (illustrationImage && !illustrationImage.hasAttribute('data-listener')) {
                 illustrationImage.addEventListener('click', function () {
+                    document.getElementById('profilePicInput').click();
+                });
+                illustrationImage.addEventListener('keydown', function (event) {
+                    if (event.key !== 'Enter' && event.key !== ' ') return;
+                    event.preventDefault();
                     document.getElementById('profilePicInput').click();
                 });
                 illustrationImage.setAttribute('data-listener', 'true');

--- a/LongevityWorldCup.Website/wwwroot/onboarding/convergence.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/convergence.html
@@ -683,10 +683,11 @@
             </fieldset>
             <fieldset id="applyDetails">
                 <!-- Email Field -->
-                <legend for="accountEmail">Contact email</legend>
+                <legend>Contact email</legend>
                 <div id="congratsText" class="convergence-application-copy" style="display:none">
                     <strong>Congratulations!</strong> All that's left to do is to provide an email where we can reach you about your application.
                 </div>
+                <label for="accountEmail" class="visually-hidden">Email address</label>
                 <input type="text" id="accountEmail" name="accountEmail" required aria-required="true" inputmode="email" autocomplete="email" autocapitalize="none" spellcheck="false" placeholder="pizza_lover@hungry.com">
             </fieldset>
 

--- a/LongevityWorldCup.Website/wwwroot/onboarding/convergence.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/convergence.html
@@ -141,11 +141,6 @@
             cursor: pointer;
         }
 
-        .clickable:focus-visible {
-            outline: 3px solid var(--primary-color);
-            outline-offset: 4px;
-        }
-
         .convergence-upload-guidance {
             width: min(100%, 408px);
             margin: 0.75rem auto 1.2rem;
@@ -1360,9 +1355,6 @@
 
             // Remove 'clickable' class initially
             illustrationImage.classList.remove('clickable');
-            illustrationImage.removeAttribute('role');
-            illustrationImage.removeAttribute('tabindex');
-            illustrationImage.removeAttribute('aria-label');
 
             switch (stage) {
                 case 1:
@@ -1473,9 +1465,6 @@
                     document.getElementById('profileUploadSection').style.display = '';
 
                     illustrationImage.classList.add('clickable');
-                    illustrationImage.setAttribute('role', 'button');
-                    illustrationImage.setAttribute('tabindex', '0');
-                    illustrationImage.setAttribute('aria-label', 'Choose a profile picture');
                     nextButton.innerHTML = '<span class="flow-action__label">Next</span><i class="fas fa-arrow-right" aria-hidden="true"></i>';
                     updateSubProgress(4);
 
@@ -2046,11 +2035,6 @@
             const illustrationImage = document.getElementById('illustrationImage');
             if (illustrationImage && !illustrationImage.hasAttribute('data-listener')) {
                 illustrationImage.addEventListener('click', function () {
-                    document.getElementById('profilePicInput').click();
-                });
-                illustrationImage.addEventListener('keydown', function (event) {
-                    if (event.key !== 'Enter' && event.key !== ' ') return;
-                    event.preventDefault();
                     document.getElementById('profilePicInput').click();
                 });
                 illustrationImage.setAttribute('data-listener', 'true');

--- a/LongevityWorldCup.Website/wwwroot/onboarding/pheno-age.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/pheno-age.html
@@ -1009,7 +1009,7 @@
                         <legend>Blood draw date:</legend>
                         <p class="privacy-note">When did you get your blood test done?</p>
                         <div class="input-group lwc-date-flex">
-                            <input type="date" id="blood-draw-date" name="blood-draw-date" required aria-required="true" max="" onchange="calculateResultIfResultAlreadyCalculated()" autocomplete="off">
+                            <input type="date" id="blood-draw-date" name="blood-draw-date" required aria-required="true" aria-label="Blood draw date" max="" onchange="calculateResultIfResultAlreadyCalculated()" autocomplete="off">
                         </div>
                     </fieldset>
                     <div class="lwc-step-actions flow-action-stack">
@@ -1037,7 +1037,7 @@
                             </div>
                             <div class="biomarker-card-content">
                                 <div class="input-group">
-                                    <input type="number" id="wbc" name="wbc" step="any" required aria-required="true" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
+                                    <input type="number" id="wbc" name="wbc" step="any" required aria-required="true" aria-label="White blood cell count (WBC)" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
                                     <label for="wbcUnit" class="visually-hidden">Select unit for White Blood Cell Count</label>
                                     <select id="wbcUnit" name="wbcUnit" aria-label="WBC unit" onchange="calculateResultIfResultAlreadyCalculated()">
                                         <option value="1">10⁹/L</option>
@@ -1054,7 +1054,7 @@
                             </div>
                             <div class="biomarker-card-content">
                                 <div class="input-group">
-                                    <input type="number" id="lymphocyte" name="lymphocyte" step="any" required aria-required="true" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
+                                    <input type="number" id="lymphocyte" name="lymphocyte" step="any" required aria-required="true" aria-label="Lymphocytes" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
                                     <label for="lymphocyteUnit" class="visually-hidden">Select unit for Lymphocytes</label>
                                     <select id="lymphocyteUnit" name="lymphocyteUnit" aria-label="Lymphocyte unit" onchange="calculateResultIfResultAlreadyCalculated()">
                                         <option value="1">%</option>
@@ -1072,7 +1072,7 @@
                             </div>
                             <div class="biomarker-card-content">
                                 <div class="input-group">
-                                    <input type="number" id="mcv" name="mcv" step="any" required aria-required="true" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
+                                    <input type="number" id="mcv" name="mcv" step="any" required aria-required="true" aria-label="Mean corpuscular volume (MCV)" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
                                     <label for="mcvUnit" class="visually-hidden">MCV unit</label>
                                     <select id="mcvUnit" name="mcvUnit" aria-label="MCV unit" onchange="calculateResultIfResultAlreadyCalculated()">
                                         <option value="1">fL</option>
@@ -1088,7 +1088,7 @@
                             </div>
                             <div class="biomarker-card-content">
                                 <div class="input-group">
-                                    <input type="number" id="rcdw" name="rcdw" step="any" required aria-required="true" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
+                                    <input type="number" id="rcdw" name="rcdw" step="any" required aria-required="true" aria-label="Red cell distribution width (RDW, RDW-CV)" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
                                     <label for="rcdwUnit" class="visually-hidden">RDW unit</label>
                                     <select id="rcdwUnit" name="rcdwUnit" aria-label="RDW unit" onchange="calculateResultIfResultAlreadyCalculated()">
                                         <option value="1">%</option>
@@ -1107,7 +1107,7 @@
                             </div>
                             <div class="biomarker-card-content">
                                 <div class="input-group">
-                                    <input type="number" id="albumin" name="albumin" step="any" required aria-required="true" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
+                                    <input type="number" id="albumin" name="albumin" step="any" required aria-required="true" aria-label="Albumin" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
                                     <label for="albuminUnit" class="visually-hidden">Albumin unit</label>
                                     <select id="albuminUnit" name="albuminUnit" aria-label="Albumin unit" onchange="calculateResultIfResultAlreadyCalculated()">
                                         <option value="1">g/L</option>
@@ -1124,7 +1124,7 @@
                             </div>
                             <div class="biomarker-card-content">
                                 <div class="input-group">
-                                    <input type="number" id="ap" name="ap" step="any" required aria-required="true" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
+                                    <input type="number" id="ap" name="ap" step="any" required aria-required="true" aria-label="Alkaline phosphatase (ALP)" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
                                     <label for="apUnit" class="visually-hidden">ALP unit</label>
                                     <select id="apUnit" name="apUnit" aria-label="ALP unit" onchange="calculateResultIfResultAlreadyCalculated()">
                                         <option value="1">U/L</option>
@@ -1144,7 +1144,7 @@
                             </div>
                             <div class="biomarker-card-content">
                                 <div class="input-group">
-                                    <input type="number" id="creatinine" name="creatinine" step="any" required aria-required="true" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
+                                    <input type="number" id="creatinine" name="creatinine" step="any" required aria-required="true" aria-label="Creatinine" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
                                     <label for="creatinineUnit" class="visually-hidden">Creatinine unit</label>
                                     <select id="creatinineUnit" name="creatinineUnit" aria-label="Creatinine unit" onchange="calculateResultIfResultAlreadyCalculated()">
                                         <option value="1">µmol/L</option>
@@ -1164,7 +1164,7 @@
                             </div>
                             <div class="biomarker-card-content">
                                 <div class="input-group">
-                                    <input type="number" id="glucose" name="glucose" step="any" required aria-required="true" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
+                                    <input type="number" id="glucose" name="glucose" step="any" required aria-required="true" aria-label="Glucose" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
                                     <label for="glucoseUnit" class="visually-hidden">Glucose unit</label>
                                     <select id="glucoseUnit" name="glucoseUnit" aria-label="Glucose unit" onchange="calculateResultIfResultAlreadyCalculated()">
                                         <option value="1">mmol/L</option>
@@ -1188,14 +1188,14 @@
                                         <span title="Check this box if your result is below your lab's 'the detection limit and this limit is unknown" class="bioageform-toggle-text">Set if negative:</span>
                                         <div title="Check this box if your result is below your lab's 'the detection limit and this limit is unknown" class="negative-toggle">
                                             <label for="crp-negative" class="toggle-label">
-                                                <input type="checkbox" id="crp-negative" onchange="toggleCRPInput()">
+                                                <input type="checkbox" id="crp-negative" aria-label="Set CRP as below the detection limit" onchange="toggleCRPInput()">
                                                 <span class="slider"></span>
                                             </label>
                                         </div>
                                     </div>
 
                                     <div class="input-group">
-                                        <input type="number" id="crp" name="crp" step="any" required aria-required="true" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
+                                        <input type="number" id="crp" name="crp" step="any" required aria-required="true" aria-label="C-reactive protein (CRP)" inputmode="decimal" onchange="calculateResultIfResultAlreadyCalculated()">
                                         <label for="crpUnit" class="visually-hidden">CRP unit</label>
                                         <select id="crpUnit" name="crpUnit" aria-label="CRP unit" onchange="calculateResultIfResultAlreadyCalculated()">
                                             <option value="10">mg/L</option>

--- a/LongevityWorldCup.Website/wwwroot/onboarding/pheno-age.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/pheno-age.html
@@ -703,6 +703,11 @@
                 background: #f1f5f9;
             }
 
+            .biomarker-card-header:focus-visible {
+                outline: 3px solid rgba(0, 188, 212, 0.45);
+                outline-offset: -3px;
+            }
+
             .biomarker-card.active .biomarker-card-header {
                 background: #f8feff;
                 color: #1f2937;
@@ -2930,7 +2935,11 @@
 
         // Wire up all biomarker‐card headers
         document.querySelectorAll('.biomarker-card-header').forEach(header => {
-            header.addEventListener('click', function handler() {
+            header.setAttribute('role', 'button');
+            header.setAttribute('tabindex', '0');
+            header.querySelector('.toggle-icon')?.setAttribute('aria-hidden', 'true');
+
+            const toggleCard = function () {
                 const card = header.parentNode;
                 const content = card.querySelector('.biomarker-card-content');
                 const icon = header.querySelector('.toggle-icon');
@@ -2945,6 +2954,8 @@
                         content.style.paddingBottom = '0.75rem';
                         header.style.pointerEvents = 'none';
                         header.style.cursor = 'default';
+                        header.setAttribute('aria-disabled', 'true');
+                        header.setAttribute('tabindex', '-1');
                         icon.style.display = 'none';
                     }
                     return;
@@ -2965,6 +2976,13 @@
                     content.style.paddingTop = '0';
                     content.style.paddingBottom = '0';
                 }
+            };
+
+            header.addEventListener('click', toggleCard);
+            header.addEventListener('keydown', event => {
+                if (event.key !== 'Enter' && event.key !== ' ') return;
+                event.preventDefault();
+                toggleCard();
             });
         });
 
@@ -3006,6 +3024,8 @@
                     if (header) {
                         header.style.pointerEvents = 'none';
                         header.style.cursor = 'default';
+                        header.setAttribute('aria-disabled', 'true');
+                        header.setAttribute('tabindex', '-1');
                     }
                 } else {
                     // In update mode: show a minus icon

--- a/LongevityWorldCup.Website/wwwroot/onboarding/pheno-age.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/pheno-age.html
@@ -959,7 +959,7 @@
                 </a>
             </section>
             <form id="phenoAgeForm" class="bioageform" data-aos="fade" data-aos-duration="700" data-aos-delay="350">
-                <div class="lwc-wizard-nav" aria-hidden="true">
+                <div class="lwc-wizard-nav">
                     <div class="lwc-dot lwc-dot--on" id="lwcDot1" role="button" tabindex="0" aria-label="Go to Step 1"></div>
                     <div class="lwc-dot" id="lwcDot2" role="button" tabindex="0" aria-label="Go to Step 2"></div>
                 </div>

--- a/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
@@ -662,9 +662,12 @@
         top:50%;
         transform:translateY(-50%);
     }
-    .custom-event-expander:hover,
+    .custom-event-expander:hover{
+        background:rgba(0,188,212,.08) !important;
+    }
     .custom-event-expander:focus-visible{
         background:rgba(0,188,212,.08) !important;
+        box-shadow:0 0 0 3px rgba(0,188,212,.28) !important;
     }
 
     .custom-event-expander::before{

--- a/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
@@ -1383,7 +1383,12 @@
                     : String(label);
                 const url=(allowBadgeClicks && typeof window.pickClickUrl==='function')?window.pickClickUrl(b, athlete||null):'';
                 const familyClass=typeof window.getBadgeFamilyClass==='function'?window.getBadgeFamilyClass(b):'badge-family-utility';
-                if(url) return `<a class="badge-class ${familyClass} badge-clickable" href="${esc(url)}" aria-label="Open league" title="${esc(tip)}" style="${style}"><i class="fa ${icon}"></i></a>`;
+                if(url){
+                    const isPodcast=String(label||'').trim().toLowerCase()==='podcast';
+                    const targetAttrs=isPodcast?' target="_blank" rel="noopener"':'';
+                    const accessibleLabel=isPodcast?'Open podcast':'Open league';
+                    return `<a class="badge-class ${familyClass} badge-clickable" href="${esc(url)}"${targetAttrs} aria-label="${accessibleLabel}" title="${esc(tip)}" style="${style}"><i class="fa ${icon}"></i></a>`;
+                }
                 return `<span class="badge-class ${familyClass}" title="${esc(tip)}" style="${style}"><i class="fa ${icon}"></i></span>`;
             }catch(e){
                 return `<span class="badge-chip"><strong>${esc(String(label))}</strong></span>`;

--- a/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
@@ -1380,8 +1380,8 @@
                     : String(label);
                 const url=(allowBadgeClicks && typeof window.pickClickUrl==='function')?window.pickClickUrl(b, athlete||null):'';
                 const familyClass=typeof window.getBadgeFamilyClass==='function'?window.getBadgeFamilyClass(b):'badge-family-utility';
-                const attrs=url?`class="badge-class ${familyClass} badge-clickable" role="button" tabindex="0" onclick="window.location.href='${url}'"`:`class="badge-class ${familyClass}"`;
-                return `<span ${attrs} title="${esc(tip)}" style="${style}"><i class="fa ${icon}"></i></span>`;
+                if(url) return `<a class="badge-class ${familyClass} badge-clickable" href="${esc(url)}" aria-label="Open league" title="${esc(tip)}" style="${style}"><i class="fa ${icon}"></i></a>`;
+                return `<span class="badge-class ${familyClass}" title="${esc(tip)}" style="${style}"><i class="fa ${icon}"></i></span>`;
             }catch(e){
                 return `<span class="badge-chip"><strong>${esc(String(label))}</strong></span>`;
             }

--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -797,7 +797,7 @@
     .podium-item-lower{
         position:absolute; bottom:0; width:100%; min-height:var(--podium-prize-panel-height); padding:10px 0; border-radius:0 0 15px 15px;
         display:flex; flex-direction:column; align-items:center; clip-path:polygon(0 0, 100% 0, 100% 100%, 0% 100%);
-        transition:clip-path .3s ease-in-out; pointer-events:auto; cursor:pointer;
+        transition:clip-path .3s ease-in-out; pointer-events:auto; cursor:pointer; color:inherit; text-decoration:none;
         box-sizing:border-box;
     }
     .podium-item-lower:hover{ clip-path:polygon(0 0, 100% 0, 100% 100%, 0% 100%); }
@@ -4356,10 +4356,10 @@
                                                 ${renderMediaContact(athlete.mediaContact, true, athlete.displayName)}
                                             </div>
                                             <div><span class="age-reduction">${Math.abs(getDisplayAgeReductionValue(athlete)).toFixed(athlete.ageReductionDisplayDecimals || 1)} years</span> reduced</div>
-                                            <div class="podium-item-lower">
+                                            <a class="podium-item-lower" href="#donation-section" aria-label="Donate to the prize pool">
                                                 <div class="btc-amount">(${prizeMoney[athlete.rank].btc})</div>
                                                 <div class="prize-money">${prizeMoney[athlete.rank].amount}</div>
-                                            </div>
+                                            </a>
                                         `;
 
                                         // Append the podiumItem to the podium container
@@ -4371,7 +4371,6 @@
                                         podiumItem.setAttribute('data-generation', athlete.generation.toLowerCase());
                                         podiumItem.setAttribute('data-athlete-name', athlete.name);
 
-                                        subscribeLowerPodiumClick();
                                     });
 
                                     // Attach click event listeners to athlete names
@@ -4755,20 +4754,6 @@
                     child.style.transitionDelay = '0ms';
                     child.classList.add('is-visible');
                 });
-            });
-        });
-    }
-
-    function subscribeLowerPodiumClick() {
-        const targetElement = document.querySelector("#donation-section");
-        if (!targetElement) {
-            console.error("Donation section (#donation-section) not found.");
-            return;
-        }
-
-        document.querySelectorAll('.podium-item-lower').forEach(moneyArea => {
-            moneyArea.addEventListener('click', () => {
-                targetElement.scrollIntoView({ behavior: 'smooth' });
             });
         });
     }

--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -2709,7 +2709,7 @@
                     </div>
                     <button class="sticky-close-btn" id="stickyCloseBtn" aria-label="Close athlete details">&times;</button>
                 </div>
-                <span id="closeAthleteDetailsModal" class="close">&times;</span>
+                <button type="button" id="closeAthleteDetailsModal" class="close" aria-label="Close athlete details">&times;</button>
 
                 <div class="athlete-profile" id="athlete-profile">
                     <span class="portrait-wrapper">

--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -835,6 +835,9 @@
     .athlete-name:hover{
         color:var(--secondary-color); background-color:rgba(255,64,129,.08); box-shadow:inset 0 0 0 1px rgba(255,64,129,.12);
     }
+    .athlete-name:focus-visible{
+        color:var(--secondary-color); background-color:rgba(255,64,129,.08); outline:3px solid rgba(0,188,212,.38); outline-offset:2px;
+    }
     .podium .athlete-name{ font-size:1.1rem; padding-bottom:.2rem; }
 
     .media-contact{
@@ -4772,12 +4775,26 @@
     addClickListenerToImages('.portrait, .podium-portrait', handleAthleteNameClick);
 
     // Function to attach click event listener to all athlete-name elements
-    function attachAthleteNameClickListeners() {
-        const athleteNameElements = document.querySelectorAll('.athlete-name');
+    function activateAthleteName(event) {
+        event.stopPropagation();
+        handleAthleteNameClick(event);
+    }
 
+    function handleAthleteNameKeydown(event) {
+        if (event.key !== 'Enter' && event.key !== ' ') return;
+        event.preventDefault();
+        activateAthleteName(event);
+    }
+
+    function attachAthleteNameClickListeners() {
         document.querySelectorAll('.athlete-name').forEach(athleteNameElement => {
-            athleteNameElement.removeEventListener('click', handleAthleteNameClick); // Remove existing listeners to prevent duplicates
-            athleteNameElement.addEventListener('click', handleAthleteNameClick);
+            athleteNameElement.setAttribute('role', 'button');
+            athleteNameElement.setAttribute('tabindex', '0');
+            athleteNameElement.setAttribute('aria-label', athleteNameElement.title || `View stats of ${athleteNameElement.textContent.trim()}`);
+            athleteNameElement.removeEventListener('click', activateAthleteName);
+            athleteNameElement.removeEventListener('keydown', handleAthleteNameKeydown);
+            athleteNameElement.addEventListener('click', activateAthleteName);
+            athleteNameElement.addEventListener('keydown', handleAthleteNameKeydown);
         });
     }
 

--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -1467,8 +1467,6 @@
     .proof-item:hover{ transform: scale(1.05); }
     .proof-item img{ display:block; width:auto; max-width:100%; height:auto; max-height:72vh; object-fit:contain; margin:0 auto; background:#fff; }
     .proof-item img:focus-visible,
-    .portrait:focus-visible,
-    .podium-portrait:focus-visible,
     #modalProfilePic:focus-visible{ outline:3px solid rgba(0,188,212,.58); outline-offset:-3px; }
     .proofs-empty{ margin:.5rem 0 0; color:#666; text-align:center; font-size:.95rem; }
     #detailsModal .biomarkers-section,
@@ -4396,7 +4394,10 @@
                                     animatePodiumContent();
                                     autoshrinkPodiumNames();
 
-                                    addClickListenerToImages('.portrait, #modalProfilePic', function () {
+                                    addClickListenerToImages('.portrait', function () {
+                                        openEnlargedView(this);
+                                    });
+                                    addClickListenerToImages('#modalProfilePic', function () {
                                         openEnlargedView(this);
                                     }, img => `Enlarge ${img.alt || 'image'}`);
 
@@ -4515,7 +4516,7 @@
                     addClickListenerToImages('#modalProfilePic', function () {
                         openEnlargedView(this);
                     }, img => `Enlarge ${img.alt || 'athlete profile picture'}`);
-                    addClickListenerToImages('.portrait, .podium-portrait', handleAthleteNameClick, img => `View details for ${(img.alt || 'athlete').replace(/ portrait$/i, '')}`);
+                    addClickListenerToImages('.portrait, .podium-portrait', handleAthleteNameClick);
 
                     row.style.cursor = 'pointer';
                     row.addEventListener('click', function (e) {
@@ -4762,7 +4763,7 @@
     addClickListenerToImages('#modalProfilePic', function () {
         openEnlargedView(this);
     }, img => `Enlarge ${img.alt || 'athlete profile picture'}`);
-    addClickListenerToImages('.portrait, .podium-portrait', handleAthleteNameClick, img => `View details for ${(img.alt || 'athlete').replace(/ portrait$/i, '')}`);
+    addClickListenerToImages('.portrait, .podium-portrait', handleAthleteNameClick);
 
     // Function to attach click event listener to all athlete-name elements
     function activateAthleteName(event) {
@@ -4778,9 +4779,12 @@
 
     function attachAthleteNameClickListeners() {
         document.querySelectorAll('.athlete-name').forEach(athleteNameElement => {
+            const athleteName = athleteNameElement.textContent.trim();
+            if (!athleteName) return;
+
             athleteNameElement.setAttribute('role', 'button');
             athleteNameElement.setAttribute('tabindex', '0');
-            athleteNameElement.setAttribute('aria-label', athleteNameElement.title || `View stats of ${athleteNameElement.textContent.trim()}`);
+            athleteNameElement.setAttribute('aria-label', athleteNameElement.title || `View stats of ${athleteName}`);
             athleteNameElement.removeEventListener('click', activateAthleteName);
             athleteNameElement.removeEventListener('keydown', handleAthleteNameKeydown);
             athleteNameElement.addEventListener('click', activateAthleteName);
@@ -8176,15 +8180,17 @@
     function addClickListenerToImages(selector, callback, accessibleLabel) {
         document.querySelectorAll(selector).forEach(img => {
             if (!img.dataset.listenerAdded) {
-                img.setAttribute('role', 'button');
-                img.setAttribute('tabindex', '0');
-                img.setAttribute('aria-label', accessibleLabel(img));
+                if (typeof accessibleLabel === 'function') {
+                    img.setAttribute('role', 'button');
+                    img.setAttribute('tabindex', '0');
+                    img.setAttribute('aria-label', accessibleLabel(img));
+                    img.addEventListener('keydown', event => {
+                        if (event.key !== 'Enter' && event.key !== ' ') return;
+                        event.preventDefault();
+                        callback.call(img, event);
+                    });
+                }
                 img.addEventListener('click', callback);
-                img.addEventListener('keydown', event => {
-                    if (event.key !== 'Enter' && event.key !== ' ') return;
-                    event.preventDefault();
-                    callback.call(img, event);
-                });
                 img.dataset.listenerAdded = true; // Mark this element as having a listener added
             }
         });

--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -1466,6 +1466,10 @@
     .proof-item{ width:100%; height:auto; border-radius:10px; overflow:hidden; cursor:pointer; transition:transform .3s ease; background:#fff; box-shadow:0 1px 8px rgba(0,0,0,.08); }
     .proof-item:hover{ transform: scale(1.05); }
     .proof-item img{ display:block; width:auto; max-width:100%; height:auto; max-height:72vh; object-fit:contain; margin:0 auto; background:#fff; }
+    .proof-item img:focus-visible,
+    .portrait:focus-visible,
+    .podium-portrait:focus-visible,
+    #modalProfilePic:focus-visible{ outline:3px solid rgba(0,188,212,.58); outline-offset:-3px; }
     .proofs-empty{ margin:.5rem 0 0; color:#666; text-align:center; font-size:.95rem; }
     #detailsModal .biomarkers-section,
     #detailsModal .proofs-section,
@@ -1634,6 +1638,7 @@
         transition:color .3s, background-color .3s, transform .2s; padding:0; z-index:1;
     }
     .enlarged-portrait .close-btn:hover{ color:var(--light-text-color); background:rgba(0,0,0,.9); transform:scale(1.1); }
+    .enlarged-portrait .close-btn:focus-visible{ color:var(--light-text-color); background:rgba(0,0,0,.9); outline:3px solid rgba(0,188,212,.68); outline-offset:3px; }
     .enlarged-portrait img{
         width:auto;
         height:auto;
@@ -2862,9 +2867,9 @@
 </template>
 
 <template id="enlargedPortraitTemplate">
-    <div class="enlarged-portrait">
+    <div class="enlarged-portrait" role="dialog" aria-modal="true" aria-label="Enlarged image">
         <img src="" alt="" loading="lazy">
-        <span class="close-btn">&times;</span>
+        <button type="button" class="close-btn" aria-label="Close enlarged image">&times;</button>
     </div>
 </template>
 
@@ -4394,7 +4399,7 @@
 
                                     addClickListenerToImages('.portrait, #modalProfilePic', function () {
                                         openEnlargedView(this);
-                                    });
+                                    }, img => `Enlarge ${img.alt || 'image'}`);
 
                                     if (hasActiveLeaderboardState()) {
                                         performFilter();
@@ -4510,8 +4515,8 @@
                     attachAthleteNameClickListeners();
                     addClickListenerToImages('#modalProfilePic', function () {
                         openEnlargedView(this);
-                    });
-                    addClickListenerToImages('.portrait, .podium-portrait', handleAthleteNameClick);
+                    }, img => `Enlarge ${img.alt || 'athlete profile picture'}`);
+                    addClickListenerToImages('.portrait, .podium-portrait', handleAthleteNameClick, img => `View details for ${(img.alt || 'athlete').replace(/ portrait$/i, '')}`);
 
                     row.style.cursor = 'pointer';
                     row.addEventListener('click', function (e) {
@@ -4771,8 +4776,8 @@
     // Usage
     addClickListenerToImages('#modalProfilePic', function () {
         openEnlargedView(this);
-    });
-    addClickListenerToImages('.portrait, .podium-portrait', handleAthleteNameClick);
+    }, img => `Enlarge ${img.alt || 'athlete profile picture'}`);
+    addClickListenerToImages('.portrait, .podium-portrait', handleAthleteNameClick, img => `View details for ${(img.alt || 'athlete').replace(/ portrait$/i, '')}`);
 
     // Function to attach click event listener to all athlete-name elements
     function activateAthleteName(event) {
@@ -4802,6 +4807,7 @@
         // Retrieve and clone the template content
         const template = document.getElementById("enlargedPortraitTemplate");
         const clone = template.content.firstElementChild.cloneNode(true);
+        clone.returnFocusTo = document.activeElement;
 
         // Set the image source and alt attributes based on the clicked image
         const img = clone.querySelector("img");
@@ -4812,12 +4818,14 @@
         document.body.appendChild(clone);
         lockBodyScroll();
         history.pushState({ modal: 'enlarged' }, "");
+        const closeButton = clone.querySelector('.close-btn');
+        closeButton.focus();
 
         // Trigger a transition to show the element
         setTimeout(() => clone.classList.add('show'), 10);
 
         // Add event listener for the close button
-        clone.querySelector('.close-btn').addEventListener('click', () => {
+        closeButton.addEventListener('click', () => {
             closeEnlargedView(clone);
         });
 
@@ -4830,12 +4838,16 @@
     }
 
     function closeEnlargedView(enlargedElem) {
+        const returnFocusTo = enlargedElem.returnFocusTo;
         enlargedElem.classList.remove('show');
         setTimeout(() => {
             document.body.removeChild(enlargedElem);
             // If no modal is open, restore body scroll
             if (modal.style.display !== "block") {
                 restoreBodyScroll();
+            }
+            if (returnFocusTo && typeof returnFocusTo.focus === 'function') {
+                returnFocusTo.focus();
             }
         }, 300);
     }
@@ -7844,12 +7856,21 @@
             const img = document.createElement('img');
             img.src = proofUrl;
             img.alt = `Proof image ${index + 1}`;
+            img.setAttribute('role', 'button');
+            img.setAttribute('tabindex', '0');
+            img.setAttribute('aria-label', `Enlarge proof image ${index + 1}`);
             img.loading = 'lazy';
             proofItem.appendChild(img);
             proofsGallery.appendChild(proofItem);
 
-            img.addEventListener('click', function () {
+            const openProofImage = function () {
                 openEnlargedView(this);
+            };
+            img.addEventListener('click', openProofImage);
+            img.addEventListener('keydown', function (event) {
+                if (event.key !== 'Enter' && event.key !== ' ') return;
+                event.preventDefault();
+                openProofImage.call(this);
             });
         });
     }
@@ -8167,10 +8188,18 @@
     function resetPageTitle() {
         document.title = originalDocumentTitle;
     }
-    function addClickListenerToImages(selector, callback) {
+    function addClickListenerToImages(selector, callback, accessibleLabel) {
         document.querySelectorAll(selector).forEach(img => {
             if (!img.dataset.listenerAdded) {
+                img.setAttribute('role', 'button');
+                img.setAttribute('tabindex', '0');
+                img.setAttribute('aria-label', accessibleLabel(img));
                 img.addEventListener('click', callback);
+                img.addEventListener('keydown', event => {
+                    if (event.key !== 'Enter' && event.key !== ' ') return;
+                    event.preventDefault();
+                    callback.call(img, event);
+                });
                 img.dataset.listenerAdded = true; // Mark this element as having a listener added
             }
         });

--- a/LongevityWorldCup.Website/wwwroot/play/edit-profile.html
+++ b/LongevityWorldCup.Website/wwwroot/play/edit-profile.html
@@ -515,7 +515,7 @@
             </div>
         </div>
         <div class="options-container edit-profile-actions flow-action-stack" data-aos="fade" data-aos-duration="700" data-aos-delay="400">
-            <button id="submitButton" type="submit" disabled class="option-button green flow-action"></button>
+            <button id="submitButton" type="submit" disabled class="option-button green flow-action"><span class="flow-action__label">Submit change request</span><i class="fa fa-rocket" aria-hidden="true"></i></button>
             <button type="button" class="option-button back-button flow-action flow-action--secondary flow-action--icon-left" onclick="window.navigateToFlowDestination('/dashboard')">
                 <i class="fas fa-arrow-left" aria-hidden="true"></i><span class="flow-action__label">Back</span>
             </button>

--- a/LongevityWorldCup.Website/wwwroot/play/edit-profile.html
+++ b/LongevityWorldCup.Website/wwwroot/play/edit-profile.html
@@ -431,7 +431,7 @@
                 <img src="../assets/content-images/headshot.jpg" alt="Headshot" class="illustration" loading="lazy">
             </picture>
         </div>
-        <div id="editOptionsGroup" cdata-aos="fade" data-aos-duration="700" data-aos-delay="350">
+        <div id="editOptionsGroup" data-aos="fade" data-aos-duration="700" data-aos-delay="350">
             <div id="changeProfilePicWrapper" class="options-container flow-action-stack flow-action-stack--flush">
                 <button type="button" id="takeProfileSelfieButton" class="option-button grey flow-action flow-action--secondary">
                     <span class="flow-action__label">Take selfie</span><i class="fa fa-camera" aria-hidden="true"></i>

--- a/LongevityWorldCup.Website/wwwroot/play/edit-profile.html
+++ b/LongevityWorldCup.Website/wwwroot/play/edit-profile.html
@@ -447,12 +447,14 @@
                 </button>
             </div>
             <div class="niceInputFieldDisplayWrapper options-container inline-option-group">
+                <label for="divisionDisplaySelect" class="visually-hidden">Division</label>
                 <select id="divisionDisplaySelect"></select>
                 <button id="restoreDivisionBtn" class="option-button icon-only" style="display:none" title="Restore division">
                     <i class="fa fa-undo"></i>
                 </button>
             </div>
             <div class="niceInputFieldDisplayWrapper options-container inline-option-group">
+                <label for="flagDisplayInput" class="visually-hidden">Flag</label>
                 <input type="text"
                        id="flagDisplayInput"
                        name="flagDisplay"
@@ -469,6 +471,7 @@
                 </button>
             </div>
             <div class="niceInputFieldDisplayWrapper options-container inline-option-group">
+                <label for="personalLinkInput" class="visually-hidden">Personal link</label>
                 <input type="text"
                        id="personalLinkInput"
                        name="personalLink"
@@ -482,6 +485,7 @@
                 </button>
             </div>
             <div class="niceInputFieldDisplayWrapper options-container inline-option-group">
+                <label for="mediaContactInput" class="visually-hidden">Media contact</label>
                 <input type="text"
                        id="mediaContactInput"
                        name="mediaContact"
@@ -497,6 +501,7 @@
                 </button>
             </div>
             <div class="niceInputFieldDisplayWrapper options-container inline-option-group">
+                <label for="whyDisplayInput" class="visually-hidden">Your why</label>
                 <textarea id="whyDisplayInput"
                           name="whyDisplay"
                           rows="3"

--- a/LongevityWorldCup.Website/wwwroot/play/menu.html
+++ b/LongevityWorldCup.Website/wwwroot/play/menu.html
@@ -923,6 +923,7 @@
             </div>
             <div class="play-autocomplete-wrapper">
                 <div class="play-autocomplete-container">
+                    <label for="playAthleteInput" class="visually-hidden">Athlete name</label>
                     <input type="text"
                            id="playAthleteInput"
                            name="athlete"

--- a/LongevityWorldCup.Website/wwwroot/play/proof-upload.html
+++ b/LongevityWorldCup.Website/wwwroot/play/proof-upload.html
@@ -443,7 +443,7 @@
         <div id="biomarker-checklist"></div>
 
         <div class="options-container proof-upload-final-actions flow-action-stack" data-aos="fade" data-aos-duration="700" data-aos-delay="450">
-            <button id="submitButton" type="submit" class="option-button green flow-action"></button>
+            <button id="submitButton" type="submit" class="option-button green flow-action"><span class="flow-action__label">Submit new results</span><i class="fa fa-rocket" aria-hidden="true"></i></button>
             <button type="button" class="option-button back-button flow-action flow-action--secondary flow-action--icon-left" onclick="window.navigateToFlowDestination('/dashboard')">
                 <i class="fas fa-arrow-left" aria-hidden="true"></i><span class="flow-action__label">Back</span>
             </button>


### PR DESCRIPTION
## Summary

This ready-for-review PR retains 22 deliberately narrow UI/UX fixes. Every retained change had to be easy to implement and clearly better in context; subjective redesigns and uncertain behavior changes were left alone.

A regression review found two over-broad keyboard changes. Commits `1c656335` and `e12175b0` narrow/revert those changes: leaderboard portraits and the application illustration remain pointer conveniences, while the adjacent athlete-name and native upload controls provide the keyboard path. The proof/profile image viewer, modal dialog behavior, focus restoration, and visible keyboard focus remain intact.

A fresh regression review found one additional issue in the badge-link conversion. Commit `2f77b56d` makes event-board podcast badges announce their actual destination and open safely in a new tab, matching podcast badges on the leaderboard; league badges continue to navigate in the current tab.

PR review feedback identified one inaccurate Ruleset diagram description. Commit `9ae8cba1` now separates the primary pheno age comparison from the actual tie-break sequence: older chronological age, then username alphabetically.

## Four-round audit

1. **Broad pass:** reviewed the main public, onboarding, calculator, athlete, event, challenge, error, privacy, and internal-tool flows; checked forms, semantics, keyboard paths, links, dialogs, titles, responsive behavior, and recovery states.
2. **Seven-principle pass:** applied accessible operation, clear mapping to the competition model, visible status, error prevention/recovery, control consistency, responsive/touch resilience, and efficient progressive disclosure only where each principle materially helped this site.
3. **Entire-codebase pass:** read all 815 tracked textual/code files (218,401 lines / 8,978,794 characters), inventoried binary media, then ran focused scans for missing names/labels/alternatives, invalid hidden focus targets, duplicate IDs, malformed attributes, focus suppression, non-native interactions, and layout hazards.
4. **Visual pass:** inspected normal routes and changed states at 1440×980, 768×1024, 390×844, 320×568, and 844×390; exercised keyboard activation, dialogs, carousel state, modals, internal tools, and browser-console output.

## Retained fixes, one by one

1. `0def08a0` — gave the newsletter email input a persistent label and email autocomplete metadata.
2. `9ea35865` — gave the athlete selector a persistent accessible name.
3. `eea8f14b` — replaced an invalid form legend/label relationship on the application contact email field.
4. `9f5ed2d9` — named both custom time-zone search fields.
5. `68f7076a` — stopped hiding visible biological-age step navigation from assistive technology.
6. `3d1ecd46` — replaced script-only badge navigation spans with native links and corrected the personal-page label.
7. `e4f6c839` — named biological-age date, biomarker, and CRP switch inputs.
8. `e4e8ec68` — added Enter/Space operation and visible focus to expandable biomarker card headers.
9. `95fd5559` — made non-empty athlete-name detail controls keyboard operable without duplicate row activation.
10. `4e782e5c` — made proof images and the modal profile image keyboard-operable and made the enlarged viewer dialog-like, focus-managed, and focus-restoring. The later regression correction excludes leaderboard row/podium portraits.
11. `7024b844` — replaced the athlete-details modal’s span close affordance with a native labeled button.
12. `9b208a47` — preserved specific browser-tab titles for privacy, calculator, onboarding, and athlete utility pages.
13. `94333f22` — replaced seven generic Ruleset diagram alternatives with content-specific descriptions.
14. `de4fcabc` — replaced repeatedly wired podium prize `<div>` click targets with native donation anchors.
15. `96c1230a` — labeled division, flag, personal link, media contact, and “your why” on athlete profile editing.
16. `dbd02e7e` — fixed the malformed `data-aos` attribute that prevented profile options from receiving their configured entrance animation.
17. `2c2d4b30` — named the generated hash, cleanup SQL, and server-command output fields in the internal event tool.
18. `9df95d26` — merged the homepage’s unnamed duplicate History icon link into the adjacent named link.
19. `6323db3d` — gave edit-profile and proof-upload submit buttons meaningful fallback content before scripts run.
20. `bc2088eb` — merged the homepage’s hidden duplicate FAQ icon link into the adjacent named link.
21. `d7c5c341` — added a clearly visible keyboard focus ring to custom-event expanders.
22. `2049b7af` — removed transparent inactive merch slides from the mobile carousel’s Tab order.

## Regression corrections

1. `1c6563354e03b7fd5be42db26807ddc7d8bb34ac` — removed redundant portrait tab stops from leaderboard rows/podiums, skipped empty loading-skeleton athlete names, and retained keyboard access through the single adjacent athlete-name control. Live count changed from 212 portrait tab stops to 0; the modal profile image remains keyboard-reachable.
2. `e12175b0b88b1854707b4ef83e1d6c6c5622a631` — reverted `2d149a94` because the stage-four illustration duplicated the native `Upload profile picture` button immediately below it. The image remains a pointer shortcut; keyboard users retain the native upload button.
3. `2f77b56d37d82e5a865b00c675c988d9c774d591` — corrected event-board podcast badges that had inherited the league-only accessible name and same-tab behavior. Podcast links now use `Open podcast`, `target="_blank"`, and `rel="noopener"`; league links are unchanged.
4. `9ae8cba14aea963e212b35efc130d5cf3e6c58a3` — corrected the tie-break diagram description so pheno age is identified as the primary comparison, while ties are accurately described as older chronological age followed by username alphabetically.

Each retained fix and each regression correction has its own PR comment with the full commit ID, cause, implementation, impact, and focused verification. The original `2d149a94` comment remains as commit history but is explicitly superseded by `e12175b0`.

## Validation

- Clean build: **0 warnings, 0 errors**
- Focused regression suite: **110 passed, 0 failed, 0 skipped**
- Fresh focused review suite: **5 passed, 0 failed, 0 skipped**
- Ruleset review regression test: **1 passed, 0 failed, 0 skipped**
- Full test suite: **998 passed, 0 failed, 0 skipped**
- Browser verification: desktop and 375×812 mobile; no positive horizontal overflow
- Fresh live route verification: event badge links, standalone leaderboard podium state, and privacy-page title/indexing metadata
- Leaderboard: **212 → 0** portrait tab stops; athlete-name activation, modal image activation, enlarged-dialog focus, and focus restoration verified live
- Mobile merch: exactly one active slide at `tabIndex=0`; two inactive slides at `-1`
- Screenshots and audit scripts remain under ignored `.artifacts/`; no screenshot was committed to the application repository

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e12175b0b88b1854707b4ef83e1d6c6c5622a631. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
