### PR TITLE
Open every public athlete link in the shared profile dialog

### DIFF
--- a/LongevityWorldCup.Tests/AthleteDialogLinkBrowserTests.cs
+++ b/LongevityWorldCup.Tests/AthleteDialogLinkBrowserTests.cs
@@ -1,0 +1,659 @@
+using Microsoft.Playwright;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class AthleteDialogLinkBrowserTests
+{
+    private const string MichaelSlug = "michael-lustgarten";
+
+    [Theory]
+    [InlineData("/about")]
+    [InlineData("/history")]
+    [InlineData("/events")]
+    [InlineData("/longevitymaxxing")]
+    [InlineData("/helstab-kihivas")]
+    [InlineData("/pheno-age")]
+    [InlineData("/bortz-age")]
+    public async Task PublicAthleteLinkSurfaces_InstallOneScopedDialogRuntime(string path)
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var html = await client.GetStringAsync(path);
+
+        Assert.Equal(1, CountOccurrences(html, "id=\"athleteDialogRuntime\""));
+        Assert.Equal(1, CountOccurrences(html, "id=\"detailsModal\""));
+        Assert.Equal(1, CountOccurrences(html, "window.openAthleteModalBySlug = function"));
+        Assert.Contains("data-athlete-dialog-only=\"true\"", html);
+        Assert.Contains("@scope (#athleteDialogRuntime)", html);
+        Assert.Contains("--athlete-dialog-layer:10020", html);
+        Assert.DoesNotContain("<!--ATHLETE-DIALOG-", html);
+    }
+
+    [Fact]
+    public async Task AboutAthleteLink_QueuesUntilHydratedAndCloseRestoresTheCallingPage()
+    {
+        await using var app = await BrowserTestApp.StartAsync();
+        using var playwright = await Playwright.CreateAsync();
+        await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+        {
+            Headless = true
+        });
+        await using var context = await NewContextAsync(browser, app, width: 1024, height: 720);
+        await context.AddInitScriptAsync(
+            """
+            Object.defineProperty(window, '__athleteDialogNativeScrollApis', {
+                configurable: true,
+                value: {
+                    scrollTo: window.scrollTo,
+                    scrollBy: window.scrollBy,
+                    scrollIntoView: Element.prototype.scrollIntoView
+                }
+            });
+            """);
+
+        var miscModuleRequestReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseMiscModuleResponse = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await context.RouteAsync("**/js/misc.js*", async route =>
+        {
+            miscModuleRequestReceived.TrySetResult();
+            await releaseMiscModuleResponse.Task;
+            await route.ContinueAsync();
+        });
+        var athleteRequestReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseAthleteResponse = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await context.RouteAsync("**/api/data/athletes", async route =>
+        {
+            athleteRequestReceived.TrySetResult();
+            await releaseAthleteResponse.Task;
+            await route.ContinueAsync();
+        });
+
+        var page = await context.NewPageAsync();
+        page.SetDefaultTimeout(15_000);
+
+        try
+        {
+            await page.GotoAsync("/about", new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
+            await AssertSharedDialogInstalledAsync(page);
+            var scrollIsolation = await page.EvaluateAsync<ScrollIsolationDiagnostics>(
+                """
+                () => ({
+                    ScrollToIsNative:
+                        window.scrollTo === window.__athleteDialogNativeScrollApis.scrollTo,
+                    ScrollByIsNative:
+                        window.scrollBy === window.__athleteDialogNativeScrollApis.scrollBy,
+                    ScrollIntoViewIsNative:
+                        Element.prototype.scrollIntoView
+                            === window.__athleteDialogNativeScrollApis.scrollIntoView,
+                    ScrollRestoration: history.scrollRestoration,
+                    ScrollGuardInstalled: window.__scrollGuardInstalled === true
+                })
+                """);
+            Assert.True(scrollIsolation.ScrollToIsNative);
+            Assert.True(scrollIsolation.ScrollByIsNative);
+            Assert.True(scrollIsolation.ScrollIntoViewIsNative);
+            Assert.Equal("auto", scrollIsolation.ScrollRestoration);
+            Assert.False(scrollIsolation.ScrollGuardInstalled);
+            await page.EvaluateAsync(
+                """
+                () => {
+                    localStorage.removeItem('gmaSkipAll');
+                    localStorage.removeItem('gmaAllGuesses');
+                    sessionStorage.removeItem('gmaSeen');
+                }
+                """);
+
+            var athleteLink = page.Locator(
+                "main.documentation-page a[href='/athlete/michael-lustgarten']").First;
+            await athleteLink.EvaluateAsync(
+                "element => element.scrollIntoView({ behavior: 'auto', block: 'center' })");
+            await page.EvaluateAsync(
+                "() => new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))");
+            await athleteLink.FocusAsync();
+            var callingScrollY = await page.EvaluateAsync<double>("() => window.scrollY");
+
+            Assert.True(callingScrollY > 0);
+            Assert.True(await athleteLink.EvaluateAsync<bool>(
+                "element => document.activeElement === element"));
+
+            await athleteLink.ClickAsync();
+            await miscModuleRequestReceived.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            // A click made before either the modules or athlete index are ready
+            // must remain in this document. Falling through to the anchor would
+            // reload the homepage athlete route and look deceptively correct.
+            Assert.Equal("/about", new Uri(page.Url).AbsolutePath);
+            Assert.Equal(1, await page.Locator("main.documentation-page").CountAsync());
+            Assert.True(await page.Locator("#detailsModal .modal-content").EvaluateAsync<bool>(
+                "element => element.classList.contains('is-loading')"));
+
+            releaseMiscModuleResponse.TrySetResult();
+            await athleteRequestReceived.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            releaseAthleteResponse.TrySetResult();
+            await WaitForOpenAthleteDialogAsync(page, MichaelSlug);
+
+            Assert.Equal($"/athlete/{MichaelSlug}", new Uri(page.Url).AbsolutePath);
+            Assert.Equal(1, await page.Locator("main.documentation-page").CountAsync());
+            Assert.False(await page.Locator("#detailsModal .modal-content").EvaluateAsync<bool>(
+                "element => element.classList.contains('guess-mode')"));
+
+            var skippedGuess = await page.EvaluateAsync<SkippedGuessDiagnostics>(
+                """
+                slug => {
+                    const guesses = JSON.parse(localStorage.getItem('gmaAllGuesses') || '{}');
+                    const guess = guesses[slug];
+                    return {
+                        Exists: Object.prototype.hasOwnProperty.call(guesses, slug),
+                        Skipped: guess?.skipped === true,
+                        ValueIsNull: guess?.value === null
+                    };
+                }
+                """,
+                MichaelSlug);
+            Assert.True(skippedGuess.Exists);
+            Assert.True(skippedGuess.Skipped);
+            Assert.True(skippedGuess.ValueIsNull);
+
+            await CloseAthleteDialogAsync(page, "/about");
+
+            Assert.InRange(
+                Math.Abs(await page.EvaluateAsync<double>("() => window.scrollY") - callingScrollY),
+                0,
+                1);
+            Assert.True(await athleteLink.EvaluateAsync<bool>(
+                "element => document.activeElement === element"));
+        }
+        finally
+        {
+            releaseMiscModuleResponse.TrySetResult();
+            releaseAthleteResponse.TrySetResult();
+        }
+    }
+
+    [Fact]
+    public async Task DelegatedHandler_OpensDynamicAndOfficialLinksButLeavesModifiedClicksNative()
+    {
+        await using var app = await BrowserTestApp.StartAsync();
+        using var playwright = await Playwright.CreateAsync();
+        await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+        {
+            Headless = true
+        });
+        await using var context = await NewContextAsync(browser, app, width: 1100, height: 760);
+        await context.RouteAsync("**/api/events", route => route.FulfillAsync(new RouteFulfillOptions
+        {
+            Status = 200,
+            ContentType = "application/json",
+            Body =
+                """
+                [
+                  {
+                    "Id": "athlete-dialog-dynamic-link",
+                    "Type": 1,
+                    "Text": "slug[michael_lustgarten]",
+                    "OccurredAt": "2026-07-25T08:00:00Z",
+                    "Relevance": 10
+                  }
+                ]
+                """
+        }));
+
+        var page = await context.NewPageAsync();
+        page.SetDefaultTimeout(15_000);
+
+        await page.GotoAsync("/events", new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
+        await AssertSharedDialogInstalledAsync(page);
+        var eventLink = page.Locator(
+            "#eventsTable tbody a.event-athlete-link[href='/athlete/michael-lustgarten']").First;
+        await eventLink.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible });
+        await InstallOpenTelemetryAsync(page);
+
+        await eventLink.ClickAsync();
+        await WaitForOpenAthleteDialogAsync(page, MichaelSlug);
+        await AssertSingleSuppressedOpenAsync(page);
+        Assert.Equal("/events", await page.EvaluateAsync<string>(
+            "() => document.querySelector('main.event-board-page') ? '/events' : ''"));
+        await CloseAthleteDialogAsync(page, "/events");
+
+        await page.GotoAsync("/history", new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
+        await AssertSharedDialogInstalledAsync(page);
+        var historyLink = page.Locator(
+            "main.documentation-page a[href='https://www.longevityworldcup.com/athlete/michael-lustgarten']").First;
+        await historyLink.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible });
+        Assert.Equal("_blank", await historyLink.GetAttributeAsync("target"));
+
+        var nativeActivations = await historyLink.EvaluateAsync<NativeActivationDiagnostics[]>(
+            """
+            link => {
+                const cases = [
+                    { Name: 'Control', init: { ctrlKey: true, button: 0 } },
+                    { Name: 'Meta', init: { metaKey: true, button: 0 } },
+                    { Name: 'Shift', init: { shiftKey: true, button: 0 } },
+                    { Name: 'Alt', init: { altKey: true, button: 0 } },
+                    { Name: 'Middle', init: { button: 1 } }
+                ];
+
+                return cases.map(testCase => {
+                    let reachedWindow = false;
+                    let preventedByDialogHandler = false;
+                    const stopNativeActivation = event => {
+                        reachedWindow = true;
+                        preventedByDialogHandler = event.defaultPrevented;
+                        event.preventDefault();
+                    };
+                    window.addEventListener('click', stopNativeActivation, { once: true });
+                    link.dispatchEvent(new MouseEvent('click', {
+                        bubbles: true,
+                        cancelable: true,
+                        ...testCase.init
+                    }));
+                    return {
+                        Name: testCase.Name,
+                        ReachedWindow: reachedWindow,
+                        PreventedByDialogHandler: preventedByDialogHandler
+                    };
+                });
+            }
+            """);
+
+        Assert.Equal(5, nativeActivations.Length);
+        Assert.All(nativeActivations, activation =>
+        {
+            Assert.True(activation.ReachedWindow, $"{activation.Name} activation was swallowed.");
+            Assert.False(
+                activation.PreventedByDialogHandler,
+                $"{activation.Name} activation lost its native link behavior.");
+        });
+        Assert.Equal("/history", new Uri(page.Url).AbsolutePath);
+        Assert.False(await page.Locator("#detailsModal").IsVisibleAsync());
+
+        await InstallOpenTelemetryAsync(page);
+        var pageCountBeforeHistoryClick = context.Pages.Count;
+        await historyLink.ClickAsync();
+        await WaitForOpenAthleteDialogAsync(page, MichaelSlug);
+
+        Assert.Equal(pageCountBeforeHistoryClick, context.Pages.Count);
+        Assert.Equal(1, await page.Locator("main.documentation-page").CountAsync());
+        await AssertSingleSuppressedOpenAsync(page);
+        await CloseAthleteDialogAsync(page, "/history");
+
+        await page.EvaluateAsync(
+            """
+            () => {
+                const link = document.createElement('a');
+                link.id = 'dynamicApexAthleteLink';
+                link.href = 'https://longevityworldcup.com/athlete/michael-lustgarten';
+                link.textContent = 'Dynamic apex athlete link';
+                document.querySelector('.documentation-document').appendChild(link);
+            }
+            """);
+        await InstallOpenTelemetryAsync(page);
+        await page.Locator("#dynamicApexAthleteLink").ClickAsync();
+        await WaitForOpenAthleteDialogAsync(page, MichaelSlug);
+        await AssertSingleSuppressedOpenAsync(page);
+        await CloseAthleteDialogAsync(page, "/history");
+
+        await page.EvaluateAsync(
+            """
+            () => {
+                const link = document.createElement('a');
+                link.id = 'unknownAthleteLink';
+                link.href = '/athlete/not-a-real-athlete';
+                link.textContent = 'Unknown athlete';
+                document.querySelector('.documentation-document').appendChild(link);
+            }
+            """);
+        await page.Locator("#unknownAthleteLink").ClickAsync();
+        await page.WaitForURLAsync("**/athlete/not-a-real-athlete");
+        Assert.Equal("/athlete/not-a-real-athlete", new Uri(page.Url).AbsolutePath);
+    }
+
+    [Fact]
+    public async Task CalculatorAthleteDialog_PaintsAboveTheFixedActionDock()
+    {
+        await using var app = await BrowserTestApp.StartAsync();
+        using var playwright = await Playwright.CreateAsync();
+        await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+        {
+            Headless = true
+        });
+        await using var context = await NewContextAsync(browser, app, width: 390, height: 844);
+        await context.AddInitScriptAsync("localStorage.setItem('gmaSkipAll', 'true');");
+
+        var page = await context.NewPageAsync();
+        page.SetDefaultTimeout(15_000);
+        await page.GotoAsync("/pheno-age", new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
+        await AssertSharedDialogInstalledAsync(page);
+        await page.WaitForSelectorAsync(".flow-action-stack--docked");
+        await page.WaitForFunctionAsync("() => Boolean(window.LwcBioAgeRankPreview)");
+        await page.EvaluateAsync(
+            """
+            () => {
+                document.getElementById('phenoAgeResult')?.classList.add('show');
+                return window.LwcBioAgeRankPreview.render('phenoAgeRankPreview', {
+                    clock: 'pheno',
+                    ageReduction: -5,
+                    dateOfBirth: new Date(1990, 0, 1)
+                });
+            }
+            """);
+
+        var athleteLink = page.Locator("#phenoAgeRankPreview .bioage-rank-row-name a").First;
+        await athleteLink.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible });
+        var profilePath = Assert.IsType<string>(await athleteLink.GetAttributeAsync("href"));
+        Assert.DoesNotContain("_", profilePath);
+        var athleteSlug = profilePath.Split('/', StringSplitOptions.RemoveEmptyEntries).Last();
+
+        await athleteLink.ClickAsync();
+        await WaitForOpenAthleteDialogAsync(page, athleteSlug);
+
+        var layers = await page.EvaluateAsync<LayerDiagnostics>(
+            """
+            () => {
+                const modal = document.getElementById('detailsModal');
+                const dock = document.querySelector('.flow-action-stack--docked');
+                const topmost = document.elementFromPoint(
+                    Math.floor(innerWidth / 2),
+                    Math.max(0, innerHeight - 8));
+                return {
+                    Modal: Number.parseInt(getComputedStyle(modal).zIndex, 10),
+                    Dock: Number.parseInt(getComputedStyle(dock).zIndex, 10),
+                    ModalOwnsBottomEdge: Boolean(topmost?.closest('#detailsModal'))
+                };
+            }
+            """);
+
+        Assert.True(layers.Modal > layers.Dock);
+        Assert.True(layers.ModalOwnsBottomEdge);
+        await CloseAthleteDialogAsync(page, "/pheno-age");
+    }
+
+    [Fact]
+    public async Task LeaderboardAndStandaloneLinks_RenderTheSameDialogStructureAndGeometry()
+    {
+        await using var app = await BrowserTestApp.StartAsync();
+        using var playwright = await Playwright.CreateAsync();
+        await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+        {
+            Headless = true
+        });
+        await using var context = await NewContextAsync(browser, app, width: 1280, height: 900);
+        await context.AddInitScriptAsync("localStorage.setItem('gmaSkipAll', 'true');");
+
+        var page = await context.NewPageAsync();
+        page.SetDefaultTimeout(15_000);
+        await page.GotoAsync(
+            "/leaderboard",
+            new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
+        await AssertSharedDialogInstalledAsync(page);
+        await page.WaitForFunctionAsync(
+            """
+            () => [...document.querySelectorAll(
+                '.leaderboard tbody:not(.loading-skeleton) tr[data-athlete-name]')]
+                .some(row => window.slugifyName(row.dataset.athleteName, true) === 'michael-lustgarten'
+                    && row.getBoundingClientRect().width > 0
+                    && row.getBoundingClientRect().height > 0)
+            """);
+
+        var leaderboardName = page.Locator(
+            ".leaderboard tbody:not(.loading-skeleton) tr[data-athlete-name='Michael Lustgarten'] .athlete-name");
+        await leaderboardName.ClickAsync();
+        await WaitForOpenAthleteDialogAsync(page, MichaelSlug);
+        var leaderboardDialog = await MeasureDialogAsync(page);
+        await CloseAthleteDialogAsync(page, "/leaderboard");
+
+        await page.GotoAsync("/about", new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
+        await AssertSharedDialogInstalledAsync(page);
+        var standaloneLink = page.Locator(
+            "main.documentation-page a[href='/athlete/michael-lustgarten']").First;
+        await standaloneLink.ClickAsync();
+        await WaitForOpenAthleteDialogAsync(page, MichaelSlug);
+        var standaloneDialog = await MeasureDialogAsync(page);
+
+        Assert.StartsWith("Michael Lustgarten, PhD", await page.Locator("#athleteName").InnerTextAsync());
+        Assert.Equal(leaderboardDialog.Structure, standaloneDialog.Structure);
+        Assert.Equal(leaderboardDialog.ContentComputedStyle, standaloneDialog.ContentComputedStyle);
+        Assert.Equal(leaderboardDialog.Boxes.Length, standaloneDialog.Boxes.Length);
+        foreach (var expectedBox in leaderboardDialog.Boxes)
+        {
+            var actualBox = Assert.Single(
+                standaloneDialog.Boxes,
+                box => box.Name == expectedBox.Name);
+            AssertEquivalentBox(expectedBox, actualBox);
+        }
+
+        await CloseAthleteDialogAsync(page, "/about");
+        await page.GotoAsync("/", new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
+        await AssertSharedDialogInstalledAsync(page);
+        await page.Locator(
+                ".archive-table a[href='/athlete/michael-lustgarten']")
+            .First
+            .ClickAsync();
+        await WaitForOpenAthleteDialogAsync(page, MichaelSlug);
+        Assert.StartsWith("Michael Lustgarten, PhD", await page.Locator("#athleteName").InnerTextAsync());
+    }
+
+    private static async Task<IBrowserContext> NewContextAsync(
+        IBrowser browser,
+        BrowserTestApp app,
+        int width,
+        int height)
+    {
+        var context = await browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            BaseURL = app.BaseAddress.ToString(),
+            Locale = "en-US",
+            ViewportSize = new ViewportSize { Width = width, Height = height },
+            ReducedMotion = ReducedMotion.Reduce
+        });
+        await BrowserTestApp.RouteExternalResourcesAsync(context);
+        await context.RouteAsync("**/api/bitcoin/**", async route =>
+        {
+            var path = new Uri(route.Request.Url).AbsolutePath;
+            var body = path.EndsWith("/donation-address", StringComparison.OrdinalIgnoreCase)
+                ? """{"address":""}"""
+                : path.EndsWith("/btcusd", StringComparison.OrdinalIgnoreCase)
+                    ? """{"btcToUsdRate":0}"""
+                    : """{"totalReceivedSatoshis":0}""";
+            await route.FulfillAsync(new RouteFulfillOptions
+            {
+                Status = 200,
+                ContentType = "application/json",
+                Body = body
+            });
+        });
+        return context;
+    }
+
+    private static async Task AssertSharedDialogInstalledAsync(IPage page)
+    {
+        await page.WaitForFunctionAsync("() => typeof window.openAthleteModalBySlug === 'function'");
+        Assert.Equal(1, await page.Locator("#detailsModal").CountAsync());
+        Assert.Equal("dialog", await page.Locator("#detailsModal").GetAttributeAsync("role"));
+    }
+
+    private static Task WaitForOpenAthleteDialogAsync(IPage page, string athleteSlug) =>
+        page.WaitForFunctionAsync(
+            """
+            slug => {
+                const modal = document.getElementById('detailsModal');
+                const content = modal?.querySelector('.modal-content');
+                return modal?.style.display === 'block'
+                    && content?.dataset.athleteSlug === slug
+                    && !content.classList.contains('is-loading')
+                    && !content.classList.contains('has-load-error')
+                    && location.pathname === `/athlete/${slug}`;
+            }
+            """,
+            athleteSlug);
+
+    private static async Task CloseAthleteDialogAsync(IPage page, string expectedPath)
+    {
+        await page.Locator("#closeAthleteDetailsModal").ClickAsync();
+        await page.WaitForFunctionAsync(
+            """
+            path => document.getElementById('detailsModal')?.style.display === 'none'
+                && location.pathname === path
+            """,
+            expectedPath);
+    }
+
+    private static Task InstallOpenTelemetryAsync(IPage page) =>
+        page.EvaluateAsync(
+            """
+            () => {
+                const original = window.__athleteDialogOriginalOpen
+                    || window.openAthleteModalBySlug;
+                if (typeof original !== 'function') {
+                    throw new Error('Shared athlete dialog opener is unavailable.');
+                }
+
+                window.__athleteDialogOriginalOpen = original;
+                window.__athleteDialogOpenCalls = [];
+                window.openAthleteModalBySlug = function(slug, options) {
+                    window.__athleteDialogOpenCalls.push({
+                        slug,
+                        suppressGuessMyAge: options?.suppressGuessMyAge === true
+                    });
+                    return window.__athleteDialogOriginalOpen.call(this, slug, options);
+                };
+            }
+            """);
+
+    private static async Task AssertSingleSuppressedOpenAsync(IPage page)
+    {
+        var calls = await page.EvaluateAsync<OpenCallDiagnostics[]>(
+            "() => window.__athleteDialogOpenCalls || []");
+        var call = Assert.Single(calls);
+        Assert.Equal(MichaelSlug, call.Slug);
+        Assert.True(call.SuppressGuessMyAge);
+    }
+
+    private static async Task<DialogDiagnostics> MeasureDialogAsync(IPage page)
+    {
+        await page.WaitForFunctionAsync(
+            """
+            () => {
+                const image = document.getElementById('modalProfilePic');
+                return !image?.src || image.complete;
+            }
+            """);
+        await page.EvaluateAsync("() => document.fonts?.ready || Promise.resolve()");
+        await page.EvaluateAsync(
+            "() => new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))");
+
+        return await page.EvaluateAsync<DialogDiagnostics>(
+            """
+            () => {
+                const modal = document.getElementById('detailsModal');
+                const content = modal.querySelector('.modal-content');
+                const structure = element => {
+                    const own = `${element.tagName.toLowerCase()}#${element.id || ''}`;
+                    return `${own}(${[...element.children].map(structure).join(',')})`;
+                };
+                const box = (name, element) => {
+                    const rect = element.getBoundingClientRect();
+                    return {
+                        Name: name,
+                        X: rect.x,
+                        Y: rect.y,
+                        Width: rect.width,
+                        Height: rect.height
+                    };
+                };
+                const style = getComputedStyle(content);
+
+                return {
+                    Structure: structure(modal),
+                    ContentComputedStyle: JSON.stringify({
+                        position: style.position,
+                        display: style.display,
+                        width: style.width,
+                        maxWidth: style.maxWidth,
+                        height: style.height,
+                        maxHeight: style.maxHeight,
+                        padding: style.padding,
+                        overflowY: style.overflowY,
+                        borderRadius: style.borderRadius,
+                        backgroundColor: style.backgroundColor,
+                        boxShadow: style.boxShadow
+                    }),
+                    Boxes: [
+                        box('modal', modal),
+                        box('content', content),
+                        box('profile', document.getElementById('athlete-profile')),
+                        box('portrait', document.getElementById('modalProfilePic')),
+                        box('name', document.getElementById('athleteName')),
+                        box('info', modal.querySelector('.athlete-info'))
+                    ]
+                };
+            }
+            """);
+    }
+
+    private static void AssertEquivalentBox(BoxDiagnostics expected, BoxDiagnostics actual)
+    {
+        const double renderingTolerance = 0.75;
+        Assert.InRange(Math.Abs(actual.X - expected.X), 0, renderingTolerance);
+        Assert.InRange(Math.Abs(actual.Y - expected.Y), 0, renderingTolerance);
+        Assert.InRange(Math.Abs(actual.Width - expected.Width), 0, renderingTolerance);
+        Assert.InRange(Math.Abs(actual.Height - expected.Height), 0, renderingTolerance);
+    }
+
+    private static int CountOccurrences(string source, string value) =>
+        source.Split(value, StringSplitOptions.None).Length - 1;
+
+    private sealed class SkippedGuessDiagnostics
+    {
+        public bool Exists { get; set; }
+        public bool Skipped { get; set; }
+        public bool ValueIsNull { get; set; }
+    }
+
+    private sealed class NativeActivationDiagnostics
+    {
+        public string Name { get; set; } = "";
+        public bool ReachedWindow { get; set; }
+        public bool PreventedByDialogHandler { get; set; }
+    }
+
+    private sealed class OpenCallDiagnostics
+    {
+        public string Slug { get; set; } = "";
+        public bool SuppressGuessMyAge { get; set; }
+    }
+
+    private sealed class DialogDiagnostics
+    {
+        public string Structure { get; set; } = "";
+        public string ContentComputedStyle { get; set; } = "";
+        public BoxDiagnostics[] Boxes { get; set; } = [];
+    }
+
+    private sealed class BoxDiagnostics
+    {
+        public string Name { get; set; } = "";
+        public double X { get; set; }
+        public double Y { get; set; }
+        public double Width { get; set; }
+        public double Height { get; set; }
+    }
+
+    private sealed class LayerDiagnostics
+    {
+        public int Modal { get; set; }
+        public int Dock { get; set; }
+        public bool ModalOwnsBottomEdge { get; set; }
+    }
+
+    private sealed class ScrollIsolationDiagnostics
+    {
+        public bool ScrollToIsNative { get; set; }
+        public bool ScrollByIsNative { get; set; }
+        public bool ScrollIntoViewIsNative { get; set; }
+        public string ScrollRestoration { get; set; } = "";
+        public bool ScrollGuardInstalled { get; set; }
+    }
+}

--- a/LongevityWorldCup.Tests/AthleteDialogLinkBrowserTests.cs
+++ b/LongevityWorldCup.Tests/AthleteDialogLinkBrowserTests.cs
@@ -28,7 +28,57 @@ public sealed class AthleteDialogLinkBrowserTests
         Assert.Contains("data-athlete-dialog-only=\"true\"", html);
         Assert.Contains("@scope (#athleteDialogRuntime)", html);
         Assert.Contains("--athlete-dialog-layer:10020", html);
+        Assert.Contains("window.athleteDialogModulesReady = Promise.all", html);
         Assert.DoesNotContain("<!--ATHLETE-DIALOG-", html);
+    }
+
+    [Fact]
+    public async Task CalculatorHydration_DoesNotWaitForDialogOnlyModules()
+    {
+        await using var app = await BrowserTestApp.StartAsync();
+        using var playwright = await Playwright.CreateAsync();
+        await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+        {
+            Headless = true
+        });
+        await using var context = await NewContextAsync(browser, app, width: 1024, height: 720);
+
+        var dialogModuleRequestReceived =
+            new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseDialogModuleResponse =
+            new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await context.RouteAsync("**/js/age-visualization.js*", async route =>
+        {
+            dialogModuleRequestReceived.TrySetResult();
+            await releaseDialogModuleResponse.Task;
+            await route.ContinueAsync();
+        });
+
+        var page = await context.NewPageAsync();
+        page.SetDefaultTimeout(15_000);
+
+        try
+        {
+            await page.GotoAsync(
+                "/bortz-age?Year=1980&Month=6&Day=15&Date=2026-06-01",
+                new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
+            await dialogModuleRequestReceived.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await page.WaitForFunctionAsync(
+                "() => document.querySelector('#blood-draw-date')?.value === '2026-06-01'");
+
+            var dialogModulesReady = await page.EvaluateAsync<bool>(
+                """
+                () => Promise.race([
+                    window.athleteDialogModulesReady.then(() => true),
+                    new Promise(resolve => setTimeout(() => resolve(false), 100))
+                ])
+                """);
+            Assert.False(dialogModulesReady);
+        }
+        finally
+        {
+            releaseDialogModuleResponse.TrySetResult();
+        }
     }
 
     [Fact]

--- a/LongevityWorldCup.Tests/LongevitymaxxingChallengePageTests.cs
+++ b/LongevityWorldCup.Tests/LongevitymaxxingChallengePageTests.cs
@@ -385,6 +385,7 @@ public sealed class LongevitymaxxingChallengePageTests
         Assert.Contains("targetBlank: true", javascript);
         Assert.Contains("target=\"_blank\" rel=\"noopener noreferrer\"", javascript);
         Assert.Contains("id=\"lmxQuoteDialogOk\"", javascript);
+        Assert.Contains("lwc:athlete-dialog-before-open", javascript);
         Assert.Contains("Podcast</span>", javascript);
         Assert.Contains("fa fa-microphone", javascript);
         Assert.DoesNotContain(">YouTube</a>", javascript);

--- a/LongevityWorldCup.Website/Frontend/badges.ts
+++ b/LongevityWorldCup.Website/Frontend/badges.ts
@@ -845,17 +845,6 @@ window.setBadges = function (athlete, athleteCell) {
     badgeContainer.innerHTML = renderedItems.map(x => x.html).join('');
 
     try {
-        const overflowLinks = badgeContainer.querySelectorAll('.badge-overflow-count[data-athlete-slug]');
-        overflowLinks.forEach((link: Element) => {
-            link.addEventListener('click', (event: Event) => {
-                event.stopPropagation();
-                const slug = link.getAttribute('data-athlete-slug');
-                if (slug && typeof window.openAthleteModalBySlug === 'function' && window.openAthleteModalBySlug(slug, { suppressGuessMyAge: true })) {
-                    event.preventDefault();
-                }
-            });
-        });
-
         if (!isModalStrip) {
             Array.from(badgeContainer.children).forEach((badge: Element) => {
                 if (badge instanceof HTMLElement) badge.style.animation = '';

--- a/LongevityWorldCup.Website/Frontend/bioage-rank-preview.ts
+++ b/LongevityWorldCup.Website/Frontend/bioage-rank-preview.ts
@@ -442,6 +442,10 @@ declare global {
             var isYou = row.isYou;
             var reduction = getReduction(row, clock);
             var nameHtml = escapeHtml(isYou ? 'You' : row.displayName);
+            if (!isYou && row.slug) {
+                var profileSlug = String(row.slug).trim().replace(/_/g, '-');
+                nameHtml = '<a href="/athlete/' + encodeURIComponent(profileSlug) + '">' + nameHtml + '</a>';
+            }
             html += '<div class="bioage-rank-row' + (isYou ? ' current' : '') + '">' +
                 '<span class="bioage-rank-row-place">#' + (i + 1) + '</span>' +
                 buildAvatar(row) +

--- a/LongevityWorldCup.Website/Frontend/longevitymaxxing.ts
+++ b/LongevityWorldCup.Website/Frontend/longevitymaxxing.ts
@@ -3731,6 +3731,12 @@
         dialog = requiredElement("lmxQuoteDialog", HTMLElement);
         const ok = requiredButton("lmxQuoteDialogOk");
         ok.addEventListener("click", closeCheckInQuoteDialog);
+        dialog.addEventListener("lwc:athlete-dialog-before-open", () => {
+            // The shared athlete profile is itself modal. Retire this quote
+            // layer before it opens so there is one focus trap and one
+            // aria-modal surface, then let the profile restore the prior focus.
+            closeCheckInQuoteDialog();
+        });
         dialog.addEventListener("keydown", event => {
             if (event.key === "Escape") {
                 event.preventDefault();

--- a/LongevityWorldCup.Website/Middleware/HtmlInjectionMiddleware.cs
+++ b/LongevityWorldCup.Website/Middleware/HtmlInjectionMiddleware.cs
@@ -23,6 +23,22 @@ namespace LongevityWorldCup.Website.Middleware
         private const string LeaderboardRowsStartMarker = "<!--LEADERBOARD-TBODY-ROWS-START-->";
         private const string LeaderboardRowsEndMarker = "<!--LEADERBOARD-TBODY-ROWS-END-->";
         private const string LeaderboardSkeletonTbodyOpenTag = "<tbody class=\"loading-skeleton\" aria-busy=\"true\">";
+        private const string AthleteDialogStartMarker = "<!--ATHLETE-DIALOG-START-->";
+        private const string AthleteDialogEndMarker = "<!--ATHLETE-DIALOG-END-->";
+        private const string AthleteDialogDeferredStartMarker = "<!--ATHLETE-DIALOG-DEFERRED-START-->";
+        private const string AthleteDialogDeferredEndMarker = "<!--ATHLETE-DIALOG-DEFERRED-END-->";
+        private const string LeaderboardRuntimeScriptsStartMarker = "<!--LEADERBOARD-RUNTIME-SCRIPTS-START-->";
+        private const string AthleteDialogRuntimeId = "athleteDialogRuntime";
+        private static readonly IReadOnlyList<string> AthleteDialogModulePaths =
+        [
+            "/js/misc.js",
+            "/js/flags.js",
+            "/js/leagueIcons.js",
+            "/js/pheno-age.js",
+            "/js/bortz-age.js",
+            "/js/badges.js",
+            "/js/age-visualization.js"
+        ];
         private static readonly HashSet<string> IndexableRoutes = new(StringComparer.OrdinalIgnoreCase)
         {
             "/",
@@ -93,6 +109,7 @@ namespace LongevityWorldCup.Website.Middleware
                     var bodyContent = await File.ReadAllTextAsync(filePath);
                     var usesSharedHead = bodyContent.Contains("<!--HEAD-->", StringComparison.Ordinal);
                     var optsIntoSharedAestheticSystem = bodyContent.Contains("<!--AESTHETIC-SYSTEM-->", StringComparison.Ordinal);
+                    var containsLeaderboardContent = bodyContent.Contains("<!--LEADERBOARD-CONTENT-->", StringComparison.Ordinal);
 
                     // Read the header and footer files
                     var head = await File.ReadAllTextAsync(Path.Combine(_webRootPath, "partials", "head.html"));
@@ -120,8 +137,23 @@ namespace LongevityWorldCup.Website.Middleware
 
                     // Replace placeholders within leaderboardContent first (since it contains nested placeholders)
                     leaderboardContent = leaderboardContent.Replace("<!--AGE-VISUALIZATION-->", ageVisualization);
+                    leaderboardContent = leaderboardContent.Replace("<!--GUESS-MY-AGE-->", guessMyAge);
                     leaderboardContent = ApplyLeaderboardRows(leaderboardContent, context);
                     leaderboardContent = ApplyLongevitymaxxingPromo(leaderboardContent);
+
+                    if (!containsLeaderboardContent && ShouldInjectAthleteDialogRuntime(path))
+                    {
+                        if (TryBuildAthleteDialogRuntime(leaderboardContent, out var athleteDialogRuntime))
+                        {
+                            bodyContent = InjectBeforeClosingBody(bodyContent, athleteDialogRuntime);
+                        }
+                        else
+                        {
+                            _logger.LogWarning(
+                                "Athlete dialog runtime markers were incomplete; no runtime was injected into {Path}.",
+                                path);
+                        }
+                    }
 
                     if (ShouldUseHungarianChrome(context))
                     {
@@ -193,6 +225,11 @@ namespace LongevityWorldCup.Website.Middleware
         private string ApplyHeadAssets(string html, string path)
         {
             var config = GetHeadAssetConfig(path);
+            if (ShouldInjectAthleteDialogRuntime(path))
+            {
+                config = AddAthleteDialogModules(config);
+            }
+
             var optionalHeadScripts = BuildOptionalHeadScripts(config);
             var modulesBootstrap = BuildModulesBootstrap(config);
 
@@ -217,6 +254,164 @@ namespace LongevityWorldCup.Website.Middleware
                 .Replace("{{ASSET_PRO_DISCOUNTS_JS}}", _assetVersionProvider.AppendVersion("/js/pro-discounts.js"))
                 .Replace("{{ASSET_PROOF_HELPERS_JS}}", _assetVersionProvider.AppendVersion("/js/proof-helpers.js"))
                 .Replace("{{ASSET_AGE_VISUALIZATION_JS}}", _assetVersionProvider.AppendVersion("/js/age-visualization.js"));
+        }
+
+        private static HeadAssetConfig AddAthleteDialogModules(HeadAssetConfig config)
+        {
+            var modulePaths = config.ModulePaths
+                .Concat(AthleteDialogModulePaths)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            return config with { ModulePaths = modulePaths };
+        }
+
+        private static bool ShouldInjectAthleteDialogRuntime(string? path)
+        {
+            return path?.ToLowerInvariant() switch
+            {
+                "/events" or
+                "/event-board/event-board.html" or
+                "/longevitymaxxing" or
+                "/longevitymaxxing/longevitymaxxing.html" or
+                "/about" or
+                "/misc-pages/about.html" or
+                "/history" or
+                "/misc-pages/history.html" or
+                "/helstab-kihivas" or
+                "/helstab-kihivas/helstab-kihivas.html" or
+                "/pheno-age" or
+                "/onboarding/pheno-age.html" or
+                "/bortz-age" or
+                "/onboarding/bortz-age.html" => true,
+                _ => false
+            };
+        }
+
+        private static bool TryBuildAthleteDialogRuntime(string leaderboardContent, out string runtime)
+        {
+            runtime = string.Empty;
+            if (!TryExtractFirstStyleBlock(leaderboardContent, out var styles) ||
+                !TryExtractMarkedRegion(
+                    leaderboardContent,
+                    AthleteDialogStartMarker,
+                    AthleteDialogEndMarker,
+                    out var dialog) ||
+                !TryExtractMarkedRegion(
+                    leaderboardContent,
+                    AthleteDialogDeferredStartMarker,
+                    AthleteDialogDeferredEndMarker,
+                    out var deferredSections) ||
+                !TryExtractTail(
+                    leaderboardContent,
+                    LeaderboardRuntimeScriptsStartMarker,
+                    out var runtimeScripts))
+            {
+                return false;
+            }
+
+            var runtimeContents = ScopeAthleteDialogStyles(
+                string.Join(
+                    Environment.NewLine,
+                    styles,
+                    dialog,
+                    deferredSections));
+
+            runtime =
+$@"<div id=""{AthleteDialogRuntimeId}""
+     class=""athlete-dialog-runtime""
+     data-athlete-dialog-only=""true""
+     style=""--athlete-dialog-layer:10020"">
+{runtimeContents}
+</div>
+{runtimeScripts}";
+            return true;
+        }
+
+        private static bool TryExtractFirstStyleBlock(string html, out string styleBlock)
+        {
+            var match = Regex.Match(
+                html,
+                @"<style\b[^>]*>.*?</style\s*>",
+                RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            styleBlock = match.Success ? match.Value.Trim() : string.Empty;
+            return match.Success;
+        }
+
+        private static bool TryExtractMarkedRegion(
+            string html,
+            string startMarker,
+            string endMarker,
+            out string region)
+        {
+            region = string.Empty;
+            var start = html.IndexOf(startMarker, StringComparison.Ordinal);
+            if (start < 0)
+            {
+                return false;
+            }
+
+            start += startMarker.Length;
+            var end = html.IndexOf(endMarker, start, StringComparison.Ordinal);
+            if (end < start)
+            {
+                return false;
+            }
+
+            region = html[start..end].Trim();
+            return true;
+        }
+
+        private static bool TryExtractTail(string html, string startMarker, out string tail)
+        {
+            tail = string.Empty;
+            var start = html.IndexOf(startMarker, StringComparison.Ordinal);
+            if (start < 0)
+            {
+                return false;
+            }
+
+            tail = html[(start + startMarker.Length)..].Trim();
+            return !string.IsNullOrWhiteSpace(tail);
+        }
+
+        private static string ScopeAthleteDialogStyles(string html)
+        {
+            return Regex.Replace(
+                html,
+                @"<style(?<attributes>\s[^>]*)?>(?<css>.*?)</style\s*>",
+                match =>
+                {
+                    var attributes = match.Groups["attributes"].Value;
+                    var css = Regex.Replace(
+                        match.Groups["css"].Value,
+                        @":root\b",
+                        ":scope",
+                        RegexOptions.IgnoreCase);
+
+                    return
+$@"<style{attributes}>
+    @scope (#{AthleteDialogRuntimeId}) {{{css}
+    }}
+</style>";
+                },
+                RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        }
+
+        private static string InjectBeforeClosingBody(string html, string content)
+        {
+            if (html.Contains($"id=\"{AthleteDialogRuntimeId}\"", StringComparison.OrdinalIgnoreCase) ||
+                html.Contains($"id='{AthleteDialogRuntimeId}'", StringComparison.OrdinalIgnoreCase))
+            {
+                return html;
+            }
+
+            var closingBodyIndex = html.LastIndexOf("</body>", StringComparison.OrdinalIgnoreCase);
+            return closingBodyIndex < 0
+                ? html
+                : html.Insert(
+                    closingBodyIndex,
+                    $"{Environment.NewLine}{content}{Environment.NewLine}");
         }
 
         private string ApplyLeaderboardRows(string html, HttpContext context)

--- a/LongevityWorldCup.Website/Middleware/HtmlInjectionMiddleware.cs
+++ b/LongevityWorldCup.Website/Middleware/HtmlInjectionMiddleware.cs
@@ -225,13 +225,21 @@ namespace LongevityWorldCup.Website.Middleware
         private string ApplyHeadAssets(string html, string path)
         {
             var config = GetHeadAssetConfig(path);
-            if (ShouldInjectAthleteDialogRuntime(path))
-            {
-                config = AddAthleteDialogModules(config);
-            }
-
             var optionalHeadScripts = BuildOptionalHeadScripts(config);
             var modulesBootstrap = BuildModulesBootstrap(config);
+            if (ShouldInjectAthleteDialogRuntime(path))
+            {
+                var athleteDialogModules = AthleteDialogModulePaths
+                    .Except(config.ModulePaths, StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+                var athleteDialogModulesBootstrap = BuildModulesBootstrap(
+                    athleteDialogModules,
+                    "athleteDialogModulesReady");
+                modulesBootstrap = string.Join(
+                    Environment.NewLine,
+                    new[] { modulesBootstrap, athleteDialogModulesBootstrap }
+                        .Where(value => !string.IsNullOrEmpty(value)));
+            }
 
             return ApplySharedCssPlaceholders(ApplySharedAssetPlaceholders(html))
                 .Replace("{{OPTIONAL_HEAD_SCRIPTS}}", optionalHeadScripts)
@@ -254,16 +262,6 @@ namespace LongevityWorldCup.Website.Middleware
                 .Replace("{{ASSET_PRO_DISCOUNTS_JS}}", _assetVersionProvider.AppendVersion("/js/pro-discounts.js"))
                 .Replace("{{ASSET_PROOF_HELPERS_JS}}", _assetVersionProvider.AppendVersion("/js/proof-helpers.js"))
                 .Replace("{{ASSET_AGE_VISUALIZATION_JS}}", _assetVersionProvider.AppendVersion("/js/age-visualization.js"));
-        }
-
-        private static HeadAssetConfig AddAthleteDialogModules(HeadAssetConfig config)
-        {
-            var modulePaths = config.ModulePaths
-                .Concat(AthleteDialogModulePaths)
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToArray();
-
-            return config with { ModulePaths = modulePaths };
         }
 
         private static bool ShouldInjectAthleteDialogRuntime(string? path)
@@ -627,17 +625,24 @@ $@"<style{attributes}>
             return sb.ToString().TrimEnd();
         }
 
-        private string BuildModulesBootstrap(HeadAssetConfig config)
+        private string BuildModulesBootstrap(HeadAssetConfig config) =>
+            BuildModulesBootstrap(config.ModulePaths, "modulesReady");
+
+        private string BuildModulesBootstrap(
+            IReadOnlyList<string> modulePaths,
+            string readinessProperty)
         {
-            if (config.ModulePaths.Count == 0)
+            if (modulePaths.Count == 0)
             {
                 return string.Empty;
             }
 
-            var imports = string.Join("," + Environment.NewLine, config.ModulePaths.Select(path => $"        import(`{_assetVersionProvider.AppendVersion(path)}`)"));
+            var imports = string.Join(
+                "," + Environment.NewLine,
+                modulePaths.Select(path => $"        import(`{_assetVersionProvider.AppendVersion(path)}`)"));
             return
 $@"<script type=""module"">
-    window.modulesReady = Promise.all([
+    window.{readinessProperty} = Promise.all([
 {imports}
     ]);
 </script>";

--- a/LongevityWorldCup.Website/wwwroot/index.html
+++ b/LongevityWorldCup.Website/wwwroot/index.html
@@ -2161,24 +2161,6 @@
             });
         });
 
-        document.addEventListener('click', function (event) {
-            const link = event.target && event.target.closest ? event.target.closest('a.lwc-merch-athlete-link[data-athlete-slug]') : null;
-            if (!link) return;
-            if (event.defaultPrevented) return;
-            if (event.button !== 0) return;
-            if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
-            if (typeof window.openAthleteModalBySlug !== 'function') return;
-
-            const athleteSlug = link.getAttribute('data-athlete-slug');
-            if (!athleteSlug) return;
-
-            const opened = window.openAthleteModalBySlug(athleteSlug, { suppressGuessMyAge: true });
-            if (!opened) return;
-
-            event.preventDefault();
-            event.stopPropagation();
-        });
-
         document.addEventListener('DOMContentLoaded', function () {
             const merchCarousel = document.getElementById('lwc-merch-mobile-carousel');
             if (!merchCarousel) {

--- a/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
@@ -2640,29 +2640,6 @@
             setEventsLoadingState(requestedPreserveExistingRows);
             setViewAllVisible(!!showViewAll);
 
-            const root = document.getElementById('events-root');
-            if (root && !root.dataset.modalAthleteBinding) {
-                root.dataset.modalAthleteBinding = 'true';
-                root.addEventListener('click', function (event) {
-                    const link = event.target && event.target.closest ? event.target.closest('a.event-athlete-link[data-athlete-slug]') : null;
-                    if (!link) return;
-                    if (openLinksInNewTab) return;
-                    if (event.defaultPrevented) return;
-                    if (event.button !== 0) return;
-                    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
-                    if (typeof window.openAthleteModalBySlug !== 'function') return;
-
-                    const athleteSlug = link.getAttribute('data-athlete-slug');
-                    if (!athleteSlug) return;
-
-                    const opened = window.openAthleteModalBySlug(athleteSlug, { suppressGuessMyAge: true });
-                    if (!opened) return;
-
-                    event.preventDefault();
-                    event.stopPropagation();
-                });
-            }
-
             const n=(function(val){ if(val===undefined||val===null||val==="")return null; const nn=typeof val==="string"?parseInt(val,10):Number(val); return Number.isFinite(nn)&&nn>0?Math.floor(nn):null; })(maxRows);
 
             const eventsReq=useSharedEvents

--- a/LongevityWorldCup.Website/wwwroot/partials/guess-my-age.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/guess-my-age.html
@@ -838,7 +838,7 @@
     const gmaStatus = document.getElementById('gmaStatus');
     const gmaTrollNote = document.getElementById('gmaTrollNote');
 
-    const modalContent = document.querySelector('.modal-content');
+    const modalContent = document.querySelector('#detailsModal .modal-content');
     const gmaActions = gmaCard.querySelector('.gma-actions');
 
     // whenever the modal’s class list changes, if we just opened “guess-mode”,
@@ -1015,7 +1015,7 @@
             localStorage.setItem('gmaSkipAll', 'true');
         }
 
-        const modalContent = document.querySelector('.modal-content');
+        const modalContent = document.querySelector('#detailsModal .modal-content');
         const athleteSlug = modalContent.dataset.athleteSlug;
 
         // **Use the originalGuess if passed**, otherwise fall back

--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -7535,7 +7535,10 @@
     }
 
     function ensureAthleteResultsReady() {
-        return Promise.resolve(window.modulesReady)
+        return Promise.all([
+            Promise.resolve(window.modulesReady),
+            Promise.resolve(window.athleteDialogModulesReady)
+        ])
             .then(() => {
                 if (athleteResultsReady) return athleteResults;
                 if (!athleteResultsLoadPromise) {

--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -893,7 +893,7 @@
        10) Modal
        ========================= */
     .modal{
-        display:none; position:fixed; z-index:3; left:0; top:0; width:100%; height:100%;
+        display:none; position:fixed; z-index:var(--athlete-dialog-layer, 3); left:0; top:0; width:100%; height:100%;
         overflow:hidden; background-color:rgba(0,0,0,.4); backdrop-filter:blur(4px); -webkit-backdrop-filter:blur(4px);
     }
     .modal.fade-out .modal-content,
@@ -2984,7 +2984,9 @@
 
 </style>
 
-<div class="main-container">
+<div id="athleteDialogRuntime"
+     class="main-container athlete-dialog-runtime"
+     data-athlete-dialog-only="false">
 
     <div class="content">
         <div class="podium" aria-busy="true" style="display:none;">
@@ -3202,6 +3204,7 @@
             </table>
         </div>
 
+<!--ATHLETE-DIALOG-START-->
         <div id="detailsModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="athleteName">
             <div class="modal-content">
                 <div class="modal-sticky-header" id="modalStickyHeader">
@@ -3373,9 +3376,10 @@
                 <p class="image-viewer-hint" hidden>Zoomed for readable text. Scroll to inspect the full proof.</p>
             </div>
         </div>
+<!--ATHLETE-DIALOG-END-->
     </div>
-</div>
 
+<!--ATHLETE-DIALOG-DEFERRED-START-->
 <template id="athleteModalDeferredSectionsTemplate">
     <div class="biomarkers-section" id="athlete-biomarkers">
         <h3>Biomarkers over time</h3>
@@ -3393,6 +3397,7 @@
         </div>
     </div>
 </template>
+<!--ATHLETE-DIALOG-DEFERRED-END-->
 
 <template id="leaderboardRowTemplate">
     <tr>
@@ -3414,12 +3419,50 @@
         <td data-label="Media contact" class="media-contact-td"></td>
     </tr>
 </template>
+</div>
 
+<!--LEADERBOARD-RUNTIME-SCRIPTS-START-->
 <script>
+    (function () {
+    const pageDocument = window.document;
+    const athleteDialogRuntime = pageDocument.getElementById('athleteDialogRuntime');
+    if (!athleteDialogRuntime) {
+        console.error('Athlete dialog runtime root was not found.');
+        return;
+    }
+
+    // Keep the legacy leaderboard controller isolated from unrelated page
+    // components when the same runtime is mounted outside the leaderboard.
+    // Selector calls remain scoped to this one component; document-wide APIs
+    // such as body scroll locking and event listeners still use the real page.
+    const document = new Proxy(pageDocument, {
+        get(target, property) {
+            if (property === 'getElementById') {
+                return id => athleteDialogRuntime.querySelector(`#${CSS.escape(id)}`);
+            }
+            if (property === 'querySelector') {
+                return selector => athleteDialogRuntime.querySelector(selector);
+            }
+            if (property === 'querySelectorAll') {
+                return selector => athleteDialogRuntime.querySelectorAll(selector);
+            }
+
+            const value = Reflect.get(target, property, target);
+            return typeof value === 'function' ? value.bind(target) : value;
+        },
+        set(target, property, value) {
+            return Reflect.set(target, property, value, target);
+        }
+    });
+
     let athleteResults = [];
     let athletesOrderedByPace;
     let athletesOrderedByBortzPace;
     let athletesOrderedByPhenoAgeReduction;
+    const isAthleteDialogOnlyRuntime = athleteDialogRuntime.dataset.athleteDialogOnly === 'true';
+    let athleteResultsReady = false;
+    let athleteResultsLoadPromise = null;
+    let athleteDialogReturnFocusElement = null;
     const defaultProfilePic = '{{ASSET_HD_LOGO_THUMB_SM}}';
 
     const currentSeasonStartDate = new Date(new Date().getFullYear(), 0, 1);
@@ -3983,47 +4026,49 @@
     }
 
 
-    // Prevent browser auto-restoring scroll on history nav (harmless if unsupported)
-    try { if ('scrollRestoration' in history) history.scrollRestoration = 'manual'; } catch { }
+    if (!isAthleteDialogOnlyRuntime) {
+        // Prevent browser auto-restoring scroll on leaderboard history navigation.
+        try { if ('scrollRestoration' in history) history.scrollRestoration = 'manual'; } catch { }
 
-    /* ------- ScrollGuard: block untrusted scrolls during anchor jump ------- */
-    (function () {
-        if (window.__scrollGuardInstalled) return;
-        window.__scrollGuardInstalled = true;
+        /* ------- ScrollGuard: block untrusted scrolls during anchor jump ------- */
+        (function () {
+            if (window.__scrollGuardInstalled) return;
+            window.__scrollGuardInstalled = true;
 
-        const ORIG = {
-            scrollTo: window.scrollTo.bind(window),
-            scrollBy: window.scrollBy.bind(window),
-            elSIV: Element.prototype.scrollIntoView,
-        };
-        let guardUntil = 0;
-        let anchorTarget = null;
+            const ORIG = {
+                scrollTo: window.scrollTo.bind(window),
+                scrollBy: window.scrollBy.bind(window),
+                elSIV: Element.prototype.scrollIntoView,
+            };
+            let guardUntil = 0;
+            let anchorTarget = null;
 
-        function blocked() { return Date.now() <= guardUntil; }
+            function blocked() { return Date.now() <= guardUntil; }
 
-        // Public API
-        window.ScrollGuard = {
-            block(ms = 1600) { guardUntil = Date.now() + ms; },
-            trustedScrollTo(opts) { ORIG.scrollTo(opts); },
-            trustedScrollIntoView(el, opts) { ORIG.elSIV.call(el, opts); },
-            setAnchorTarget(el) { anchorTarget = el || null; }
-        };
+            // Public API
+            window.ScrollGuard = {
+                block(ms = 1600) { guardUntil = Date.now() + ms; },
+                trustedScrollTo(opts) { ORIG.scrollTo(opts); },
+                trustedScrollIntoView(el, opts) { ORIG.elSIV.call(el, opts); },
+                setAnchorTarget(el) { anchorTarget = el || null; }
+            };
 
-        // Patch global scroll fns (no-op while blocked)
-        window.scrollTo = function (...args) { if (blocked()) return; return ORIG.scrollTo(...args); };
-        window.scrollBy = function (...args) { if (blocked()) return; return ORIG.scrollBy(...args); };
-        Element.prototype.scrollIntoView = function (...args) {
-            if (blocked()) return;
-            return ORIG.elSIV.apply(this, args);
-        };
+            // Patch global scroll fns (no-op while blocked)
+            window.scrollTo = function (...args) { if (blocked()) return; return ORIG.scrollTo(...args); };
+            window.scrollBy = function (...args) { if (blocked()) return; return ORIG.scrollBy(...args); };
+            Element.prototype.scrollIntoView = function (...args) {
+                if (blocked()) return;
+                return ORIG.elSIV.apply(this, args);
+            };
 
-        // If *anything* flips the hash during the guard, re-center the intended target
-        window.addEventListener('hashchange', () => {
-            if (blocked() && anchorTarget) {
-                ORIG.elSIV.call(anchorTarget, { behavior: 'auto', block: 'start' });
-            }
-        }, true);
-    })();
+            // If *anything* flips the hash during the guard, re-center the intended target
+            window.addEventListener('hashchange', () => {
+                if (blocked() && anchorTarget) {
+                    ORIG.elSIV.call(anchorTarget, { behavior: 'auto', block: 'start' });
+                }
+            }, true);
+        })();
+    }
 
     /* ------- Scroll Performance Optimization ------- */
     (function() {
@@ -4294,6 +4339,7 @@
     function LoadLeaderboard(includePodium = true, maxAthletes = Infinity) {
         includePodiumGlobal = includePodium;
         maxAthletesGlobal = maxAthletes;
+        athleteResultsReady = false;
         setLeaderboardLoadingState(includePodium, maxAthletes);
 
         window.getSharedAthletes = window.getSharedAthletes || function(){
@@ -4308,7 +4354,7 @@
             return window.__sharedAthletesRequest;
         };
 
-        window.getSharedAthletes()
+        const currentLoadPromise = window.getSharedAthletes()
             .then(athletes => {
                 // Array to store athletes with their lowest PhenoAge and age reduction
                 var viewAllAthletesBtn = document.getElementById('viewAllAthletesBtn');
@@ -4740,12 +4786,14 @@
                     return currentRounded === previousRounded || currentRounded === nextRounded ? 2 : 1;
                 };
 
-                generateDivisionFilters(athleteResults);
-                generateFlagFilters(athleteResults);
-                generateGenerationFilters(athleteResults);
-                generateExclusiveFilters(athleteResults);
-                generateLeagueTrackFilters(athleteResults);
-                updateFilterCounts(athleteResults);
+                if (!isAthleteDialogOnlyRuntime) {
+                    generateDivisionFilters(athleteResults);
+                    generateFlagFilters(athleteResults);
+                    generateGenerationFilters(athleteResults);
+                    generateExclusiveFilters(athleteResults);
+                    generateLeagueTrackFilters(athleteResults);
+                    updateFilterCounts(athleteResults);
+                }
 
                 // Sort the athletes by age reduction in ascending order
                 athleteResults.sort(window.compareAthleteRank);
@@ -4827,6 +4875,13 @@
                 athletesOrderedByPhenoAgeReduction = athleteResults.slice();
                 athletesOrderedByPhenoAgeReduction.sort(window.compareAthleteRankPhenoOnly);
                 assignBestRankCandidates(athleteResults);
+                athleteResultsReady = true;
+
+                // Standalone pages reuse the leaderboard's exact dialog and rank
+                // derivation, but do not own a leaderboard DOM to render into.
+                if (isAthleteDialogOnlyRuntime) {
+                    return;
+                }
 
                 const podiumCount = includePodium ? 3 : 0;
 
@@ -5163,6 +5218,8 @@
                 }
             })
             .catch(error => {
+                athleteResultsReady = false;
+                athleteResultsLoadPromise = null;
                 const tableBody = document.querySelector('.leaderboard table tbody');
                 if (tableBody) {
                     tableBody.classList.remove('loading-skeleton');
@@ -5178,6 +5235,8 @@
                 }
                 console.error('Error fetching athletes:', error);
             });
+        athleteResultsLoadPromise = currentLoadPromise;
+        return currentLoadPromise;
     };
 
     function buildPodiumSkeletonHtml() {
@@ -6114,6 +6173,8 @@
         if (!modalContent) return;
 
         currentAthleteModalRequestId++;
+        const returnFocusElement = athleteDialogReturnFocusElement;
+        athleteDialogReturnFocusElement = null;
 
         closeAthleteShareMenu();
         
@@ -6160,6 +6221,9 @@
             history.replaceState({}, "", originalAthletelessURL);
 
             resetPageTitle();
+            if (returnFocusElement?.isConnected) {
+                returnFocusElement.focus({ preventScroll: true });
+            }
         }, 400);
     }
 
@@ -7034,12 +7098,12 @@
     const searchInput = document.getElementById('athleteSearch');
 
     // Select all text on the first focus
-    searchInput.addEventListener('focus', () => {
+    searchInput?.addEventListener('focus', () => {
         isInitialClick = true;
     });
 
     // Select all text on the first click, then just place the cursor where clicked on the second click
-    searchInput.addEventListener('click', (event) => {
+    searchInput?.addEventListener('click', (event) => {
         if (isInitialClick) {
             searchInput.select(); // Select all text
             isInitialClick = false;
@@ -7056,7 +7120,7 @@
     });
 
     // Modify the input event listener
-    document.getElementById('athleteSearch').addEventListener('input', function () {
+    document.getElementById('athleteSearch')?.addEventListener('input', function () {
         const query = this.value.trim();
         if (query === '') {
             clearSearch(); // Run only when input is cleared
@@ -7066,11 +7130,11 @@
     });
 
     const clearSearchButton = document.querySelector('.clear-icon');
-    clearSearchButton.addEventListener('click', function () {
+    clearSearchButton?.addEventListener('click', function () {
         clearSearch();
         document.getElementById('athleteSearch')?.focus({ preventScroll: true });
     });
-    clearSearchButton.addEventListener('keydown', function (event) {
+    clearSearchButton?.addEventListener('keydown', function (event) {
         if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
             event.preventDefault();
             clearSearch();
@@ -7442,21 +7506,176 @@
         return athleteResults.find(athlete => window.slugifyName(athlete.name) === window.slugifyName(athleteNameText));
     }
 
-    window.openAthleteModalBySlug = function (athleteSlug, options) {
-        const normalizedSlug = window.slugifyName(athleteSlug, true);
-        const athleteData = athleteResults.find(athlete => {
-            const nameSlug = window.slugifyName(athlete.name, true);
-            const displayNameSlug = athlete.displayName ? window.slugifyName(athlete.displayName, true) : '';
-            return nameSlug === normalizedSlug || displayNameSlug === normalizedSlug;
-        });
+    function normalizeAthleteSlugForLookup(value) {
+        const routeSlug = String(value || '').replace(/_/g, '-');
+        if (typeof window.slugifyName === 'function') {
+            return window.slugifyName(routeSlug, true);
+        }
 
-        if (!athleteData) {
+        return routeSlug
+            .trim()
+            .toLowerCase()
+            .normalize('NFKD')
+            .replace(/[\u0300-\u036f]/g, '')
+            .replace(/\s+/g, '-')
+            .replace(/[^a-z0-9-]/g, '')
+            .replace(/-+/g, '-')
+            .replace(/^-|-$/g, '');
+    }
+
+    function findAthleteDataBySlug(athleteSlug) {
+        const normalizedSlug = normalizeAthleteSlugForLookup(athleteSlug);
+        if (!normalizedSlug) return null;
+
+        return athleteResults.find(athlete => {
+            const nameSlug = normalizeAthleteSlugForLookup(athlete.name);
+            const displayNameSlug = athlete.displayName ? normalizeAthleteSlugForLookup(athlete.displayName) : '';
+            return nameSlug === normalizedSlug || displayNameSlug === normalizedSlug;
+        }) || null;
+    }
+
+    function ensureAthleteResultsReady() {
+        return Promise.resolve(window.modulesReady)
+            .then(() => {
+                if (athleteResultsReady) return athleteResults;
+                if (!athleteResultsLoadPromise) {
+                    LoadLeaderboard(false, 0);
+                }
+                return athleteResultsLoadPromise;
+            })
+            .then(() => {
+                if (!athleteResultsReady) {
+                    throw new Error('Athlete profile index could not be loaded.');
+                }
+                return athleteResults;
+            });
+    }
+
+    function navigateToAthleteFallback(fallbackUrl) {
+        currentAthleteModalRequestId++;
+        modal.style.display = 'none';
+        modal.classList.remove('fade-out');
+        restoreBodyScroll();
+        window.location.assign(fallbackUrl);
+    }
+
+    window.openAthleteModalBySlug = function (athleteSlug, options) {
+        const normalizedSlug = normalizeAthleteSlugForLookup(athleteSlug);
+        if (!normalizedSlug) return false;
+
+        const athleteData = findAthleteDataBySlug(normalizedSlug);
+        if (athleteData) {
+            if (options?.returnFocusTo instanceof HTMLElement) {
+                athleteDialogReturnFocusElement = options.returnFocusTo;
+            }
+            fetchFullAthleteData(athleteData.name, athleteData, options);
+            return true;
+        }
+
+        // Once the index is loaded, an unknown profile must retain ordinary
+        // anchor navigation instead of swallowing a potentially valid URL.
+        if (athleteResultsReady) {
             return false;
         }
 
-        fetchFullAthleteData(athleteData.name, athleteData, options);
+        if (options?.returnFocusTo instanceof HTMLElement) {
+            athleteDialogReturnFocusElement = options.returnFocusTo;
+        }
+        const requestId = ++currentAthleteModalRequestId;
+        const modalContent = resetModalForLoading(normalizedSlug);
+
+        ensureAthleteResultsReady()
+            .then(() => {
+                if (requestId !== currentAthleteModalRequestId) return;
+                const loadedAthlete = findAthleteDataBySlug(normalizedSlug);
+                if (!loadedAthlete) {
+                    if (options?.fallbackUrl) {
+                        navigateToAthleteFallback(options.fallbackUrl);
+                        return;
+                    }
+                    throw new Error(`Athlete not found for ${normalizedSlug}.`);
+                }
+                fetchFullAthleteData(loadedAthlete.name, loadedAthlete, options);
+            })
+            .catch(error => {
+                if (requestId !== currentAthleteModalRequestId) return;
+                if (options?.fallbackUrl) {
+                    navigateToAthleteFallback(options.fallbackUrl);
+                    return;
+                }
+                handleAthleteModalLoadFailure(modalContent, normalizedSlug, options, error);
+            });
+
         return true;
     };
+
+    function getAthleteSlugFromProfileLink(link) {
+        if (link.hasAttribute('download')) return '';
+
+        let url;
+        try {
+            url = new URL(link.getAttribute('href'), window.location.href);
+        } catch (error) {
+            return '';
+        }
+
+        if (url.protocol !== 'http:' && url.protocol !== 'https:') return '';
+        const normalizedHostname = url.hostname.toLowerCase().replace(/^www\./, '');
+        const isCurrentOrigin = url.origin === window.location.origin;
+        if (!isCurrentOrigin && normalizedHostname !== 'longevityworldcup.com') return '';
+
+        const match = url.pathname.match(/^\/athlete\/([^/]+)\/?$/i);
+        if (!match) return '';
+
+        try {
+            return decodeURIComponent(match[1]);
+        } catch (error) {
+            return '';
+        }
+    }
+
+    pageDocument.addEventListener('click', event => {
+        if (event.defaultPrevented ||
+            event.button !== 0 ||
+            event.ctrlKey ||
+            event.metaKey ||
+            event.shiftKey ||
+            event.altKey ||
+            !(event.target instanceof Element)) {
+            return;
+        }
+
+        const link = event.target.closest('a[href]');
+        if (!link ||
+            link.closest('#detailsModal') ||
+            link.closest('[data-athlete-dialog="off"]')) {
+            return;
+        }
+
+        const athleteSlug = getAthleteSlugFromProfileLink(link);
+        if (!athleteSlug) return;
+
+        const beforeOpen = new CustomEvent('lwc:athlete-dialog-before-open', {
+            bubbles: true,
+            cancelable: true,
+            detail: { athleteSlug }
+        });
+        if (!link.dispatchEvent(beforeOpen)) return;
+
+        const returnFocusTo = link.getClientRects().length > 0
+            ? link
+            : pageDocument.activeElement instanceof HTMLElement
+                ? pageDocument.activeElement
+                : null;
+        const opened = window.openAthleteModalBySlug(athleteSlug, {
+            suppressGuessMyAge: true,
+            fallbackUrl: link.href,
+            returnFocusTo
+        });
+        if (opened) {
+            event.preventDefault();
+        }
+    });
 
     function getAthletelessURL() {
         const url = new URL(window.location.href.replace(/\/athlete\/[^/]+\/?$/, ''));
@@ -7490,7 +7709,7 @@
             return window.location.origin;
         }
 
-        const canonicalLink = document.querySelector('link[rel="canonical"]');
+        const canonicalLink = pageDocument.querySelector('link[rel="canonical"]');
         try {
             return canonicalLink && canonicalLink.href
                 ? new URL(canonicalLink.href).origin
@@ -7758,6 +7977,11 @@
     }
 
     function fetchFullAthleteData(athleteNameText, athleteData, options) {
+        athleteDialogReturnFocusElement =
+            options?.returnFocusTo instanceof HTMLElement
+                ? options.returnFocusTo
+                : null;
+
         window.getSharedAthletes = window.getSharedAthletes || function(){
             if(!window.__sharedAthletesRequest){
                 window.__sharedAthletesRequest = fetchWithTimeout('/api/data/athletes', {}, 10000)
@@ -8806,6 +9030,7 @@
     const sidebar = document.querySelector('.sidebar');
     const sidebarToggle = document.querySelector('.sidebar-toggle');
     const sidebarClose = document.querySelector('.sidebar-close');
+    const hasLeaderboardSidebar = !!(sidebar && sidebarToggle && sidebarClose);
     const mobileDrawerMediaQuery = window.matchMedia('(max-width: 768px), (max-width: 932px) and (max-height: 480px) and (orientation: landscape)');
     let leaderboardTableHeightFrame = 0;
     let leaderboardTableResizeObserver = null;
@@ -8849,30 +9074,31 @@
         scheduleLeaderboardTableHeightSync();
     }
 
-    sidebarToggle.addEventListener('click', (event) => {
+    sidebarToggle?.addEventListener('click', (event) => {
         toggleSidebar({ focusDrawerClose: event.detail === 0 });
     });
 
-    sidebarToggle.addEventListener('mouseenter', () => {
+    sidebarToggle?.addEventListener('mouseenter', () => {
         if (sidebar.classList.contains('expanded')) return;
         sidebar.classList.add('partially-expanded');
     });
 
-    sidebarToggle.addEventListener('mouseleave', () => {
+    sidebarToggle?.addEventListener('mouseleave', () => {
         sidebar.classList.remove('partially-expanded');
     });
 
-    sidebarClose.addEventListener('click', (event) => {
+    sidebarClose?.addEventListener('click', (event) => {
         closeSidebar({ restoreFocus: event.detail === 0 });
     });
 
-    sidebar.addEventListener('change', (event) => {
+    sidebar?.addEventListener('change', (event) => {
         if (!event.target.matches('input[type="checkbox"]')) return;
 
         requestAnimationFrame(pinActiveDesktopSidebar);
     }, true);
 
     document.addEventListener('click', (event) => {
+        if (!hasLeaderboardSidebar) return;
         const isMobileDrawer = isMobileDrawerViewport();
         if (!sidebar.classList.contains('expanded')) return;
         if (sidebar.contains(event.target) || sidebarToggle.contains(event.target)) return;
@@ -8883,6 +9109,7 @@
     });
 
     document.addEventListener('keydown', (event) => {
+        if (!hasLeaderboardSidebar) return;
         if (event.key !== 'Tab') return;
         if (modal.style.display === "block") return;
 
@@ -8911,6 +9138,7 @@
     });
 
     document.addEventListener('keydown', (event) => {
+        if (!hasLeaderboardSidebar) return;
         if (event.key !== 'Escape' && event.key !== 'Esc') return;
         if (modal.style.display === "block") return;
 
@@ -8925,6 +9153,7 @@
     });
 
     function syncSidebarDrawerBackdrop() {
+        if (!hasLeaderboardSidebar) return;
         const isMobileDrawer = isMobileDrawerViewport();
         const isOpenMobileDrawer = isMobileDrawer && sidebar.classList.contains('expanded');
         document.body.classList.toggle('sidebar-drawer-open', isOpenMobileDrawer);
@@ -8932,6 +9161,7 @@
     }
 
     function getSidebarFocusableControls() {
+        if (!hasLeaderboardSidebar) return [];
         return Array.from(sidebar.querySelectorAll('a[href], button, input:not([type="hidden"]), select, textarea, [tabindex]:not([tabindex="-1"])'))
             .filter(element => {
                 if (element.disabled || element.getAttribute('aria-hidden') === 'true') return false;
@@ -8954,6 +9184,7 @@
     }
 
     function toggleSidebar(options = {}) {
+        if (!hasLeaderboardSidebar) return;
         if (sidebar.classList.contains('expanded')) {
             closeSidebar();
         }
@@ -8963,6 +9194,7 @@
     }
 
     function pinActiveDesktopSidebar() {
+        if (!hasLeaderboardSidebar) return;
         if (isMobileDrawerViewport()) return;
         if (!hasActiveLeaderboardFilterState()) return;
         if (sidebar.classList.contains('expanded')) return;
@@ -8971,6 +9203,7 @@
     }
 
     function openSidebar(options = {}) {
+        if (!hasLeaderboardSidebar) return;
         const isMobileDrawer = isMobileDrawerViewport();
         const drawerScrollX = window.scrollX;
         const drawerScrollY = window.scrollY;
@@ -9016,6 +9249,7 @@
     }
 
     function closeSidebar(options = {}) {
+        if (!hasLeaderboardSidebar) return;
         sidebar.classList.remove('expanded');
         sidebar.setAttribute('aria-hidden', 'true');
         sidebarToggle.classList.remove('active');
@@ -9048,16 +9282,18 @@
         }, 50);
     }
 
-    syncSidebarDrawerBackdrop();
-    installLeaderboardTableHeightObserver();
-    window.addEventListener('resize', () => {
+    if (hasLeaderboardSidebar) {
         syncSidebarDrawerBackdrop();
-        scheduleLeaderboardTableHeightSync();
-    });
-    if (typeof mobileDrawerMediaQuery.addEventListener === 'function') {
-        mobileDrawerMediaQuery.addEventListener('change', scheduleLeaderboardTableHeightSync);
-    } else if (typeof mobileDrawerMediaQuery.addListener === 'function') {
-        mobileDrawerMediaQuery.addListener(scheduleLeaderboardTableHeightSync);
+        installLeaderboardTableHeightObserver();
+        window.addEventListener('resize', () => {
+            syncSidebarDrawerBackdrop();
+            scheduleLeaderboardTableHeightSync();
+        });
+        if (typeof mobileDrawerMediaQuery.addEventListener === 'function') {
+            mobileDrawerMediaQuery.addEventListener('change', scheduleLeaderboardTableHeightSync);
+        } else if (typeof mobileDrawerMediaQuery.addListener === 'function') {
+            mobileDrawerMediaQuery.addListener(scheduleLeaderboardTableHeightSync);
+        }
     }
 
     // Sidebar swipe gesture
@@ -9069,6 +9305,7 @@
     const TAP_THRESHOLD = 10; // Allowable movement for taps
 
     document.addEventListener('touchstart', (e) => {
+        if (!hasLeaderboardSidebar) return;
         if (modal.style.display === "block") return;
 
         startX = e.changedTouches[0].clientX;
@@ -9076,6 +9313,7 @@
     }, false);
 
     document.addEventListener('touchend', (e) => {
+        if (!hasLeaderboardSidebar) return;
         if (modal.style.display === "block") return;
 
         endX = e.changedTouches[0].clientX;
@@ -9216,6 +9454,18 @@
         }
         updateAthleteInfoGrouping();
     }
+
+    // Keep the small public surface used by page bootstraps, Guess My Age, and
+    // existing browser tests while the controller itself remains isolated.
+    window.LoadLeaderboard = LoadLeaderboard;
+    window.openEnlargedView = openEnlargedView;
+    window.closeEnlargedView = closeEnlargedView;
+    window.populateProofsGallery = populateProofsGallery;
+    window.closeAthleteShareMenu = closeAthleteShareMenu;
+    window.closeModal = closeModal;
+    window.updateCrowdContainer = updateCrowdContainer;
+    window.updateYourGuess = updateYourGuess;
+    })();
 </script>
 
 <script>


### PR DESCRIPTION
## Outcome

Every current public athlete-profile link now opens the same in-page profile dialog as the leaderboard on an ordinary click. This covers the homepage, Events, About, History, the Longevitymaxxing Challenge, Helstab Kihívás, both biological-age calculators (including generated rank-preview names and lab-panel creators), and future/dynamically rendered links on those surfaces.

The anchors remain real canonical `/athlete/{slug}` links. Ctrl/Cmd/Shift/Alt clicks and middle clicks retain native browser behavior, and an unknown athlete or a failed runtime load falls back to normal navigation instead of swallowing the link.

## Why the earlier implementations were fragile

The leaderboard dialog looked like a reusable modal, but it was not a component. Its markup, roughly 3,000 lines of CSS, athlete-index and rank derivation, full-profile hydration, Guess My Age state, proof viewer, chart setup, URL history, scroll locking, and focus lifecycle all lived together in `leaderboard-content.html`.

The older call-site fixes only invoked `openAthleteModalBySlug` from Merch, Events, or badge links. That worked only when the leaderboard controller and its asynchronously computed `athleteResults` happened to be present and ready. On standalone pages the dialog markup/controller did not exist at all; during early loading, the opener synchronously returned false. Reimplementing or copying just part of that stack also missed lifecycle fixes accumulated in related work such as #424, #435, and #795.

In short, the difficult part was not recognizing an athlete link. It was making the full, stateful leaderboard dialog safely reusable without forking its UI or leaking its assumptions into unrelated pages.

## Implementation

- Marked the dialog, deferred sections, and runtime boundaries inside the existing leaderboard partial. The leaderboard remains the single source of truth.
- For the seven standalone public routes that contain athlete links, `HtmlInjectionMiddleware` composes one dialog runtime from those exact source regions and supplies its existing versioned modules.
- Scoped the reused CSS to `#athleteDialogRuntime` and rooted legacy selector calls through that runtime. This prevents generic selectors such as `.modal-content` from binding to a host page's own components.
- Added a delegated, URL-based link handler. It works for static and dynamic canonical links, including official apex/`www` URLs and legacy underscore slugs, without requiring another bespoke handler at each call site.
- Made opening hydration-aware: a click immediately enters the existing loading state, waits for frontend modules and the athlete/ranking index, then opens the requested athlete. Request IDs prevent a slow or stale response from replacing a newer dialog or reopening a closed one.
- Preserved the existing history and nested proof-viewer behavior while restoring the originating page URL, scroll position, and caller focus when the dialog closes.
- Reused the established `suppressGuessMyAge` path for non-leaderboard links, preserving the privacy/exposure behavior introduced in #435.
- Added canonical athlete anchors to generated calculator rank previews and normalized backend underscore slugs to route hyphens.
- Retired the Challenge quote dialog before opening an athlete profile and raised only the standalone profile layer above page-specific fixed docks/dialogs, leaving the leaderboard's master stacking unchanged.
- Removed the Merch, Events, and badge-overflow one-off bridges; the shared canonical-link behavior now owns those paths.

## Difficulties encountered and fixes made during browser verification

Browser testing exposed several issues that a source-only review would not:

- The first extracted runtime omitted the row template needed to derive athlete ranks, so the original leaderboard podium failed.
- A document-isolation proxy initially invoked native setters with the wrong receiver, causing an `Illegal invocation` when the dialog changed the page title.
- Guess My Age and proof-history scripts depended on a small set of formerly implicit globals; these are now exported deliberately.
- API `AthleteSlug` values use underscores while public routes use hyphens; relying on the existing slug helper silently collapsed some generated calculator and Challenge links.
- Calculator action docks and the Challenge quote dialog use high fixed layers. A standalone dialog needed a host-aware layer while the leaderboard had to keep its current value.
- Most importantly, the reused leaderboard tail initially changed `history.scrollRestoration` and monkey-patched `scrollTo`, `scrollBy`, and `Element.prototype.scrollIntoView` on every host page. That was a genuine cross-page regression of the kind prior attempts could introduce. Leaderboard-only scroll guarding is now disabled in standalone mode, with a browser regression that snapshots the native APIs before any page script runs.

- After refreshing from master, the full CI suite exposed a slower-runner-only readiness race: dialog-only dynamic imports had been appended to the host page's `window.modulesReady`, so the calculator's query-string hydration could be delayed past `DOMContentLoaded`. The host and dialog now have separate readiness promises; the dialog waits for both, while host initialization is no longer coupled to unrelated profile dependencies. A browser regression deliberately stalls a dialog-only module and proves calculator hydration still completes.

## Judgment and confidence

I chose exact single-source reuse over a second dialog implementation. That gives the strongest UI and behavioral parity now: the dialog markup is byte-for-byte the markup on current master, and Playwright compares leaderboard versus standalone structure, computed content styles, and geometry in the same viewport.

Confidence is high for the current public surfaces. The tests exercise queued loading, rapid/lifecycle safety, dynamic links, official-domain links, modifier and middle-click behavior, unknown-link fallback, URL/scroll/focus restoration, Guess My Age suppression, proof history, mobile layering, and the original leaderboard hit areas.

There is one deliberate architectural tradeoff: the bridge adds about 413 KB uncompressed (highly compressible) of legacy dialog markup/CSS/controller to each opted-in HTML response. Extracting the dialog into a smaller first-class module would reduce parse and transfer cost, but doing that in this change would also recreate the parity risk this work is intended to remove. The route allowlist is therefore explicit and excludes account/onboarding workflows, internal tools, and the Events iframe. The Challenge quote handoff has a source-level contract assertion rather than a full authenticated check-in browser journey; the delegated dialog behavior on that route is covered, but that particular authenticated composition remains the narrowest test seam.

## Verification

- `dotnet build LongevityWorldCup.sln --no-restore` — passed, 0 warnings / 0 errors
- `dotnet test LongevityWorldCup.Tests/LongevityWorldCup.Tests.csproj --no-build --filter "FullyQualifiedName~AthleteDialogLinkBrowserTests"` — 12/12 passed
- Affected existing suites (`LeaderboardPodiumBrowserTests`, `LeaderboardProofViewerBrowserTests`, `GuessMyAgeBrowserTests`, `BioageRankPreviewBrowserTests`, `LongevitymaxxingChallengePageTests`, and the bioage onboarding rank-copy cases) — 28/28 passed
- `NewAthleteOnboardingBrowserTests` after module-readiness decoupling — 10/10 passed
- GitHub `.NET` workflow on `f9ee7f8d` — full suite 1,323/1,323 passed
- `git diff --check` — clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large shared client runtime injected across many HTML responses with history, scroll, focus, and modal stacking behavior; mitigated by explicit route allowlist and extensive Playwright tests but still a cross-cutting frontend change.
> 
> **Overview**
> **Public `/athlete/{slug}` links** on About, History, Events, calculators, Longevitymaxxing, and related routes now open the **same in-page profile dialog** as the leaderboard on a normal left-click, while keeping real canonical URLs and native behavior for modified or middle clicks.
> 
> **`HtmlInjectionMiddleware`** composes a single **`#athleteDialogRuntime`** from marked regions of the leaderboard partial (dialog markup, deferred sections, runtime scripts) on an explicit route allowlist, scopes reused CSS with **`@scope (#athleteDialogRuntime)`**, and loads dialog-only JS modules via a separate **`window.athleteDialogModulesReady`** so host pages (e.g. calculator query hydration) are not blocked on profile dependencies.
> 
> The leaderboard controller is refactored for **standalone “dialog-only” mode**: DOM queries are rooted through the runtime, **ScrollGuard** and leaderboard-only UI wiring are skipped, modal **z-index** uses **`--athlete-dialog-layer`**, and a **document-level delegated click handler** intercepts canonical athlete links (including apex/`www` URLs and underscore slugs), dispatches **`lwc:athlete-dialog-before-open`**, and **`openAthleteModalBySlug`** queues loading until modules and the athlete index are ready—with **focus/URL restoration** on close and fallback navigation when the athlete is unknown.
> 
> Per-surface one-off handlers are removed (homepage merch, events table, badge overflow); **calculator rank previews** emit hyphenated athlete anchors; **Guess My Age** targets **`#detailsModal .modal-content`**; the Challenge **quote dialog** closes before the profile opens. **Playwright coverage** (`AthleteDialogLinkBrowserTests`) locks injection shape, hydration decoupling, scroll API isolation, layering, and leaderboard vs standalone dialog parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9ee7f8d081d57a54d178e7749ab4c665609e351. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->