### PR TITLE
Fix optional pledge analytics

### DIFF
--- a/LongevityWorldCup.Tests/LongevitymaxxingChallengePageTests.cs
+++ b/LongevityWorldCup.Tests/LongevitymaxxingChallengePageTests.cs
@@ -614,6 +614,8 @@ public sealed class LongevitymaxxingChallengePageTests
         Assert.Contains("Fall below your recent average and either pay it or stop. Choose an amount that would hurt.", javascript);
         Assert.Contains("Make a pledge", javascript);
         Assert.Contains("Fall below your recent average and either pay it or stop longevitymaxxing. You can keep checking in without a pledge.", javascript);
+        Assert.Contains("data-commitment-prompt=\"optional\"", javascript);
+        Assert.Contains("data-commitment-block=\"true\"", javascript);
         Assert.Contains("id=\"lmxPledgeCommitmentAmount\"", javascript);
         Assert.Contains("Check again", javascript);
         Assert.Contains("Waiting for payment confirmation...", javascript);

--- a/LongevityWorldCup.Tests/SiteStatisticsDashboardPageTests.cs
+++ b/LongevityWorldCup.Tests/SiteStatisticsDashboardPageTests.cs
@@ -154,6 +154,8 @@ public sealed class SiteStatisticsDashboardPageTests
         Assert.Contains("proof_file_rejected", proofHelpers);
         Assert.Contains("#lmxSignupAthlete-autocomplete-list .lmx-athlete-option", tracker);
         Assert.Contains("lmxCommitmentPanel", tracker);
+        Assert.Contains("querySelector(\".lmx-commitment-card[data-commitment-block='true']\")", tracker);
+        Assert.DoesNotContain("querySelector(\".lmx-commitment-card\")", tracker);
         Assert.Contains("setupPublicContentTracking", tracker);
         Assert.Contains("trackPublicPageViews", tracker);
         Assert.Contains("function isIgnoredClientError(e)", dashboard);

--- a/LongevityWorldCup.Website/wwwroot/js/longevitymaxxing.js
+++ b/LongevityWorldCup.Website/wwwroot/js/longevitymaxxing.js
@@ -1158,7 +1158,7 @@
         const commitment = state.commitment || {};
         if (shouldShowCheckInPledgePrompt(state, activeTab)) {
             panel.innerHTML = `
-                <form id="lmxCommitmentAmountForm" class="lmx-commitment-card setup">
+                <form id="lmxCommitmentAmountForm" class="lmx-commitment-card setup" data-commitment-prompt="optional">
                     <div class="lmx-commitment-main">
                         <i class="fas fa-pen-nib" aria-hidden="true"></i>
                         <div>
@@ -1194,7 +1194,7 @@
 
         if (commitment.status === "needs-amount") {
             panel.innerHTML = `
-                <form id="lmxCommitmentAmountForm" class="lmx-commitment-card setup">
+                <form id="lmxCommitmentAmountForm" class="lmx-commitment-card setup" data-commitment-block="true">
                     <div class="lmx-commitment-main">
                         <i class="fas fa-lock" aria-hidden="true"></i>
                         <div>
@@ -1231,7 +1231,7 @@
         const showCheckAgain = hasInvoice && !replacesInvoice;
         const editableDays = getCommitmentEditableDays(state);
         panel.innerHTML = `
-            <div class="lmx-commitment-card due">
+            <div class="lmx-commitment-card due" data-commitment-block="true">
                 <div class="lmx-commitment-main">
                     <i class="fas fa-triangle-exclamation" aria-hidden="true"></i>
                     <div>

--- a/LongevityWorldCup.Website/wwwroot/js/site-statistics-tracking.js
+++ b/LongevityWorldCup.Website/wwwroot/js/site-statistics-tracking.js
@@ -806,7 +806,7 @@
         if (commitmentPanel && typeof MutationObserver === "function") {
             const trackCommitmentBlock = () => {
                 if (commitmentPanel.classList.contains("lmx-hidden")) return;
-                const card = commitmentPanel.querySelector(".lmx-commitment-card");
+                const card = commitmentPanel.querySelector(".lmx-commitment-card[data-commitment-block='true']");
                 if (!card) return;
                 trackOnce("challenge-commitment-block-seen", "challenge_commitment_block_seen", {
                     component: "commitment",


### PR DESCRIPTION
## Summary
- mark only genuine commitment-block cards as analytics blocks
- keep the optional pledge prompt distinct from blocking commitment UI
- add regression assertions for the block-only selector

## Root cause
The commitment analytics observer treated every visible card in the shared panel as a participant block. The optional pledge prompt introduced by #785 uses that panel but does not block check-ins, so it was incorrectly emitted as `challenge_commitment_block_seen`.

## Validation
- `dotnet test .\LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --no-restore --filter "FullyQualifiedName~LongevitymaxxingChallengePageTests|FullyQualifiedName~SiteStatisticsDashboardPageTests" --logger "console;verbosity=minimal"` (36 passed)
- `git diff --check`

Follow-up to #785.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side analytics and DOM attributes only; no auth or payment logic changes.
> 
> **Overview**
> Fixes **misclassified commitment analytics** after the optional check-in pledge prompt started sharing `lmxCommitmentPanel` with real blockers.
> 
> Commitment cards are now tagged in `longevitymaxxing.js`: optional pledge forms use `data-commitment-prompt="optional"`, while genuine block states (needs amount, commitment due) use `data-commitment-block="true"`. `site-statistics-tracking.js` only emits `challenge_commitment_block_seen` when it finds a card with that block attribute, so the optional prompt no longer counts as a participant block.
> 
> Tests lock in the new markup strings and the block-only `querySelector`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9acece890f451b396bf68133284ac018c28e6ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->