### PR TITLE
Validate deployment SDK resolution

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -169,14 +169,20 @@ jobs:
             git clean -fd
             test "$(git rev-parse HEAD)" = "$verified_sha"
 
-            dotnet_version="$(dotnet --version)"
+            git ls-files -z | rsync -a --from0 --files-from=- ./ "$deploy_source"/
+            if ! dotnet_version="$(cd "$deploy_source" && dotnet --version 2>&1)"; then
+              echo "The production host cannot resolve the SDK required by global.json:" >&2
+              echo "$dotnet_version" >&2
+              echo "Installed SDKs:" >&2
+              (cd /tmp && dotnet --list-sdks) >&2
+              exit 1
+            fi
             dotnet_major="${dotnet_version%%.*}"
             if [ "$dotnet_major" != "10" ]; then
               echo "Expected .NET SDK 10.x on production server, found $dotnet_version."
               exit 1
             fi
 
-            git ls-files -z | rsync -a --from0 --files-from=- ./ "$deploy_source"/
             tar -xzf "$frontend_stage/frontend-assets.tar.gz" \
               --no-same-owner \
               --no-same-permissions \

--- a/LongevityWorldCup.Documentation/ServerDeployment.md
+++ b/LongevityWorldCup.Documentation/ServerDeployment.md
@@ -115,14 +115,20 @@ git reset --hard "$verified_sha"
 git clean -fd
 test "$(git rev-parse HEAD)" = "$verified_sha"
 
-dotnet_version="$(dotnet --version)"
+git ls-files -z | rsync -a --from0 --files-from=- ./ "$deploy_source"/
+if ! dotnet_version="$(cd "$deploy_source" && dotnet --version 2>&1)"; then
+  echo "The production host cannot resolve the SDK required by global.json:" >&2
+  echo "$dotnet_version" >&2
+  echo "Installed SDKs:" >&2
+  (cd /tmp && dotnet --list-sdks) >&2
+  exit 1
+fi
 dotnet_major="${dotnet_version%%.*}"
 if [ "$dotnet_major" != "10" ]; then
   echo "Expected .NET SDK 10.x on production server, found $dotnet_version."
   exit 1
 fi
 
-git ls-files -z | rsync -a --from0 --files-from=- ./ "$deploy_source"/
 tar -xzf "$frontend_stage/frontend-assets.tar.gz" \
   --no-same-owner \
   --no-same-permissions \
@@ -212,6 +218,8 @@ deploy_succeeded=1
 Publish from the temporary source, not from `~/LongevityWorldCup`. The website build regenerates documentation HTML during publish, and publishing from the checkout can dirty tracked files and break the next pull or deploy.
 
 The production host intentionally does not need Node.js. Generated `wwwroot/js` files are ignored rather than committed. The automatic deploy runner builds and verifies them, packages an exact-commit artifact, checks its checksum after transfer, and injects it into the temporary source before publishing with `BuildFrontend=false`.
+
+The production host must have an SDK compatible with the repository's `global.json`. When that pin advances, install the matching SDK before deployment. The deploy preflight resolves the SDK from the isolated source tree and prints both the resolution error and installed SDK list when the host is behind.
 
 Before changing the live publish tree, deployment stops the service and creates a same-filesystem hard-link snapshot. A failed sync, health check, or byte-for-byte script probe restores that prior release before restarting the service. Every master push schedules the workflow; stale runs skip only when a newer run exists, so an otherwise ignored documentation or test commit cannot strand an earlier website change undeployed.
 


### PR DESCRIPTION
## What changed

- resolve the production SDK from the isolated deployment source tree that contains `global.json`
- handle SDK resolution failures explicitly and print the installed SDK list
- document the production SDK compatibility requirement

## Why

The Dependabot SDK pin update to 10.0.302 exposed a deployment invariant: the production host still had 10.0.301. The previous `dotnet --version` command ran under `set -e` inside the checkout, so it exited before the workflow's major-version guard could explain the mismatch.

The production host has now been updated to SDK 10.0.302; this change makes future mismatches diagnosable without altering deployment behavior when resolution succeeds.

## Verification

- `git diff --check`
- workflow YAML parsed successfully
- the new preflight was exercised against an isolated tracked-source copy on the production host and resolved SDK 10.0.302
- the rerun of the previously failing production deployment is being monitored separately

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deploy-script and documentation-only changes; behavior is unchanged when the host already has a matching SDK, with clearer failure modes when it does not.
> 
> **Overview**
> Production deploy preflight **moves tracked-file rsync into the isolated `deploy_source` tree before** `dotnet publish`, and runs **`dotnet --version` from that directory** so SDK resolution follows the repo’s `global.json` instead of the bare checkout.
> 
> When resolution fails under `set -e`, the script **no longer exits silently**: it prints the resolution error, lists installed SDKs via `dotnet --list-sdks`, and exits with a clear message. The existing **10.x major-version guard** is unchanged when resolution succeeds.
> 
> **ServerDeployment.md** documents that the production host must carry an SDK compatible with `global.json` and describes this preflight behavior for manual deploys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be988858338feacde77fce98378e962f91cdae40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->