### PR TITLE
Verify production CORS ownership

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -250,6 +250,50 @@ jobs:
             fi
             rm -f "$health_body"
 
+            cors_headers="$frontend_stage/cors-headers.txt"
+            normalized_cors_headers="$frontend_stage/cors-headers.normalized.txt"
+            assert_single_public_cors_origin() {
+              origin_count="$(grep -Eic '^access-control-allow-origin:[[:space:]]*\*[[:space:]]*$' "$normalized_cors_headers" || true)"
+              if [ "$origin_count" -ne 1 ]; then
+                echo "Expected exactly one wildcard Access-Control-Allow-Origin header, found $origin_count." >&2
+                cat "$normalized_cors_headers" >&2
+                exit 1
+              fi
+            }
+
+            curl -fsS --max-time 10 \
+              -H "Origin: https://public-api-client.example" \
+              -D "$cors_headers" \
+              -o /dev/null \
+              "https://www.longevityworldcup.com/api/data/flags"
+            tr -d '\r' < "$cors_headers" > "$normalized_cors_headers"
+            assert_single_public_cors_origin
+
+            curl -fsS --max-time 10 \
+              -X OPTIONS \
+              -H "Origin: https://public-api-client.example" \
+              -H "Access-Control-Request-Method: POST" \
+              -H "Access-Control-Request-Headers: content-type" \
+              -D "$cors_headers" \
+              -o /dev/null \
+              "https://www.longevityworldcup.com/api/data/pheno-age"
+            tr -d '\r' < "$cors_headers" > "$normalized_cors_headers"
+            assert_single_public_cors_origin
+            grep -Eiq '^access-control-allow-methods:.*POST' "$normalized_cors_headers"
+            grep -Eiq '^access-control-allow-headers:.*content-type' "$normalized_cors_headers"
+
+            curl -fsS --max-time 10 \
+              -H "Origin: https://public-api-client.example" \
+              -D "$cors_headers" \
+              -o /dev/null \
+              "$health_url"
+            tr -d '\r' < "$cors_headers" > "$normalized_cors_headers"
+            if grep -Eiq '^access-control-allow-origin:' "$normalized_cors_headers"; then
+              echo "A non-public endpoint unexpectedly allowed an arbitrary CORS origin." >&2
+              cat "$normalized_cors_headers" >&2
+              exit 1
+            fi
+
             downloaded_script="$frontend_stage/deployed-script.js"
             for script_path in "$publish_output"/wwwroot/js/*.js; do
               curl -fsS --max-time 10 \

--- a/LongevityWorldCup.Documentation/ServerDeployment.md
+++ b/LongevityWorldCup.Documentation/ServerDeployment.md
@@ -223,6 +223,12 @@ The production host must have an SDK compatible with the repository's `global.js
 
 Before changing the live publish tree, deployment stops the service and creates a same-filesystem hard-link snapshot. A failed sync, health check, or byte-for-byte script probe restores that prior release before restarting the service. Every master push schedules the workflow; stale runs skip only when a newer run exists, so an otherwise ignored documentation or test commit cannot strand an earlier website change undeployed.
 
+### Reverse proxy CORS ownership
+
+ASP.NET Core owns the route-specific CORS policies. The nginx reverse-proxy location must pass those response headers through unchanged: do not add `Access-Control-Allow-*` or `Access-Control-Expose-Headers` directives at the proxy layer, and do not intercept `OPTIONS` requests. Adding CORS headers in both layers produces duplicate values that browsers reject; applying wildcard headers in nginx also bypasses the application's restricted policy for non-public routes.
+
+The automatic deployment probes production after each release. It requires exactly one wildcard `Access-Control-Allow-Origin` header on public API GET and preflight responses, validates the requested preflight method and header, and rejects an arbitrary-origin CORS header on `/health`.
+
 Configure the repository's `SSH_FINGERPRINT` Actions secret with the production host-key fingerprint to enforce host verification for both artifact transfer and remote deployment. The workflow remains compatible with the existing secret set when it is absent, but then host identity is not pinned.
 
 The temporary source is copied with `rsync -a` from tracked Git files instead of `git archive` so unchanged athlete media keeps its original modification time. Startup uses those timestamps to decide whether profile thumbnails are stale; resetting every athlete image timestamp can force hundreds of thumbnail regenerations before Kestrel starts listening.


### PR DESCRIPTION
## Summary

- probe production CORS behavior after every deployment
- require exactly one wildcard origin header on public API GET and preflight responses
- reject wildcard CORS leakage onto a non-public health route
- document that ASP.NET Core—not nginx—owns route-specific CORS

## Why

After #804 moved the documented public API policy into ASP.NET Core, the production nginx configuration was still adding legacy wildcard CORS headers. That yielded duplicate `Access-Control-Allow-Origin` values on `/api/data` and bypassed the restricted policy elsewhere. The live nginx directives have been removed and validated; these checks prevent that infrastructure drift from silently returning.

This completes the unresolved review follow-up from #803 and makes the application/proxy ownership boundary explicit.

## Validation

- GitHub Actions YAML parsed successfully
- production public GET: HTTP 200, exactly one `Access-Control-Allow-Origin: *`
- production public preflight: HTTP 204, exactly one wildcard origin plus requested method/header
- production `/health` with arbitrary origin: HTTP 200, no CORS origin header
- production `/health` with trusted origin: HTTP 200, one matching origin header

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to deploy verification shell and deployment documentation; no application runtime or nginx config is modified in-repo.
> 
> **Overview**
> Adds **post-deploy production CORS checks** to the auto-deploy SSH script so nginx cannot silently reintroduce duplicate or overly permissive headers after ASP.NET Core took ownership of route-specific policies.
> 
> After the existing health probe, the workflow curls public API routes (`/api/data/flags` GET and `/api/data/pheno-age` OPTIONS) with an arbitrary `Origin` and **fails the deploy** unless there is exactly one `Access-Control-Allow-Origin: *` and the preflight response includes the requested POST method and `content-type` header. It also curls `/health` with the same origin and **fails if any** `Access-Control-Allow-Origin` is present, guarding against wildcard CORS leaking onto non-public routes.
> 
> **ServerDeployment.md** gains a *Reverse proxy CORS ownership* section: nginx must pass app CORS headers through (no proxy-added `Access-Control-*`, no OPTIONS interception) and documents that these automated probes enforce the expected live behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb765016de8c99b1520f16486e76dc234d9aee6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->