### PR TITLE
Document public API access

### DIFF
--- a/LongevityWorldCup.Tests/SwaggerOpenApiTests.cs
+++ b/LongevityWorldCup.Tests/SwaggerOpenApiTests.cs
@@ -201,7 +201,12 @@ public sealed class SwaggerOpenApiTests
             .GetProperty("servers")[0]
             .GetProperty("url")
             .GetString());
-        Assert.Contains("no-auth", root.GetProperty("info").GetProperty("description").GetString());
+        var description = root.GetProperty("info").GetProperty("description").GetString();
+        Assert.Contains("no-auth", description);
+        Assert.Contains("Access for every documented endpoint", description);
+        Assert.Contains("Auth: No", description);
+        Assert.Contains("HTTPS: Yes", description);
+        Assert.Contains("CORS: Yes", description);
         Assert.Equal("https://longevityworldcup.com/", root
             .GetProperty("info")
             .GetProperty("contact")

--- a/LongevityWorldCup.Website/Program.cs
+++ b/LongevityWorldCup.Website/Program.cs
@@ -56,7 +56,13 @@ namespace LongevityWorldCup.Website
                     Description = """
                         Public no-auth JSON endpoints for Longevity World Cup athlete, field, biological aging clock calculation, and rank-preview data.
 
-                        The documented endpoints are public data and biological aging clock calculation surfaces used by the website and external clients. They do not require API keys, OAuth, cookies, or other authentication.
+                        The documented endpoints are public data and biological aging clock calculation surfaces used by the website and external clients.
+
+                        Access for every documented endpoint:
+
+                        - **Auth: No.** No API key, OAuth, cookie, or other authentication is required.
+                        - **HTTPS: Yes.** Use the production HTTPS server listed below.
+                        - **CORS: Yes.** The production endpoints accept cross-origin browser requests from any origin without credentials.
                         """,
                     Contact = new OpenApiContact
                     {


### PR DESCRIPTION
## Summary

- state `Auth: No`, `HTTPS: Yes`, and `CORS: Yes` prominently in the Swagger description
- verify those access labels in the OpenAPI integration tests
- leave API behavior, middleware, endpoints, and proxy configuration unchanged

## Why

The review on [marcelscruz/public-apis#915](https://github.com/marcelscruz/public-apis/pull/915) found that the submitted documentation link did not make authentication, HTTPS, and CORS behavior directly verifiable. The live API already provides Swagger/OpenAPI documentation and cross-origin access; this change makes those characteristics explicit before resubmission.

## Verification

- `dotnet test LongevityWorldCup.Tests\LongevityWorldCup.Tests.csproj --no-restore --filter "FullyQualifiedName~SwaggerOpenApiTests" --logger "console;verbosity=minimal"`
- 11 passed, 0 failed
- build completed with 0 warnings and 0 errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test-only changes; no runtime API or security middleware modifications.
> 
> **Overview**
> Expands the Swagger **v1** `info.description` so third-party listings can verify access without reading runtime code. It adds an **Access for every documented endpoint** section with explicit **Auth: No**, **HTTPS: Yes**, and **CORS: Yes** bullets (replacing a single long paragraph about no authentication).
> 
> `SwaggerJson_DocumentsProductionServerAndPublicInfo` now asserts those strings appear in the OpenAPI description, alongside the existing production server and `no-auth` checks. **No API, middleware, or endpoint behavior changes**—documentation and tests only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b1f09bc3301a3ba43e8b74e1cccfb1384383541. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->