### PR TITLE
Reimplement the salvageable UI/UX from #679 and #686

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -8,6 +8,18 @@ This file records durable UI decisions for Longevity World Cup. Keep it short: a
 
 ## Decisions
 
+- Dark scoreboard chrome should frame warm, light, readable content rather than swallowing whole pages. Reserve dark surfaces for deliberate sport moments such as the header, hero, sticky chrome, footer, and athlete modal.
+
+- Live competition scores, ranks, and field counts must come from the authoritative leaderboard snapshot. When that data is unavailable, omit the metric or show an honest unavailable state; never substitute fake zeroes or hardcoded competition facts.
+
+- Condensed or display type belongs on scores, ranks, short titles, and other brief sport moments. Body copy, forms, tables, documentation, and dense operational UI should use a readable sans-serif face.
+
+- Color roles should stay disciplined: green for primary actions, live/current state, scores, links, and focus; amber only for Amateur, crowd, prize, or equivalent competition semantics; red for danger and destructive states.
+
+- The homepage should lead with real score or rank context and then real athletes or standings. Keep one clear primary call to action and avoid duplicate CTAs, duplicate leaderboard cards, or pseudo-podiums competing with the actual podium.
+
+- Long footer navigation should use labeled project/trust and community/social groups so it remains scannable instead of becoming an undifferentiated link field.
+
 - Direct-tap controls in mobile, toolbar, footer, and modal contexts should generally be easy to hit, with about a 44px target when space allows.
 
 - Controls that belong to the same flow should share the same visual language: inherited font, consistent height, modest radius, light border, and a visible focus state.

--- a/LongevityWorldCup.Tests/FooterStructureTests.cs
+++ b/LongevityWorldCup.Tests/FooterStructureTests.cs
@@ -1,0 +1,100 @@
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed partial class FooterStructureTests
+{
+    [GeneratedRegex(@"<a\b[^>]*\bhref=""([^""]+)""", RegexOptions.IgnoreCase)]
+    private static partial Regex FooterLinkRegex();
+
+    [Fact]
+    public void Footer_GroupsEveryDestinationInPriorityOrder()
+    {
+        var footer = ReadFooter();
+
+        Assert.Contains(
+            "<h2 id=\"footer-competition-heading\" class=\"footer-heading\">Competition</h2>",
+            footer,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "<h2 id=\"footer-community-heading\" class=\"footer-heading\">Community</h2>",
+            footer,
+            StringComparison.Ordinal);
+
+        var expectedLinks = new[]
+        {
+            "/about",
+            "/ruleset",
+            "/history",
+            "/media",
+            "mailto:hi@longevityworldcup.com",
+            "https://github.com/nopara73/LongevityWorldCup/",
+            "https://merch.longevityworldcup.com/",
+            "https://www.youtube.com/playlist?list=PL4nqc85w185sO4i7eR3oUO_lMmlJ2K1cL",
+            "https://x.com/LongevityWorldC",
+            "https://www.reddit.com/r/LongevityWorldCup/",
+            "https://www.tiktok.com/@nopara73",
+            "https://www.threads.com/@longevityworldcup",
+            "https://www.youtube.com/@longevityworldcup",
+            "https://www.instagram.com/LongevityWorldCup/"
+        };
+
+        var actualLinks = FooterLinkRegex()
+            .Matches(footer)
+            .Select(match => match.Groups[1].Value)
+            .ToArray();
+
+        Assert.Equal(expectedLinks, actualLinks);
+        Assert.Equal(
+            actualLinks.Length,
+            Regex.Matches(footer, "class=\"footer-link\"", RegexOptions.IgnoreCase).Count);
+    }
+
+    [Fact]
+    public void Footer_KeepsCompactTouchTargetsStableAtNarrowWidths()
+    {
+        var footer = ReadFooter();
+
+        Assert.Contains("grid-template-columns: repeat(2, minmax(0, 1fr));", footer, StringComparison.Ordinal);
+        Assert.Contains("min-height: 2.75rem;", footer, StringComparison.Ordinal);
+        Assert.Contains("overflow-wrap: anywhere;", footer, StringComparison.Ordinal);
+        Assert.Contains(".footer-link:focus-visible", footer, StringComparison.Ordinal);
+        Assert.Contains(
+            "outline: 3px solid var(--footer-focus-color, var(--footer-accent-color, #43ee83));",
+            footer,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("translate", footer, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotMatch(@"(?<!text-)transform\s*:", footer);
+        Assert.DoesNotContain("transition: transform", footer, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string ReadFooter()
+    {
+        var repoRoot = FindRepoRoot();
+        return File.ReadAllText(Path.Combine(
+            repoRoot,
+            "LongevityWorldCup.Website",
+            "wwwroot",
+            "partials",
+            "footer.html"));
+    }
+
+    private static string FindRepoRoot([CallerFilePath] string sourceFilePath = "")
+    {
+        var startDirectory = Path.GetDirectoryName(sourceFilePath) ?? AppContext.BaseDirectory;
+        var current = new DirectoryInfo(startDirectory);
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "LongevityWorldCup.sln")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException($"Could not find repository root from {startDirectory}.");
+    }
+}

--- a/LongevityWorldCup.Tests/HomepageScoreboardBrowserTests.cs
+++ b/LongevityWorldCup.Tests/HomepageScoreboardBrowserTests.cs
@@ -1,0 +1,125 @@
+using Microsoft.Playwright;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class HomepageScoreboardBrowserTests
+{
+    [Theory]
+    [InlineData(1440, 900)]
+    [InlineData(390, 844)]
+    [InlineData(375, 667)]
+    public async Task HomepageScoreboard_FitsFirstViewportWithoutRuntimeErrors(int viewportWidth, int viewportHeight)
+    {
+        await using var app = await BrowserTestApp.StartAsync();
+        using var playwright = await Playwright.CreateAsync();
+        await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+        {
+            Headless = true
+        });
+        await using var context = await browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            BaseURL = app.BaseAddress.ToString(),
+            Locale = "en-US",
+            ViewportSize = new ViewportSize { Width = viewportWidth, Height = viewportHeight }
+        });
+        await BrowserTestApp.RouteExternalResourcesAsync(context);
+        if (!string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("LWC_SCREENSHOT_DIR")))
+        {
+            await context.RouteAsync(
+                "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/**",
+                route => route.ContinueAsync());
+        }
+
+        var page = await context.NewPageAsync();
+        var errors = CapturePageErrors(page);
+
+        await page.GotoAsync("/", new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
+        var scoreboard = page.Locator(".homepage-scoreboard");
+        await scoreboard.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible });
+        await page.WaitForLoadStateAsync(LoadState.Load);
+        await page.EvaluateAsync("() => new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))");
+
+        var hasHorizontalOverflow = await page.EvaluateAsync<bool>(
+            """
+            () => document.documentElement.scrollWidth > window.innerWidth + 1
+                || document.body.scrollWidth > window.innerWidth + 1
+            """);
+        Assert.False(hasHorizontalOverflow, $"Homepage overflowed horizontally at {viewportWidth}x{viewportHeight}.");
+
+        var scoreboardBox = await scoreboard.BoundingBoxAsync();
+        Assert.NotNull(scoreboardBox);
+        Assert.True(scoreboardBox.Y >= -1, $"Scoreboard starts above the viewport at {viewportWidth}x{viewportHeight}: {scoreboardBox.Y}px.");
+        Assert.True(
+            scoreboardBox.Y + scoreboardBox.Height <= viewportHeight + 1,
+            $"Scoreboard ends below the first viewport at {viewportWidth}x{viewportHeight}: {scoreboardBox.Y + scoreboardBox.Height}px > {viewportHeight}px.");
+
+        foreach (var (selector, description) in new[]
+        {
+            (".homepage-scoreboard-action", "Explore live standings action"),
+            (".homepage-scoreboard-rules", "Ranking rules action"),
+            (".homepage-scoreboard-leader", "current leader link")
+        })
+        {
+            var link = page.Locator(selector);
+            Assert.Equal(1, await link.CountAsync());
+            Assert.True(await link.IsVisibleAsync(), $"The {description} is not visible at {viewportWidth}x{viewportHeight}.");
+            await AssertMinimumActionHeightAsync(link, 44, description, viewportWidth, viewportHeight);
+        }
+
+        var playButton = page.GetByRole(AriaRole.Button, new() { Name = "Play the game", Exact = true }).First;
+        await AssertMinimumActionHeightAsync(playButton, 44, "header Play the game button", viewportWidth, viewportHeight);
+
+        await CaptureOptionalScreenshotAsync(page, viewportWidth, viewportHeight);
+        Assert.Empty(errors);
+    }
+
+    private static List<string> CapturePageErrors(IPage page)
+    {
+        var errors = new List<string>();
+        page.Console += (_, message) =>
+        {
+            if (message.Type == "error")
+                errors.Add(message.Text);
+        };
+        page.PageError += (_, error) => errors.Add(error);
+        return errors;
+    }
+
+    private static async Task AssertMinimumActionHeightAsync(
+        ILocator locator,
+        double minimumHeight,
+        string description,
+        int viewportWidth,
+        int viewportHeight)
+    {
+        var box = await locator.BoundingBoxAsync();
+        Assert.NotNull(box);
+        Assert.True(
+            box.Height >= minimumHeight - 0.5,
+            $"The {description} is only {box.Height:0.##}px tall at {viewportWidth}x{viewportHeight}; expected at least {minimumHeight}px.");
+    }
+
+    private static async Task CaptureOptionalScreenshotAsync(IPage page, int viewportWidth, int viewportHeight)
+    {
+        var screenshotDirectory = Environment.GetEnvironmentVariable("LWC_SCREENSHOT_DIR");
+        if (string.IsNullOrWhiteSpace(screenshotDirectory))
+            return;
+
+        var fullDirectory = Path.GetFullPath(screenshotDirectory);
+        Directory.CreateDirectory(fullDirectory);
+        await page.ScreenshotAsync(new PageScreenshotOptions
+        {
+            Path = Path.Combine(fullDirectory, $"homepage-scoreboard-{viewportWidth}x{viewportHeight}.png"),
+            FullPage = false
+        });
+
+        var footer = page.Locator(".footer");
+        await footer.ScrollIntoViewIfNeededAsync();
+        await page.EvaluateAsync("() => new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))");
+        await footer.ScreenshotAsync(new LocatorScreenshotOptions
+        {
+            Path = Path.Combine(fullDirectory, $"grouped-footer-{viewportWidth}x{viewportHeight}.png")
+        });
+    }
+}

--- a/LongevityWorldCup.Tests/HomepageScoreboardPageTests.cs
+++ b/LongevityWorldCup.Tests/HomepageScoreboardPageTests.cs
@@ -1,0 +1,111 @@
+using System.Net;
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class HomepageScoreboardPageTests
+{
+    [Fact]
+    public async Task Homepage_InjectsLiveScoreboardWithOneVisiblePrimaryHeading()
+    {
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        var html = await client.GetStringAsync("/");
+        var scoreboard = ExtractScoreboard(html);
+
+        Assert.Contains("data-state=\"live\"", scoreboard);
+        Assert.DoesNotContain("<!--HOMEPAGE-SCOREBOARD-->", html);
+
+        var h1Matches = Regex.Matches(html, @"<h1\b[^>]*>", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+        var h1 = Assert.Single(h1Matches.Cast<Match>()).Value;
+        Assert.Contains("class=\"homepage-scoreboard-title\"", h1);
+        Assert.DoesNotContain("visually-hidden", h1, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("aria-hidden=\"true\"", h1, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(" hidden", h1, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Homepage_UsesCanonicalClockCopyAndNamedLiveStandingsAnchor()
+    {
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        var html = await client.GetStringAsync("/");
+        var scoreboard = ExtractScoreboard(html);
+        var scoreboardText = VisibleText(scoreboard);
+
+        Assert.Contains("pheno age", scoreboardText, StringComparison.Ordinal);
+        Assert.Contains("bortz age", scoreboardText, StringComparison.Ordinal);
+        Assert.DoesNotContain("Pheno Age", scoreboardText, StringComparison.Ordinal);
+        Assert.DoesNotContain("Bortz Age", scoreboardText, StringComparison.Ordinal);
+
+        var standingsLink = Regex.Match(
+            scoreboard,
+            """<a\b(?=[^>]*\bhref\s*=\s*["']#live-standings["'])[^>]*>[\s\S]*?</a>""",
+            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+        Assert.True(standingsLink.Success, "The homepage scoreboard must link to the in-page live standings anchor.");
+        Assert.Equal("Explore live standings", VisibleText(standingsLink.Value));
+        Assert.Contains("id=\"live-standings\"", html);
+    }
+
+    [Fact]
+    public async Task Homepage_DoesNotReintroducePseudoPodiumMarkup()
+    {
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        var scoreboard = ExtractScoreboard(await client.GetStringAsync("/"));
+
+        Assert.DoesNotContain("data-homepage-rank-card", scoreboard);
+        Assert.DoesNotContain("homepage-rank-card", scoreboard);
+        Assert.DoesNotContain("homepage-live-panel", scoreboard);
+        Assert.DoesNotContain("Top Amateur", scoreboard, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Scoreboard_IsInjectedOnHomepageOnly()
+    {
+        using var factory = CreateFactory();
+        using var client = factory.CreateClient();
+
+        foreach (var path in new[] { "/leaderboard", "/about", "/play", "/longevitymaxxing" })
+        {
+            var html = await client.GetStringAsync(path);
+
+            Assert.DoesNotContain("class=\"homepage-scoreboard\"", html);
+            Assert.DoesNotContain("<!--HOMEPAGE-SCOREBOARD-->", html);
+        }
+    }
+
+    private static string ExtractScoreboard(string html)
+    {
+        var match = Regex.Match(
+            html,
+            """<section\b(?=[^>]*\bclass\s*=\s*["'][^"']*\bhomepage-scoreboard\b[^"']*["'])[^>]*>[\s\S]*?</section>""",
+            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+        Assert.True(match.Success, "The homepage response did not contain the injected scoreboard section.");
+        return match.Value;
+    }
+
+    private static TestWebApplicationFactory CreateFactory()
+    {
+        return new TestWebApplicationFactory(builder =>
+            builder.ConfigureLogging(logging => logging.ClearProviders()));
+    }
+
+    private static string VisibleText(string html)
+    {
+        var withoutHiddenContent = Regex.Replace(
+            html,
+            """<(?<tag>[a-z][a-z0-9]*)\b[^>]*\baria-hidden\s*=\s*["']true["'][^>]*>[\s\S]*?</\k<tag>>""",
+            " ",
+            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+        var withoutTags = Regex.Replace(withoutHiddenContent, "<[^>]+>", " ", RegexOptions.CultureInvariant);
+        return Regex.Replace(WebUtility.HtmlDecode(withoutTags), @"\s+", " ", RegexOptions.CultureInvariant).Trim();
+    }
+}

--- a/LongevityWorldCup.Tests/HomepageScoreboardRendererTests.cs
+++ b/LongevityWorldCup.Tests/HomepageScoreboardRendererTests.cs
@@ -1,0 +1,139 @@
+using System.Net;
+using System.Text.RegularExpressions;
+using LongevityWorldCup.Website.Business;
+using LongevityWorldCup.Website.Tools;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class HomepageScoreboardRendererTests
+{
+    [Fact]
+    public void Render_UsesAuthoritativeSnapshotOrderAndShowsFieldCounts()
+    {
+        var snapshot = new LeaderboardSnapshot([
+            Row(1, "ordered_pro", "Ordered Pro", "Pro", -4.2),
+            Row(2, "lower_amateur", "Numerically Lower Amateur", "Amateur", -30.0),
+            Row(3, "second_pro", "Second Pro", "Pro", 1.5)
+        ]);
+
+        var html = HomepageScoreboardRenderer.Render(snapshot);
+        var text = VisibleText(html);
+
+        Assert.Contains("class=\"homepage-scoreboard\"", html);
+        Assert.Contains("class=\"homepage-scoreboard-title\"", html);
+        Assert.Contains("homepage-scoreboard-leader", html);
+        Assert.Contains("homepage-scoreboard-score", html);
+        Assert.Contains("homepage-scoreboard-metrics", html);
+        Assert.Contains("data-state=\"live\"", html);
+        Assert.Contains("href=\"/athlete/ordered-pro\"", html);
+        Assert.Contains("Ordered Pro", text);
+        Assert.DoesNotContain("Numerically Lower Amateur", text);
+        Assert.Contains("3 ranked athletes", text);
+        Assert.Contains("2 Pro", text);
+        Assert.Contains("1 Amateur", text);
+    }
+
+    [Fact]
+    public void Render_EncodesDynamicLeaderContentAndAttributes()
+    {
+        var snapshot = new LeaderboardSnapshot([
+            Row(
+                1,
+                "unsafe",
+                "<script>alert(\"leader\")</script>",
+                "Pro",
+                -1.0,
+                athletePath: "/athlete/unsafe\" onclick=\"alert(1)")
+        ]);
+
+        var html = HomepageScoreboardRenderer.Render(snapshot);
+
+        Assert.DoesNotContain("<script>", html);
+        Assert.DoesNotContain("onclick=\"alert(1)\"", html);
+        Assert.Contains("&lt;script&gt;alert(&quot;leader&quot;)&lt;/script&gt;", html);
+        Assert.Contains("/athlete/unsafe&quot; onclick=&quot;alert(1)", html);
+    }
+
+    [Theory]
+    [InlineData(-4.2, "4.2 years younger")]
+    [InlineData(2.1, "2.1 years older")]
+    [InlineData(null, "pending")]
+    public void Render_DescribesAgeDifferenceWithoutExposingTheRawSign(double? ageDifference, string expected)
+    {
+        var html = HomepageScoreboardRenderer.Render(new LeaderboardSnapshot([
+            Row(1, "leader", "Leaderboard Leader", "Pro", ageDifference)
+        ]));
+        var text = VisibleText(html);
+
+        Assert.Contains(expected, text, StringComparison.OrdinalIgnoreCase);
+        if (ageDifference < 0)
+        {
+            Assert.DoesNotContain(ageDifference.Value.ToString("0.0", System.Globalization.CultureInfo.InvariantCulture), text);
+        }
+    }
+
+    [Fact]
+    public void Render_EmptySnapshotUsesUnavailableStateWithoutFabricatedMetrics()
+    {
+        AssertUnavailable(HomepageScoreboardRenderer.Render(new LeaderboardSnapshot([])));
+    }
+
+    [Fact]
+    public void RenderUnavailable_UsesUnavailableStateWithoutFabricatedMetrics()
+    {
+        AssertUnavailable(HomepageScoreboardRenderer.RenderUnavailable());
+    }
+
+    private static void AssertUnavailable(string html)
+    {
+        var text = VisibleText(html);
+
+        Assert.Contains("class=\"homepage-scoreboard\"", html);
+        Assert.Contains("data-state=\"unavailable\"", html);
+        Assert.DoesNotContain("data-state=\"live\"", html);
+        Assert.DoesNotContain("homepage-scoreboard-metrics", html);
+        Assert.DoesNotContain("Ultimate League #1", text, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotMatch(@"\b0\s+(?:ranked athletes|Pro|Amateur)\b", text);
+        Assert.DoesNotContain("years younger", text, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("years older", text, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("· Live", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("reconnect", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string VisibleText(string html)
+    {
+        var withoutTags = Regex.Replace(html, "<[^>]+>", " ", RegexOptions.CultureInvariant);
+        return Regex.Replace(WebUtility.HtmlDecode(withoutTags), @"\s+", " ", RegexOptions.CultureInvariant).Trim();
+    }
+
+    private static LeaderboardSnapshotRow Row(
+        int rank,
+        string slug,
+        string displayName,
+        string track,
+        double? ageDifference,
+        string? athletePath = null)
+    {
+        var path = athletePath ?? $"/athlete/{slug.Replace('_', '-')}";
+        return new LeaderboardSnapshotRow(
+            Rank: rank,
+            Slug: slug,
+            RouteSlug: slug.Replace('_', '-'),
+            DisplayName: displayName,
+            AthletePath: path,
+            AthleteUrl: $"https://longevityworldcup.com{path}",
+            Track: track,
+            Tier: track.ToLowerInvariant(),
+            EffectiveAgeReductionYears: ageDifference,
+            LowestBortzAge: string.Equals(track, "Pro", StringComparison.OrdinalIgnoreCase) ? 40 : null,
+            LowestPhenoAge: 45,
+            ChronologicalAge: 50,
+            Division: "Open",
+            Generation: "Millennials",
+            Flag: "",
+            ExclusiveLeague: "",
+            MediaContact: "",
+            LeaderboardThumbnailUrl: null);
+    }
+}

--- a/LongevityWorldCup.Tests/HtmlPlaceholderInjectionTests.cs
+++ b/LongevityWorldCup.Tests/HtmlPlaceholderInjectionTests.cs
@@ -1,0 +1,81 @@
+using System.Net;
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class HtmlPlaceholderInjectionTests
+{
+    private static readonly string[] CanonicalHtmlRoutes =
+    [
+        "/",
+        "/events",
+        "/leaderboard",
+        "/longevitymaxxing",
+        "/helstab-kihivas",
+        "/media",
+        "/about",
+        "/history",
+        "/ruleset",
+        "/privacy",
+        "/play",
+        "/join",
+        "/apply",
+        "/review",
+        "/proofs",
+        "/select-athlete",
+        "/dashboard",
+        "/edit-profile",
+        "/unsubscribe",
+        "/pheno-age",
+        "/bortz-age"
+    ];
+
+    private static readonly string[] TopLevelCompositionMarkers =
+    [
+        "<!--HEAD-->",
+        "<!--HEADER-->",
+        "<!--FOOTER-->",
+        "<!--HOMEPAGE-SCOREBOARD-->",
+        "<!--MAIN-PROGRESS-BAR-->",
+        "<!--SUB-PROGRESS-BAR-->",
+        "<!--LEADERBOARD-CONTENT-->",
+        "<!--GUESS-MY-AGE-->",
+        "<!--EVENT-BOARD-CONTENT-->",
+        "<!--AGE-VISUALIZATION-->"
+    ];
+
+    [Fact]
+    public async Task CanonicalHtmlRoutes_DoNotLeakCompositionPlaceholders()
+    {
+        using var factory = new TestWebApplicationFactory(builder =>
+            builder.ConfigureLogging(logging => logging.ClearProviders()));
+        using var client = factory.CreateClient();
+
+        foreach (var path in CanonicalHtmlRoutes)
+        {
+            using var response = await client.GetAsync(path);
+            var html = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("text/html", response.Content.Headers.ContentType?.MediaType);
+
+            var unresolvedToken = Regex.Match(
+                html,
+                @"\{\{[A-Z][A-Z0-9_-]*\}\}",
+                RegexOptions.CultureInvariant);
+            Assert.False(
+                unresolvedToken.Success,
+                $"Route {path} leaked unresolved token {unresolvedToken.Value}.");
+
+            foreach (var marker in TopLevelCompositionMarkers)
+            {
+                Assert.False(
+                    html.Contains(marker, StringComparison.Ordinal),
+                    $"Route {path} leaked top-level composition marker {marker}.");
+            }
+        }
+    }
+}

--- a/LongevityWorldCup.Website/Middleware/HtmlInjectionMiddleware.cs
+++ b/LongevityWorldCup.Website/Middleware/HtmlInjectionMiddleware.cs
@@ -132,6 +132,7 @@ namespace LongevityWorldCup.Website.Middleware
                         .Replace("<!--HEAD-->", head)
                         .Replace("<!--HEADER-->", ApplySharedAssetPlaceholders(header))
                         .Replace("<!--FOOTER-->", footer)
+                        .Replace("<!--HOMEPAGE-SCOREBOARD-->", BuildHomepageScoreboard(context))
                         .Replace("<!--MAIN-PROGRESS-BAR-->", progressBar)
                         .Replace("<!--SUB-PROGRESS-BAR-->", subProgressBar)
                         .Replace("<!--LEADERBOARD-CONTENT-->", leaderboardContent)
@@ -204,6 +205,24 @@ namespace LongevityWorldCup.Website.Middleware
                 .Replace("{{ASSET_PRO_DISCOUNTS_JS}}", _assetVersionProvider.AppendVersion("/js/pro-discounts.js"))
                 .Replace("{{ASSET_PROOF_HELPERS_JS}}", _assetVersionProvider.AppendVersion("/js/proof-helpers.js"))
                 .Replace("{{ASSET_AGE_VISUALIZATION_JS}}", _assetVersionProvider.AppendVersion("/js/age-visualization.js"));
+        }
+
+        private string BuildHomepageScoreboard(HttpContext context)
+        {
+            if (!string.Equals(GetRequestCanonicalPath(context), "/", StringComparison.OrdinalIgnoreCase))
+            {
+                return string.Empty;
+            }
+
+            try
+            {
+                return HomepageScoreboardRenderer.Render(_leaderboardFacts.GetLeaderboardSnapshot());
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Rendering the homepage live scoreboard failed; showing the truthful unavailable state.");
+                return HomepageScoreboardRenderer.RenderUnavailable();
+            }
         }
 
         private string ApplyLeaderboardRows(string html, HttpContext context)
@@ -319,9 +338,13 @@ namespace LongevityWorldCup.Website.Middleware
                 .Replace("Visit Longevity World Cup on YouTube", "Hosszúéletesítési Világbajnokság a YouTube-on")
                 .Replace("Follow the Longevity World Cup on Instagram", "Hosszúéletesítési Világbajnokság az Instagramon")
                 .Replace("</i> Merch", "</i> Bolt")
+                .Replace("</i> About", "</i> Névjegy")
                 .Replace("</i> History", "</i> Történet")
                 .Replace("</i> Ruleset", "</i> Szabályok")
+                .Replace("</i> Media", "</i> Média")
                 .Replace("</i> Contact", "</i> Kapcsolat")
+                .Replace(">Competition<", ">Verseny<")
+                .Replace(">Community<", ">Közösség<")
                 .Replace(">Merch<", ">Bolt<")
                 .Replace(">History<", ">Történet<")
                 .Replace(">Ruleset<", ">Szabályok<")

--- a/LongevityWorldCup.Website/Tools/HomepageScoreboardRenderer.cs
+++ b/LongevityWorldCup.Website/Tools/HomepageScoreboardRenderer.cs
@@ -1,0 +1,152 @@
+using System.Globalization;
+using System.Net;
+using System.Text;
+using LongevityWorldCup.Website.Business;
+
+namespace LongevityWorldCup.Website.Tools;
+
+public static class HomepageScoreboardRenderer
+{
+    public static string Render(LeaderboardSnapshot snapshot)
+    {
+        if (snapshot.Rows.Count == 0)
+        {
+            return RenderUnavailable();
+        }
+
+        var leader = snapshot.Rows[0];
+        var proCount = snapshot.Rows.Count(row => IsTrack(row, "Pro"));
+        var amateurCount = snapshot.Rows.Count(row => IsTrack(row, "Amateur"));
+        var score = FormatScore(leader.EffectiveAgeReductionYears);
+
+        var html = new StringBuilder();
+        AppendOpening(html, "live");
+        AppendIntroduction(html, isLive: true);
+        html.AppendLine("        <div class=\"homepage-scoreboard-record\" aria-label=\"Current Ultimate League leader\">");
+        html.AppendLine("            <span class=\"homepage-scoreboard-record-label\">Current Ultimate League #1</span>");
+        html.Append("            <a class=\"homepage-scoreboard-leader\" href=\"")
+            .Append(Encode(leader.AthletePath))
+            .Append("\">")
+            .Append(Encode(leader.DisplayName))
+            .AppendLine("</a>");
+        html.Append("            <strong class=\"homepage-scoreboard-score")
+            .Append(score is null ? " is-pending" : string.Empty)
+            .AppendLine("\">");
+        if (score is null)
+        {
+            html.AppendLine("                <span class=\"homepage-scoreboard-score-value\">Score pending</span>");
+        }
+        else
+        {
+            html.Append("                <span class=\"homepage-scoreboard-score-value\">")
+                .Append(Encode(score.Value.Value))
+                .AppendLine("</span>");
+            html.Append("                <span class=\"homepage-scoreboard-score-unit\">")
+                .Append(Encode(score.Value.Unit))
+                .AppendLine("</span>");
+        }
+
+        html.AppendLine("            </strong>");
+        html.AppendLine("            <span class=\"homepage-scoreboard-score-label\">Effective age reduction</span>");
+        html.AppendLine("            <div class=\"homepage-scoreboard-metrics\" aria-label=\"Current ranked field\">");
+        AppendMetric(html, snapshot.Rows.Count, "ranked athletes");
+        AppendMetric(html, proCount, "Pro");
+        AppendMetric(html, amateurCount, "Amateur");
+        html.AppendLine("            </div>");
+        html.AppendLine("        </div>");
+        AppendClosing(html);
+        return html.ToString();
+    }
+
+    public static string RenderUnavailable()
+    {
+        var html = new StringBuilder();
+        AppendOpening(html, "unavailable");
+        AppendIntroduction(html, isLive: false);
+        html.AppendLine("        <div class=\"homepage-scoreboard-record is-unavailable\" role=\"status\">");
+        html.AppendLine("            <span class=\"homepage-scoreboard-record-label\">Live standings</span>");
+        html.AppendLine("            <strong class=\"homepage-scoreboard-unavailable-title\">Standings are updating</strong>");
+        html.AppendLine("            <span class=\"homepage-scoreboard-unavailable-copy\">The live summary is temporarily unavailable. The official standings remain available below.</span>");
+        html.AppendLine("            <a class=\"homepage-scoreboard-unavailable-link\" href=\"#live-standings\">Open standings</a>");
+        html.AppendLine("        </div>");
+        AppendClosing(html);
+        return html.ToString();
+    }
+
+    private static void AppendOpening(StringBuilder html, string state)
+    {
+        html.Append("<section class=\"homepage-scoreboard\" data-state=\"")
+            .Append(state)
+            .AppendLine("\" aria-labelledby=\"homepage-scoreboard-title\">");
+        html.AppendLine("    <div class=\"homepage-scoreboard-grid\">");
+    }
+
+    private static void AppendIntroduction(StringBuilder html, bool isLive)
+    {
+        html.AppendLine("        <div class=\"homepage-scoreboard-intro\">");
+        html.Append("            <p class=\"homepage-scoreboard-kicker\"><span aria-hidden=\"true\"></span> Ultimate League")
+            .Append(isLive ? " · Live" : string.Empty)
+            .AppendLine("</p>");
+        html.AppendLine("            <h1 id=\"homepage-scoreboard-title\" class=\"homepage-scoreboard-title\">The world championship of age reversal.</h1>");
+        html.AppendLine("            <p class=\"homepage-scoreboard-lede\">Proof-backed pheno age and bortz age results rank longevity athletes in public. Pro athletes rank before Amateur athletes.</p>");
+        html.AppendLine("            <div class=\"homepage-scoreboard-actions\">");
+        html.AppendLine("                <a class=\"homepage-scoreboard-action\" href=\"#live-standings\">Explore live standings <span aria-hidden=\"true\">↓</span></a>");
+        html.AppendLine("                <a class=\"homepage-scoreboard-rules\" href=\"/ruleset#point-system-ranking\">Ranking rules <span aria-hidden=\"true\">↗</span></a>");
+        html.AppendLine("            </div>");
+        html.AppendLine("        </div>");
+    }
+
+    private static void AppendMetric(StringBuilder html, int value, string label)
+    {
+        html.AppendLine("                <span class=\"homepage-scoreboard-metric\">");
+        html.Append("                    <strong>")
+            .Append(value.ToString(CultureInfo.InvariantCulture))
+            .AppendLine("</strong>");
+        html.Append("                    <span>")
+            .Append(Encode(label))
+            .AppendLine("</span>");
+        html.AppendLine("                </span>");
+    }
+
+    private static void AppendClosing(StringBuilder html)
+    {
+        html.AppendLine("    </div>");
+        html.AppendLine("    <div class=\"homepage-scoreboard-proofline\" aria-label=\"Competition basis\">");
+        html.AppendLine("        <span><i class=\"fas fa-vial\" aria-hidden=\"true\"></i> Biological-age results</span>");
+        html.AppendLine("        <span><i class=\"fas fa-file-shield\" aria-hidden=\"true\"></i> Public proof</span>");
+        html.AppendLine("        <span><i class=\"fas fa-ranking-star\" aria-hidden=\"true\"></i> Pro before Amateur</span>");
+        html.AppendLine("    </div>");
+        html.AppendLine("</section>");
+    }
+
+    private static (string Value, string Unit)? FormatScore(double? value)
+    {
+        if (!value.HasValue || double.IsNaN(value.Value) || double.IsInfinity(value.Value))
+        {
+            return null;
+        }
+
+        var magnitude = Math.Abs(value.Value).ToString("0.0", CultureInfo.InvariantCulture);
+        if (value.Value < 0)
+        {
+            return (magnitude, "years younger");
+        }
+
+        if (value.Value > 0)
+        {
+            return (magnitude, "years older");
+        }
+
+        return ("0.0", "years difference");
+    }
+
+    private static bool IsTrack(LeaderboardSnapshotRow row, string track)
+    {
+        return string.Equals(row.Track, track, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string Encode(string? value)
+    {
+        return WebUtility.HtmlEncode(value ?? string.Empty);
+    }
+}

--- a/LongevityWorldCup.Website/wwwroot/index.html
+++ b/LongevityWorldCup.Website/wwwroot/index.html
@@ -136,37 +136,508 @@
                 transition: transform 0.2s ease, color 0.2s ease; /* Smooth transition for both color and size */
             }
 
-        .game-description {
-            text-align: center;
-            margin: 0 auto 1.1rem;
-            line-height: 1.55;
-            color: #334155;
-            font-size: clamp(1.02rem, 1.3vw, 1.08rem);
-            font-weight: 400;
-            letter-spacing: 0.005em;
-            max-width: 43em;
-            padding: 0 1rem;
+        .homepage-page {
+            --homepage-chrome: var(--lwc-scoreboard-chrome, #07100c);
+            --homepage-live: var(--lwc-live-green, #43ee83);
         }
 
-        .game-description strong {
-            font-weight: 600;
-            color: #1f2937;
+        .homepage-page > header {
+            padding: 0.75rem 0 0.95rem;
+            background:
+                radial-gradient(circle at 50% -70%, rgba(67, 238, 131, 0.15), transparent 52%),
+                linear-gradient(120deg, #050806, #1a211d);
+            box-shadow: none;
         }
 
-        .game-description a {
-            color: inherit;
-            font-weight: inherit;
-            text-decoration: none;
-            border-radius: 3px;
+        .homepage-page > header .header-link > .main-logo-image {
+            width: clamp(58px, 6vw, 68px);
+            margin-bottom: 0.35rem;
         }
 
-        .game-description a:hover,
-        .game-description a:focus-visible {
-            color: var(--primary-color);
-            text-decoration: underline;
-            text-decoration-thickness: 0.08em;
-            text-underline-offset: 0.16em;
+        .homepage-page > header .bannertext {
+            font-size: clamp(1.75rem, 2.8vw, 2rem);
+        }
+
+        .homepage-page > header .tagline {
+            display: none;
+        }
+
+        .homepage-page > header .join-game {
+            min-height: 44px;
+            margin-top: 0.72rem;
+            padding: 0.72rem 1.55rem;
+            background: var(--homepage-live);
+            color: #07100c;
+            font-weight: 700;
+            box-shadow: 0 0 0 1px rgba(67, 238, 131, 0.45), 0 10px 28px rgba(0, 0, 0, 0.26);
+            animation: none;
+        }
+
+        .homepage-page > header .join-game:hover,
+        .homepage-page > header .join-game:focus-visible {
+            background: #72f4a2;
+            color: #030604;
+            transform: translateY(-1px);
+            box-shadow: 0 0 0 3px rgba(67, 238, 131, 0.2), 0 12px 30px rgba(0, 0, 0, 0.32);
             outline: none;
+        }
+
+        .homepage-page main {
+            margin-top: 1rem;
+        }
+
+        .homepage-scoreboard {
+            position: relative;
+            max-width: 1140px;
+            margin: 0 auto 1.35rem;
+            overflow: hidden;
+            color: #f6f8f6;
+            background:
+                radial-gradient(circle at 82% 16%, rgba(67, 238, 131, 0.14), transparent 34%),
+                linear-gradient(135deg, var(--homepage-chrome), #101713 72%, #152019);
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            border-radius: 18px;
+            box-shadow: 0 18px 45px rgba(6, 13, 9, 0.2);
+            isolation: isolate;
+        }
+
+        .homepage-scoreboard::before {
+            content: '';
+            position: absolute;
+            inset: 0;
+            z-index: -1;
+            pointer-events: none;
+            opacity: 0.24;
+            background-image:
+                linear-gradient(rgba(255, 255, 255, 0.035) 1px, transparent 1px),
+                linear-gradient(90deg, rgba(255, 255, 255, 0.035) 1px, transparent 1px);
+            background-size: 28px 28px;
+            mask-image: linear-gradient(90deg, #000, transparent 78%);
+        }
+
+        .homepage-scoreboard-grid {
+            display: grid;
+            grid-template-columns: minmax(0, 1.16fr) minmax(300px, 0.84fr);
+            gap: clamp(1.5rem, 4vw, 3.4rem);
+            align-items: center;
+            padding: clamp(1.6rem, 3.7vw, 3rem);
+        }
+
+        .homepage-scoreboard-intro {
+            min-width: 0;
+        }
+
+        .homepage-scoreboard-kicker {
+            display: flex;
+            align-items: center;
+            gap: 0.55rem;
+            margin: 0 0 0.75rem;
+            color: #9ef6bf;
+            font-size: 0.77rem;
+            font-weight: 700;
+            line-height: 1.2;
+            letter-spacing: 0.12em;
+            text-transform: uppercase;
+        }
+
+        .homepage-scoreboard-kicker span {
+            width: 0.52rem;
+            height: 0.52rem;
+            flex: 0 0 auto;
+            border-radius: 50%;
+            background: var(--homepage-live);
+            box-shadow: 0 0 0 4px rgba(67, 238, 131, 0.12);
+        }
+
+        .homepage-scoreboard h1 {
+            max-width: 12em;
+            margin: 0;
+            padding: 0;
+            color: #ffffff;
+            font-size: clamp(2.15rem, 4vw, 3.45rem);
+            font-weight: 700;
+            line-height: 0.98;
+            letter-spacing: -0.035em;
+            text-align: left;
+            text-shadow: none;
+            text-wrap: balance;
+        }
+
+        .homepage-scoreboard-lede {
+            max-width: 38rem;
+            margin: 1rem 0 0;
+            color: #cbd6cf;
+            font-size: clamp(0.96rem, 1.25vw, 1.06rem);
+            line-height: 1.55;
+        }
+
+        .homepage-scoreboard-actions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.65rem 1.1rem;
+            align-items: center;
+            margin-top: 1.15rem;
+        }
+
+        .homepage-scoreboard-action,
+        .homepage-scoreboard-rules,
+        .homepage-scoreboard-unavailable-link {
+            min-height: 44px;
+            box-sizing: border-box;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.45rem;
+            border-radius: 999px;
+            font-size: 0.92rem;
+            font-weight: 700;
+            text-decoration: none;
+            transition: color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+        }
+
+        .homepage-scoreboard-action {
+            padding: 0.68rem 1rem;
+            border: 1px solid rgba(67, 238, 131, 0.48);
+            background: rgba(67, 238, 131, 0.1);
+            color: #baf9d0;
+        }
+
+        .homepage-scoreboard-rules {
+            padding: 0.68rem 0.35rem;
+            color: #dce5df;
+        }
+
+        .homepage-scoreboard-action:hover,
+        .homepage-scoreboard-action:focus-visible,
+        .homepage-scoreboard-unavailable-link:hover,
+        .homepage-scoreboard-unavailable-link:focus-visible {
+            border-color: var(--homepage-live);
+            background: rgba(67, 238, 131, 0.17);
+            color: #ffffff;
+            box-shadow: 0 0 0 3px rgba(67, 238, 131, 0.14);
+            transform: translateY(-1px);
+            outline: none;
+        }
+
+        .homepage-scoreboard-rules:hover,
+        .homepage-scoreboard-rules:focus-visible {
+            color: #ffffff;
+            text-decoration: underline;
+            text-underline-offset: 0.2em;
+            outline: 2px solid rgba(67, 238, 131, 0.55);
+            outline-offset: 3px;
+        }
+
+        .homepage-scoreboard-record {
+            min-width: 0;
+            padding: clamp(1.15rem, 2.6vw, 1.65rem);
+            border: 1px solid rgba(255, 255, 255, 0.14);
+            border-radius: 14px;
+            background: linear-gradient(145deg, rgba(255, 255, 255, 0.075), rgba(255, 255, 255, 0.025));
+            box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 14px 35px rgba(0, 0, 0, 0.18);
+        }
+
+        .homepage-scoreboard-record-label,
+        .homepage-scoreboard-score-label {
+            display: block;
+            color: #91a198;
+            font-size: 0.7rem;
+            font-weight: 700;
+            line-height: 1.2;
+            letter-spacing: 0.1em;
+            text-transform: uppercase;
+        }
+
+        .homepage-scoreboard-leader {
+            display: inline-flex;
+            align-items: center;
+            max-width: 100%;
+            min-height: 44px;
+            margin-top: 0.25rem;
+            color: #ffffff;
+            font-size: clamp(1.12rem, 2vw, 1.35rem);
+            font-weight: 700;
+            line-height: 1.2;
+            overflow-wrap: anywhere;
+            text-decoration: none;
+        }
+
+        .homepage-scoreboard-leader:hover {
+            color: var(--homepage-live);
+            text-decoration: underline;
+            text-underline-offset: 0.18em;
+        }
+
+        .homepage-scoreboard-leader:focus-visible {
+            border-radius: 4px;
+            color: var(--homepage-live);
+            text-decoration: underline;
+            text-underline-offset: 0.18em;
+            outline: 2px solid var(--homepage-live);
+            outline-offset: 3px;
+        }
+
+        .homepage-scoreboard-score {
+            display: flex;
+            align-items: baseline;
+            gap: 0.55rem;
+            margin-top: 0.75rem;
+            color: var(--homepage-live);
+            line-height: 1;
+        }
+
+        .homepage-scoreboard-score-value {
+            font-family: 'Orbitron', 'Roboto', sans-serif;
+            font-size: clamp(2.25rem, 5vw, 3.75rem);
+            font-weight: 700;
+            letter-spacing: -0.055em;
+        }
+
+        .homepage-scoreboard-score-unit {
+            max-width: 6.5rem;
+            color: #c9f8d9;
+            font-size: 0.86rem;
+            font-weight: 700;
+            line-height: 1.15;
+        }
+
+        .homepage-scoreboard-score.is-pending .homepage-scoreboard-score-value {
+            font-family: 'Roboto', sans-serif;
+            font-size: 1.35rem;
+            letter-spacing: 0;
+        }
+
+        .homepage-scoreboard-score-label {
+            margin-top: 0.35rem;
+        }
+
+        .homepage-scoreboard-metrics {
+            display: grid;
+            grid-template-columns: repeat(3, minmax(0, 1fr));
+            gap: 0.55rem;
+            margin-top: 1rem;
+            padding-top: 1rem;
+            border-top: 1px solid rgba(255, 255, 255, 0.1);
+        }
+
+        .homepage-scoreboard-metric {
+            min-width: 0;
+        }
+
+        .homepage-scoreboard-metric strong,
+        .homepage-scoreboard-metric span {
+            display: block;
+        }
+
+        .homepage-scoreboard-metric strong {
+            color: #ffffff;
+            font-family: 'Orbitron', 'Roboto', sans-serif;
+            font-size: 1.15rem;
+            line-height: 1.15;
+        }
+
+        .homepage-scoreboard-metric span {
+            margin-top: 0.18rem;
+            color: #9eada4;
+            font-size: 0.69rem;
+            line-height: 1.2;
+        }
+
+        .homepage-scoreboard-record.is-unavailable {
+            display: flex;
+            flex-direction: column;
+            align-items: flex-start;
+            justify-content: center;
+            min-height: 180px;
+        }
+
+        .homepage-scoreboard-unavailable-title {
+            margin-top: 0.65rem;
+            color: #ffffff;
+            font-size: 1.4rem;
+        }
+
+        .homepage-scoreboard-unavailable-copy {
+            margin-top: 0.55rem;
+            color: #b8c5bd;
+            font-size: 0.9rem;
+            line-height: 1.45;
+        }
+
+        .homepage-scoreboard-unavailable-link {
+            margin-top: 0.85rem;
+            padding: 0.62rem 0.9rem;
+            border: 1px solid rgba(67, 238, 131, 0.4);
+            color: #baf9d0;
+        }
+
+        .homepage-scoreboard-proofline {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.65rem 1.4rem;
+            align-items: center;
+            padding: 0.78rem clamp(1.6rem, 3.7vw, 3rem);
+            border-top: 1px solid rgba(255, 255, 255, 0.08);
+            background: rgba(0, 0, 0, 0.13);
+            color: #9faca4;
+            font-size: 0.74rem;
+            font-weight: 600;
+            line-height: 1.25;
+        }
+
+        .homepage-scoreboard-proofline span {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.42rem;
+        }
+
+        .homepage-scoreboard-proofline i {
+            color: #75e99e;
+        }
+
+        .homepage-standings-anchor {
+            height: 1px;
+            scroll-margin-top: 70px;
+        }
+
+        @media (max-width: 760px) {
+            .homepage-scoreboard-grid {
+                grid-template-columns: 1fr;
+                gap: 1rem;
+                padding: 1.35rem;
+            }
+
+            .homepage-scoreboard h1 {
+                max-width: 15em;
+                font-size: clamp(1.85rem, 8vw, 2.35rem);
+                line-height: 1.02;
+            }
+
+            .homepage-scoreboard-lede {
+                margin-top: 0.8rem;
+            }
+
+            .homepage-scoreboard-actions {
+                margin-top: 0.85rem;
+            }
+
+            .homepage-scoreboard-record {
+                padding: 1rem;
+            }
+
+            .homepage-scoreboard-score-value {
+                font-size: clamp(2.15rem, 12vw, 3rem);
+            }
+
+            .homepage-scoreboard-proofline {
+                justify-content: space-between;
+                gap: 0.55rem;
+                padding: 0.7rem 1.35rem;
+            }
+        }
+
+        @media (max-width: 420px) {
+            .homepage-page > header {
+                padding: 0.56rem 0 0.68rem;
+            }
+
+            .homepage-page > header .header-link > .main-logo-image {
+                width: 54px;
+                margin-bottom: 0.25rem;
+            }
+
+            .homepage-page > header .bannertext {
+                font-size: 1.68rem;
+                line-height: 1.04;
+            }
+
+            .homepage-page > header .join-game {
+                margin-top: 0.58rem;
+                padding: 0.66rem 1.3rem;
+                font-size: 1rem;
+            }
+
+            .homepage-page main {
+                margin-top: 0.4rem;
+                padding-inline: 0.7rem;
+            }
+
+            .homepage-scoreboard {
+                margin-bottom: 1rem;
+                border-radius: 15px;
+            }
+
+            .homepage-scoreboard-grid {
+                gap: 0.8rem;
+                padding: 0.98rem 1.05rem;
+            }
+
+            .homepage-scoreboard-kicker {
+                margin-bottom: 0.55rem;
+                font-size: 0.68rem;
+            }
+
+            .homepage-scoreboard h1 {
+                font-size: 1.65rem;
+            }
+
+            .homepage-scoreboard-lede {
+                margin-top: 0.65rem;
+                font-size: 0.87rem;
+                line-height: 1.42;
+            }
+
+            .homepage-scoreboard-actions {
+                gap: 0.45rem 0.8rem;
+                margin-top: 0.68rem;
+            }
+
+            .homepage-scoreboard-action,
+            .homepage-scoreboard-rules {
+                font-size: 0.82rem;
+            }
+
+            .homepage-scoreboard-record {
+                padding: 0.88rem;
+            }
+
+            .homepage-scoreboard-leader {
+                margin-top: 0.15rem;
+                font-size: 1rem;
+            }
+
+            .homepage-scoreboard-score {
+                margin-top: 0.45rem;
+            }
+
+            .homepage-scoreboard-score-value {
+                font-size: 2rem;
+            }
+
+            .homepage-scoreboard-score-unit {
+                font-size: 0.74rem;
+            }
+
+            .homepage-scoreboard-metrics {
+                gap: 0.4rem;
+                margin-top: 0.7rem;
+                padding-top: 0.7rem;
+            }
+
+            .homepage-scoreboard-metric strong {
+                font-size: 0.96rem;
+            }
+
+            .homepage-scoreboard-metric span {
+                font-size: 0.62rem;
+            }
+
+            .homepage-scoreboard-proofline {
+                justify-content: flex-start;
+                gap: 0.38rem 0.85rem;
+                padding: 0.56rem 1.05rem;
+                font-size: 0.65rem;
+            }
         }
 
         /* Common container for sections */
@@ -1181,12 +1652,6 @@
         }
 
         @media (max-width: 576px) {
-            .game-description {
-                margin-bottom: 1.05rem;
-                padding: 0 1.35rem;
-                line-height: 1.5;
-            }
-
             .lwc-highlights-countdown-wrapper {
                 margin-top: 1.25rem;
                 gap: 1.2rem;
@@ -1688,14 +2153,12 @@
 
     </style>
 </head>
-<body>
+<body class="homepage-page">
     <!--HEADER-->
     <main>
-        <h1 class="visually-hidden">Longevity World Cup</h1>
-        <p class="game-description">
-            Too old for your sport? Not <a href="/about">this&nbsp;one</a>. Reverse&nbsp;your&nbsp;age and <strong>rise&nbsp;on&nbsp;the&nbsp;leaderboard!</strong>
-        </p>
+        <!--HOMEPAGE-SCOREBOARD-->
 
+        <div id="live-standings" class="homepage-standings-anchor" aria-hidden="true"></div>
         <!--LEADERBOARD-CONTENT-->
         <div class="full-rankings-action">
             <button id="viewAllAthletesBtn" onclick="window.location.href = window.getFullLeaderboardUrlWithCurrentState ? window.getFullLeaderboardUrlWithCurrentState() : '/leaderboard'" class="rankings-btn" aria-label="View all athletes on the leaderboard">

--- a/LongevityWorldCup.Website/wwwroot/partials/footer.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/footer.html
@@ -1,154 +1,169 @@
 <style>
-    /* Footer Styles */
     .footer {
-        background: var(--background-color);
-        color: var(--light-text-color);
-        padding: 1.75rem 0 1.6rem;
-        margin-top: 4rem;
-        position: relative;
         width: 100%;
         clear: both;
-        box-shadow: 0px -3px 10px rgba(0, 0, 0, 0.3); /* Adds depth to footer */
+        margin-top: 1.5rem;
+        padding: 2rem 0 1.75rem;
+        border-top: 1px solid var(--footer-edge-color, rgba(67, 238, 131, 0.24));
+        background: var(--footer-background, var(--lwc-scoreboard-chrome, #07100c));
+        color: var(--footer-text-color, var(--light-text-color, #f2f7f4));
+        position: relative;
     }
-
-    .footer-link {
-        color: var(--light-text-color);
-        text-decoration: none;
-        padding: 0.5rem 0.65rem;
-        border-radius: 8px;
-        transition: transform 0.3s ease-out, color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
-        display: flex;
-        align-items: center;
-        min-height: 2.75rem;
-        box-sizing: border-box;
-        width: 100%;
-        will-change: transform;
-        font-weight: 400;
-        font-size: 0.95rem;
-        letter-spacing: 0.005em;
-    }
-
-        .footer-link:hover {
-            color: var(--primary-color);
-            background: rgba(255, 255, 255, 0.08);
-            transform: translateX(4px);
-        }
-
-        .footer-link:focus-visible {
-            color: var(--primary-color);
-            background: rgba(0, 188, 212, 0.12);
-            outline: 2px solid rgba(0, 188, 212, 0.72);
-            outline-offset: 3px;
-            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
-        }
-
-        .footer-link i {
-            width: 1.25rem;
-            margin-right: 0.75rem;
-            text-align: center;
-            font-size: 1.125rem;
-        }
 
     .footer-container {
-        max-width: 1200px;
+        width: min(100%, 58rem);
         margin: 0 auto;
-        padding: 0 1.5rem;
+        padding: 0 clamp(0.75rem, 4vw, 2rem);
+        box-sizing: border-box;
         display: grid;
-        grid-template-columns: repeat(2, minmax(8.5rem, max-content));
-        column-gap: clamp(4rem, 16vw, 13rem);
-        justify-content: center;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: clamp(0.75rem, 5vw, 4rem);
         align-items: start;
-        margin-bottom: 0;
     }
 
     .footer-column {
+        min-width: 0;
         display: flex;
         flex-direction: column;
-        gap: 0.05rem;
-        margin: 0;
-        align-items: flex-start;
+        gap: 0.125rem;
     }
 
-    @media (max-width: 768px) {
+    .footer-heading {
+        margin: 0 0 0.5rem;
+        padding: 0 0.625rem;
+        color: var(--footer-heading-color, var(--footer-accent-color, #43ee83));
+        font-family: var(--body-font-family, "Roboto", Arial, sans-serif);
+        font-size: 0.75rem;
+        font-weight: 700;
+        line-height: 1.25;
+        letter-spacing: 0.11em;
+        text-align: left;
+        text-transform: uppercase;
+    }
+
+    .footer-link {
+        width: 100%;
+        min-width: 0;
+        min-height: 2.75rem;
+        padding: 0.5rem 0.625rem;
+        border: 1px solid transparent;
+        border-radius: var(--control-radius, 8px);
+        box-sizing: border-box;
+        display: flex;
+        align-items: center;
+        color: var(--footer-text-color, var(--light-text-color, #f2f7f4));
+        font-family: var(--body-font-family, "Roboto", Arial, sans-serif);
+        font-size: 0.95rem;
+        font-weight: 500;
+        line-height: 1.3;
+        overflow-wrap: anywhere;
+        text-decoration: none;
+        transition: color 0.16s ease, background-color 0.16s ease, border-color 0.16s ease, box-shadow 0.16s ease;
+    }
+
+    .footer-link:hover {
+        border-color: var(--footer-hover-edge-color, rgba(67, 238, 131, 0.3));
+        background: var(--footer-hover-background, rgba(67, 238, 131, 0.09));
+        color: var(--footer-hover-color, #ffffff);
+    }
+
+    .footer-link:focus-visible {
+        border-color: var(--footer-focus-color, var(--footer-accent-color, #43ee83));
+        background: var(--footer-focus-background, rgba(67, 238, 131, 0.12));
+        color: var(--footer-focus-text-color, #ffffff);
+        outline: 3px solid var(--footer-focus-color, var(--footer-accent-color, #43ee83));
+        outline-offset: 2px;
+        box-shadow: 0 0 0 1px var(--footer-background, var(--lwc-scoreboard-chrome, #07100c));
+    }
+
+    .footer-link i {
+        width: 1.25rem;
+        margin-right: 0.625rem;
+        flex: 0 0 1.25rem;
+        color: var(--footer-icon-color, var(--footer-accent-color, #43ee83));
+        font-size: 1rem;
+        text-align: center;
+    }
+
+    @media (max-width: 480px) {
         .footer {
-            padding: 1.65rem 0 1.35rem;
+            padding: 1.6rem 0 1.4rem;
         }
 
         .footer-container {
-            margin-bottom: 0;
-            padding: 0 2.5rem;
-            column-gap: clamp(2rem, 9vw, 3.25rem);
+            padding-inline: 0.75rem;
+            gap: 0.625rem;
+        }
+
+        .footer-heading {
+            padding-inline: 0.5rem;
+            font-size: 0.7rem;
+            letter-spacing: 0.08em;
         }
 
         .footer-link {
-            padding: 0.5rem 0.55rem;
-        }
-    }
-
-    @media (max-width: 375px) {
-        .footer-container {
-            grid-template-columns: repeat(2, minmax(0, 1fr));
-            padding: 0 1rem;
-            column-gap: 1rem;
-        }
-
-        .footer-column {
-            margin: 0;
-        }
-
-        .footer-link {
-            padding-inline: 0.45rem;
-            font-size: 0.9rem;
+            padding-inline: 0.5rem;
+            font-size: 0.875rem;
         }
 
         .footer-link i {
-            width: 1.1rem;
-            margin-right: 0.55rem;
+            width: 1.125rem;
+            margin-right: 0.45rem;
+            flex-basis: 1.125rem;
+            font-size: 0.95rem;
         }
     }
 </style>
 
-<footer class="footer" style="margin-top: 1.5rem;">
-    <div class="footer-container">
-        <div class="footer-column">
-            <a href="https://merch.longevityworldcup.com/" target="_blank" rel="noopener" class="footer-link" aria-label="Shop Longevity World Cup merchandise">
-                <i class="fas fa-store"></i> Merch
-            </a>
-            <a href="https://github.com/nopara73/LongevityWorldCup/" target="_blank" rel="noopener" class="footer-link" aria-label="Visit Longevity World&nbsp;Cup GitHub repository">
-                <i class="fab fa-github"></i> GitHub
-            </a>
-            <a href="/history" class="footer-link" aria-label="Read the history of Longevity as a Sport">
-                <i class="fas fa-book-open"></i> History
+<footer class="footer">
+    <nav class="footer-container" aria-label="Footer navigation">
+        <section class="footer-column" aria-labelledby="footer-competition-heading">
+            <h2 id="footer-competition-heading" class="footer-heading">Competition</h2>
+            <a href="/about" class="footer-link">
+                <i class="fas fa-circle-info" aria-hidden="true"></i> About
             </a>
             <a href="/ruleset" class="footer-link" aria-label="Review the ruleset for Longevity World&nbsp;Cup">
-                <i class="fas fa-balance-scale"></i> Ruleset
+                <i class="fas fa-balance-scale" aria-hidden="true"></i> Ruleset
+            </a>
+            <a href="/history" class="footer-link" aria-label="Read the history of Longevity as a Sport">
+                <i class="fas fa-book-open" aria-hidden="true"></i> History
+            </a>
+            <a href="/media" class="footer-link">
+                <i class="fas fa-photo-film" aria-hidden="true"></i> Media
             </a>
             <a href="mailto:hi@longevityworldcup.com" class="footer-link" aria-label="Contact Longevity World&nbsp;Cup via email">
-                <i class="fas fa-envelope"></i> Contact
+                <i class="fas fa-envelope" aria-hidden="true"></i> Contact
+            </a>
+            <a href="https://github.com/nopara73/LongevityWorldCup/" target="_blank" rel="noopener" class="footer-link" aria-label="Visit Longevity World&nbsp;Cup GitHub repository">
+                <i class="fab fa-github" aria-hidden="true"></i> GitHub
+            </a>
+        </section>
+        <section class="footer-column" aria-labelledby="footer-community-heading">
+            <h2 id="footer-community-heading" class="footer-heading">Community</h2>
+            <a href="https://merch.longevityworldcup.com/" target="_blank" rel="noopener" class="footer-link" aria-label="Shop Longevity World Cup merchandise">
+                <i class="fas fa-store" aria-hidden="true"></i> Merch
             </a>
             <a href="https://www.youtube.com/playlist?list=PL4nqc85w185sO4i7eR3oUO_lMmlJ2K1cL" target="_blank" rel="noopener" class="footer-link" aria-label="Listen to Immortal Combat podcast on YouTube">
-                <i class="fas fa-podcast"></i> Podcast
+                <i class="fas fa-podcast" aria-hidden="true"></i> Podcast
             </a>
-        </div>
-        <div class="footer-column">
             <a href="https://x.com/LongevityWorldC" target="_blank" rel="noopener" class="footer-link" aria-label="Follow Longevity World Cup on X">
-                <i class="fab fa-twitter"></i> X
+                <i class="fab fa-twitter" aria-hidden="true"></i> X
             </a>
             <a href="https://www.reddit.com/r/LongevityWorldCup/" target="_blank" rel="noopener" class="footer-link" aria-label="Join the Longevity World Cup subreddit">
-                <i class="fab fa-reddit"></i> Reddit
+                <i class="fab fa-reddit" aria-hidden="true"></i> Reddit
             </a>
             <a href="https://www.tiktok.com/@nopara73" target="_blank" rel="noopener" class="footer-link" aria-label="Follow the Longevity World Cup on TikTok">
-                <i class="fab fa-tiktok"></i> TikTok
+                <i class="fab fa-tiktok" aria-hidden="true"></i> TikTok
             </a>
             <a href="https://www.threads.com/@longevityworldcup" target="_blank" rel="noopener" class="footer-link" aria-label="Follow Longevity World Cup on Threads">
-                <i class="fa-brands fa-threads"></i> Threads
+                <i class="fa-brands fa-threads" aria-hidden="true"></i> Threads
             </a>
             <a href="https://www.youtube.com/@longevityworldcup" target="_blank" rel="noopener" class="footer-link" aria-label="Visit Longevity World Cup on YouTube">
-                <i class="fab fa-youtube"></i> YouTube
+                <i class="fab fa-youtube" aria-hidden="true"></i> YouTube
             </a>
             <a href="https://www.instagram.com/LongevityWorldCup/" target="_blank" rel="noopener" class="footer-link" aria-label="Follow the Longevity World Cup on Instagram">
-                <i class="fab fa-instagram"></i> Instagram
+                <i class="fab fa-instagram" aria-hidden="true"></i> Instagram
             </a>
-        </div>
-    </div>
+        </section>
+    </nav>
 </footer>

--- a/LongevityWorldCup.Website/wwwroot/partials/header.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/header.html
@@ -13,6 +13,8 @@
         --gma-gold-light: #ffd700;
         --gma-gold-dark: #d4af37;
         --gma-gold-shine: #f8e473;
+        --lwc-scoreboard-chrome: #07100c;
+        --lwc-live-green: #43ee83;
     }
 
     /* Roboto Font Faces */


### PR DESCRIPTION
> [!IMPORTANT]
> **Deep reimplementation in progress. This draft is not ready for review or merge.**
>
> The earlier homepage-only pass and its validation claims are obsolete. This PR is being expanded into a product-by-product reimplementation of the salvageable intent from #679 and #686 on current `master`. Final test counts and screenshots will be added only after the branch is frozen and the exact final build passes every gate below.

## Reimplementation contract

- No merge, cherry-pick, generated JavaScript, committed screenshot, audit diary, or stale PR branch code.
- Keep current `master` as the behavioral baseline and preserve canonical routes, payloads, rankings, competition rules, storage safety, asset versioning, and responsive flow behavior.
- Bring over product ideas only when they are truthful, harmonious with `DESIGN.md`, and demonstrably safer than the reference implementation.
- One authoritative implementation for every score/rank/state; no hardcoded competition facts or duplicate client ranking algorithms.
- Honest loading, empty, partial, unavailable, error, retry, and stale-request states.
- Keyboard, focus restoration, reduced motion, 44px direct targets, 200% zoom, long names/content, storage denial, malformed API data, and narrow/short viewports are release requirements.

## Product-by-product plan

- [x] Establish the current-master baseline and inspect both reference PRs as product proposals rather than patch sources.
- [x] Build an acceptance ledger covering worthy intent, explicit rejection, domain risk, implementation owner, and required evidence.
- [ ] Finish the shared semantic design layer: disciplined green/amber/red roles, dark sport chrome framing warm readable surfaces, stable type/spacing, focus, targets, and reduced motion.
- [ ] Homepage: authoritative server-rendered field summary, honest unavailable state, one primary hierarchy, and clean handoff to the real standings.
- [ ] Ultimate League: dense readable controls/table, Pro-before-Amateur preservation, honest sparse/error states, stable mobile overflow, and safe best-rank cues.
- [ ] Athlete dossier and evidence viewer: loading/error/retry, partial clocks, proof fallback/full-resolution failure, history/Escape/backdrop ownership, inert background, and focus restoration.
- [ ] Events and badges: UTC grouping, truthful pulse counts, accessible disclosures/deep links, compact non-reflowing badges, and embedded Event-board compatibility.
- [ ] Play hub and returning-athlete tools: stable primary action, bounded athlete lookup, safe autocomplete, storage-denied recovery, URL/history synchronization, and responsive dashboard.
- [ ] Pheno/Bortz calculators and progress: semantic journey steps, strict calendar/chronology checks, keyboard-visible focus, cancellation of stale transitions/results/rank loads, bfcache preservation, and clock-specific rank previews.
- [ ] Application, proof, edit, and review: one immutable seven-stage model, task-first layouts, bounded/validated file processing, truthful HEIC/PDF behavior, cropper focus trap/recovery, single-flight submission, and failure-safe controls.
- [ ] Guess My Age: explicit idle/submitting/success/error/closed states, whole-operation timeout, stale-athlete cancellation, strict accepted-response schema, no failure-side reveal/persistence/discount, and modal label/focus restoration.
- [ ] Longevitymaxxing Challenge: current 14-day scoring truth, practice vs scored zero, active/resting states, indefinite participation copy, commitment privacy, retry focus, and no fabricated metrics.
- [ ] Generated About/History/Ruleset: canonical language, source-owned generation, reproducibility, malformed hash safety, readable navigation, and no rule changes hidden in copy.
- [ ] Media, recovery, legal, and subscription surfaces: same-origin whitelisted archive, historical-material honesty, true 404 status preservation, calm 5xx pages, privacy-text preservation, and bounded unsubscribe retry.
- [ ] Cross-site hardening: no unsafe dynamic HTML, unguarded storage/JSON, accidental controller route ownership, raw unversioned injected assets, new runtime origin, nested interactive control, or generated artifact.
- [ ] Freeze the source and run the exact-build gate: TypeScript check/build, serialized .NET build, all focused suites, then the complete test suite with no redesign skips.
- [ ] Run the exact-build browser matrix at 1440×900, 1366×768, 768×1024, 390×844, 375×667, 320×700, short landscape, reduced motion, keyboard-only, long content, and effective 200% zoom; require no console/page errors, failed first-party resources, target violations, or horizontal overflow.
- [ ] Capture the final states under ignored `.artifacts/`, upload them as GitHub-hosted PR assets, add grouped screenshot evidence here, audit the staged diff, push, wait for every GitHub check, fix failures, and only then mark ready.

## Concrete defects already found during the expanded pass

- Unreachable or route-stealing media actions and a friendly 404 path that accidentally became a redirect/200 after status-page re-execution.
- Application/profile controls that advertised HEIC support without converting before Cropper, plus unbounded raw file and PDF dependency/render waits.
- Proof uploads that could exceed the server data-URL contract, accept unconverted HEIC, lock controls during failure, or lose keyboard focus after removal/retry.
- Calculator races where an old animation/rank result could overwrite a newer calculation, invalid calendar dates could pass, and back-forward restoration erased unsaved edits.
- Guess My Age requests that could remain submitting forever and a legacy marker path that could grant a perfect-guess discount without an accepted exact response.
- Event, leaderboard, Challenge, application, edit-profile, and returning-athlete directory requests with ineffective or missing timeout paths.
- Challenge presentation that mixed historical check-ins with the current scoring window and could show a standing for resting/unscored participants.
- Proof/dossier viewer history, inertness, fallback failure, drawer gestures, clear-filter semantics, and several hidden or undersized focus/target problems.
- Generated competition copy that inverted the signed biological-age convention and media copy that presented a stale 2025 archive as current.

This list is evidence of why the branch remains a draft, not a claim that the work is complete.

## Final evidence (pending exact-build gate)

Final commands, test counts, browser measurements, hosted screenshots, CI links, and the staged-file audit will replace this section after all work above is accepted. Screenshots will not be committed to the repository.

Reference-only prior experiments: #679, #686.

Closes #538

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches homepage HTML injection and public competition numbers from the leaderboard snapshot; failures are mitigated by unavailable fallback and broad tests, but any snapshot or rendering bug would be highly visible on `/`.
> 
> **Overview**
> **Homepage hero** replaces the old tagline and hidden `h1` with a server-injected **live scoreboard** (`<!--HOMEPAGE-SCOREBOARD-->`) that reads the same **leaderboard snapshot** as the official standings. It surfaces the Ultimate League #1 athlete, effective age reduction copy, Pro/Amateur field counts, primary CTAs to `#live-standings` and ranking rules, and an honest **unavailable** state when the snapshot is empty or rendering fails—no fabricated zeros or pseudo-podium markup.
> 
> **Visual system** adds dark sport chrome on the homepage header/scoreboard, shared `--lwc-scoreboard-chrome` / `--lwc-live-green` tokens, responsive scoreboard layout, and 44px action targets. **`DESIGN.md`** records the related product rules (authoritative scores, typography, color roles, footer grouping).
> 
> **Footer** is reorganized into labeled **Competition** and **Community** columns with a fixed link order (including About and Media), dark styling, accessible focus, and stable touch targets without hover `transform` shifts. Hungarian chrome localization picks up the new labels.
> 
> **Tests** lock in renderer behavior (ordering, encoding, unavailable metrics), homepage-only injection and semantics, canonical routes not leaking composition placeholders, footer structure/CSS expectations, and Playwright checks for first-viewport fit, overflow, and tap height.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8369790b3fba79ab30f15570799b76adda3cdda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->