### PR TITLE
Fix search deep-link chrome

### DIFF
--- a/LongevityWorldCup.Tests/AestheticSystemPageTests.cs
+++ b/LongevityWorldCup.Tests/AestheticSystemPageTests.cs
@@ -9,6 +9,7 @@ public sealed class AestheticSystemPageTests
     [InlineData("/league/pheno", false)]
     [InlineData("/flag/hu", false)]
     [InlineData("/athlete/nonexistent-athlete", false)]
+    [InlineData("/?search=pascoe", false)]
     [InlineData("/?view=pheno", false)]
     public async Task HomepageHeroClass_IsLimitedToTheActualHomepage(string path, bool expectsHomepageHero)
     {
@@ -26,6 +27,18 @@ public sealed class AestheticSystemPageTests
         {
             Assert.DoesNotContain("class=\"home-page\"", html, StringComparison.Ordinal);
         }
+    }
+
+    [Fact]
+    public async Task SearchDeepLink_UsesLeaderboardChrome()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var html = await client.GetStringAsync("/?search=pascoe");
+
+        Assert.DoesNotContain("class=\"home-page\"", html, StringComparison.Ordinal);
+        Assert.Contains("<span class=\"tagline\">", html, StringComparison.Ordinal);
     }
 
     [Theory]

--- a/LongevityWorldCup.Tests/HomepageVisitLayoutTests.cs
+++ b/LongevityWorldCup.Tests/HomepageVisitLayoutTests.cs
@@ -16,7 +16,7 @@ public sealed class HomepageVisitLayoutTests
 
         Assert.Contains("function isHomepageVisitCounterRoute()", indexHtml);
         Assert.Contains("path === '/' || path === '/index.html'", indexHtml);
-        Assert.Contains("!params.has('athlete')", indexHtml);
+        Assert.Contains("['athlete', 'filters', 'search', 'view'].some(param => params.has(param))", indexHtml);
 
         var layoutStart = indexHtml.IndexOf("function placeHomepageHighlightsForVisit()", StringComparison.Ordinal);
         Assert.True(layoutStart >= 0, "Could not find placeHomepageHighlightsForVisit.");

--- a/LongevityWorldCup.Website/Middleware/HtmlInjectionMiddleware.cs
+++ b/LongevityWorldCup.Website/Middleware/HtmlInjectionMiddleware.cs
@@ -285,6 +285,7 @@ namespace LongevityWorldCup.Website.Middleware
             => string.Equals(GetRequestCanonicalPath(context), "/", StringComparison.Ordinal)
                && !context.Request.Query.ContainsKey("athlete")
                && !context.Request.Query.ContainsKey("filters")
+               && !context.Request.Query.ContainsKey("search")
                && !context.Request.Query.ContainsKey("view");
 
         private static bool ShouldUseHungarianChrome(HttpContext context)

--- a/LongevityWorldCup.Website/wwwroot/index.html
+++ b/LongevityWorldCup.Website/wwwroot/index.html
@@ -2057,7 +2057,7 @@
 
             try {
                 const params = new URLSearchParams(window.location.search || '');
-                return !params.has('athlete');
+                return !['athlete', 'filters', 'search', 'view'].some(param => params.has(param));
             } catch (_) {
                 return true;
             }


### PR DESCRIPTION
## What changed

- treat `search` as active leaderboard state when selecting server-rendered homepage chrome
- keep `athlete`, `filters`, `search`, and `view` deep links out of the homepage-only fourth-visit highlights behavior
- add focused coverage for the rendered body class, preserved header tagline, and visit-route guard

## Why

Follow-up to the valid review finding on #795: `/?search=pascoe` was initialized as a filtered leaderboard client-side but still received homepage-only server chrome. Because #795 had already merged before the review arrived, this PR applies the correction on top of current `master`.

Review: https://github.com/nopara73/LongevityWorldCup/pull/795#discussion_r3622977682

## Validation

- `dotnet test LongevityWorldCup.Tests/LongevityWorldCup.Tests.csproj --filter "FullyQualifiedName~AestheticSystemPageTests|FullyQualifiedName~HomepageVisitLayoutTests" --no-restore --verbosity minimal`
- 35 passed, 0 failed, 0 skipped
- build completed with 0 warnings and 0 errors; frontend TypeScript build and output verification passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow presentation and client-route guard changes with no auth or data impact; behavior aligns server HTML with existing client-side leaderboard state.
> 
> **Overview**
> **Search deep links** such as `/?search=pascoe` now get **leaderboard** server and client treatment instead of the bare homepage shell.
> 
> Server-side `IsHomepageRequest` treats a `search` query param like `athlete`, `filters`, and `view`, so those URLs no longer receive `home-page` body class or homepage header stripping (tagline stays). Client-side `isHomepageVisitCounterRoute()` uses the same query-param list so fourth-visit homepage highlights and visit counting do not run on those deep links.
> 
> Tests cover rendered body class, preserved tagline, and the visit-route guard string in `index.html`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9aab3a8c9d35a1ba8b5b528b82766d3f0298529. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->