### PR TITLE
Scope permissive CORS to the public API

### DIFF
--- a/LongevityWorldCup.Tests/PublicApiCorsTests.cs
+++ b/LongevityWorldCup.Tests/PublicApiCorsTests.cs
@@ -1,0 +1,83 @@
+using System.Net;
+using System.Net.Http.Json;
+using LongevityWorldCup.Website;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class PublicApiCorsTests
+{
+    private const string ArbitraryOrigin = "https://public-api-client.example";
+    private const string TrustedSiteOrigin = "https://www.longevityworldcup.com";
+
+    [Fact]
+    public async Task PublicDataGet_AllowsAnyOrigin()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/api/data/flags");
+        request.Headers.Add("Origin", ArbitraryOrigin);
+
+        using var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("*", Assert.Single(response.Headers.GetValues("Access-Control-Allow-Origin")));
+    }
+
+    [Fact]
+    public async Task PublicDataPostPreflight_AllowsAnyOrigin()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+        using var request = new HttpRequestMessage(HttpMethod.Options, "/api/data/pheno-age");
+        request.Headers.Add("Origin", ArbitraryOrigin);
+        request.Headers.Add("Access-Control-Request-Method", "POST");
+        request.Headers.Add("Access-Control-Request-Headers", "content-type");
+
+        using var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        Assert.Equal("*", Assert.Single(response.Headers.GetValues("Access-Control-Allow-Origin")));
+        Assert.Contains("POST", response.Headers.GetValues("Access-Control-Allow-Methods"));
+        Assert.Contains("content-type", response.Headers.GetValues("Access-Control-Allow-Headers"));
+    }
+
+    [Fact]
+    public async Task PublicDataValidationError_AllowsAnyOrigin()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/api/data/pheno-age")
+        {
+            Content = JsonContent.Create(new { })
+        };
+        request.Headers.Add("Origin", ArbitraryOrigin);
+
+        using var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("*", Assert.Single(response.Headers.GetValues("Access-Control-Allow-Origin")));
+    }
+
+    [Fact]
+    public async Task NonPublicEndpoints_PreserveRestrictedOriginPolicy()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+        using var arbitraryRequest = new HttpRequestMessage(HttpMethod.Get, "/health");
+        arbitraryRequest.Headers.Add("Origin", ArbitraryOrigin);
+        using var trustedRequest = new HttpRequestMessage(HttpMethod.Get, "/health");
+        trustedRequest.Headers.Add("Origin", TrustedSiteOrigin);
+
+        using var arbitraryResponse = await client.SendAsync(arbitraryRequest);
+        using var trustedResponse = await client.SendAsync(trustedRequest);
+
+        Assert.Equal(HttpStatusCode.OK, arbitraryResponse.StatusCode);
+        Assert.False(arbitraryResponse.Headers.Contains("Access-Control-Allow-Origin"));
+        Assert.Equal(HttpStatusCode.OK, trustedResponse.StatusCode);
+        Assert.Equal(
+            TrustedSiteOrigin,
+            Assert.Single(trustedResponse.Headers.GetValues("Access-Control-Allow-Origin")));
+    }
+}

--- a/LongevityWorldCup.Website/Program.cs
+++ b/LongevityWorldCup.Website/Program.cs
@@ -26,6 +26,9 @@ namespace LongevityWorldCup.Website
         private static readonly TimeSpan PublicAnalyticsPostRateLimitWindow = TimeSpan.FromMinutes(1);
         private const int PublicPostRateLimitPermitLimit = 120;
         private const int PublicAnalyticsPostRateLimitPermitLimit = 240;
+        private const string PublicApiCorsPolicy = "AllowPublicApi";
+        private const string SiteCorsPolicy = "AllowSpecificOrigin";
+        private const string PublicApiPathPrefix = "/api/data";
 
         public static void Main(string[] args)
         {
@@ -334,13 +337,20 @@ namespace LongevityWorldCup.Website
                 builder.Services.AddQuartzHostedService(o => o.WaitForJobsToComplete = true);
             }
 
-            // Add CORS policy
+            // Add CORS policies
             builder.Services.AddCors(options =>
             {
-                options.AddPolicy("AllowSpecificOrigin",
-                    builder =>
+                options.AddPolicy(PublicApiCorsPolicy,
+                    policy =>
                     {
-                        builder.WithOrigins(
+                        policy.AllowAnyOrigin()
+                              .AllowAnyHeader()
+                              .AllowAnyMethod();
+                    });
+                options.AddPolicy(SiteCorsPolicy,
+                    policy =>
+                    {
+                        policy.WithOrigins(
                             "https://www.longevityworldcup.com",
                             "http://lwc7tszawiykmkjoq4u2yxramezkwbdys2wxr2fmf6sdr6ug5t36ckqd.onion",
                             "https://lwc7tszawiykmkjoq4u2yxramezkwbdys2wxr2fmf6sdr6ug5t36ckqd.onion")
@@ -421,12 +431,17 @@ namespace LongevityWorldCup.Website
                 options.ConfigObject.ValidatorUrl = null;
             });
 
-            // Use CORS
-            app.UseCors("AllowSpecificOrigin");
+            app.UseRouting();
+
+            // The documented public API is intentionally callable from any browser origin.
+            app.UseWhen(
+                context => context.Request.Path.StartsWithSegments(PublicApiPathPrefix),
+                publicApi => publicApi.UseCors(PublicApiCorsPolicy));
+            app.UseWhen(
+                context => !context.Request.Path.StartsWithSegments(PublicApiPathPrefix),
+                site => site.UseCors(SiteCorsPolicy));
 
             app.UseStatusCodePagesWithReExecute("/error/{0}");
-
-            app.UseRouting();
 
             app.UseRateLimiter();
 


### PR DESCRIPTION
## Summary

- allow any browser origin for the documented `/api/data` surface
- preserve the existing trusted-origin policy for every non-public-API route
- move CORS after routing so endpoint selection is available before the policy runs
- add integration coverage for public GETs, POST preflight, validation errors, and restricted non-public routes

## Why

PR #803 documented the public API as supporting CORS. Production already emitted wildcard CORS headers through the reverse proxy, but the ASP.NET Core application itself allowed only the website and onion origins. That made the documented behavior depend on deployment infrastructure and contradicted local or alternate deployments.

This addresses the unresolved review feedback on #803 by enforcing the public API contract in the application while avoiding a site-wide permissive policy.

## Validation

`dotnet test LongevityWorldCup.Tests/LongevityWorldCup.Tests.csproj --no-restore -m:1 --filter "FullyQualifiedName~PublicApiCorsTests|FullyQualifiedName~SwaggerOpenApiTests" --logger "console;verbosity=minimal"`

Result: 15 passed, 0 failed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CORS is security-sensitive and changes which browser origins can call public vs site routes; scope is limited to `/api/data` with tests, but mis-path matching could widen exposure.
> 
> **Overview**
> **CORS is split by route** so the documented public API matches in-app behavior instead of relying on reverse-proxy headers.
> 
> Requests under **`/api/data`** use a new **`AllowAnyOrigin`** policy (GET, POST, OPTIONS preflight, and validation error responses). All other routes keep the existing **trusted-origin** list (site + onion URLs); arbitrary origins get no `Access-Control-Allow-Origin` on routes like **`/health`**.
> 
> **Pipeline order** changes: **`UseRouting`** runs before CORS, and **`UseWhen`** selects the policy from the request path.
> 
> **`PublicApiCorsTests`** adds integration coverage for public GET, POST preflight, bad-request CORS headers, and non-public restricted behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06e7bb4534a55874b9a3131721319a690ac49bd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->