### PR TITLE
Synchronize X token refreshes

### DIFF
--- a/LongevityWorldCup.Tests/XApiClientTests.cs
+++ b/LongevityWorldCup.Tests/XApiClientTests.cs
@@ -1,0 +1,128 @@
+using System.Net;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging.Abstractions;
+using LongevityWorldCup.Website;
+using LongevityWorldCup.Website.Business;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class XApiClientTests
+{
+    [Fact]
+    public async Task ConcurrentClientsShareOneTokenRefresh()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "lwc-x-client-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var config = new Config
+            {
+                XAccessToken = "old-access",
+                XRefreshToken = "old-refresh",
+                XApiKey = "client-id",
+                XApiSecret = "client-secret"
+            }.UseFilePathsForTesting(
+                Path.Combine(root, "config.json"),
+                Path.Combine(root, "runtime-config.json"));
+            var handler = new ConcurrentRefreshHandler();
+            var preview = CreatePreviewService();
+            var environment = new ProductionEnvironment(root);
+            var first = new XApiClient(
+                new HttpClient(handler, disposeHandler: false),
+                config,
+                environment,
+                NullLogger<XApiClient>.Instance,
+                preview);
+            var second = new XApiClient(
+                new HttpClient(handler, disposeHandler: false),
+                config,
+                environment,
+                NullLogger<XApiClient>.Instance,
+                preview);
+
+            var tweetIds = await Task.WhenAll(
+                first.SendTweetAsync("first"),
+                second.SendTweetAsync("second"));
+
+            Assert.All(tweetIds, id => Assert.NotNull(id));
+            Assert.Equal(1, handler.RefreshRequestCount);
+            Assert.Equal(2, handler.OldAccessTweetCount);
+            Assert.Equal(2, handler.NewAccessTweetCount);
+            Assert.Equal("new-access", config.XAccessToken);
+            Assert.Equal("new-refresh", config.XRefreshToken);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static XDevPreviewService CreatePreviewService()
+    {
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection().Build();
+        return new XDevPreviewService(
+            NullLogger<XDevPreviewService>.Instance,
+            new StaticHttpClientFactory(),
+            configuration);
+    }
+
+    private sealed class ConcurrentRefreshHandler : HttpMessageHandler
+    {
+        private readonly TaskCompletionSource _bothOldRequestsStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _oldAccessTweetCount;
+        private int _newAccessTweetCount;
+        private int _refreshRequestCount;
+
+        public int OldAccessTweetCount => Volatile.Read(ref _oldAccessTweetCount);
+        public int NewAccessTweetCount => Volatile.Read(ref _newAccessTweetCount);
+        public int RefreshRequestCount => Volatile.Read(ref _refreshRequestCount);
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request.RequestUri?.AbsolutePath == "/2/tweets")
+            {
+                var token = request.Headers.Authorization?.Parameter;
+                if (token == "old-access")
+                {
+                    if (Interlocked.Increment(ref _oldAccessTweetCount) == 2)
+                        _bothOldRequestsStarted.TrySetResult();
+
+                    await _bothOldRequestsStarted.Task.WaitAsync(cancellationToken);
+                    return Json(HttpStatusCode.Unauthorized, """{"title":"Unauthorized","status":401}""");
+                }
+
+                Assert.Equal("new-access", token);
+                var id = Interlocked.Increment(ref _newAccessTweetCount);
+                return Json(HttpStatusCode.Created, "{\"data\":{\"id\":\"tweet-" + id + "\"}}");
+            }
+
+            Assert.Equal("/2/oauth2/token", request.RequestUri?.AbsolutePath);
+            Interlocked.Increment(ref _refreshRequestCount);
+            return Json(HttpStatusCode.OK, """{"access_token":"new-access","refresh_token":"new-refresh"}""");
+        }
+
+        private static HttpResponseMessage Json(HttpStatusCode statusCode, string body)
+        {
+            return new HttpResponseMessage(statusCode) { Content = new StringContent(body) };
+        }
+    }
+
+    private sealed class StaticHttpClientFactory : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new(new HttpClientHandler());
+    }
+
+    private sealed class ProductionEnvironment(string root) : IWebHostEnvironment
+    {
+        public string ApplicationName { get; set; } = "LongevityWorldCup.Tests";
+        public IFileProvider WebRootFileProvider { get; set; } = new NullFileProvider();
+        public string WebRootPath { get; set; } = root;
+        public string EnvironmentName { get; set; } = "Production";
+        public string ContentRootPath { get; set; } = root;
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+}

--- a/LongevityWorldCup.Website/Business/XApiClient.cs
+++ b/LongevityWorldCup.Website/Business/XApiClient.cs
@@ -16,9 +16,6 @@ public class XApiClient
     private readonly ILogger<XApiClient> _log;
     private readonly IWebHostEnvironment _env;
     private readonly XDevPreviewService _preview;
-    private readonly object _tokenLock = new();
-    private readonly SemaphoreSlim _refreshLock = new(1, 1);
-    private string? _accessToken;
 
     public sealed record XApiFailure(
         bool Retryable,
@@ -39,7 +36,6 @@ public class XApiClient
         _env = env;
         _log = log;
         _preview = preview;
-        _accessToken = config.XAccessToken;
     }
 
     public bool IsConfigured => _env.IsDevelopment() || !string.IsNullOrWhiteSpace(GetAccessToken());
@@ -200,7 +196,7 @@ public class XApiClient
 
             if (res.StatusCode == HttpStatusCode.Unauthorized)
             {
-                var refreshed = await TryRefreshTokenAsync();
+                var refreshed = await TryRefreshTokenAsync(token);
                 if (refreshed)
                 {
                     token = GetAccessToken();
@@ -247,29 +243,32 @@ public class XApiClient
 
     private string? GetAccessToken()
     {
-        lock (_tokenLock)
-        {
-            if (!string.IsNullOrWhiteSpace(_accessToken)) return _accessToken;
-            _accessToken = _config.XAccessToken;
-            return _accessToken;
-        }
+        return _config.XAccessToken;
     }
 
-    private async Task<bool> TryRefreshTokenAsync()
+    private async Task<bool> TryRefreshTokenAsync(string? rejectedAccessToken)
     {
-        var refreshToken = _config.XRefreshToken;
-        var clientId = _config.XApiKey;
-        var clientSecret = _config.XApiSecret;
-
-        if (string.IsNullOrWhiteSpace(refreshToken) || string.IsNullOrWhiteSpace(clientId) || string.IsNullOrWhiteSpace(clientSecret))
-        {
-            _log.LogWarning("X refresh token or API credentials not configured. Cannot refresh.");
-            return false;
-        }
-
-        await _refreshLock.WaitAsync();
+        await _config.XTokenRefreshLock.WaitAsync();
         try
         {
+            var currentAccessToken = GetAccessToken();
+            if (!string.IsNullOrWhiteSpace(currentAccessToken) &&
+                !string.Equals(currentAccessToken, rejectedAccessToken, StringComparison.Ordinal))
+            {
+                _log.LogInformation("X access token was refreshed by another client.");
+                return true;
+            }
+
+            var refreshToken = _config.XRefreshToken;
+            var clientId = _config.XApiKey;
+            var clientSecret = _config.XApiSecret;
+
+            if (string.IsNullOrWhiteSpace(refreshToken) || string.IsNullOrWhiteSpace(clientId) || string.IsNullOrWhiteSpace(clientSecret))
+            {
+                _log.LogWarning("X refresh token or API credentials not configured. Cannot refresh.");
+                return false;
+            }
+
             var body = new List<KeyValuePair<string, string>>
             {
                 new("grant_type", "refresh_token"),
@@ -314,13 +313,9 @@ public class XApiClient
                 return false;
             }
 
-            lock (_tokenLock)
-            {
-                _accessToken = newAccess;
-                _config.XAccessToken = newAccess;
-                if (!string.IsNullOrWhiteSpace(newRefresh))
-                    _config.XRefreshToken = newRefresh;
-            }
+            _config.XAccessToken = newAccess;
+            if (!string.IsNullOrWhiteSpace(newRefresh))
+                _config.XRefreshToken = newRefresh;
 
             try
             {
@@ -336,7 +331,7 @@ public class XApiClient
         }
         finally
         {
-            _refreshLock.Release();
+            _config.XTokenRefreshLock.Release();
         }
     }
 

--- a/LongevityWorldCup.Website/Config.cs
+++ b/LongevityWorldCup.Website/Config.cs
@@ -12,6 +12,9 @@ namespace LongevityWorldCup.Website
         private const string RuntimeConfigFileName = "runtime-config.json";
         private string? _configFilePath;
         private string? _runtimeConfigFilePath;
+        private readonly SemaphoreSlim _xTokenRefreshLock = new(1, 1);
+
+        internal SemaphoreSlim XTokenRefreshLock => _xTokenRefreshLock;
 
         public string? EmailFrom { get; set; }
         public string? EmailTo { get; set; }


### PR DESCRIPTION
## What changed

- share X token refresh synchronization across every `XApiClient` instance through the singleton runtime config
- stop caching access tokens per client, so clients immediately observe a token rotated elsewhere in the process
- after acquiring the refresh lock, skip a redundant refresh when another client already replaced the rejected access token
- add a concurrency regression test that forces two clients through the same expired-token path

## Root cause

`XApiClient` is a typed HTTP client and can be constructed in multiple service/job scopes, but its access-token cache and refresh semaphore were instance-local. Concurrent clients could therefore keep using stale access tokens and race a rotating one-time refresh token, producing `invalid_request`/401 errors even when a later dispatch recovered.

## Impact

Concurrent X jobs now perform one refresh, share the rotated access/refresh token pair, and retry their posts with the same current access token. This prevents spurious auth incidents and avoids invalidating refresh attempts across client instances.

## Validation

- `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --no-restore`
- 1,003 passed, 0 failed, 0 skipped

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication refresh behavior for concurrent X API usage; scope is narrow but auth races can still cause transient failures if config sharing assumptions differ across hosts.
> 
> **Overview**
> **X (Twitter) OAuth refresh is now coordinated process-wide** via a `SemaphoreSlim` on the shared `Config`, instead of per-`XApiClient` locks and in-memory token caches.
> 
> `XApiClient` reads the access token from `Config` on each use and, on 401, calls `TryRefreshTokenAsync` with the token that failed. After taking the shared lock, it **skips a second refresh** if another client already rotated the access token, then persists new tokens on `Config` only. A new **`ConcurrentClientsShareOneTokenRefresh`** test asserts two concurrent clients share a single `/2/oauth2/token` call and both tweets retry with the updated token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44ddf8e55ab49c6c52c6dfabe5ef538bd0dcc02d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->