### PR TITLE
Fix mobile biological age entry

### DIFF
--- a/LongevityWorldCup.Tests/ApplicationOnboardingPageTests.cs
+++ b/LongevityWorldCup.Tests/ApplicationOnboardingPageTests.cs
@@ -57,6 +57,9 @@ public sealed class ApplicationOnboardingPageTests
         var html = await client.GetStringAsync("/onboarding/convergence.html");
 
         Assert.Contains("function getConvergenceBackDestination()", html);
+        Assert.Contains("const storedClock = getSessionItem('bioageClock');", html);
+        Assert.Contains("if (storedClock === 'bortz') return '/bortz-age';", html);
+        Assert.Contains("if (storedClock === 'pheno') return '/pheno-age';", html);
         Assert.Contains("return paymentOffer && paymentOffer.offerType === 'pro'", html);
         Assert.Contains("? '/bortz-age'", html);
         Assert.Contains(": '/pheno-age';", html);
@@ -565,8 +568,14 @@ public sealed class ApplicationOnboardingPageTests
         Assert.Contains("const match = /^(\\d{4})-(\\d{2})-(\\d{2})$/.exec(value.trim());", html);
         Assert.Contains("return parsedDate <= todayUtc;", html);
         Assert.Contains("function hasStoredBiomarkerValues(biomarkerData)", html);
-        Assert.Contains("function hasCompleteSubmittedBiomarkerValues(biomarkerData, chronoPhenoDifference, chronoBortzDifference)", html);
-        Assert.Contains("!hasCompleteSubmittedBiomarkerValues(biomarkerData, chronoPhenoDifference, chronoBortzDifference)", parseBody);
+        Assert.Contains("function hasCompleteSubmittedBiomarkerValues(biomarkerData, bioageClock)", html);
+        Assert.Contains("!hasCompleteSubmittedBiomarkerValues(biomarkerData, bioageClock)", parseBody);
+        Assert.Contains("function readStoredBioageClock(biomarkerData, chronoPhenoDifference, chronoBortzDifference)", html);
+        Assert.Contains("const storedClock = getSessionItem('bioageClock');", html);
+        Assert.Contains("const isLegacyUnclockedResult = !bioageClock", parseBody);
+        Assert.Contains("&& getSessionItem('bioageClock') === null", parseBody);
+        Assert.Contains("const hasRequiredAgeDifferences = isLegacyUnclockedResult || (chronoPhenoDifference !== null", parseBody);
+        Assert.Contains("(!bioageClock && !isLegacyUnclockedResult)", parseBody);
         Assert.Contains("function hasStoredBiomarkerValue(value)", html);
         Assert.Contains("Object.keys(entry).some(key => key !== 'Date' && hasStoredBiomarkerValue(entry[key]))", html);
         Assert.Contains("const PHENO_RESULT_BIOMARKER_KEYS = ['AlbGL', 'CreatUmolL', 'GluMmolL', 'CrpMgL', 'Wbc1000cellsuL', 'LymPc', 'McvFL', 'RdwPc', 'AlpUL'];", html);
@@ -579,10 +588,12 @@ public sealed class ApplicationOnboardingPageTests
         Assert.Contains("clearStoredBiomarkerHandoff();", parseBody);
         Assert.Contains("function clearStoredBiomarkerHandoff()", html);
         Assert.Contains("removeSessionItem('biomarkerData');", html);
+        Assert.Contains("removeSessionItem('bioageClock');", html);
         Assert.Contains("removeSessionItem('chronoPhenoDifference');", html);
         Assert.Contains("removeSessionItem('chronoBortzDifference');", html);
         Assert.Contains("customAlert('Biomarker data is missing. Please complete the biomarker step.')", parseBody);
-        Assert.Contains(".then(() => window.location.href = '/onboarding/pheno-age');", parseBody);
+        Assert.Contains("const biomarkerRoute = bioageClock === 'bortz' ? '/bortz-age' : '/pheno-age';", parseBody);
+        Assert.Contains(".then(() => window.location.href = biomarkerRoute);", parseBody);
     }
 
     [Fact]
@@ -604,7 +615,10 @@ public sealed class ApplicationOnboardingPageTests
         Assert.Contains("return window[storageName].getItem(key);", html);
         Assert.Contains("return null;", html);
         Assert.Contains("const chronoPhenoDifference = readStoredAgeDifference('chronoPhenoDifference');", collectBody);
-        Assert.Contains("const chronoBortzDifference = readStoredAgeDifference('chronoBortzDifference');", collectBody);
+        Assert.Contains("let chronoBortzDifference = readStoredAgeDifference('chronoBortzDifference');", collectBody);
+        Assert.Contains("const bioageClock = readStoredBioageClock(", collectBody);
+        Assert.Contains("biomarkerData,\n                chronoPhenoDifference,\n                chronoBortzDifference);", collectBody);
+        Assert.Contains("if (bioageClock === 'pheno') chronoBortzDifference = null;", collectBody);
         Assert.Contains("function readStoredAgeDifference(key)", html);
         Assert.Contains("if (text && Number.isFinite(Number(text)))", html);
         Assert.Contains("removeSessionItem(key);", html);

--- a/LongevityWorldCup.Tests/BioageKeyboardViewportBrowserTests.cs
+++ b/LongevityWorldCup.Tests/BioageKeyboardViewportBrowserTests.cs
@@ -1,0 +1,195 @@
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class BioageKeyboardViewportBrowserTests
+{
+    [Theory]
+    [InlineData("/pheno-age", "#crp", "1", 390, 844, 420, 0)]
+    [InlineData("/bortz-age", "#vitamin_d", "50", 390, 844, 420, 0)]
+    [InlineData("/pheno-age", "#crp", "1", 844, 390, 200, 24)]
+    [InlineData("/bortz-age", "#vitamin_d", "50", 844, 390, 200, 24)]
+    [InlineData("/pheno-age", "#crp", "1", 956, 440, 230, 24)]
+    [InlineData("/bortz-age", "#vitamin_d", "50", 956, 440, 230, 24)]
+    public async Task BioageBiomarker_FocusStaysVisibleWhenTheMobileKeyboardOpens(
+        string path,
+        string inputSelector,
+        string inputValue,
+        int viewportWidth,
+        int viewportHeight,
+        int keyboardViewportHeight,
+        int keyboardViewportOffsetTop)
+    {
+        using var factory = new TestWebApplicationFactory();
+        factory.UseKestrel(0);
+        factory.StartServer();
+        var baseAddress = factory.ClientOptions.BaseAddress;
+
+        using var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+            BaseAddress = baseAddress
+        });
+        using var healthResponse = await client.GetAsync("/health");
+        healthResponse.EnsureSuccessStatusCode();
+
+        using var playwright = await Playwright.CreateAsync();
+        await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+        {
+            Headless = true
+        });
+        await using var context = await browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            BaseURL = baseAddress.ToString(),
+            Locale = "en-US",
+            IsMobile = true,
+            HasTouch = true,
+            ViewportSize = new ViewportSize { Width = viewportWidth, Height = viewportHeight },
+            ScreenSize = new ScreenSize { Width = viewportWidth, Height = viewportHeight }
+        });
+        await BrowserTestApp.RouteExternalResourcesAsync(context);
+        await context.AddInitScriptAsync(VisualViewportTestBootstrap());
+
+        var page = await context.NewPageAsync();
+        await page.GotoAsync(path, new PageGotoOptions
+        {
+            WaitUntil = WaitUntilState.DOMContentLoaded
+        });
+        await page.WaitForFunctionAsync("() => window.LwcFlowActionDock");
+        await page.EvaluateAsync(
+            """
+            () => {
+                window.__testSetVisualViewport(window.innerHeight, 0);
+                window.LwcFlowActionDock.refreshNow();
+            }
+            """);
+
+        await page.Locator("#dob-year").SelectOptionAsync("1980");
+        await page.Locator("#dob-month").SelectOptionAsync("5");
+        await page.WaitForFunctionAsync(
+            "() => Array.from(document.querySelector('#dob-day')?.options || []).some(option => option.value === '20')");
+        await page.Locator("#dob-day").SelectOptionAsync("20");
+        await page.Locator("#blood-draw-date")
+            .FillAsync(DateTime.UtcNow.Date.AddDays(-9).ToString("yyyy-MM-dd"));
+        await page.Locator("#lwcToStep2Btn").ClickAsync();
+        await page.WaitForFunctionAsync(
+            "() => document.querySelector('#lwc-step-2')?.classList.contains('lwc-step--visible')");
+
+        var biomarker = page.Locator(inputSelector);
+        await biomarker.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible });
+        await biomarker.ScrollIntoViewIfNeededAsync();
+
+        await page.EvaluateAsync("() => window.LwcFlowActionDock.refreshNow()");
+        await page.WaitForFunctionAsync(
+            "() => document.querySelector('#lwcStepTwoActions')?.classList.contains('flow-action-stack--docked')");
+
+        await biomarker.FillAsync(inputValue);
+        await page.EvaluateAsync(
+            "viewport => window.__testSetVisualViewport(viewport.height, viewport.offsetTop)",
+            new { height = keyboardViewportHeight, offsetTop = keyboardViewportOffsetTop });
+        await page.WaitForFunctionAsync(
+            """
+            () => document.documentElement.classList.contains('flow-input-keyboard-open')
+                && document.body.classList.contains('flow-input-keyboard-open')
+                && !document.querySelector('#lwcStepTwoActions')?.classList.contains('flow-action-stack--docked')
+            """);
+        await page.WaitForTimeoutAsync(750);
+
+        var state = await page.EvaluateAsync<KeyboardViewportState>(
+            """
+            selector => {
+                const input = document.querySelector(selector);
+                const dock = document.querySelector('#lwcStepTwoActions');
+                const viewport = window.visualViewport;
+                const rect = input.getBoundingClientRect();
+                return {
+                    HtmlKeyboardOpen: document.documentElement.classList.contains('flow-input-keyboard-open'),
+                    BodyKeyboardOpen: document.body.classList.contains('flow-input-keyboard-open'),
+                    Docked: dock.classList.contains('flow-action-stack--docked'),
+                    InputFocused: document.activeElement === input,
+                    InputTop: rect.top,
+                    InputBottom: rect.bottom,
+                    VisualViewportTop: viewport.offsetTop,
+                    VisualViewportBottom: viewport.offsetTop + viewport.height
+                };
+            }
+            """,
+            inputSelector);
+
+        Assert.True(state.HtmlKeyboardOpen, "The document element should expose the keyboard-open state.");
+        Assert.True(state.BodyKeyboardOpen, "The body should expose the keyboard-open state.");
+        Assert.False(state.Docked, "The mobile action dock should return to document flow while the keyboard is open.");
+        Assert.True(state.InputFocused, "The biomarker input should retain focus after the visual viewport shrinks.");
+        Assert.True(
+            state.InputTop >= state.VisualViewportTop && state.InputBottom <= state.VisualViewportBottom,
+            $"The focused biomarker must remain fully visible: input {state.InputTop}-{state.InputBottom}, "
+            + $"visual viewport {state.VisualViewportTop}-{state.VisualViewportBottom}.");
+        Assert.Equal("next", await biomarker.GetAttributeAsync("enterkeyhint"));
+
+        await biomarker.PressAsync("Enter");
+        await page.WaitForFunctionAsync(
+            """
+            () => {
+                const input = document.querySelector('#wbc');
+                const viewport = window.visualViewport;
+                if (!input || !viewport || document.activeElement !== input) return false;
+                const rect = input.getBoundingClientRect();
+                return rect.top >= viewport.offsetTop
+                    && rect.bottom <= viewport.offsetTop + viewport.height;
+            }
+            """);
+
+        await page.EvaluateAsync("() => window.__testSetVisualViewport(window.innerHeight, 0)");
+        await page.WaitForTimeoutAsync(750);
+        var restoredState = await page.EvaluateAsync<string>(
+            """
+            () => JSON.stringify({
+                visualHeight: window.visualViewport?.height,
+                innerHeight: window.innerHeight,
+                screenWidth: window.screen?.width,
+                screenHeight: window.screen?.height,
+                orientation: window.screen?.orientation?.type,
+                keyboardOpen: document.documentElement.classList.contains('flow-input-keyboard-open'),
+                occlusion: getComputedStyle(document.documentElement)
+                    .getPropertyValue('--flow-input-keyboard-occlusion'),
+                docked: document.querySelector('#lwcStepTwoActions')
+                    ?.classList.contains('flow-action-stack--docked')
+            })
+            """);
+        Assert.False(await page.Locator("html").EvaluateAsync<bool>(
+            "html => html.classList.contains('flow-input-keyboard-open')"), restoredState);
+        Assert.True(await page.Locator("#lwcStepTwoActions").EvaluateAsync<bool>(
+            "dock => dock.classList.contains('flow-action-stack--docked')"), restoredState);
+    }
+
+    private static string VisualViewportTestBootstrap()
+        => """
+        const visualViewport = new EventTarget();
+        visualViewport.offsetTop = 0;
+        visualViewport.height = window.innerHeight;
+        Object.defineProperty(window, 'visualViewport', {
+            configurable: true,
+            value: visualViewport
+        });
+        window.__testVisualViewport = visualViewport;
+        window.__testSetVisualViewport = (height, offsetTop = 0) => {
+            visualViewport.height = height;
+            visualViewport.offsetTop = offsetTop;
+            visualViewport.dispatchEvent(new Event('resize'));
+        };
+        """;
+
+    private sealed class KeyboardViewportState
+    {
+        public bool HtmlKeyboardOpen { get; set; }
+        public bool BodyKeyboardOpen { get; set; }
+        public bool Docked { get; set; }
+        public bool InputFocused { get; set; }
+        public double InputTop { get; set; }
+        public double InputBottom { get; set; }
+        public double VisualViewportTop { get; set; }
+        public double VisualViewportBottom { get; set; }
+    }
+}

--- a/LongevityWorldCup.Tests/BioageMobileUxBrowserTests.cs
+++ b/LongevityWorldCup.Tests/BioageMobileUxBrowserTests.cs
@@ -171,16 +171,13 @@ public sealed class BioageMobileUxBrowserTests
     [Theory]
     [InlineData(
         "/pheno-age?Year=1980&Month=6&Day=15&Date=2026-06-01&AlbGL=45&CreatUmolL=80&GluMmolL=5&CrpMgL=1&Wbc1000cellsuL=5.5&LymPc=30&McvFL=90&RdwPc=13&AlpUL=70",
-        "#phenoAgeResult",
-        9)]
+        "#phenoAgeResult")]
     [InlineData(
         "/bortz-age?Year=1980&Month=6&Day=15&Date=2026-06-01&AlbGL=45&AlpUL=70&UreaMmolL=5&CholesterolMmolL=4.5&CreatUmolL=80&CystatinCMgL=0.9&Hba1cMmolMol=33.33&CrpMgL=1&GgtUL=20&Rbc10e12L=4.8&McvFL=90&RdwPc=13&GluMmolL=5&MchPg=30&ApoA1GL=1.5&LymPc=30&AltUL=25&ShbgNmolL=40&VitaminDNmolL=200&Wbc1000cellsuL=5.5&MonocytePc=6&NeutrophilPc=60",
-        "#bortzAgeResult",
-        22)]
-    public async Task MobileResult_EditValuesReturnsToThePreservedWorksheet(
+        "#bortzAgeResult")]
+    public async Task MobileResult_DoesNotShowInlineEditValuesAction(
         string path,
-        string resultSelector,
-        int biomarkerCount)
+        string resultSelector)
     {
         await using var app = await BrowserTestApp.StartAsync();
         using var playwright = await Playwright.CreateAsync();
@@ -210,87 +207,22 @@ public sealed class BioageMobileUxBrowserTests
         await page.GotoAsync(path, new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
         await page.WaitForFunctionAsync(
             "() => document.querySelector('.bioageform')?.classList.contains('bioage-biomarker-entry-ready')");
-        var unchangedUrl = page.Url;
-        var editValues = page.Locator($"{resultSelector} .bioage-edit-values-button");
-        Assert.NotNull(await page.Locator(resultSelector).GetAttributeAsync("inert"));
-        Assert.False(await editValues.EvaluateAsync<bool>(
-            "button => { button.focus(); return document.activeElement === button; }"));
 
         await page.Locator("#lwcToStep2Btn").TapAsync();
         await page.WaitForFunctionAsync(
             "() => document.querySelector('#lwc-step-2')?.classList.contains('lwc-step--visible')");
-        Assert.Equal($"{biomarkerCount} of {biomarkerCount} biomarkers entered",
-            await page.Locator(".bioage-biomarker-progress").InnerTextAsync());
 
-        var firstValue = await page.Locator("#wbc").InputValueAsync();
         var calculate = page.Locator("#calculateBioageButton");
         Assert.False(await calculate.IsDisabledAsync());
         await calculate.TapAsync();
         await page.WaitForSelectorAsync($"{resultSelector}.show");
 
-        await editValues.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible });
         Assert.Null(await page.Locator(resultSelector).GetAttributeAsync("inert"));
-        await editValues.TapAsync();
-        await page.WaitForFunctionAsync(
-            "selector => !document.querySelector(selector)?.classList.contains('show')",
-            resultSelector);
-
-        Assert.True(await page.Locator("#lwc-step-2").IsVisibleAsync());
-        Assert.Equal(firstValue, await page.Locator("#wbc").InputValueAsync());
-        Assert.False(await calculate.IsDisabledAsync());
-        Assert.Equal(unchangedUrl, page.Url);
-        Assert.False(await page.Locator("body").EvaluateAsync<bool>(
-            "body => body.classList.contains('bioage-result-ready')"));
-        Assert.NotNull(await page.Locator(resultSelector).GetAttributeAsync("inert"));
-        Assert.False(await editValues.EvaluateAsync<bool>(
-            "button => { button.focus(); return document.activeElement === button; }"));
+        Assert.Equal(0, await page.GetByRole(
+            AriaRole.Button,
+            new() { Name = "Edit values" }).CountAsync());
+        Assert.Equal(0, await page.Locator(".bioage-edit-values-button").CountAsync());
         Assert.Empty(errors);
-    }
-
-    [Theory]
-    [InlineData(
-        "/pheno-age?Year=1980&Month=6&Day=15&Date=2026-06-01&AlbGL=45&CreatUmolL=80&GluMmolL=5&CrpMgL=1&Wbc1000cellsuL=5.5&LymPc=30&McvFL=90&RdwPc=10000&AlpUL=70",
-        "#phenoAgeResult")]
-    [InlineData(
-        "/bortz-age?Year=1980&Month=6&Day=15&Date=2026-06-01&AlbGL=45&AlpUL=70&UreaMmolL=5&CholesterolMmolL=4.5&CreatUmolL=80&CystatinCMgL=0.9&Hba1cMmolMol=33.33&CrpMgL=0&GgtUL=20&Rbc10e12L=4.8&McvFL=90&RdwPc=13&GluMmolL=5&MchPg=30&ApoA1GL=1.5&LymPc=30&AltUL=25&ShbgNmolL=40&VitaminDNmolL=200&Wbc1000cellsuL=5.5&MonocytePc=6&NeutrophilPc=60",
-        "#bortzAgeResult")]
-    public async Task MobileNonFiniteResult_EditValuesStillReturnsToTheWorksheet(
-        string path,
-        string resultSelector)
-    {
-        await using var app = await BrowserTestApp.StartAsync();
-        using var playwright = await Playwright.CreateAsync();
-        await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
-        {
-            Headless = true
-        });
-        await using var context = await browser.NewContextAsync(new BrowserNewContextOptions
-        {
-            BaseURL = app.BaseAddress.ToString(),
-            Locale = "en-US",
-            IsMobile = true,
-            HasTouch = true,
-            ViewportSize = new ViewportSize { Width = 390, Height = 844 }
-        });
-        await BrowserTestApp.RouteExternalResourcesAsync(context);
-
-        var page = await context.NewPageAsync();
-        await page.GotoAsync(path, new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
-        await page.Locator("#lwcToStep2Btn").TapAsync();
-        await page.WaitForFunctionAsync(
-            "() => document.querySelector('#lwc-step-2')?.classList.contains('lwc-step--visible')");
-        await page.Locator("#calculateBioageButton").TapAsync();
-        await page.WaitForSelectorAsync($"{resultSelector}.show");
-        Assert.True(await page.Locator("#ensureCorrectInputSuggestion").IsVisibleAsync());
-
-        await page.GetByRole(AriaRole.Button, new() { Name = "Edit values" }).TapAsync();
-        await page.WaitForFunctionAsync(
-            "selector => !document.querySelector(selector)?.classList.contains('show')",
-            resultSelector);
-
-        Assert.True(await page.Locator("#lwc-step-2").IsVisibleAsync());
-        Assert.False(await page.Locator("body").EvaluateAsync<bool>(
-            "body => body.classList.contains('bioage-result-ready')"));
     }
 
     [Theory]

--- a/LongevityWorldCup.Tests/BioageMobileUxBrowserTests.cs
+++ b/LongevityWorldCup.Tests/BioageMobileUxBrowserTests.cs
@@ -298,6 +298,8 @@ public sealed class BioageMobileUxBrowserTests
         var firstUnit = page.Locator($"#{firstInputId}Unit");
         Assert.True(await firstInput.IsVisibleAsync());
         Assert.True(await firstUnit.IsVisibleAsync());
+        Assert.Equal("textfield", await firstInput.EvaluateAsync<string>(
+            "input => getComputedStyle(input).appearance"));
 
         var inlineLayout = await firstInput.EvaluateAsync<double[]>(
             """

--- a/LongevityWorldCup.Tests/BioageMobileUxBrowserTests.cs
+++ b/LongevityWorldCup.Tests/BioageMobileUxBrowserTests.cs
@@ -85,31 +85,37 @@ public sealed class BioageMobileUxBrowserTests
                 Name: 'Mobile Update Athlete',
                 DisplayName: 'Mobile Update Athlete',
                 DateOfBirth: { Year: 1980, Month: 5, Day: 20 },
-                Biomarkers: [{
-                    Date: '2026-06-01',
-                    AlbGL: 45,
-                    AlpUL: 83,
-                    AltUL: 22,
-                    ApoA1GL: 1.52,
-                    CholesterolMmolL: 5.6,
-                    CreatUmolL: 72,
-                    CrpMgL: 1.35,
-                    CystatinCMgL: 0.9,
-                    GluMmolL: 5,
-                    GgtUL: 29,
-                    Hba1cMmolMol: 35.5,
-                    LymPc: 28.6,
-                    MchPg: 31.8,
-                    McvFL: 92,
-                    MonocytePc: 7.2,
-                    NeutrophilPc: 64.2,
-                    Rbc10e12L: 4.5,
-                    RdwPc: 13.4,
-                    ShbgNmolL: 45.6,
-                    UreaMmolL: 5.4,
-                    VitaminDNmolL: 50,
-                    Wbc1000cellsuL: 6.54
-                }]
+                Biomarkers: [
+                    {
+                        Date: '2026-06-01',
+                        AlbGL: 45,
+                        AlpUL: 83,
+                        AltUL: 22,
+                        ApoA1GL: 1.52,
+                        CholesterolMmolL: 5.6,
+                        CreatUmolL: 72,
+                        CrpMgL: 1.35,
+                        CystatinCMgL: 0.9,
+                        GluMmolL: 5,
+                        GgtUL: 29,
+                        Hba1cMmolMol: 35.5,
+                        LymPc: 28.6,
+                        MchPg: 31.8,
+                        McvFL: 92,
+                        MonocytePc: 7.2,
+                        NeutrophilPc: 64.2,
+                        Rbc10e12L: 4.5,
+                        RdwPc: 13.4,
+                        ShbgNmolL: 45.6,
+                        UreaMmolL: 5.4,
+                        VitaminDNmolL: 50,
+                        Wbc1000cellsuL: 6.54
+                    },
+                    {
+                        Date: '2026-07-01',
+                        GluMmolL: 5.1
+                    }
+                ]
             }));
             """);
 
@@ -164,7 +170,9 @@ public sealed class BioageMobileUxBrowserTests
         await calculate.TapAsync();
         await page.WaitForSelectorAsync($"{resultSelector}.show");
         Assert.Equal("5.2", await page.Locator("#glucose").InputValueAsync());
-        Assert.NotEqual("", await page.Locator("#wbc").InputValueAsync());
+        Assert.Equal("6.54", await page.Locator("#wbc").InputValueAsync());
+        Assert.True(await page.Locator("#validAgeInput").IsVisibleAsync());
+        Assert.False(await page.Locator("#ensureCorrectInputSuggestion").IsVisibleAsync());
         Assert.Empty(errors);
     }
 

--- a/LongevityWorldCup.Tests/BioageMobileUxBrowserTests.cs
+++ b/LongevityWorldCup.Tests/BioageMobileUxBrowserTests.cs
@@ -1,0 +1,447 @@
+using Microsoft.Playwright;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class BioageMobileUxBrowserTests
+{
+    [Fact]
+    public async Task RestoredDraftEdit_InvalidatesThePreviouslyCalculatedHandoff()
+    {
+        const string path =
+            "/pheno-age?Year=1980&Month=6&Day=15&Date=2026-06-01&AlbGL=45&CreatUmolL=80&GluMmolL=5&CrpMgL=1&Wbc1000cellsuL=5.5&LymPc=30&McvFL=90&RdwPc=13&AlpUL=70";
+        await using var app = await BrowserTestApp.StartAsync();
+        using var playwright = await Playwright.CreateAsync();
+        await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+        {
+            Headless = true
+        });
+        await using var context = await browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            BaseURL = app.BaseAddress.ToString(),
+            Locale = "en-US",
+            IsMobile = true,
+            HasTouch = true,
+            ViewportSize = new ViewportSize { Width = 390, Height = 844 }
+        });
+        await BrowserTestApp.RouteExternalResourcesAsync(context);
+
+        var page = await context.NewPageAsync();
+        await page.GotoAsync(path, new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
+        await page.Locator("#lwcToStep2Btn").TapAsync();
+        await page.WaitForFunctionAsync(
+            "() => document.querySelector('#lwc-step-2')?.classList.contains('lwc-step--visible')");
+        await page.Locator("#calculateBioageButton").TapAsync();
+        await page.WaitForSelectorAsync("#phenoAgeResult.show");
+        await page.Locator("#continueButton").TapAsync();
+        await page.WaitForURLAsync("**/apply");
+        Assert.Equal("pheno", await page.EvaluateAsync<string?>(
+            "() => sessionStorage.getItem('bioageClock')"));
+
+        await page.Locator("#backButton").TapAsync();
+        await page.WaitForURLAsync("**/pheno-age");
+        await page.WaitForFunctionAsync(
+            "() => document.querySelector('#lwc-step-2')?.classList.contains('lwc-step--visible')");
+        await page.Locator("#wbc").FillAsync("6.1");
+
+        var staleKeys = await page.EvaluateAsync<string?[]>(
+            """
+            () => [
+                sessionStorage.getItem('biomarkerData'),
+                sessionStorage.getItem('bioageClock'),
+                sessionStorage.getItem('chronoPhenoDifference'),
+                sessionStorage.getItem('chronoBortzDifference')
+            ]
+            """);
+        Assert.All(staleKeys, Assert.Null);
+    }
+
+    [Theory]
+    [InlineData("/pheno-age?update=1", "#phenoAgeResult", 9)]
+    [InlineData("/bortz-age?update=1", "#bortzAgeResult", 22)]
+    public async Task MobileUpdate_AllowsOneNewBiomarkerAndLeavesOtherFieldsOptional(
+        string path,
+        string resultSelector,
+        int biomarkerCount)
+    {
+        await using var app = await BrowserTestApp.StartAsync();
+        using var playwright = await Playwright.CreateAsync();
+        await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+        {
+            Headless = true
+        });
+        await using var context = await browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            BaseURL = app.BaseAddress.ToString(),
+            Locale = "en-US",
+            IsMobile = true,
+            HasTouch = true,
+            ViewportSize = new ViewportSize { Width = 390, Height = 844 }
+        });
+        await BrowserTestApp.RouteExternalResourcesAsync(context);
+        await context.AddInitScriptAsync(
+            """
+            sessionStorage.setItem('selectedAthlete', JSON.stringify({
+                Name: 'Mobile Update Athlete',
+                DisplayName: 'Mobile Update Athlete',
+                DateOfBirth: { Year: 1980, Month: 5, Day: 20 },
+                Biomarkers: [{
+                    Date: '2026-06-01',
+                    AlbGL: 45,
+                    AlpUL: 83,
+                    AltUL: 22,
+                    ApoA1GL: 1.52,
+                    CholesterolMmolL: 5.6,
+                    CreatUmolL: 72,
+                    CrpMgL: 1.35,
+                    CystatinCMgL: 0.9,
+                    GluMmolL: 5,
+                    GgtUL: 29,
+                    Hba1cMmolMol: 35.5,
+                    LymPc: 28.6,
+                    MchPg: 31.8,
+                    McvFL: 92,
+                    MonocytePc: 7.2,
+                    NeutrophilPc: 64.2,
+                    Rbc10e12L: 4.5,
+                    RdwPc: 13.4,
+                    ShbgNmolL: 45.6,
+                    UreaMmolL: 5.4,
+                    VitaminDNmolL: 50,
+                    Wbc1000cellsuL: 6.54
+                }]
+            }));
+            """);
+
+        var page = await context.NewPageAsync();
+        var errors = new List<string>();
+        page.Console += (_, message) =>
+        {
+            if (message.Type == "error")
+                errors.Add(message.Text);
+        };
+        page.PageError += (_, error) => errors.Add(error);
+
+        await page.GotoAsync(path, new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
+        await page.WaitForFunctionAsync(
+            "() => document.querySelector('#lwc-step-2')?.classList.contains('lwc-step--visible')");
+
+        var calculate = page.Locator("#calculateBioageButton");
+        Assert.True(await calculate.IsDisabledAsync());
+        Assert.Equal("Enter the blood draw date and at least 1 new biomarker value",
+            await page.Locator(".bioage-biomarker-progress").InnerTextAsync());
+        Assert.Equal(biomarkerCount, await page.Locator(
+            "#lwc-step-2 .biomarker-card input[type=\"number\"][required]").CountAsync());
+
+        var bloodDrawDate = page.Locator("#blood-draw-date");
+        Assert.True(await bloodDrawDate.IsVisibleAsync());
+        Assert.Equal("", await bloodDrawDate.InputValueAsync());
+        await bloodDrawDate.FillAsync(DateTime.UtcNow.Date.AddDays(-9).ToString("yyyy-MM-dd"));
+        Assert.Equal("Enter at least 1 new biomarker value",
+            await page.Locator(".bioage-biomarker-progress").InnerTextAsync());
+        Assert.True(await calculate.IsDisabledAsync());
+
+        await page.Locator("#glucose").FillAsync("5.2");
+        var updateState = await page.EvaluateAsync<string>(
+            """
+            () => {
+                const input = document.querySelector('#glucose');
+                const calculate = document.querySelector('#calculateBioageButton');
+                const progress = document.querySelector('.bioage-biomarker-progress');
+                return JSON.stringify({
+                    value: input?.value,
+                    valid: input?.validity?.valid,
+                    complete: input?.dataset?.bioageComplete,
+                    calculateDisabled: calculate?.disabled,
+                    progress: progress?.textContent
+                });
+            }
+            """);
+        Assert.False(await calculate.IsDisabledAsync(), updateState);
+        Assert.Equal("1 biomarker ready to update",
+            await page.Locator(".bioage-biomarker-progress").InnerTextAsync());
+
+        await calculate.TapAsync();
+        await page.WaitForSelectorAsync($"{resultSelector}.show");
+        Assert.Equal("5.2", await page.Locator("#glucose").InputValueAsync());
+        Assert.NotEqual("", await page.Locator("#wbc").InputValueAsync());
+        Assert.Empty(errors);
+    }
+
+    [Theory]
+    [InlineData(
+        "/pheno-age?Year=1980&Month=6&Day=15&Date=2026-06-01&AlbGL=45&CreatUmolL=80&GluMmolL=5&CrpMgL=1&Wbc1000cellsuL=5.5&LymPc=30&McvFL=90&RdwPc=13&AlpUL=70",
+        "#phenoAgeResult",
+        9)]
+    [InlineData(
+        "/bortz-age?Year=1980&Month=6&Day=15&Date=2026-06-01&AlbGL=45&AlpUL=70&UreaMmolL=5&CholesterolMmolL=4.5&CreatUmolL=80&CystatinCMgL=0.9&Hba1cMmolMol=33.33&CrpMgL=1&GgtUL=20&Rbc10e12L=4.8&McvFL=90&RdwPc=13&GluMmolL=5&MchPg=30&ApoA1GL=1.5&LymPc=30&AltUL=25&ShbgNmolL=40&VitaminDNmolL=200&Wbc1000cellsuL=5.5&MonocytePc=6&NeutrophilPc=60",
+        "#bortzAgeResult",
+        22)]
+    public async Task MobileResult_EditValuesReturnsToThePreservedWorksheet(
+        string path,
+        string resultSelector,
+        int biomarkerCount)
+    {
+        await using var app = await BrowserTestApp.StartAsync();
+        using var playwright = await Playwright.CreateAsync();
+        await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+        {
+            Headless = true
+        });
+        await using var context = await browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            BaseURL = app.BaseAddress.ToString(),
+            Locale = "en-US",
+            IsMobile = true,
+            HasTouch = true,
+            ViewportSize = new ViewportSize { Width = 390, Height = 844 }
+        });
+        await BrowserTestApp.RouteExternalResourcesAsync(context);
+
+        var page = await context.NewPageAsync();
+        var errors = new List<string>();
+        page.Console += (_, message) =>
+        {
+            if (message.Type == "error")
+                errors.Add(message.Text);
+        };
+        page.PageError += (_, error) => errors.Add(error);
+
+        await page.GotoAsync(path, new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
+        await page.WaitForFunctionAsync(
+            "() => document.querySelector('.bioageform')?.classList.contains('bioage-biomarker-entry-ready')");
+        var unchangedUrl = page.Url;
+        var editValues = page.Locator($"{resultSelector} .bioage-edit-values-button");
+        Assert.NotNull(await page.Locator(resultSelector).GetAttributeAsync("inert"));
+        Assert.False(await editValues.EvaluateAsync<bool>(
+            "button => { button.focus(); return document.activeElement === button; }"));
+
+        await page.Locator("#lwcToStep2Btn").TapAsync();
+        await page.WaitForFunctionAsync(
+            "() => document.querySelector('#lwc-step-2')?.classList.contains('lwc-step--visible')");
+        Assert.Equal($"{biomarkerCount} of {biomarkerCount} biomarkers entered",
+            await page.Locator(".bioage-biomarker-progress").InnerTextAsync());
+
+        var firstValue = await page.Locator("#wbc").InputValueAsync();
+        var calculate = page.Locator("#calculateBioageButton");
+        Assert.False(await calculate.IsDisabledAsync());
+        await calculate.TapAsync();
+        await page.WaitForSelectorAsync($"{resultSelector}.show");
+
+        await editValues.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible });
+        Assert.Null(await page.Locator(resultSelector).GetAttributeAsync("inert"));
+        await editValues.TapAsync();
+        await page.WaitForFunctionAsync(
+            "selector => !document.querySelector(selector)?.classList.contains('show')",
+            resultSelector);
+
+        Assert.True(await page.Locator("#lwc-step-2").IsVisibleAsync());
+        Assert.Equal(firstValue, await page.Locator("#wbc").InputValueAsync());
+        Assert.False(await calculate.IsDisabledAsync());
+        Assert.Equal(unchangedUrl, page.Url);
+        Assert.False(await page.Locator("body").EvaluateAsync<bool>(
+            "body => body.classList.contains('bioage-result-ready')"));
+        Assert.NotNull(await page.Locator(resultSelector).GetAttributeAsync("inert"));
+        Assert.False(await editValues.EvaluateAsync<bool>(
+            "button => { button.focus(); return document.activeElement === button; }"));
+        Assert.Empty(errors);
+    }
+
+    [Theory]
+    [InlineData(
+        "/pheno-age?Year=1980&Month=6&Day=15&Date=2026-06-01&AlbGL=45&CreatUmolL=80&GluMmolL=5&CrpMgL=1&Wbc1000cellsuL=5.5&LymPc=30&McvFL=90&RdwPc=10000&AlpUL=70",
+        "#phenoAgeResult")]
+    [InlineData(
+        "/bortz-age?Year=1980&Month=6&Day=15&Date=2026-06-01&AlbGL=45&AlpUL=70&UreaMmolL=5&CholesterolMmolL=4.5&CreatUmolL=80&CystatinCMgL=0.9&Hba1cMmolMol=33.33&CrpMgL=0&GgtUL=20&Rbc10e12L=4.8&McvFL=90&RdwPc=13&GluMmolL=5&MchPg=30&ApoA1GL=1.5&LymPc=30&AltUL=25&ShbgNmolL=40&VitaminDNmolL=200&Wbc1000cellsuL=5.5&MonocytePc=6&NeutrophilPc=60",
+        "#bortzAgeResult")]
+    public async Task MobileNonFiniteResult_EditValuesStillReturnsToTheWorksheet(
+        string path,
+        string resultSelector)
+    {
+        await using var app = await BrowserTestApp.StartAsync();
+        using var playwright = await Playwright.CreateAsync();
+        await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+        {
+            Headless = true
+        });
+        await using var context = await browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            BaseURL = app.BaseAddress.ToString(),
+            Locale = "en-US",
+            IsMobile = true,
+            HasTouch = true,
+            ViewportSize = new ViewportSize { Width = 390, Height = 844 }
+        });
+        await BrowserTestApp.RouteExternalResourcesAsync(context);
+
+        var page = await context.NewPageAsync();
+        await page.GotoAsync(path, new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
+        await page.Locator("#lwcToStep2Btn").TapAsync();
+        await page.WaitForFunctionAsync(
+            "() => document.querySelector('#lwc-step-2')?.classList.contains('lwc-step--visible')");
+        await page.Locator("#calculateBioageButton").TapAsync();
+        await page.WaitForSelectorAsync($"{resultSelector}.show");
+        Assert.True(await page.Locator("#ensureCorrectInputSuggestion").IsVisibleAsync());
+
+        await page.GetByRole(AriaRole.Button, new() { Name = "Edit values" }).TapAsync();
+        await page.WaitForFunctionAsync(
+            "selector => !document.querySelector(selector)?.classList.contains('show')",
+            resultSelector);
+
+        Assert.True(await page.Locator("#lwc-step-2").IsVisibleAsync());
+        Assert.False(await page.Locator("body").EvaluateAsync<bool>(
+            "body => body.classList.contains('bioage-result-ready')"));
+    }
+
+    [Theory]
+    [InlineData("/pheno-age", "pheno", 9, "wbc", "lymphocyte")]
+    [InlineData("/bortz-age", "bortz", 22, "wbc", "lymphocyte_percentage")]
+    public async Task MobileBiomarkerEntry_IsDirectProgressiveAndDraftSafe(
+        string path,
+        string clock,
+        int biomarkerCount,
+        string firstInputId,
+        string nextInputId)
+    {
+        await using var app = await BrowserTestApp.StartAsync();
+        using var playwright = await Playwright.CreateAsync();
+        await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+        {
+            Headless = true
+        });
+        await using var context = await browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            BaseURL = app.BaseAddress.ToString(),
+            Locale = "en-US",
+            IsMobile = true,
+            HasTouch = true,
+            ViewportSize = new ViewportSize { Width = 390, Height = 844 }
+        });
+        await BrowserTestApp.RouteExternalResourcesAsync(context);
+
+        var page = await context.NewPageAsync();
+        var errors = new List<string>();
+        page.Console += (_, message) =>
+        {
+            if (message.Type == "error")
+                errors.Add(message.Text);
+        };
+        page.PageError += (_, error) => errors.Add(error);
+
+        await page.GotoAsync(path, new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
+        await page.WaitForFunctionAsync(
+            "() => document.querySelector('.bioageform')?.classList.contains('bioage-biomarker-entry-ready')");
+
+        var bloodDrawDate = page.Locator("#blood-draw-date");
+        Assert.Equal("", await bloodDrawDate.InputValueAsync());
+
+        var submittedDate = DateTime.UtcNow.Date.AddDays(-9).ToString("yyyy-MM-dd");
+        await page.Locator("#dob-year").SelectOptionAsync("1980");
+        await page.Locator("#dob-month").SelectOptionAsync("5");
+        await page.WaitForFunctionAsync(
+            "() => Array.from(document.querySelector('#dob-day')?.options || []).some(option => option.value === '20')");
+        await page.Locator("#dob-day").SelectOptionAsync("20");
+        await bloodDrawDate.FillAsync(submittedDate);
+        await page.Locator("#lwcToStep2Btn").TapAsync();
+        await page.WaitForFunctionAsync(
+            "() => document.querySelector('#lwc-step-2')?.classList.contains('lwc-step--visible')");
+
+        var requiredInputs = page.Locator("#lwc-step-2 .biomarker-card input[type=\"number\"][required]");
+        Assert.Equal(biomarkerCount, await requiredInputs.CountAsync());
+        Assert.True(
+            await requiredInputs.EvaluateAllAsync<bool>(
+                """
+                inputs => inputs.every(input => {
+                    const rect = input.getBoundingClientRect();
+                    const style = getComputedStyle(input);
+                    return rect.width > 0
+                        && rect.height > 0
+                        && style.display !== 'none'
+                        && style.visibility !== 'hidden';
+                })
+                """),
+            "Every required biomarker value should be directly visible without opening a header.");
+
+        var firstInput = page.Locator($"#{firstInputId}");
+        var firstUnit = page.Locator($"#{firstInputId}Unit");
+        Assert.True(await firstInput.IsVisibleAsync());
+        Assert.True(await firstUnit.IsVisibleAsync());
+
+        var inlineLayout = await firstInput.EvaluateAsync<double[]>(
+            """
+            input => {
+                const unit = document.getElementById(`${input.id}Unit`);
+                const inputRect = input.getBoundingClientRect();
+                const unitRect = unit.getBoundingClientRect();
+                const groupRect = input.closest('.input-group').getBoundingClientRect();
+                return [
+                    inputRect.left,
+                    inputRect.right,
+                    inputRect.top,
+                    inputRect.bottom,
+                    inputRect.height,
+                    unitRect.left,
+                    unitRect.right,
+                    unitRect.top,
+                    unitRect.bottom,
+                    unitRect.height,
+                    groupRect.left,
+                    groupRect.right
+                ];
+            }
+            """);
+
+        Assert.True(inlineLayout[1] <= inlineLayout[5],
+            $"Biomarker input and unit should not overlap: {string.Join(", ", inlineLayout)}");
+        Assert.InRange(Math.Abs(inlineLayout[2] - inlineLayout[7]), 0, 1);
+        Assert.InRange(Math.Abs(inlineLayout[3] - inlineLayout[8]), 0, 1);
+        Assert.True(inlineLayout[4] >= 44, $"Biomarker input is only {inlineLayout[4]}px high.");
+        Assert.True(inlineLayout[9] >= 44, $"Biomarker unit is only {inlineLayout[9]}px high.");
+        Assert.True(inlineLayout[0] >= inlineLayout[10] - 1);
+        Assert.True(inlineLayout[6] <= inlineLayout[11] + 1);
+
+        var progress = page.Locator($"#{clock}BiomarkerProgress");
+        await progress.WaitForAsync();
+        Assert.Equal($"0 of {biomarkerCount} biomarkers entered", await progress.InnerTextAsync());
+
+        var calculate = page.Locator("#calculateBioageButton");
+        Assert.True(await calculate.IsDisabledAsync());
+        Assert.Contains("grey", await calculate.GetAttributeAsync("class") ?? "");
+
+        await firstInput.FillAsync("6.54");
+        await page.WaitForFunctionAsync(
+            "expected => document.querySelector('.bioage-biomarker-progress')?.textContent === expected",
+            $"1 of {biomarkerCount} biomarkers entered");
+        Assert.True(await calculate.IsDisabledAsync());
+
+        await firstInput.PressAsync("Enter");
+        await page.WaitForFunctionAsync(
+            "nextId => document.activeElement?.id === nextId",
+            nextInputId);
+        Assert.Equal(nextInputId, await page.EvaluateAsync<string>("() => document.activeElement?.id || ''"));
+
+        await firstUnit.SelectOptionAsync(new SelectOptionValue { Index = 1 });
+        var draftKey = $"bioageDraft:{clock}:v1";
+        await page.WaitForFunctionAsync(
+            "key => sessionStorage.getItem(key)?.includes('6.54') === true",
+            draftKey);
+
+        Assert.Null(await page.EvaluateAsync<string?>(
+            "key => sessionStorage.getItem(key)",
+            clock == "pheno" ? "bioageDraft:bortz:v1" : "bioageDraft:pheno:v1"));
+
+        await page.ReloadAsync(new PageReloadOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
+        await page.WaitForFunctionAsync(
+            "() => document.querySelector('#lwc-step-2')?.classList.contains('lwc-step--visible')");
+
+        Assert.Equal(submittedDate, await page.Locator("#blood-draw-date").InputValueAsync());
+        Assert.Equal("6.54", await page.Locator($"#{firstInputId}").InputValueAsync());
+        Assert.Equal(1, await page.Locator($"#{firstInputId}Unit").EvaluateAsync<int>("unit => unit.selectedIndex"));
+        Assert.Equal($"1 of {biomarkerCount} biomarkers entered", await progress.InnerTextAsync());
+
+        var horizontalOverflow = await page.EvaluateAsync<double>(
+            "() => Math.max(document.documentElement.scrollWidth, document.body.scrollWidth) - window.innerWidth");
+        Assert.True(horizontalOverflow <= 1, $"Page has {horizontalOverflow}px horizontal overflow.");
+        Assert.Empty(errors);
+    }
+}

--- a/LongevityWorldCup.Tests/BioageMobileUxBrowserTests.cs
+++ b/LongevityWorldCup.Tests/BioageMobileUxBrowserTests.cs
@@ -414,6 +414,14 @@ public sealed class BioageMobileUxBrowserTests
             $"1 of {biomarkerCount} biomarkers entered");
         Assert.True(await calculate.IsDisabledAsync());
 
+        await firstInput.PressAsync("Tab");
+        await page.WaitForFunctionAsync(
+            "nextId => document.activeElement?.id === nextId",
+            nextInputId);
+        Assert.NotEqual($"{firstInputId}Unit", await page.EvaluateAsync<string>(
+            "() => document.activeElement?.id || ''"));
+
+        await firstInput.FocusAsync();
         await firstInput.PressAsync("Enter");
         await page.WaitForFunctionAsync(
             "nextId => document.activeElement?.id === nextId",

--- a/LongevityWorldCup.Tests/BioageStoredBiomarkerTests.cs
+++ b/LongevityWorldCup.Tests/BioageStoredBiomarkerTests.cs
@@ -9,18 +9,22 @@ public sealed class BioageStoredBiomarkerTests
     [Theory]
     [InlineData("pheno-age.html")]
     [InlineData("bortz-age.html")]
-    public void BiomarkerCards_AreKeyboardOperableAndShowFocus(string fileName)
+    public void BiomarkerCards_AreKeyboardOperableOnDesktopAndDirectEntryOnMobile(string fileName)
     {
         var html = File.ReadAllText(GetPagePath(fileName));
+        var flow = File.ReadAllText(GetBioageFlowTypeScriptPath());
 
-        Assert.Contains("header.setAttribute('role', 'button');", html);
-        Assert.Contains("header.setAttribute('tabindex', '0');", html);
-        Assert.Contains("header.querySelector('.toggle-icon')?.setAttribute('aria-hidden', 'true');", html);
-        Assert.Contains("header.addEventListener('keydown', event => {", html);
-        Assert.Contains("if (event.key !== 'Enter' && event.key !== ' ') return;", html);
+        Assert.Contains("header.setAttribute('role', 'button');", flow);
+        Assert.Contains("header.tabIndex = 0;", flow);
+        Assert.Contains("icon?.setAttribute('aria-hidden', 'true');", flow);
+        Assert.Contains("header.addEventListener('keydown', event => {", flow);
+        Assert.Contains("if (event.key !== 'Enter' && event.key !== ' ') return;", flow);
+        Assert.Contains("if (bioageMobileMedia.matches) return;", flow);
+        Assert.Contains("header.removeAttribute('role');", flow);
+        Assert.Contains("header.removeAttribute('tabindex');", flow);
+        Assert.Contains("options.form.classList.add('bioage-biomarker-entry-ready');", flow);
         Assert.Contains(".biomarker-card-header:focus-visible", html);
-        Assert.Contains("header.setAttribute('aria-disabled', 'true');", html);
-        Assert.Contains("header.setAttribute('tabindex', '-1');", html);
+        Assert.DoesNotContain("header.setAttribute('aria-disabled', 'true');", html);
     }
 
     [Theory]
@@ -98,6 +102,7 @@ public sealed class BioageStoredBiomarkerTests
         Assert.Contains("const clearStoredBiomarkerHandoff = () => bioageFlow.clearStoredBiomarkerHandoff(removeSessionItem);", html);
         Assert.Contains("function clearStoredBiomarkerHandoff(removeItem)", flow);
         Assert.Contains("remove('biomarkerData');", flow);
+        Assert.Contains("remove('bioageClock');", flow);
         Assert.Contains("remove('chronoPhenoDifference');", flow);
         Assert.Contains("remove('chronoBortzDifference');", flow);
         Assert.Contains("clearStoredBiomarkerHandoff();", html);
@@ -133,7 +138,7 @@ public sealed class BioageStoredBiomarkerTests
         Assert.Contains("serializedBiomarkerData = JSON.stringify(biomarkerData);", html);
         Assert.Contains("setSessionItem('chronoPhenoDifference', chronoPhenoDifference.toFixed(2))", html);
         Assert.Contains("setSessionItem('biomarkerData', serializedBiomarkerData)", html);
-        Assert.Contains("setSessionItem('lwcStep', '1')", html);
+        Assert.Contains("setSessionItem('bioageClock', 'pheno')", html);
         Assert.Contains("setSessionItem(PENDING_PAYMENT_OFFER_KEY, serializedPaymentOffer)", html);
         Assert.DoesNotContain("sessionStorage.setItem('chronoPhenoDifference', chronoPhenoDifference.toFixed(2));", html);
         Assert.DoesNotContain("sessionStorage.setItem('biomarkerData', JSON.stringify(biomarkerData));", html);
@@ -151,20 +156,23 @@ public sealed class BioageStoredBiomarkerTests
     [Theory]
     [InlineData("pheno-age.html")]
     [InlineData("bortz-age.html")]
-    public void BioagePages_PersistAndRestoreWizardStepWithSafeStorage(string fileName)
+    public void BioagePages_PersistAndRestorePerClockDraftWithSafeStorage(string fileName)
     {
         var html = File.ReadAllText(GetPagePath(fileName));
+        var flow = File.ReadAllText(GetBioageFlowTypeScriptPath());
+        var clock = fileName == "pheno-age.html" ? "pheno" : "bortz";
 
         Assert.Contains("function lwcValidateStep1(silent)", html);
         Assert.Contains("const yearSelect = document.getElementById('dob-year');", html);
         Assert.Contains("customAlert('Please select your birth year.')\n                        .then(() => yearSelect.focus());", html);
-        Assert.Contains("setSessionItem('lwcStep', '2');", html);
-        Assert.Contains("setSessionItem('lwcStep', '1');", html);
-        Assert.Contains("function activateDot1() { lwcSetStep(1); setSessionItem('lwcStep', '1'); }", html);
-        Assert.Contains("function activateDot2() { if (lwcValidateStep1()) { lwcSetStep(2); setSessionItem('lwcStep', '2'); } }", html);
-        Assert.Contains("if (getSessionItem('lwcStep') === '2' && lwcValidateStep1(true))", html);
-        Assert.Contains("let restoredStep = false;", html);
+        Assert.Contains($"bioageFlow.setDraftStep('{clock}', step);", html);
+        Assert.Contains($"clock: '{clock}'", html);
+        Assert.Contains("const biomarkerEntry = bioageFlow.initializeBiomarkerEntry({", html);
+        Assert.Contains("const restoredStep = biomarkerEntry.step === 2 && lwcValidateStep1(true);", html);
         Assert.Contains("if (!restoredStep) {", html);
+        Assert.Contains("return `bioageDraft:${clock}:v${BIOAGE_DRAFT_VERSION}`;", flow);
+        Assert.Contains("setSessionItem(getBioageDraftKey(controller.clock), JSON.stringify(draft));", flow);
+        Assert.Contains("const restoredDraft = options.restoreDraft !== false && restoreBioageDraft(controller);", flow);
         Assert.DoesNotContain("sessionStorage.setItem('lwcStep'", html);
     }
 
@@ -180,7 +188,7 @@ public sealed class BioageStoredBiomarkerTests
         Assert.Contains("customAlert('Please enter the date when your blood was drawn.')\n                        .then(() => bloodDrawDateInput.focus());", html);
         Assert.Contains("customAlert('Blood draw date cannot be in the future.')\n                        .then(() => bloodDrawDateInput.focus());", html);
         Assert.Contains("const bd = getValidatedBloodDrawDate(silent);", html);
-        Assert.Contains("if (getSessionItem('lwcStep') === '2' && lwcValidateStep1(true))", html);
+        Assert.Contains("const restoredStep = biomarkerEntry.step === 2 && lwcValidateStep1(true);", html);
     }
 
     [Fact]
@@ -197,9 +205,10 @@ public sealed class BioageStoredBiomarkerTests
     [Theory]
     [InlineData("pheno-age.html", "function storePhenoResultForNextStep")]
     [InlineData("bortz-age.html", "function storeBortzResultForNextStep")]
-    public void BioagePages_ResetWizardStepBeforeHandoff(string fileName, string storeFunctionMarker)
+    public void BioagePages_RecordExplicitClockAndClearStaleHandoff(string fileName, string storeFunctionMarker)
     {
         var html = File.ReadAllText(GetPagePath(fileName));
+        var clock = fileName == "pheno-age.html" ? "pheno" : "bortz";
         var storeStart = html.IndexOf(storeFunctionMarker, StringComparison.Ordinal);
         var storeEnd = html.IndexOf("return true;", storeStart, StringComparison.Ordinal);
 
@@ -208,8 +217,10 @@ public sealed class BioageStoredBiomarkerTests
 
         var storeBody = html[storeStart..storeEnd];
 
+        Assert.Contains("clearStoredBiomarkerHandoff();", storeBody);
+        Assert.Contains($"setSessionItem('bioageClock', '{clock}')", storeBody);
         Assert.Contains("setSessionItem('biomarkerData', serializedBiomarkerData)", storeBody);
-        Assert.Contains("setSessionItem('lwcStep', '1')", storeBody);
+        Assert.DoesNotContain("setSessionItem('lwcStep'", storeBody);
     }
 
     [Theory]
@@ -307,7 +318,7 @@ public sealed class BioageStoredBiomarkerTests
     [Theory]
     [InlineData("pheno-age.html", "phenoAgeForm")]
     [InlineData("bortz-age.html", "bortzAgeForm")]
-    public void BioagePages_ReportRequiredFieldValidityBeforeCalculating(string fileName, string formId)
+    public void BioagePages_ReportRequiredFieldValidityForNewApplicationsBeforeCalculating(string fileName, string formId)
     {
         var html = File.ReadAllText(GetPagePath(fileName));
         var formStart = html.IndexOf($"const form = document.getElementById('{formId}');", StringComparison.Ordinal);
@@ -319,7 +330,7 @@ public sealed class BioageStoredBiomarkerTests
         Assert.True(submitStart > formStart);
 
         var calculateIndex = html.IndexOf("calculateResult();", submitStart, StringComparison.Ordinal);
-        var validityIndex = html.IndexOf("if (!this.reportValidity())", submitStart, StringComparison.Ordinal);
+        var validityIndex = html.IndexOf("if (!isUpdate && !this.reportValidity())", submitStart, StringComparison.Ordinal);
 
         Assert.True(validityIndex > submitStart);
         Assert.True(calculateIndex > submitStart);
@@ -391,9 +402,9 @@ public sealed class BioageStoredBiomarkerTests
         var html = File.ReadAllText(GetPagePath(fileName));
 
         Assert.Contains("yearsTextElement.textContent = `${yearsDelta}years${ageDiff < 0 ? ' 🚀' : ''}`;", html);
-        Assert.Contains("document.getElementById('mainInstructions').textContent = 'Submit your latest test results. All fields are required and must be from the same day.';", html);
+        Assert.Contains("document.getElementById('mainInstructions').textContent = 'Enter the blood draw date and at least one new biomarker value. Unchanged values will carry over from your latest result.';", html);
         Assert.DoesNotContain("yearsTextElement.innerHTML =", html);
-        Assert.DoesNotContain("document.getElementById('mainInstructions').innerHTML = 'Submit your latest test results. All fields are required and must be from the same day.';", html);
+        Assert.DoesNotContain("document.getElementById('mainInstructions').innerHTML =", html);
     }
 
     [Theory]
@@ -428,16 +439,14 @@ public sealed class BioageStoredBiomarkerTests
         var updateBranch = html.IndexOf("if (isUpdate && hasSelectedAthlete)", StringComparison.Ordinal);
         var hideNav = html.IndexOf("hideUpdateModeStepNavigation();", updateBranch, StringComparison.Ordinal);
         var forceStep2 = html.IndexOf("lwcSetStep(2, { focus: false });", hideNav, StringComparison.Ordinal);
-        var storeStep2 = html.IndexOf("setSessionItem('lwcStep', '2');", forceStep2, StringComparison.Ordinal);
-        var resetScroll = html.IndexOf("bioageFlow.resetUpdateModeScroll();", storeStep2, StringComparison.Ordinal);
+        var resetScroll = html.IndexOf("bioageFlow.resetUpdateModeScroll();", forceStep2, StringComparison.Ordinal);
         var onboardingBranch = html.IndexOf("} else {", resetScroll, StringComparison.Ordinal);
         Assert.True(updateBranch >= 0);
         Assert.True(hideNav > updateBranch);
         Assert.True(forceStep2 > hideNav);
-        Assert.True(storeStep2 > forceStep2);
-        Assert.True(resetScroll > storeStep2);
+        Assert.True(resetScroll > forceStep2);
         Assert.True(onboardingBranch > resetScroll);
-        Assert.Contains("if (getSessionItem('lwcStep') === '2' && lwcValidateStep1(true))", html);
+        Assert.Contains("const restoredStep = biomarkerEntry.step === 2 && lwcValidateStep1(true);", html);
     }
 
     [Theory]
@@ -600,7 +609,7 @@ public sealed class BioageStoredBiomarkerTests
         Assert.Contains("setSessionItem('chronoBortzDifference', chronoBortzDifference.toFixed(2))", html);
         Assert.Contains("setSessionItem('chronoPhenoDifference', chronoPhenoDifference.toFixed(2))", html);
         Assert.Contains("setSessionItem('biomarkerData', serializedBiomarkerData)", html);
-        Assert.Contains("setSessionItem('lwcStep', '1')", html);
+        Assert.Contains("setSessionItem('bioageClock', 'bortz')", html);
         Assert.Contains("setSessionItem(PENDING_PAYMENT_OFFER_KEY, serializedPaymentOffer)", html);
         Assert.DoesNotContain("sessionStorage.setItem('chronoBortzDifference', chronoBortzDifference.toFixed(2));", html);
         Assert.DoesNotContain("sessionStorage.setItem('chronoPhenoDifference', chronoPhenoDifference.toFixed(2));", html);

--- a/LongevityWorldCup.Tests/FlowActionDockBrowserTests.cs
+++ b/LongevityWorldCup.Tests/FlowActionDockBrowserTests.cs
@@ -3035,7 +3035,7 @@ public sealed class FlowActionDockBrowserTests
         await page.WaitForSelectorAsync("#continueButton.show");
 
         await ExpectActionStackDockedInViewportAsync(page, resultActionsSelector);
-        await ExpectBioageResultVisibleAboveDockAsync(page, resultSelector, resultActionsSelector);
+        await ExpectBioageResultReadableWithDockAsync(page, resultSelector, resultActionsSelector);
         Assert.False(await HasDockClassAsync(page, "#lwcStepTwoActions"));
 
         var dockedVisibleActionCount = await page.EvaluateAsync<int>(
@@ -3056,7 +3056,7 @@ public sealed class FlowActionDockBrowserTests
     }
 
     [Fact]
-    public async Task BioageResult_RevealsAgainAfterDelayedRankPreviewExpands()
+    public async Task BioageResult_DoesNotMoveTheReadingPositionWhenRankPreviewExpands()
     {
         await using var app = await BrowserTestApp.StartAsync();
         using var playwright = await Playwright.CreateAsync();
@@ -3089,7 +3089,7 @@ public sealed class FlowActionDockBrowserTests
         await page.WaitForFunctionAsync(
             "() => document.getElementById('phenoAgeRankPreview')?.getAttribute('aria-busy') === 'true'");
         await ExpectActionStackDockedInViewportAsync(page, ".phenoage-result-actions");
-        await ExpectBioageResultVisibleAboveDockAsync(page, "#phenoAgeResult", ".phenoage-result-actions");
+        await ExpectBioageResultReadableWithDockAsync(page, "#phenoAgeResult", ".phenoage-result-actions");
 
         await page.EvaluateAsync(
             """
@@ -3126,12 +3126,10 @@ public sealed class FlowActionDockBrowserTests
             () => {
                 const preview = document.getElementById('phenoAgeRankPreview');
                 const result = document.getElementById('phenoAgeResult');
-                const dock = document.querySelector('.phenoage-result-actions');
                 if (preview?.getAttribute('aria-busy') !== 'false'
                     || !preview.querySelector('.bioage-rank-neighbors')
-                    || !result
-                    || !dock) return false;
-                return result.getBoundingClientRect().bottom <= dock.getBoundingClientRect().top - 8;
+                    || !result) return false;
+                return result.getBoundingClientRect().height >= 300;
             }
             """);
 
@@ -3146,15 +3144,15 @@ public sealed class FlowActionDockBrowserTests
         Assert.True(
             finalLayout[0] >= initialLayout[0] + 50,
             $"Rank preview did not materially expand the result: {initialLayout[0]}px to {finalLayout[0]}px.");
-        Assert.True(
-            finalLayout[3] >= initialLayout[3] + 20,
-            $"Expanded rank preview was not re-revealed: scrollY {initialLayout[3]}px to {finalLayout[3]}px.");
-        Assert.True(finalLayout[1] <= finalLayout[2] - 8);
+        Assert.InRange(
+            Math.Abs(finalLayout[3] - initialLayout[3]),
+            0,
+            2);
         Assert.Empty(errors);
     }
 
     [Fact]
-    public async Task BioageResultReveal_IsNotStarvedByContinuousResultResizing()
+    public async Task BioageResult_DoesNotChaseContinuousResultResizing()
     {
         await using var app = await BrowserTestApp.StartAsync();
         using var playwright = await Playwright.CreateAsync();
@@ -3179,7 +3177,7 @@ public sealed class FlowActionDockBrowserTests
         await page.WaitForSelectorAsync("#bortzAgeResult.show");
         await page.WaitForSelectorAsync("#continueButton.show");
         await ExpectActionStackDockedInViewportAsync(page, ".bioage-result-actions");
-        await ExpectBioageResultVisibleAboveDockAsync(page, "#bortzAgeResult", ".bioage-result-actions");
+        await ExpectBioageResultReadableWithDockAsync(page, "#bortzAgeResult", ".bioage-result-actions");
 
         await page.EvaluateAsync(
             """
@@ -3189,6 +3187,7 @@ public sealed class FlowActionDockBrowserTests
                 const resultRect = result.getBoundingClientRect();
                 const dockRect = dock.getBoundingClientRect();
                 window.scrollBy({ top: resultRect.bottom - (dockRect.top - 12), behavior: 'auto' });
+                window.__bioageResizeStartScrollY = window.scrollY;
 
                 const growingContent = document.createElement('div');
                 growingContent.setAttribute('aria-hidden', 'true');
@@ -3216,18 +3215,19 @@ public sealed class FlowActionDockBrowserTests
                 window.__bioageResizeStormActive = false;
                 const result = document.getElementById('bortzAgeResult').getBoundingClientRect();
                 const dock = document.querySelector('.bioage-result-actions').getBoundingClientRect();
-                return [result.bottom, dock.top, window.__bioageResizeStormFrame, window.scrollY];
+                return [result.bottom, dock.top, window.__bioageResizeStormFrame, window.scrollY, window.__bioageResizeStartScrollY];
             }
             """);
 
         Assert.InRange(layout[2], 24, 599);
-        Assert.True(
-            layout[0] <= layout[1] - 8,
-            $"Continuous result resizing starved the dock-clearance reveal. result bottom={layout[0]:F1}, dock top={layout[1]:F1}, frame={layout[2]}, scrollY={layout[3]:F1}.");
+        Assert.InRange(
+            Math.Abs(layout[3] - layout[4]),
+            0,
+            2);
         Assert.Empty(errors);
     }
 
-    private static async Task ExpectBioageResultVisibleAboveDockAsync(
+    private static async Task ExpectBioageResultReadableWithDockAsync(
         IPage page,
         string resultSelector,
         string dockSelector)
@@ -3281,7 +3281,14 @@ public sealed class FlowActionDockBrowserTests
         Assert.True(layout.ResultVisible, $"{resultSelector} is not visibly rendered. {layout}");
         Assert.True(layout.DockVisible, $"{dockSelector} is not visibly rendered. {layout}");
         Assert.True(layout.ResultTop >= 0, $"{resultSelector} starts above the viewport. {layout}");
-        Assert.True(layout.ResultBottom <= layout.DockTop - 8, $"{resultSelector} is covered by the result action dock. {layout}");
+        Assert.True(
+            layout.ResultTop <= layout.DockTop - 44,
+            $"{resultSelector} does not begin in the readable area above the result action dock. {layout}");
+
+        var remainingScroll = Math.Max(0, layout.MaxScrollY - layout.ScrollY);
+        Assert.True(
+            layout.ResultBottom - remainingScroll <= layout.DockTop - 8,
+            $"{resultSelector} cannot be scrolled fully clear of the result action dock. {layout}");
     }
 
     [Fact]

--- a/LongevityWorldCup.Tests/NewAthleteOnboardingBrowserTests.cs
+++ b/LongevityWorldCup.Tests/NewAthleteOnboardingBrowserTests.cs
@@ -185,11 +185,22 @@ public sealed class NewAthleteOnboardingBrowserTests
         {
             await page.GotoAsync("/pheno-age", new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
             await SetPendingPaymentOfferAsync(page, "join-game", "pro", 100);
+            await page.EvaluateAsync(
+                """
+                () => {
+                    sessionStorage.setItem('bioageClock', 'bortz');
+                    sessionStorage.setItem('chronoBortzDifference', '-4.20');
+                }
+                """);
             await FillAndCalculatePhenoAgeAsync(page, bloodDrawDate);
             await page.Locator("#continueButton").ClickAsync();
             await page.WaitForURLAsync("**/apply");
 
             await AssertPaymentOfferAsync(page, "direct-pheno-age", "amateur", 10);
+            Assert.Equal("pheno", await page.EvaluateAsync<string?>(
+                "() => sessionStorage.getItem('bioageClock')"));
+            Assert.Null(await page.EvaluateAsync<string?>(
+                "() => sessionStorage.getItem('chronoBortzDifference')"));
             Assert.Empty(errors);
         });
     }
@@ -208,6 +219,95 @@ public sealed class NewAthleteOnboardingBrowserTests
             await page.WaitForURLAsync("**/apply");
 
             await AssertPaymentOfferAsync(page, "direct-bortz-age", "pro", 100);
+            Assert.Empty(errors);
+        });
+    }
+
+    [Fact]
+    public async Task LegacyClockInference_UsesOfferAndPanelCompletenessWithZeroDifferences()
+    {
+        await RunOnboardingBrowserAsync(async (page, errors) =>
+        {
+            await page.GotoAsync("/apply?fake=1", new PageGotoOptions
+            {
+                WaitUntil = WaitUntilState.DOMContentLoaded
+            });
+
+            var clocks = await page.EvaluateAsync<string[]>(
+                """
+                () => {
+                    const phenoEntry = {
+                        Date: '2026-06-01',
+                        AlbGL: 45,
+                        CreatUmolL: 72,
+                        GluMmolL: 5,
+                        CrpMgL: 1.35,
+                        Wbc1000cellsuL: 6.54,
+                        LymPc: 28.6,
+                        McvFL: 92,
+                        RdwPc: 13.4,
+                        AlpUL: 83
+                    };
+                    const bortzEntry = {
+                        ...phenoEntry,
+                        UreaMmolL: 5.4,
+                        CholesterolMmolL: 5.6,
+                        CystatinCMgL: 0.9,
+                        Hba1cMmolMol: 35.5,
+                        GgtUL: 29,
+                        Rbc10e12L: 4.5,
+                        MonocytePc: 7.2,
+                        NeutrophilPc: 64.2,
+                        AltUL: 22,
+                        ShbgNmolL: 45.6,
+                        VitaminDNmolL: 50,
+                        MchPg: 31.8,
+                        ApoA1GL: 1.52
+                    };
+
+                    sessionStorage.removeItem('bioageClock');
+                    sessionStorage.setItem('pendingPaymentOffer', JSON.stringify({
+                        source: 'join-game',
+                        offerType: 'amateur',
+                        currency: 'USD',
+                        amountUsd: 10
+                    }));
+                    const pheno = readStoredBioageClock(
+                        { Biomarkers: [phenoEntry] },
+                        '0.00',
+                        '0.00');
+
+                    sessionStorage.setItem('pendingPaymentOffer', JSON.stringify({
+                        source: 'join-game',
+                        offerType: 'pro',
+                        currency: 'USD',
+                        amountUsd: 100
+                    }));
+                    const staleProPheno = readStoredBioageClock(
+                        { Biomarkers: [phenoEntry] },
+                        '0.00',
+                        '0.00');
+                    sessionStorage.setItem('biomarkerData', JSON.stringify({
+                        Biomarkers: [phenoEntry]
+                    }));
+                    sessionStorage.setItem('chronoPhenoDifference', '0.00');
+                    sessionStorage.setItem('chronoBortzDifference', '0.00');
+                    const staleProBackDestination = getConvergenceBackDestination();
+
+                    sessionStorage.removeItem('pendingPaymentOffer');
+                    const fallbackPheno = readStoredBioageClock(
+                        { Biomarkers: [phenoEntry] },
+                        '0.00',
+                        '0.00');
+                    const fallbackBortz = readStoredBioageClock(
+                        { Biomarkers: [bortzEntry] },
+                        '0.00',
+                        '0.00');
+                    return [pheno, staleProPheno, fallbackPheno, fallbackBortz, staleProBackDestination];
+                }
+                """);
+
+            Assert.Equal(["pheno", "pheno", "pheno", "bortz", "/pheno-age"], clocks);
             Assert.Empty(errors);
         });
     }
@@ -575,7 +675,7 @@ public sealed class NewAthleteOnboardingBrowserTests
                 return {
                     offerType: offer.offerType,
                     amountUsd: offer.amountUsd,
-                    lwcStep: sessionStorage.getItem('lwcStep'),
+                    bioageClock: sessionStorage.getItem('bioageClock'),
                     hasChronoPhenoDifference: !!(chronoPhenoDifference && chronoPhenoDifference.trim()),
                     chronoPhenoDifference: chronoPhenoDifference === null ? null : Number(chronoPhenoDifference),
                     dobYear: biomarkerData.DateOfBirth?.Year,
@@ -598,7 +698,7 @@ public sealed class NewAthleteOnboardingBrowserTests
 
         Assert.Equal("amateur", handoff.GetProperty("offerType").GetString());
         Assert.Equal(10, handoff.GetProperty("amountUsd").GetDouble());
-        Assert.Equal("1", handoff.GetProperty("lwcStep").GetString());
+        Assert.Equal("pheno", handoff.GetProperty("bioageClock").GetString());
         Assert.True(handoff.GetProperty("hasChronoPhenoDifference").GetBoolean());
         Assert.True(double.IsFinite(handoff.GetProperty("chronoPhenoDifference").GetDouble()));
         Assert.Equal(1980, handoff.GetProperty("dobYear").GetInt32());
@@ -649,7 +749,7 @@ public sealed class NewAthleteOnboardingBrowserTests
                 return {
                     offerType: offer.offerType,
                     amountUsd: offer.amountUsd,
-                    lwcStep: sessionStorage.getItem('lwcStep'),
+                    bioageClock: sessionStorage.getItem('bioageClock'),
                     hasChronoBortzDifference: !!(chronoBortzDifference && chronoBortzDifference.trim()),
                     hasChronoPhenoDifference: !!(chronoPhenoDifference && chronoPhenoDifference.trim()),
                     chronoBortzDifference: chronoBortzDifference === null ? null : Number(chronoBortzDifference),
@@ -687,7 +787,7 @@ public sealed class NewAthleteOnboardingBrowserTests
 
         Assert.Equal("pro", handoff.GetProperty("offerType").GetString());
         Assert.Equal(100, handoff.GetProperty("amountUsd").GetDouble());
-        Assert.Equal("1", handoff.GetProperty("lwcStep").GetString());
+        Assert.Equal("bortz", handoff.GetProperty("bioageClock").GetString());
         Assert.True(handoff.GetProperty("hasChronoBortzDifference").GetBoolean());
         Assert.True(handoff.GetProperty("hasChronoPhenoDifference").GetBoolean());
         Assert.True(double.IsFinite(handoff.GetProperty("chronoBortzDifference").GetDouble()));

--- a/LongevityWorldCup.Tests/PlayMenuPageTests.cs
+++ b/LongevityWorldCup.Tests/PlayMenuPageTests.cs
@@ -109,6 +109,9 @@ public sealed class PlayMenuPageTests
         Assert.DoesNotContain("onclick=\"window.location.href='/join'\"", html);
         Assert.Contains("flow.setPendingPaymentOffer({", playMenu);
         Assert.Contains("source: 'join-game'", playMenu);
+        Assert.Contains("function clearCompletedBioageHandoff(playFlow: PlayAthleteFlowApi): void", playMenuSource);
+        Assert.Contains("'bioageClock'", playMenuSource);
+        Assert.Contains("clearCompletedBioageHandoff(flow);", playMenuSource);
         Assert.Contains("window.location.href = `/pheno-age${getCheckoutQuerySuffix()}`;", playMenu);
         Assert.Contains("window.location.href = `/bortz-age${getCheckoutQuerySuffix()}`;", playMenu);
         Assert.Contains("createPriceHtmlFallback", flow);

--- a/LongevityWorldCup.Tests/ProofUploadPageTests.cs
+++ b/LongevityWorldCup.Tests/ProofUploadPageTests.cs
@@ -466,8 +466,13 @@ public sealed class ProofUploadPageTests
         Assert.Contains("const match = /^(\\d{4})-(\\d{2})-(\\d{2})$/.exec(value.trim());", html);
         Assert.Contains("return parsedDate <= todayUtc;", html);
         Assert.Contains("function hasStoredBiomarkerValues(biomarkerData)", html);
-        Assert.Contains("function hasCompleteSubmittedBiomarkerValues(biomarkerData, chronoPhenoDifference, chronoBortzDifference)", html);
-        Assert.Contains("!hasCompleteSubmittedBiomarkerValues(biomarkerData, chronoPhenoDifference, chronoBortzDifference)", parseBody);
+        Assert.Contains("function hasCompleteSubmittedBiomarkerValues(biomarkerData, bioageClock)", html);
+        Assert.Contains("!hasCompleteSubmittedBiomarkerValues(biomarkerData, bioageClock)", parseBody);
+        Assert.Contains("function readStoredBioageClock(biomarkerData, chronoPhenoDifference, chronoBortzDifference)", html);
+        Assert.Contains("const isLegacyUnclockedResult = !bioageClock", parseBody);
+        Assert.Contains("&& getSessionItem('bioageClock') === null", parseBody);
+        Assert.Contains("const hasRequiredAgeDifferences = isLegacyUnclockedResult || (chronoPhenoDifference !== null", parseBody);
+        Assert.Contains("(!bioageClock && !isLegacyUnclockedResult)", parseBody);
         Assert.Contains("function hasStoredBiomarkerValue(value)", html);
         Assert.Contains("Object.keys(entry).some(key => key !== 'Date' && hasStoredBiomarkerValue(entry[key]))", html);
         Assert.Contains("const PHENO_RESULT_BIOMARKER_KEYS = ['AlbGL', 'CreatUmolL', 'GluMmolL', 'CrpMgL', 'Wbc1000cellsuL', 'LymPc', 'McvFL', 'RdwPc', 'AlpUL'];", html);
@@ -480,6 +485,7 @@ public sealed class ProofUploadPageTests
         Assert.Contains("clearStoredBiomarkerHandoff();", parseBody);
         Assert.Contains("function clearStoredBiomarkerHandoff()", html);
         Assert.Contains("removeSessionItem('biomarkerData');", html);
+        Assert.Contains("removeSessionItem('bioageClock');", html);
         Assert.Contains("removeSessionItem('chronoPhenoDifference');", html);
         Assert.Contains("removeSessionItem('chronoBortzDifference');", html);
         Assert.Contains("customAlert('Biomarker data is missing. Please fill out the biomarker form first.')", parseBody);
@@ -514,7 +520,9 @@ public sealed class ProofUploadPageTests
         Assert.Contains("|| readStoredContactEmail();", html);
         Assert.Contains("accountEmail: readResultUploadContactEmail()", submitBody);
         Assert.Contains("const chronoPhenoDifference = readStoredAgeDifference('chronoPhenoDifference');", html);
-        Assert.Contains("const chronoBortzDifference = readStoredAgeDifference('chronoBortzDifference');", html);
+        Assert.Contains("let chronoBortzDifference = readStoredAgeDifference('chronoBortzDifference');", html);
+        Assert.Contains("const bioageClock = readStoredBioageClock(", html);
+        Assert.Contains("if (bioageClock === 'pheno') chronoBortzDifference = null;", html);
         Assert.Contains("chronoPhenoDifference: chronoPhenoDifference", submitBody);
         Assert.Contains("chronoBortzDifference: chronoBortzDifference", submitBody);
         Assert.Contains("function readStoredAgeDifference(key)", html);

--- a/LongevityWorldCup.Website/Frontend/bioage-flow.ts
+++ b/LongevityWorldCup.Website/Frontend/bioage-flow.ts
@@ -1,6 +1,7 @@
 type BioageBrowserStorageName = 'localStorage' | 'sessionStorage';
 type BioageStorageGetter = (key: string) => string | null;
 type BioageStorageRemover = (key: string) => void;
+type BioageClock = 'pheno' | 'bortz';
 
 interface BioageSelectedAthleteDateOfBirth {
     Year: unknown;
@@ -38,8 +39,47 @@ interface BioageResultRevealOptions {
     instant?: boolean;
 }
 
+interface BioageBiomarkerEntryOptions {
+    clock: BioageClock;
+    form: HTMLFormElement;
+    isUpdate?: boolean;
+    restoreDraft?: boolean;
+}
+
+interface BioageBiomarkerEntryResult {
+    restoredDraft: boolean;
+    step: 1 | 2;
+}
+
+interface BioageDraftField {
+    checked?: boolean;
+    selectedIndex?: number;
+    value: string;
+}
+
+interface BioageDraft {
+    clock: BioageClock;
+    fields: Record<string, BioageDraftField>;
+    step: 1 | 2;
+    version: 1;
+}
+
+interface BioageBiomarkerEntryController {
+    clock: BioageClock;
+    form: HTMLFormElement;
+    inputs: HTMLInputElement[];
+    invalidBatchActive: boolean;
+    isUpdate: boolean;
+    progress: HTMLParagraphElement;
+    restoring: boolean;
+    saveTimer: number;
+    step: 1 | 2;
+    visitedInputs: Set<HTMLInputElement>;
+}
+
 interface LwcBioageFlowApi {
     bindBiomarkerComparison: (inputId: string, getState: BioageBiomarkerComparisonGetter) => void;
+    clearBioageDraft: (clock?: BioageClock) => void;
     clearStoredBiomarkerHandoff: (removeItem?: BioageStorageRemover) => void;
     buildUnitSpecificBiomarkerPlaceholders: (
         inputId: string,
@@ -52,8 +92,10 @@ interface LwcBioageFlowApi {
     getBrowserStorageItem: (storageName: BioageBrowserStorageName, key: string) => string | null;
     getLocalItem: BioageStorageGetter;
     getSessionItem: BioageStorageGetter;
+    getDraftStep: (clock: BioageClock) => 1 | 2;
     hasFiniteBiomarkerValue: (value: unknown) => boolean;
     hideUpdateModeStepNavigation: () => void;
+    initializeBiomarkerEntry: (options: BioageBiomarkerEntryOptions) => BioageBiomarkerEntryResult;
     isUpdateMode: (search?: string) => boolean;
     isValidSelectedAthlete: (value: unknown) => value is BioageSelectedAthlete;
     navigateBack: (isUpdate: boolean) => void;
@@ -63,12 +105,14 @@ interface LwcBioageFlowApi {
     removeBrowserStorageItem: (storageName: BioageBrowserStorageName, key: string) => void;
     removeLocalItem: BioageStorageRemover;
     removeSessionItem: BioageStorageRemover;
+    expandBiomarkerCard: (field: string | Element | null | undefined) => void;
     resetUpdateModeScroll: () => void;
     revealBioageResult: (resultElement: HTMLElement | null, revealOptions?: BioageResultRevealOptions) => void;
     setBrowserStorageItem: (storageName: BioageBrowserStorageName, key: string, value: string) => boolean;
     setLocalItem: (key: string, value: string) => boolean;
     setSubmittedBiomarkerPlaceholders: (placeholdersByInputId: unknown) => void;
     setSessionItem: (key: string, value: string) => boolean;
+    setDraftStep: (clock: BioageClock, step: number) => void;
     syncBioageResultActions: () => void;
     syncBioageResultVisibility: () => void;
     syncBiomarkerExamplePlaceholders: (root?: ParentNode | null) => void;
@@ -489,6 +533,533 @@ interface Window {
         });
     }
 
+    const BIOAGE_DRAFT_VERSION = 1;
+    const bioageMobileMedia = window.matchMedia(
+        '(max-width: 600px), (max-width: 1024px) and (max-height: 600px) and (orientation: landscape)'
+    );
+    const biomarkerEntryControllers = new Map<BioageClock, BioageBiomarkerEntryController>();
+
+    function getBioageDraftKey(clock: BioageClock): string {
+        return `bioageDraft:${clock}:v${BIOAGE_DRAFT_VERSION}`;
+    }
+
+    function isBioageClock(value: unknown): value is BioageClock {
+        return value === 'pheno' || value === 'bortz';
+    }
+
+    function readBioageDraft(clock: BioageClock): BioageDraft | null {
+        const raw = getSessionItem(getBioageDraftKey(clock));
+        if (!raw) return null;
+
+        try {
+            const draft: unknown = JSON.parse(raw);
+            if (!isObject(draft)
+                || Reflect.get(draft, 'version') !== BIOAGE_DRAFT_VERSION
+                || Reflect.get(draft, 'clock') !== clock
+                || !isObject(Reflect.get(draft, 'fields'))) {
+                throw new Error('Invalid biological age draft');
+            }
+
+            const stepValue = Reflect.get(draft, 'step');
+            return {
+                version: BIOAGE_DRAFT_VERSION,
+                clock,
+                step: stepValue === 2 ? 2 : 1,
+                fields: Reflect.get(draft, 'fields') as Record<string, BioageDraftField>
+            };
+        } catch (_) {
+            removeSessionItem(getBioageDraftKey(clock));
+            return null;
+        }
+    }
+
+    function clearBioageDraft(clock?: BioageClock): void {
+        const clocks: BioageClock[] = clock ? [clock] : ['pheno', 'bortz'];
+        clocks.forEach(draftClock => {
+            const controller = biomarkerEntryControllers.get(draftClock);
+            if (controller?.saveTimer) window.clearTimeout(controller.saveTimer);
+            biomarkerEntryControllers.delete(draftClock);
+            removeSessionItem(getBioageDraftKey(draftClock));
+        });
+    }
+
+    function getDraftControls(form: HTMLFormElement): Array<HTMLInputElement | HTMLSelectElement> {
+        return Array.from(form.querySelectorAll<HTMLInputElement | HTMLSelectElement>(
+            '#dob-year, #dob-month, #dob-day, #blood-draw-date, .biomarker-card input[id], .biomarker-card select[id]'
+        ));
+    }
+
+    function serializeDraftFields(form: HTMLFormElement): Record<string, BioageDraftField> {
+        const fields: Record<string, BioageDraftField> = {};
+        getDraftControls(form).forEach(control => {
+            if (!control.id) return;
+
+            const field: BioageDraftField = { value: control.value };
+            if (control instanceof HTMLInputElement && control.type === 'checkbox') {
+                field.checked = control.checked;
+            }
+            if (control instanceof HTMLSelectElement) {
+                field.selectedIndex = control.selectedIndex;
+            }
+            fields[control.id] = field;
+        });
+        return fields;
+    }
+
+    function saveBioageDraft(controller: BioageBiomarkerEntryController): void {
+        controller.saveTimer = 0;
+        if (controller.isUpdate || controller.restoring) return;
+
+        const draft: BioageDraft = {
+            version: BIOAGE_DRAFT_VERSION,
+            clock: controller.clock,
+            step: controller.step,
+            fields: serializeDraftFields(controller.form)
+        };
+
+        try {
+            setSessionItem(getBioageDraftKey(controller.clock), JSON.stringify(draft));
+        } catch (_) {
+        }
+    }
+
+    function scheduleBioageDraftSave(controller: BioageBiomarkerEntryController): void {
+        if (controller.isUpdate || controller.restoring) return;
+        if (controller.saveTimer) window.clearTimeout(controller.saveTimer);
+        controller.saveTimer = window.setTimeout(() => saveBioageDraft(controller), 100);
+    }
+
+    function applyDraftField(
+        form: HTMLFormElement,
+        fields: Record<string, BioageDraftField>,
+        id: string
+    ): void {
+        const field = fields[id];
+        const control = document.getElementById(id);
+        if (!field || !control || !form.contains(control)) return;
+
+        if (control instanceof HTMLSelectElement) {
+            const selectedIndex = Number(field.selectedIndex);
+            if (Number.isInteger(selectedIndex) && selectedIndex >= 0 && selectedIndex < control.options.length) {
+                control.selectedIndex = selectedIndex;
+            } else {
+                control.value = typeof field.value === 'string' ? field.value : '';
+            }
+            return;
+        }
+
+        if (!(control instanceof HTMLInputElement)) return;
+        if (control.type === 'checkbox') {
+            control.checked = field.checked === true;
+        } else {
+            control.value = typeof field.value === 'string' ? field.value : '';
+        }
+    }
+
+    function restoreBioageDraft(controller: BioageBiomarkerEntryController): boolean {
+        if (controller.isUpdate) return false;
+        const draft = readBioageDraft(controller.clock);
+        if (!draft) return false;
+
+        controller.restoring = true;
+        try {
+            applyDraftField(controller.form, draft.fields, 'dob-year');
+            applyDraftField(controller.form, draft.fields, 'dob-month');
+            controller.form.querySelector<HTMLSelectElement>('#dob-month')
+                ?.dispatchEvent(new Event('change', { bubbles: true }));
+            applyDraftField(controller.form, draft.fields, 'dob-day');
+
+            Object.keys(draft.fields)
+                .filter(id => !['dob-year', 'dob-month', 'dob-day'].includes(id))
+                .forEach(id => applyDraftField(controller.form, draft.fields, id));
+
+            const negativeCrp = controller.form.querySelector<HTMLInputElement>('#crp-negative');
+            if (negativeCrp?.checked) {
+                negativeCrp.dispatchEvent(new Event('change', { bubbles: true }));
+            }
+            controller.step = draft.step;
+            return true;
+        } finally {
+            controller.restoring = false;
+        }
+    }
+
+    function getBiomarkerInput(field: string | Element | null | undefined): HTMLInputElement | null {
+        const candidate = typeof field === 'string' ? document.getElementById(field) : field;
+        if (candidate instanceof HTMLInputElement) return candidate;
+        return candidate?.closest<HTMLElement>('.biomarker-card')
+            ?.querySelector<HTMLInputElement>('input[type="number"]') || null;
+    }
+
+    function setBiomarkerCardExpanded(card: HTMLElement, expanded: boolean): void {
+        const header = card.querySelector<HTMLElement>('.biomarker-card-header');
+        const icon = header?.querySelector<HTMLElement>('.toggle-icon');
+        const content = card.querySelector<HTMLElement>('.biomarker-card-content');
+
+        card.classList.toggle('active', expanded);
+        header?.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+        if (icon) icon.textContent = expanded ? '−' : '+';
+        if (content) {
+            content.style.maxHeight = expanded ? `${content.scrollHeight}px` : '0';
+            content.style.paddingTop = expanded ? '0.75rem' : '0';
+            content.style.paddingBottom = expanded ? '0.75rem' : '0';
+        }
+    }
+
+    function expandBiomarkerCard(field: string | Element | null | undefined): void {
+        const input = getBiomarkerInput(field);
+        const card = input?.closest<HTMLElement>('.biomarker-card');
+        if (!card || card.classList.contains('active')) return;
+        setBiomarkerCardExpanded(card, true);
+    }
+
+    function getBiomarkerLabel(input: HTMLInputElement): string {
+        return input.getAttribute('aria-label')
+            || input.closest('.biomarker-card')
+            ?.querySelector<HTMLElement>('.biomarker-card-header')
+            ?.childNodes[0]
+            ?.textContent
+            ?.trim()
+            || 'this biomarker';
+    }
+
+    function isCompleteBiomarkerInput(input: HTMLInputElement): boolean {
+        const value = input.value.trim();
+        return value !== ''
+            && Number.isFinite(Number(value))
+            && input.validity.valid;
+    }
+
+    function getOrCreateBiomarkerError(input: HTMLInputElement): HTMLParagraphElement {
+        const cardContent = input.closest<HTMLElement>('.biomarker-card-content');
+        const errorId = `${input.id}-entry-error`;
+        let error = cardContent?.querySelector<HTMLParagraphElement>(`#${errorId}`) || null;
+        if (!error) {
+            error = document.createElement('p');
+            error.id = errorId;
+            error.className = 'bioage-biomarker-error';
+            error.hidden = true;
+            error.setAttribute('role', 'alert');
+            error.textContent = `Enter ${getBiomarkerLabel(input)}.`;
+            cardContent?.appendChild(error);
+        }
+
+        const describedBy = new Set((input.getAttribute('aria-describedby') || '').split(/\s+/).filter(Boolean));
+        describedBy.add(errorId);
+        input.setAttribute('aria-describedby', Array.from(describedBy).join(' '));
+        return error;
+    }
+
+    function setBiomarkerError(input: HTMLInputElement, visible: boolean): void {
+        const error = getOrCreateBiomarkerError(input);
+        error.hidden = !visible;
+        input.setAttribute('aria-invalid', visible ? 'true' : 'false');
+    }
+
+    function ensureBiomarkerVisible(input: HTMLInputElement): void {
+        const reveal = () => {
+            const dock = getFlowActionDock();
+            dock?.refreshNow?.();
+            dock?.ensureClear?.(input, { margin: 16, behavior: 'auto' });
+
+            const visualViewport = window.visualViewport;
+            const top = visualViewport?.offsetTop || 0;
+            const bottom = top + (visualViewport?.height || window.innerHeight);
+            const rect = input.getBoundingClientRect();
+            if (rect.bottom > bottom - 16 || rect.top < top + 16) {
+                input.scrollIntoView({
+                    block: 'center',
+                    inline: 'nearest',
+                    behavior: window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth'
+                });
+            }
+        };
+
+        window.requestAnimationFrame(() => window.requestAnimationFrame(reveal));
+    }
+
+    function syncFixedUnitPresentation(input: HTMLInputElement): void {
+        const group = input.closest<HTMLElement>('.input-group');
+        const select = group?.querySelector<HTMLSelectElement>('select');
+        if (!group || !select || select.options.length !== 1) return;
+
+        select.classList.add('bioage-fixed-unit-select');
+        let suffix = group.querySelector<HTMLElement>('.bioage-fixed-unit');
+        if (!suffix) {
+            suffix = document.createElement('span');
+            suffix.className = 'bioage-fixed-unit';
+            suffix.id = `${input.id}-fixed-unit`;
+            group.appendChild(suffix);
+        }
+        suffix.textContent = select.options[0]?.textContent?.trim() || '';
+
+        const describedBy = new Set((input.getAttribute('aria-describedby') || '').split(/\s+/).filter(Boolean));
+        describedBy.add(suffix.id);
+        input.setAttribute('aria-describedby', Array.from(describedBy).join(' '));
+    }
+
+    function syncBiomarkerHeaderSemantics(controller: BioageBiomarkerEntryController): void {
+        const isMobile = bioageMobileMedia.matches;
+        controller.form.querySelectorAll<HTMLElement>('.biomarker-card-header').forEach(header => {
+            const card = header.closest<HTMLElement>('.biomarker-card');
+            const icon = header.querySelector<HTMLElement>('.toggle-icon');
+            header.style.pointerEvents = '';
+            header.style.cursor = '';
+            header.removeAttribute('aria-disabled');
+            icon?.setAttribute('aria-hidden', 'true');
+
+            if (isMobile) {
+                header.removeAttribute('role');
+                header.removeAttribute('tabindex');
+                header.removeAttribute('aria-expanded');
+                if (icon) icon.textContent = '';
+                return;
+            }
+
+            header.setAttribute('role', 'button');
+            header.tabIndex = 0;
+            header.setAttribute('aria-expanded', card?.classList.contains('active') ? 'true' : 'false');
+            if (icon) icon.textContent = card?.classList.contains('active') ? '−' : '+';
+        });
+    }
+
+    function syncBiomarkerCompletion(controller: BioageBiomarkerEntryController): void {
+        let completed = 0;
+        const incompleteInputs: HTMLInputElement[] = [];
+        controller.inputs.forEach(input => {
+            const isComplete = isCompleteBiomarkerInput(input);
+            input.dataset.bioageComplete = isComplete ? 'true' : 'false';
+            input.closest<HTMLElement>('.biomarker-card')
+                ?.classList.toggle('biomarker-card--complete', isComplete);
+            if (isComplete) {
+                completed += 1;
+                setBiomarkerError(input, false);
+            } else if (controller.isUpdate && input.value.trim() === '') {
+                setBiomarkerError(input, false);
+            }
+            if (!isComplete) incompleteInputs.push(input);
+        });
+        controller.inputs.forEach((input, index) => {
+            const hasOtherIncompleteInput = incompleteInputs.some(candidate => candidate !== input);
+            input.enterKeyHint = (controller.isUpdate
+                ? index < controller.inputs.length - 1
+                : hasOtherIncompleteInput || index < controller.inputs.length - 1)
+                ? 'next'
+                : 'done';
+        });
+
+        const total = controller.inputs.length;
+        const bloodDrawDate = controller.form.querySelector<HTMLInputElement>('#blood-draw-date');
+        const hasBloodDrawDate = !!bloodDrawDate?.value && bloodDrawDate.validity.valid;
+        const ready = controller.isUpdate
+            ? completed > 0 && hasBloodDrawDate
+            : total > 0 && completed === total;
+        controller.progress.textContent = controller.isUpdate
+            ? !hasBloodDrawDate && completed === 0
+                ? 'Enter the blood draw date and at least 1 new biomarker value'
+                : !hasBloodDrawDate
+                    ? 'Enter the blood draw date'
+                    : completed > 0
+                        ? `${completed} biomarker${completed === 1 ? '' : 's'} ready to update`
+                        : 'Enter at least 1 new biomarker value'
+            : `${completed} of ${total} biomarkers entered`;
+        controller.progress.classList.toggle('bioage-biomarker-progress--complete', ready);
+
+        // The flow dock portals the action stack out of the form on small screens.
+        const calculateButton = document.querySelector<HTMLButtonElement>('.bioage-calculate-button');
+        if (calculateButton) {
+            calculateButton.disabled = !ready;
+            calculateButton.setAttribute('aria-describedby', controller.progress.id);
+            if (!document.getElementById('continueButton')?.classList.contains('show')) {
+                calculateButton.classList.toggle('green', ready);
+                calculateButton.classList.toggle('grey', !ready);
+                calculateButton.classList.toggle('flow-action--secondary', !ready);
+            }
+        }
+    }
+
+    function refreshAllBiomarkerCompletion(): void {
+        biomarkerEntryControllers.forEach(syncBiomarkerCompletion);
+    }
+
+    function moveToNextBiomarker(
+        controller: BioageBiomarkerEntryController,
+        input: HTMLInputElement
+    ): void {
+        const index = controller.inputs.indexOf(input);
+        const nextInput = controller.inputs.slice(index + 1).find(candidate => !isCompleteBiomarkerInput(candidate))
+            || (!controller.isUpdate
+                ? controller.inputs.slice(0, index).find(candidate => !isCompleteBiomarkerInput(candidate))
+                : null)
+            || controller.inputs[index + 1];
+        if (!nextInput) {
+            input.blur();
+            return;
+        }
+
+        expandBiomarkerCard(nextInput);
+        nextInput.focus();
+        ensureBiomarkerVisible(nextInput);
+    }
+
+    function bindBiomarkerEntry(controller: BioageBiomarkerEntryController): void {
+        controller.form.querySelectorAll<HTMLElement>('.biomarker-card-header').forEach(header => {
+            if (header.dataset.bioageEntryBound === 'true') return;
+            header.dataset.bioageEntryBound = 'true';
+
+            const toggle = () => {
+                if (bioageMobileMedia.matches) return;
+                const card = header.closest<HTMLElement>('.biomarker-card');
+                if (card) setBiomarkerCardExpanded(card, !card.classList.contains('active'));
+            };
+            header.addEventListener('click', toggle);
+            header.addEventListener('keydown', event => {
+                if (event.key !== 'Enter' && event.key !== ' ') return;
+                event.preventDefault();
+                toggle();
+            });
+        });
+
+        controller.inputs.forEach(input => {
+            syncFixedUnitPresentation(input);
+            getOrCreateBiomarkerError(input);
+
+            input.addEventListener('focus', () => {
+                controller.visitedInputs.add(input);
+                expandBiomarkerCard(input);
+                ensureBiomarkerVisible(input);
+            });
+            input.addEventListener('input', () => {
+                if (!controller.restoring) clearStoredBiomarkerHandoff();
+                syncBiomarkerCompletion(controller);
+                scheduleBioageDraftSave(controller);
+            });
+            input.addEventListener('blur', () => {
+                if (controller.visitedInputs.has(input)
+                    && !isCompleteBiomarkerInput(input)
+                    && !(controller.isUpdate && input.value.trim() === '')) {
+                    setBiomarkerError(input, true);
+                }
+                scheduleBioageDraftSave(controller);
+            });
+            input.addEventListener('keydown', event => {
+                if (event.key !== 'Enter' || !bioageMobileMedia.matches) return;
+                event.preventDefault();
+                if (controller.isUpdate && input.value.trim() === '') {
+                    moveToNextBiomarker(controller, input);
+                    return;
+                }
+                if (!isCompleteBiomarkerInput(input)) {
+                    setBiomarkerError(input, true);
+                    ensureBiomarkerVisible(input);
+                    return;
+                }
+                moveToNextBiomarker(controller, input);
+            });
+        });
+
+        controller.form.addEventListener('change', () => {
+            if (!controller.restoring) clearStoredBiomarkerHandoff();
+            syncBiomarkerCompletion(controller);
+            scheduleBioageDraftSave(controller);
+        });
+        controller.form.addEventListener('invalid', event => {
+            const input = event.target;
+            if (!(input instanceof HTMLInputElement) || !controller.inputs.includes(input)) return;
+            if (controller.invalidBatchActive) {
+                event.preventDefault();
+                return;
+            }
+
+            controller.invalidBatchActive = true;
+            expandBiomarkerCard(input);
+            setBiomarkerError(input, true);
+            window.requestAnimationFrame(() => {
+                input.focus();
+                ensureBiomarkerVisible(input);
+            });
+            window.setTimeout(() => {
+                controller.invalidBatchActive = false;
+            }, 0);
+        }, true);
+
+        bioageMobileMedia.addEventListener?.('change', () => {
+            syncBiomarkerHeaderSemantics(controller);
+            getFlowActionDock()?.refresh?.();
+        });
+        window.addEventListener('pagehide', () => saveBioageDraft(controller));
+    }
+
+    function initializeBiomarkerEntry(options: BioageBiomarkerEntryOptions): BioageBiomarkerEntryResult {
+        const existing = biomarkerEntryControllers.get(options.clock);
+        if (existing?.form === options.form) {
+            syncBiomarkerCompletion(existing);
+            return { restoredDraft: false, step: existing.step };
+        }
+
+        const stepTwo = options.form.querySelector<HTMLElement>('#lwc-step-2');
+        const stepHeading = stepTwo?.querySelector('h2');
+        if (options.isUpdate && stepTwo) {
+            const bloodDrawDateFieldset = options.form.querySelector<HTMLInputElement>('#blood-draw-date')
+                ?.closest<HTMLFieldSetElement>('fieldset');
+            const firstBiomarkerFieldset = stepTwo.querySelector<HTMLFieldSetElement>(':scope > fieldset');
+            if (bloodDrawDateFieldset && firstBiomarkerFieldset) {
+                bloodDrawDateFieldset.classList.add('bioage-update-date-fieldset');
+                stepTwo.insertBefore(bloodDrawDateFieldset, firstBiomarkerFieldset);
+            }
+        }
+        const progress = document.createElement('p');
+        progress.id = `${options.clock}BiomarkerProgress`;
+        progress.className = 'bioage-biomarker-progress';
+        progress.setAttribute('role', 'status');
+        progress.setAttribute('aria-live', 'polite');
+        progress.setAttribute('aria-atomic', 'true');
+        stepHeading?.insertAdjacentElement('afterend', progress);
+
+        const controller: BioageBiomarkerEntryController = {
+            clock: options.clock,
+            form: options.form,
+            inputs: Array.from(options.form.querySelectorAll<HTMLInputElement>(
+                '.biomarker-card input[type="number"][required]'
+            )),
+            invalidBatchActive: false,
+            isUpdate: options.isUpdate === true,
+            progress,
+            restoring: false,
+            saveTimer: 0,
+            step: 1,
+            visitedInputs: new Set()
+        };
+
+        options.form.classList.add('bioage-biomarker-entry-ready');
+        biomarkerEntryControllers.set(options.clock, controller);
+        bindBiomarkerEntry(controller);
+        syncBiomarkerHeaderSemantics(controller);
+
+        const restoredDraft = options.restoreDraft !== false && restoreBioageDraft(controller);
+        syncBiomarkerExamplePlaceholders(options.form);
+        syncBiomarkerCompletion(controller);
+        removeSessionItem('lwcStep');
+
+        return {
+            restoredDraft,
+            step: controller.step
+        };
+    }
+
+    function getDraftStep(clock: BioageClock): 1 | 2 {
+        return biomarkerEntryControllers.get(clock)?.step
+            || readBioageDraft(clock)?.step
+            || 1;
+    }
+
+    function setDraftStep(clock: BioageClock, step: number): void {
+        const controller = biomarkerEntryControllers.get(clock);
+        if (!controller) return;
+        controller.step = step === 2 ? 2 : 1;
+        scheduleBioageDraftSave(controller);
+    }
+
     function isUpdateMode(search?: string): boolean {
         return new URLSearchParams(search || window.location.search).get('update') === '1';
     }
@@ -571,6 +1142,7 @@ interface Window {
     function clearStoredBiomarkerHandoff(removeItem?: BioageStorageRemover): void {
         const remove = typeof removeItem === 'function' ? removeItem : removeSessionItem;
         remove('biomarkerData');
+        remove('bioageClock');
         remove('chronoPhenoDifference');
         remove('chronoBortzDifference');
     }
@@ -589,6 +1161,7 @@ interface Window {
         }
 
         syncBioageResultActions();
+        refreshAllBiomarkerCompletion();
     }
 
     function syncBioageResultActions(): void {
@@ -601,9 +1174,9 @@ interface Window {
         resultActions.hidden = !hasResult;
         getFlowActionDock()?.refreshNow?.();
 
-        if (hasResult) {
+        if (hasResult && !lastBioageResultActionsVisible) {
             scheduleBioageResultReveal(getShownBioageResultElement());
-        } else {
+        } else if (!hasResult) {
             clearScheduledBioageResultReveals();
         }
 
@@ -615,7 +1188,6 @@ interface Window {
     let resultRevealFrame = 0;
     let pendingResultRevealElement: HTMLElement | null = null;
     let pendingResultRevealInstant = false;
-    let resultResizeObserver: ResizeObserver | null = null;
 
     function getShownBioageResultElement(): HTMLElement | null {
         return document.querySelector<HTMLElement>('#phenoAgeResult.show, #bortzAgeResult.show');
@@ -741,6 +1313,14 @@ interface Window {
     }
 
     function syncBioageResultVisibility(): void {
+        document.querySelectorAll<HTMLElement>('#phenoAgeResult, #bortzAgeResult')
+            .forEach(candidate => {
+                const isShown = candidate.classList.contains('show');
+                candidate.toggleAttribute('inert', !isShown);
+                if (isShown) candidate.removeAttribute('aria-hidden');
+                else candidate.setAttribute('aria-hidden', 'true');
+            });
+
         const resultElement = getShownBioageResultElement();
         const hasShownResult = !!resultElement;
 
@@ -775,18 +1355,6 @@ interface Window {
                 attributeFilter: ['class']
             });
         });
-
-        resultResizeObserver?.disconnect();
-        if ('ResizeObserver' in window) {
-            resultResizeObserver = new ResizeObserver(entries => {
-                const resultElement = getShownBioageResultElement();
-                if (!resultElement || !entries.some(entry => entry.target === resultElement)) return;
-
-                scheduleBioageResultReveal(resultElement, { instant: true });
-            });
-            document.querySelectorAll<HTMLElement>('#phenoAgeResult, #bortzAgeResult')
-                .forEach(resultElement => resultResizeObserver?.observe(resultElement));
-        }
     }
 
     function hideUpdateModeStepNavigation(): void {
@@ -796,8 +1364,11 @@ interface Window {
 
     window.LwcBioageFlow = {
         bindBiomarkerComparison,
+        clearBioageDraft,
         clearStoredBiomarkerHandoff,
         buildUnitSpecificBiomarkerPlaceholders,
+        expandBiomarkerCard,
+        getDraftStep,
         getLatestBiomarkerEntry,
         getLatestBiomarkerValue,
         getBackDestination,
@@ -806,6 +1377,7 @@ interface Window {
         getSessionItem,
         hasFiniteBiomarkerValue,
         hideUpdateModeStepNavigation,
+        initializeBiomarkerEntry,
         isUpdateMode,
         isValidSelectedAthlete,
         navigateBack,
@@ -821,6 +1393,7 @@ interface Window {
         setLocalItem,
         setSubmittedBiomarkerPlaceholders,
         setSessionItem,
+        setDraftStep,
         syncBioageResultActions,
         syncBioageResultVisibility,
         syncBiomarkerExamplePlaceholders,

--- a/LongevityWorldCup.Website/Frontend/bioage-flow.ts
+++ b/LongevityWorldCup.Website/Frontend/bioage-flow.ts
@@ -882,24 +882,38 @@ interface Window {
         biomarkerEntryControllers.forEach(syncBiomarkerCompletion);
     }
 
+    function focusBiomarkerInput(input: HTMLInputElement): void {
+        expandBiomarkerCard(input);
+        input.focus();
+        ensureBiomarkerVisible(input);
+    }
+
+    function getFollowingBiomarkerInput(
+        controller: BioageBiomarkerEntryController,
+        input: HTMLInputElement
+    ): HTMLInputElement | null {
+        const index = controller.inputs.indexOf(input);
+        return controller.inputs.slice(index + 1).find(candidate => !candidate.disabled) || null;
+    }
+
     function moveToNextBiomarker(
         controller: BioageBiomarkerEntryController,
         input: HTMLInputElement
     ): void {
         const index = controller.inputs.indexOf(input);
-        const nextInput = controller.inputs.slice(index + 1).find(candidate => !isCompleteBiomarkerInput(candidate))
+        const nextInput = controller.inputs.slice(index + 1)
+            .find(candidate => !candidate.disabled && !isCompleteBiomarkerInput(candidate))
             || (!controller.isUpdate
-                ? controller.inputs.slice(0, index).find(candidate => !isCompleteBiomarkerInput(candidate))
+                ? controller.inputs.slice(0, index)
+                    .find(candidate => !candidate.disabled && !isCompleteBiomarkerInput(candidate))
                 : null)
-            || controller.inputs[index + 1];
+            || getFollowingBiomarkerInput(controller, input);
         if (!nextInput) {
             input.blur();
             return;
         }
 
-        expandBiomarkerCard(nextInput);
-        nextInput.focus();
-        ensureBiomarkerVisible(nextInput);
+        focusBiomarkerInput(nextInput);
     }
 
     function bindBiomarkerEntry(controller: BioageBiomarkerEntryController): void {
@@ -943,7 +957,15 @@ interface Window {
                 scheduleBioageDraftSave(controller);
             });
             input.addEventListener('keydown', event => {
-                if (event.key !== 'Enter' || !bioageMobileMedia.matches) return;
+                if (!bioageMobileMedia.matches) return;
+                if (event.key === 'Tab' && !event.shiftKey) {
+                    const nextInput = getFollowingBiomarkerInput(controller, input);
+                    if (!nextInput) return;
+                    event.preventDefault();
+                    focusBiomarkerInput(nextInput);
+                    return;
+                }
+                if (event.key !== 'Enter') return;
                 event.preventDefault();
                 if (controller.isUpdate && input.value.trim() === '') {
                     moveToNextBiomarker(controller, input);

--- a/LongevityWorldCup.Website/Frontend/flow-action-dock.ts
+++ b/LongevityWorldCup.Website/Frontend/flow-action-dock.ts
@@ -32,9 +32,12 @@ interface FlowActionDockApi {
     const placeholderClass = 'flow-action-dock-placeholder';
     const activeClass = 'flow-action-dock-active';
     const readyClass = 'flow-action-dock-ready';
+    const keyboardOpenClass = 'flow-input-keyboard-open';
     const singleBackActionClass = 'flow-action-stack--single-back-action';
     const backPrimaryActionClass = 'flow-action-stack--back-primary-action';
     const mobileMedia = window.matchMedia('(max-width: 760px)');
+    const keyboardMedia = window.matchMedia('(max-width: 760px), (pointer: coarse)');
+    const coarsePointerMedia = window.matchMedia('(pointer: coarse)');
     const reducedMotionMedia = window.matchMedia('(prefers-reduced-motion: reduce)');
     const states = new Map<HTMLElement, DockState>();
     let refreshFrame = 0;
@@ -43,6 +46,10 @@ interface FlowActionDockApi {
     let documentStateObserver: MutationObserver | null = null;
     let transitionsReady = false;
     let generatedFormId = 0;
+    let keyboardClearFrame = 0;
+    let largestUnobscuredViewportHeight = 0;
+    let lastLayoutViewportWidth = window.innerWidth;
+    let isKeyboardOpen = false;
 
     function getVisualViewportBounds(): VisualViewportBounds {
         const visualViewport = window.visualViewport;
@@ -56,6 +63,97 @@ interface FlowActionDockApi {
             bottom: top + height,
             height
         };
+    }
+
+    function isKeyboardEditingControl(element: Element | null): element is HTMLElement {
+        if (element instanceof HTMLTextAreaElement) return !element.disabled && !element.readOnly;
+        if (element instanceof HTMLElement && element.isContentEditable) return true;
+        if (!(element instanceof HTMLInputElement) || element.disabled || element.readOnly) return false;
+
+        return ![
+            'button',
+            'checkbox',
+            'color',
+            'file',
+            'hidden',
+            'image',
+            'radio',
+            'range',
+            'reset',
+            'submit'
+        ].includes(element.type);
+    }
+
+    function getEstimatedLayoutViewportHeight(viewport: VisualViewportBounds): number {
+        const orientationType = window.screen?.orientation?.type || '';
+        const isLandscape = orientationType.startsWith('landscape')
+            || (!orientationType && window.innerWidth > window.innerHeight);
+        const screenWidth = Number(window.screen?.width);
+        const screenHeight = Number(window.screen?.height);
+        const orientedScreenHeight = coarsePointerMedia.matches
+            && Number.isFinite(screenWidth)
+            && Number.isFinite(screenHeight)
+            ? isLandscape
+                ? Math.min(screenWidth, screenHeight)
+                : Math.max(screenWidth, screenHeight)
+            : 0;
+
+        return Math.max(viewport.height, window.innerHeight, orientedScreenHeight);
+    }
+
+    function syncKeyboardState(): void {
+        const viewport = getVisualViewportBounds();
+        const viewportWidth = window.innerWidth;
+        if (Math.abs(viewportWidth - lastLayoutViewportWidth) > 48) {
+            lastLayoutViewportWidth = viewportWidth;
+            largestUnobscuredViewportHeight = getEstimatedLayoutViewportHeight(viewport);
+        }
+
+        const editingControl = isKeyboardEditingControl(document.activeElement);
+        if (!editingControl) {
+            largestUnobscuredViewportHeight = getEstimatedLayoutViewportHeight(viewport);
+        } else if (!largestUnobscuredViewportHeight) {
+            largestUnobscuredViewportHeight = getEstimatedLayoutViewportHeight(viewport);
+        }
+
+        const keyboardThreshold = Math.max(120, largestUnobscuredViewportHeight * 0.22);
+        isKeyboardOpen = keyboardMedia.matches
+            && editingControl
+            && largestUnobscuredViewportHeight - viewport.height >= keyboardThreshold;
+        const keyboardOcclusion = isKeyboardOpen
+            ? Math.max(0, largestUnobscuredViewportHeight - viewport.bottom)
+            : 0;
+        const occlusionValue = `${Math.ceil(keyboardOcclusion)}px`;
+
+        document.documentElement.classList.toggle(keyboardOpenClass, isKeyboardOpen);
+        document.body.classList.toggle(keyboardOpenClass, isKeyboardOpen);
+        document.documentElement.style.setProperty('--flow-input-keyboard-occlusion', occlusionValue);
+        document.body.style.setProperty('--flow-input-keyboard-occlusion', occlusionValue);
+    }
+
+    function keepFocusedControlInVisualViewport(): void {
+        if (keyboardClearFrame) window.cancelAnimationFrame(keyboardClearFrame);
+        if (!isKeyboardOpen || !isKeyboardEditingControl(document.activeElement)) {
+            keyboardClearFrame = 0;
+            return;
+        }
+
+        keyboardClearFrame = window.requestAnimationFrame(() => {
+            keyboardClearFrame = 0;
+            const control = document.activeElement;
+            if (!isKeyboardOpen || !isKeyboardEditingControl(control)) return;
+
+            const viewport = getVisualViewportBounds();
+            const rect = control.getBoundingClientRect();
+            const margin = 16;
+            const topLimit = viewport.top + margin;
+            const bottomLimit = viewport.bottom - margin;
+            if (rect.bottom > bottomLimit) {
+                window.scrollBy({ top: Math.ceil(rect.bottom - bottomLimit), behavior: 'auto' });
+            } else if (rect.top < topLimit) {
+                window.scrollBy({ top: Math.floor(rect.top - topLimit), behavior: 'auto' });
+            }
+        });
     }
 
     function hasLayoutBox(element: Element | null | undefined): element is HTMLElement {
@@ -226,6 +324,7 @@ interface FlowActionDockApi {
     function shouldDock(element: HTMLElement, state: DockState): boolean {
         if (!conditionMatches(element)) return false;
         if (state.docked ? !hasLayoutBox(state.placeholder) : !isVisible(element)) return false;
+        if (isKeyboardOpen) return false;
 
         const mode = (element.getAttribute('data-flow-dock') || 'auto').toLowerCase();
         if (mode === 'off') return false;
@@ -252,6 +351,7 @@ interface FlowActionDockApi {
     function refresh(): void {
         refreshFrame = 0;
         ensureRegisteredElements();
+        syncKeyboardState();
 
         let dockedHeight = 0;
         let hasDockedElement = false;
@@ -274,6 +374,7 @@ interface FlowActionDockApi {
         const heightValue = hasDockedElement ? `${Math.ceil(dockedHeight)}px` : '0px';
         document.documentElement.style.setProperty('--flow-action-dock-height', heightValue);
         document.body.style.setProperty('--flow-action-dock-height', heightValue);
+        keepFocusedControlInVisualViewport();
     }
 
     function scheduleRefresh(): void {
@@ -371,6 +472,8 @@ interface FlowActionDockApi {
         document.addEventListener('focusin', scheduleRefresh, true);
         document.addEventListener('focusout', () => window.setTimeout(scheduleRefresh, 0), true);
         mobileMedia.addEventListener?.('change', scheduleRefresh);
+        keyboardMedia.addEventListener?.('change', scheduleRefresh);
+        coarsePointerMedia.addEventListener?.('change', scheduleRefresh);
 
         if (window.visualViewport) {
             window.visualViewport.addEventListener('resize', scheduleRefresh);

--- a/LongevityWorldCup.Website/Frontend/play-athlete-flow.ts
+++ b/LongevityWorldCup.Website/Frontend/play-athlete-flow.ts
@@ -166,6 +166,7 @@ function persistSelectedAthlete(athlete: PlayAthlete | null): boolean {
     const prevName = getLocalItem("selectedAthleteName");
     if (!isAthleteInputValue(athlete, prevName)) {
         removeSessionItem("biomarkerData");
+        removeSessionItem("bioageClock");
         removeSessionItem("chronoPhenoDifference");
         removeSessionItem("chronoBortzDifference");
         removeSessionItem("contactEmail");

--- a/LongevityWorldCup.Website/Frontend/play-menu.ts
+++ b/LongevityWorldCup.Website/Frontend/play-menu.ts
@@ -455,6 +455,15 @@
         return query ? `?${query}` : '';
     }
 
+    function clearCompletedBioageHandoff(playFlow: PlayAthleteFlowApi): void {
+        [
+            'biomarkerData',
+            'bioageClock',
+            'chronoPhenoDifference',
+            'chronoBortzDifference'
+        ].forEach(key => playFlow.removeSessionItem(key));
+    }
+
     function startAmateurApplication(retryButton: HTMLButtonElement): void {
         const flow = requirePlayFlow();
         const stored = flow.setPendingPaymentOffer({
@@ -464,6 +473,7 @@
             amountUsd: 10
         }, retryButton);
         if (!stored) return;
+        clearCompletedBioageHandoff(flow);
         window.location.href = `/pheno-age${getCheckoutQuerySuffix()}`;
     }
 
@@ -480,6 +490,7 @@
             amountUsd
         }, result);
         if (!flow.setPendingPaymentOffer(paymentOffer, retryButton)) return;
+        clearCompletedBioageHandoff(flow);
         window.location.href = `/bortz-age${getCheckoutQuerySuffix()}`;
     }
 

--- a/LongevityWorldCup.Website/wwwroot/css/bioageform.css
+++ b/LongevityWorldCup.Website/wwwroot/css/bioageform.css
@@ -40,6 +40,17 @@
         transition: border-color var(--lwc-duration-fast, 140ms) var(--lwc-ease, ease), box-shadow var(--lwc-duration-fast, 140ms) var(--lwc-ease, ease);
     }
 
+    .bioageform .biomarker-card input[type="number"] {
+        -moz-appearance: textfield;
+        appearance: textfield;
+    }
+
+    .bioageform .biomarker-card input[type="number"]::-webkit-inner-spin-button,
+    .bioageform .biomarker-card input[type="number"]::-webkit-outer-spin-button {
+        margin: 0;
+        -webkit-appearance: none;
+    }
+
     .bioageform select {
         padding-right: 2.25rem;
         background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%2371808d' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><polyline points='6 9 12 15 18 9'/></svg>");

--- a/LongevityWorldCup.Website/wwwroot/css/bioageform.css
+++ b/LongevityWorldCup.Website/wwwroot/css/bioageform.css
@@ -60,7 +60,7 @@
     }
 
 /* Responsive adjustments */
-@media (max-width: 600px) {
+@media (max-width: 600px), (max-width: 1024px) and (max-height: 600px) and (orientation: landscape) {
     .bioageform {
         width: 100%;
         max-width: calc(100vw - 1.5rem);
@@ -68,87 +68,250 @@
         padding: 0.9rem;
     }
 
-    body.flow-action-dock-active .bioageform #lwc-step-1.lwc-step--active > fieldset {
-        padding: 0.85rem 0.9rem;
+    .bioageform #lwc-step-1.lwc-step--active > fieldset {
+        padding: 0.75rem 0.9rem;
     }
 
-    body.flow-action-dock-active .bioageform #lwc-step-1.lwc-step--active label {
+    .bioageform #lwc-step-1.lwc-step--active label {
         margin-top: 0.5rem;
         line-height: 1.2;
     }
 
-    body.flow-action-dock-active .bioageform #lwc-step-1.lwc-step--active fieldset > label:first-of-type {
+    .bioageform #lwc-step-1.lwc-step--active fieldset > label:first-of-type {
         margin-top: 0.35rem;
     }
 
-    body.flow-action-dock-active .bioageform #lwc-step-1.lwc-step--active .privacy-note {
+    .bioageform #lwc-step-1.lwc-step--active .privacy-note {
         margin-top: 0.25rem;
         font-size: 0.78rem;
         line-height: 1.22;
     }
 
-    body.flow-action-dock-active .bioageform #lwc-step-1.lwc-step--active > fieldset:nth-of-type(2) {
-        margin-top: calc(var(--flow-action-dock-height, 7rem) + 3.25rem);
+    .bioageform #lwc-step-1.lwc-step--active > fieldset:nth-of-type(2) {
+        margin-top: 0.45rem;
     }
-}
 
-@media (min-width: 400px) and (max-width: 600px) and (min-height: 900px) {
-    body.flow-action-dock-active .bioageform #dobFieldset {
+    .bioageform #dobFieldset {
         display: grid;
-        grid-template-columns: repeat(3, minmax(0, 1fr));
-        column-gap: 0.45rem;
+        grid-template-columns: minmax(0, 0.85fr) minmax(0, 1.25fr) minmax(0, 0.8fr);
+        column-gap: 0.4rem;
         row-gap: 0.3rem;
     }
 
-    body.flow-action-dock-active .bioageform #dobFieldset legend {
+    .bioageform #dobFieldset legend {
         grid-column: 1 / -1;
     }
 
-    body.flow-action-dock-active .bioageform #dobFieldset label[for="dob-year"] {
+    .bioageform #dobFieldset label[for="dob-year"] {
         grid-column: 1;
         grid-row: 2;
     }
 
-    body.flow-action-dock-active .bioageform #dobFieldset #dob-year {
+    .bioageform #dobFieldset #dob-year {
         grid-column: 1;
         grid-row: 3;
     }
 
-    body.flow-action-dock-active .bioageform #dobFieldset #dob-month-label {
+    .bioageform #dobFieldset #dob-month-label {
         grid-column: 2;
         grid-row: 2;
     }
 
-    body.flow-action-dock-active .bioageform #dobFieldset #dob-month {
+    .bioageform #dobFieldset #dob-month {
         grid-column: 2;
         grid-row: 3;
     }
 
-    body.flow-action-dock-active .bioageform #dobFieldset #dob-day-label {
+    .bioageform #dobFieldset #dob-day-label {
         grid-column: 3;
         grid-row: 2;
     }
 
-    body.flow-action-dock-active .bioageform #dobFieldset #dob-day {
+    .bioageform #dobFieldset #dob-day {
         grid-column: 3;
         grid-row: 3;
     }
 
-    body.flow-action-dock-active .bioageform #dobFieldset #privacyNote {
+    .bioageform #dobFieldset #privacyNote {
         grid-column: 1 / -1;
         grid-row: 4;
     }
 
-    body.flow-action-dock-active .bioageform #dobFieldset select {
-        padding-left: 0.45rem;
-        padding-right: 1.45rem;
-        background-position: right 0.45rem center;
-        font-size: 0.875rem;
+    .bioageform #dobFieldset select {
+        padding-left: 0.38rem;
+        padding-right: 1.3rem;
+        background-position: right 0.38rem center;
+        font-size: 0.82rem;
     }
 
-    body.flow-action-dock-active .bioageform #lwc-step-1.lwc-step--active > fieldset:nth-of-type(2) {
-        margin-top: 0.85rem;
+    .bioageform.bioage-biomarker-entry-ready #lwc-step-2 > fieldset {
+        margin-top: 0.8rem;
+        padding: 0.75rem;
     }
+
+    .bioageform.bioage-biomarker-entry-ready #lwc-step-2 .biomarker-card {
+        margin-bottom: 0.55rem;
+        border-color: var(--lwc-border, rgba(148, 163, 184, 0.38));
+        border-radius: 8px;
+    }
+
+    .bioageform.bioage-biomarker-entry-ready #lwc-step-2 .biomarker-card-header {
+        min-height: 38px;
+        padding: 0.55rem 0.7rem;
+        cursor: default !important;
+        pointer-events: none !important;
+        font-size: 0.9rem;
+        line-height: 1.2;
+    }
+
+    .bioageform.bioage-biomarker-entry-ready #lwc-step-2 .toggle-icon {
+        display: inline-flex !important;
+        flex: 0 0 1.35rem;
+        width: 1.35rem;
+        height: 1.35rem;
+        border: 1px solid var(--lwc-border, rgba(148, 163, 184, 0.38));
+        border-radius: 50%;
+        color: transparent;
+        background: var(--lwc-surface-muted, #f4f7f9);
+    }
+
+    .bioageform.bioage-biomarker-entry-ready #lwc-step-2 .biomarker-card--complete {
+        border-color: var(--lwc-accent, var(--primary-color, #19c3d1));
+    }
+
+    .bioageform.bioage-biomarker-entry-ready #lwc-step-2 .biomarker-card--complete .toggle-icon {
+        border-color: var(--lwc-accent, var(--primary-color, #19c3d1));
+        background: var(--lwc-accent, var(--primary-color, #19c3d1));
+        color: var(--lwc-on-accent, #fff);
+        font-size: 0;
+    }
+
+    .bioageform.bioage-biomarker-entry-ready #lwc-step-2 .biomarker-card--complete .toggle-icon::before {
+        content: "✓";
+        font-size: 0.78rem;
+        font-weight: 900;
+    }
+
+    .bioageform.bioage-biomarker-entry-ready #lwc-step-2 .biomarker-card-content {
+        max-height: none !important;
+        overflow: visible !important;
+        padding: 0.55rem 0.65rem 0.65rem !important;
+        border-top: 1px solid rgba(148, 163, 184, 0.24);
+        background: var(--lwc-surface-muted, #fbfdff);
+    }
+
+    .bioageform.bioage-biomarker-entry-ready #lwc-step-2 .biomarker-card-content .input-group {
+        display: flex;
+        flex-direction: row !important;
+        align-items: stretch;
+        gap: 0.4rem;
+    }
+
+    .bioageform.bioage-biomarker-entry-ready #lwc-step-2 .biomarker-card-content .input-group input,
+    .bioageform.bioage-biomarker-entry-ready #lwc-step-2 .biomarker-card-content .input-group select {
+        min-width: 0 !important;
+        min-height: 46px;
+        margin: 0 !important;
+    }
+
+    .bioageform.bioage-biomarker-entry-ready #lwc-step-2 .biomarker-card-content .input-group input {
+        flex: 1 1 58% !important;
+        width: 58% !important;
+        font-size: 1rem;
+    }
+
+    .bioageform.bioage-biomarker-entry-ready #lwc-step-2 .biomarker-card-content .input-group select {
+        flex: 0 1 42% !important;
+        width: 42% !important;
+        padding-left: 0.55rem;
+        padding-right: 1.6rem;
+        background-position: right 0.5rem center;
+        font-size: 0.86rem;
+    }
+
+    .bioageform.bioage-biomarker-entry-ready #lwc-step-2 .biomarker-card-content .input-group .bioage-fixed-unit-select {
+        display: none !important;
+    }
+
+    .bioageform.bioage-biomarker-entry-ready #lwc-step-2 .bioage-fixed-unit {
+        display: inline-flex;
+        flex: 0 0 auto;
+        align-items: center;
+        justify-content: center;
+        min-width: 3.4rem;
+        min-height: 46px;
+        padding: 0 0.65rem;
+        border: 1px solid var(--lwc-border, rgba(148, 163, 184, 0.38));
+        border-radius: 4px;
+        background: var(--lwc-surface, #fff);
+        color: var(--lwc-muted, #526373);
+        font-size: 0.86rem;
+        font-weight: 700;
+        box-sizing: border-box;
+    }
+
+    .bioageform.bioage-biomarker-entry-ready #lwc-step-2 input[data-bioage-complete="true"] {
+        border-color: var(--lwc-accent, var(--primary-color, #19c3d1));
+    }
+
+    .bioageform.bioage-biomarker-entry-ready #lwc-step-2 input[aria-invalid="true"] {
+        border-color: var(--danger-color, #b4233b);
+        box-shadow: 0 0 0 3px rgba(180, 35, 59, 0.12);
+    }
+
+}
+
+.bioage-fixed-unit {
+    display: none;
+}
+
+.bioage-biomarker-progress {
+    margin: 0.4rem 0 0.7rem;
+    color: var(--lwc-muted, #526373);
+    font-size: 0.86rem;
+    font-weight: 700;
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+}
+
+.bioage-biomarker-progress--complete {
+    color: var(--lwc-accent-hover, #087f91);
+}
+
+.bioage-biomarker-error {
+    margin: 0.45rem 0 0;
+    color: var(--danger-color, #b4233b);
+    font-size: 0.82rem;
+    font-weight: 700;
+    line-height: 1.3;
+}
+
+.bioageform .bioage-update-date-fieldset {
+    margin-top: 0.75rem;
+}
+
+.bioage-edit-values-button {
+    min-height: 44px;
+    margin-top: 0.85rem;
+    padding: 0.55rem 0.9rem;
+    border: 1px solid var(--lwc-border-strong, #71808d);
+    border-radius: 6px;
+    background: var(--lwc-surface, #fff);
+    color: var(--lwc-ink, #243447);
+    font: inherit;
+    font-weight: 800;
+    cursor: pointer;
+}
+
+.bioage-edit-values-button:hover,
+.bioage-edit-values-button:focus-visible {
+    border-color: var(--lwc-accent, var(--primary-color, #19c3d1));
+    background: var(--lwc-accent-soft, rgba(0, 188, 212, 0.1));
+}
+
+.bioage-edit-values-button:focus-visible {
+    outline: 3px solid rgba(0, 188, 212, 0.28);
+    outline-offset: 2px;
 }
 
 @media (min-width: 640px) and (max-width: 932px) and (max-height: 480px) and (orientation: landscape) {

--- a/LongevityWorldCup.Website/wwwroot/css/bioageform.css
+++ b/LongevityWorldCup.Website/wwwroot/css/bioageform.css
@@ -290,30 +290,6 @@
     margin-top: 0.75rem;
 }
 
-.bioage-edit-values-button {
-    min-height: 44px;
-    margin-top: 0.85rem;
-    padding: 0.55rem 0.9rem;
-    border: 1px solid var(--lwc-border-strong, #71808d);
-    border-radius: 6px;
-    background: var(--lwc-surface, #fff);
-    color: var(--lwc-ink, #243447);
-    font: inherit;
-    font-weight: 800;
-    cursor: pointer;
-}
-
-.bioage-edit-values-button:hover,
-.bioage-edit-values-button:focus-visible {
-    border-color: var(--lwc-accent, var(--primary-color, #19c3d1));
-    background: var(--lwc-accent-soft, rgba(0, 188, 212, 0.1));
-}
-
-.bioage-edit-values-button:focus-visible {
-    outline: 3px solid rgba(0, 188, 212, 0.28);
-    outline-offset: 2px;
-}
-
 @media (min-width: 640px) and (max-width: 932px) and (max-height: 480px) and (orientation: landscape) {
     .bioageform {
         margin: 0.8rem auto;

--- a/LongevityWorldCup.Website/wwwroot/css/flow-controls.css
+++ b/LongevityWorldCup.Website/wwwroot/css/flow-controls.css
@@ -174,6 +174,14 @@ html.flow-action-dock-active {
     scroll-padding-bottom: calc(var(--flow-action-dock-height, 0px) + 1rem);
 }
 
+body.flow-input-keyboard-open::after {
+    content: "";
+    display: block;
+    width: 1px;
+    height: var(--flow-input-keyboard-occlusion, 0px);
+    pointer-events: none;
+}
+
 .flow-action-stack .flow-action,
 .option-button.flow-action {
     width: 100%;

--- a/LongevityWorldCup.Website/wwwroot/onboarding/bortz-age.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/bortz-age.html
@@ -1334,7 +1334,7 @@
                 </section>
             </form>
         </div>
-        <div id="bortzAgeResult" class="bioageform" data-aos="fade" data-aos-duration="700" data-aos-delay="400">
+        <div id="bortzAgeResult" class="bioageform" data-aos="fade" data-aos-duration="700" data-aos-delay="400" inert aria-hidden="true">
             <div id="validAgeInput">
                 <div>Bortz Age:</div>
                 <div class="bio-age-number-container">
@@ -1350,6 +1350,7 @@
                 <i class="fas fa-ambulance" aria-hidden="true"></i> <i class="fas fa-hospital" aria-hidden="true"></i> <i class="fas fa-clinic-medical" aria-hidden="true"></i>
             </div>
             <div id="bortzAgeRankPreview" class="bioage-rank-preview" hidden aria-live="polite"></div>
+            <button type="button" class="bioage-edit-values-button" onclick="editBioageValues()">Edit values</button>
         </div>
 
         <div class="options-container bioage-result-actions flow-action-stack" data-flow-dock="auto" data-flow-dock-when="body.bioage-result-ready" data-aos="fade" data-aos-duration="700" data-aos-delay="450" hidden>
@@ -1515,12 +1516,13 @@
                 serializedBiomarkerData = null;
             }
 
+            clearStoredBiomarkerHandoff();
             const stored =
                 !!serializedBiomarkerData
+                && setSessionItem('bioageClock', 'bortz')
                 && setSessionItem('chronoBortzDifference', chronoBortzDifference.toFixed(2))
                 && setSessionItem('chronoPhenoDifference', chronoPhenoDifference.toFixed(2))
                 && setSessionItem('biomarkerData', serializedBiomarkerData)
-                && setSessionItem('lwcStep', '1')
                 && (!serializedPaymentOffer || setSessionItem(PENDING_PAYMENT_OFFER_KEY, serializedPaymentOffer));
 
             if (!stored) {
@@ -1748,7 +1750,6 @@
             const d = String(todayLocal.getDate()).padStart(2, '0');
             const todayStr = `${y}-${m}-${d}`;
             bloodDrawDateInput.max = todayStr;
-            bloodDrawDateInput.value = todayStr;
 
             // Open the native picker on focus/click (only when supported)
             const lwcOpenDatePickerGuarded = () => {
@@ -1813,20 +1814,6 @@
                 el.addEventListener('input', () => {
                     if (el.value.trim() === '') touchedBiomarkers.delete(id);
                     else touchedBiomarkers.add(id);
-
-                    const card = el.closest('.biomarker-card');
-                    const headerField = card.querySelector('.biomarker-card-header');
-                    const iconField = headerField.querySelector('.toggle-icon');
-                    if (el.value.trim() !== '') {
-                        headerField.style.pointerEvents = 'none';
-                        iconField.style.display = 'none';
-
-                        expandFieldCard(card);
-                    } else if (isUpdate) {
-                        headerField.style.pointerEvents = '';
-                        iconField.style.display = '';
-                    }
-
                 });
             });
 
@@ -2208,10 +2195,20 @@
 
         let isResultCalculated = false;
         let lastCalculatedPhenoAge = NaN;
+        function hideCalculatedResult() {
+            isResultCalculated = false;
+            document.getElementById('bortzAgeResult')?.classList.remove('show');
+            document.getElementById('continueButton')?.classList.remove('show');
+            updateCalculateButton();
+        }
+
         function calculateResultIfResultAlreadyCalculated() {
-            if (isResultCalculated) {
-                calculateResult();
-            }
+            if (isResultCalculated) hideCalculatedResult();
+        }
+
+        function editBioageValues() {
+            hideCalculatedResult();
+            lwcSetStep(2);
         }
 
         function correctCorrectableUnits() {
@@ -2655,55 +2652,6 @@
                 validAgeInput.style.display = 'block';
             }
 
-            // Update URL from calculation result (merge so update=1, fake=1 are preserved)
-            (function updateUrlFromBortzResult() {
-                var two = function (n) { return Number.isFinite(n) ? parseFloat(Number(n).toFixed(2)) : n; };
-                var wbcEl = document.getElementById('wbc');
-                var wbcU = document.getElementById('wbcUnit');
-                var wbcCanonical = wbcEl && wbcU ? parseFloat(wbcEl.value) / parseFloat(wbcU.value) : NaN;
-                var formParams = {
-                    Year: year,
-                    Month: month + 1,
-                    Day: day,
-                    Date: bloodDrawDate,
-                    AlbGL: two(markerValues[1]),
-                    AlpUL: two(markerValues[2]),
-                    UreaMmolL: two(markerValues[3]),
-                    CholesterolMmolL: two(markerValues[4]),
-                    CreatUmolL: two(markerValues[5]),
-                    CystatinCMgL: two(markerValues[6]),
-                    Hba1cMmolMol: two(markerValues[7]),
-                    CrpMgL: two(markerValues[8]),
-                    GgtUL: two(markerValues[9]),
-                    Rbc10e12L: two(markerValues[10]),
-                    McvFL: two(markerValues[11]),
-                    RdwPc: two(markerValues[12]),
-                    GluMmolL: two(markerValues[19]),
-                    MchPg: two(markerValues[20]),
-                    ApoA1GL: two(markerValues[21]),
-                    LymPc: two(markerValues[15]),
-                    AltUL: two(markerValues[16]),
-                    ShbgNmolL: two(markerValues[17]),
-                    VitaminDNmolL: two(markerValues[18])
-                };
-                if (Number.isFinite(wbcCanonical) && wbcCanonical > 0) {
-                    formParams.Wbc1000cellsuL = two(wbcCanonical);
-                    formParams.MonocytePc = two((markerValues[13] / wbcCanonical) * 100);
-                    formParams.NeutrophilPc = two((markerValues[14] / wbcCanonical) * 100);
-                }
-                var BORTZ_URL_KEYS = ['Year', 'Month', 'Day', 'Date', 'AlbGL', 'AlpUL', 'CreatUmolL', 'CrpMgL', 'GluMmolL', 'LymPc', 'McvFL', 'RdwPc', 'Wbc1000cellsuL', 'NeutrophilPc', 'MonocytePc', 'Rbc10e12L', 'MchPg', 'AltUL', 'GgtUL', 'UreaMmolL', 'CystatinCMgL', 'Hba1cMmolMol', 'CholesterolMmolL', 'ApoA1GL', 'ShbgNmolL', 'VitaminDNmolL'];
-                var current = new URLSearchParams(window.location.search);
-                var next = new URLSearchParams();
-                current.forEach(function (val, key) {
-                    if (BORTZ_URL_KEYS.indexOf(key) === -1) next.set(key, val);
-                });
-                Object.keys(formParams).forEach(function (k) { if (formParams[k] != null && formParams[k] !== '') next.set(k, String(formParams[k])); });
-                var search = next.toString();
-                var base = '/bortz-age';
-                var hash = window.location.hash || '';
-                history.replaceState({}, '', base + (search ? '?' + search : '') + hash);
-            })();
-
             // Present the complete result immediately; motion must never gate the next action.
             const animatedAgeElement = document.getElementById('animatedAge');
             const yearsTextElement = document.getElementById('yearsText');
@@ -2805,6 +2753,7 @@
         function lwcSetStep(step, options) {
             const shouldFocus = options?.focus !== false;
             lwcCurrentStep = step;
+            bioageFlow.setDraftStep('bortz', step);
             const s1 = document.getElementById('lwc-step-1');
             const s2 = document.getElementById('lwc-step-2');
             const d1 = document.getElementById('lwcDot1');
@@ -2830,6 +2779,14 @@
                         recalcOpenBiomarkerHeightsLwc();
                         // run again on next tick to catch late layout/ fonts
                         setTimeout(recalcOpenBiomarkerHeightsLwc, 60);
+                        if (shouldFocus && window.matchMedia(
+                            '(max-width: 760px), (max-width: 1024px) and (max-height: 600px) and (orientation: landscape)'
+                        ).matches) {
+                            window.scrollTo({
+                                top: Math.max(0, window.scrollY + active.getBoundingClientRect().top - 12),
+                                behavior: 'auto'
+                            });
+                        }
                     }
                 });
             }
@@ -2903,7 +2860,6 @@
                 toStep2Btn.addEventListener('click', () => {
                     if (!lwcValidateStep1()) return;
                     lwcSetStep(2);
-                    setSessionItem('lwcStep', '2');
                 });
             }
             if (toStep1Btn) {
@@ -2913,7 +2869,6 @@
                         return;
                     }
 
-                    setSessionItem('lwcStep', '1');
                     lwcSetStep(1);
                 });
             }
@@ -2922,8 +2877,8 @@
             const dot1 = document.getElementById('lwcDot1');
             const dot2 = document.getElementById('lwcDot2');
 
-            function activateDot1() { lwcSetStep(1); setSessionItem('lwcStep', '1'); }
-            function activateDot2() { if (lwcValidateStep1()) { lwcSetStep(2); setSessionItem('lwcStep', '2'); } }
+            function activateDot1() { lwcSetStep(1); }
+            function activateDot2() { if (lwcValidateStep1()) lwcSetStep(2); }
 
             if (dot1) {
                 dot1.addEventListener('click', activateDot1);
@@ -2987,7 +2942,7 @@
                 hideMainProgress();
 
                 document.getElementById('mainPageTitleH2').textContent = athlete.Name;
-                document.getElementById('mainInstructions').textContent = 'Submit your latest test results. All fields are required and must be from the same day.';
+                document.getElementById('mainInstructions').textContent = 'Enter the blood draw date and at least one new biomarker value. Unchanged values will carry over from your latest result.';
 
                 // Fill out the date of birth because we'll need it for calculations, but hide it as well so the user doesn't wanna change that.
                 document.getElementById('dob-year').value = athlete.DateOfBirth.Year;
@@ -3011,52 +2966,40 @@
             // Also honor CRP-negative checkbox state
             document.getElementById('crp-negative').dispatchEvent(new Event('change'));
 
-            if (isUpdate) {
-                // any card that's .active right now came from code, not the user —
-                // so hide its toggle-icon
-                document
-                    .querySelectorAll('.biomarker-card.active .toggle-icon')
-                    .forEach(icon => icon.style.display = 'none');
-            }
-
             updateModeFormInitializerUnique();
             applyBortzSubmittedBiomarkerPlaceholders();
             setupBortzSubmittedBiomarkerComparisons();
             bioageFlow.syncBiomarkerExamplePlaceholders();
+            const hasExplicitBiomarkerPrefill = [
+                'Year', 'Month', 'Day', 'Date', 'AlbGL', 'AlpUL', 'CreatUmolL', 'CrpMgL',
+                'GluMmolL', 'LymPc', 'McvFL', 'RdwPc', 'Wbc1000cellsuL', 'NeutrophilPc',
+                'MonocytePc', 'Rbc10e12L', 'MchPg', 'AltUL', 'GgtUL', 'UreaMmolL',
+                'CystatinCMgL', 'Hba1cMmolMol', 'CholesterolMmolL', 'ApoA1GL',
+                'ShbgNmolL', 'VitaminDNmolL'
+            ].some(key => urlParams.has(key));
+            const biomarkerEntry = bioageFlow.initializeBiomarkerEntry({
+                clock: 'bortz',
+                form: document.getElementById('bortzAgeForm'),
+                isUpdate,
+                restoreDraft: !isFake && !hasExplicitBiomarkerPrefill
+            });
 
             if (isUpdate && hasSelectedAthlete) {
                 hideUpdateModeStepNavigation();
                 lwcSetStep(2, { focus: false });
-                setSessionItem('lwcStep', '2');
                 bioageFlow.resetUpdateModeScroll();
             } else {
                 // Restore step 2 after refresh if user had navigated there and step 1 is valid
-                let restoredStep = false;
-                try {
-                    if (getSessionItem('lwcStep') === '2' && lwcValidateStep1(true)) {
-                        lwcSetStep(2, { focus: false });
-                        restoredStep = true;
-                    }
-                } catch (e) {}
+                const restoredStep = biomarkerEntry.step === 2 && lwcValidateStep1(true);
+                if (restoredStep) lwcSetStep(2, { focus: false });
                 if (!restoredStep) {
                     lwcSetStep(1, { focus: false });
-                    setSessionItem('lwcStep', '1');
                 }
             }
         });
 
         function updateModeFormInitializerUnique() {
             if (!isUpdate) return;
-
-            if (bloodDrawDateInput) {
-                // In update mode, default the blood draw date to today instead of leaving it blank
-                const todayLocal = new Date();
-                todayLocal.setHours(0, 0, 0, 0);
-                const y = todayLocal.getFullYear();
-                const m = String(todayLocal.getMonth() + 1).padStart(2, '0');
-                const d = String(todayLocal.getDate()).padStart(2, '0');
-                bloodDrawDateInput.value = `${y}-${m}-${d}`;
-            }
 
 
             const idMapUnique = {
@@ -3146,19 +3089,12 @@
                         }
                     }
                 });
-                // hide toggle icons on expanded cards
-                document.querySelectorAll('.biomarker-card.active .toggle-icon')
-                    .forEach(i => i.style.display = 'none');
             }
             // Expand cards for any field filled from URL (when no sessionStorage or in addition)
             [...bortzFieldIds, 'wbc'].forEach(id => {
                 const el = document.getElementById(id);
                 if (el && el.value.trim() !== '') expandFieldCard(id);
             });
-            if (isUpdate) {
-                document.querySelectorAll('.biomarker-card.active .toggle-icon')
-                    .forEach(i => i.style.display = 'none');
-            }
         }
 
         window.addEventListener('pageshow', () => {
@@ -3166,6 +3102,7 @@
             applyBortzSubmittedBiomarkerPlaceholders();
             setupBortzSubmittedBiomarkerComparisons();
             bioageFlow.syncBiomarkerExamplePlaceholders();
+            bioageFlow.updateCalculateButton();
         });
 
         // Detect and apply preferences based on language
@@ -3441,19 +3378,6 @@
 
             bioageFlow.updateBiomarkerExamplePlaceholder(crpUnit);
             calculateResultIfResultAlreadyCalculated();
-
-            const card = document.getElementById('crp').closest('.biomarker-card');
-            const crpHeaderField = card.querySelector('.biomarker-card-header');
-            const crpIconField = crpHeaderField.querySelector('.toggle-icon');
-            if (crpNegativeCheckbox.checked || document.getElementById('crp').value.trim() !== '') {
-                crpHeaderField.style.pointerEvents = 'none';
-                crpIconField.style.display = 'none';
-
-                expandFieldCard(card);
-            } else if (isUpdate) {
-                crpHeaderField.style.pointerEvents = '';
-                crpIconField.style.display = '';
-            }
         }
 
         // Hide month/day & privacy note when age < 18
@@ -3488,112 +3412,8 @@
             );
         document.addEventListener('DOMContentLoaded', checkMinor);
 
-        // Wire up all biomarker‐card headers
-        document.querySelectorAll('.biomarker-card-header').forEach(header => {
-            header.setAttribute('role', 'button');
-            header.setAttribute('tabindex', '0');
-            header.querySelector('.toggle-icon')?.setAttribute('aria-hidden', 'true');
-
-            const toggleCard = function () {
-                const card = header.parentNode;
-                const content = card.querySelector('.biomarker-card-content');
-                const icon = header.querySelector('.toggle-icon');
-
-                if (!isUpdate) {
-                    if (!card.classList.contains('active')) {
-                        card.classList.add('active');
-                        header.setAttribute('aria-expanded', 'true');
-
-                        content.style.maxHeight = content.scrollHeight + 'px';
-                        content.style.paddingTop = '0.75rem';
-                        content.style.paddingBottom = '0.75rem';
-                        header.style.pointerEvents = 'none';
-                        header.style.cursor = 'default';
-                        header.setAttribute('aria-disabled', 'true');
-                        header.setAttribute('tabindex', '-1');
-                        icon.style.display = 'none';
-                    }
-                    return;
-                }
-
-                // update mode: full toggle with icon swap
-                const isActive = card.classList.toggle('active');
-                header.setAttribute('aria-expanded', isActive);
-
-                icon.textContent = isActive ? '−' : '+';
-                icon.style.display = '';
-                if (isActive) {
-                    content.style.maxHeight = content.scrollHeight + 'px';
-                    content.style.paddingTop = '0.75rem';
-                    content.style.paddingBottom = '0.75rem';
-                } else {
-                    content.style.maxHeight = '0';
-                    content.style.paddingTop = '0';
-                    content.style.paddingBottom = '0';
-                }
-            };
-
-            header.addEventListener('click', toggleCard);
-            header.addEventListener('keydown', event => {
-                if (event.key !== 'Enter' && event.key !== ' ') return;
-                event.preventDefault();
-                toggleCard();
-            });
-        });
-
-        /**
-         * Expands the biomarker card containing the given input field.
-         *
-         * @param {string|HTMLElement} field - The ID of the input field, or the field element itself.
-         */
         function expandFieldCard(field) {
-            // Get the input element
-            const input = typeof field === 'string'
-                ? document.getElementById(field)
-                : field;
-            if (!input) return;
-
-            // Find its enclosing card
-            const card = input.closest('.biomarker-card');
-            if (!card) return;
-
-            // If not already expanded, open it
-            if (!card.classList.contains('active')) {
-                const header = card.querySelector('.biomarker-card-header');
-
-                card.classList.add('active');
-                if (header) header.setAttribute('aria-expanded', 'true');
-
-                // Animate the content area open
-                const content = card.querySelector('.biomarker-card-content');
-                content.style.maxHeight = content.scrollHeight + 'px';
-                content.style.paddingTop = '0.75rem';
-                content.style.paddingBottom = '0.75rem';
-
-                // Handle the toggle icon and header behavior
-                const icon = card.querySelector('.toggle-icon');
-
-                if (!isUpdate) {
-                    // In non-update mode: hide the icon and disable further clicks
-                    if (icon) icon.style.display = 'none';
-                    if (header) {
-                        header.style.pointerEvents = 'none';
-                        header.style.cursor = 'default';
-                        header.setAttribute('aria-disabled', 'true');
-                        header.setAttribute('tabindex', '-1');
-                    }
-                } else {
-                    // In update mode: show a minus icon
-                    if (icon) {
-                        icon.textContent = '−';
-                        icon.style.display = '';
-
-                        if (touchedBiomarkers.has(input.id)) {
-                            icon.style.display = 'none';
-                        }
-                    }
-                }
-            }
+            bioageFlow.expandBiomarkerCard(field);
         }
 
         function focusFirstEditableBiomarker(fieldIds) {
@@ -3606,13 +3426,7 @@
             input.focus();
         }
 
-        // Let the browser show its validation bubbles, but expand the card first
         const form = document.getElementById('bortzAgeForm');
-
-        form.addEventListener('invalid', e => {
-            // invalid fires during the capture phase before the bubble appears
-            expandFieldCard(e.target);
-        }, true);
 
         // On submit, defer to browser validation; only when the form is fully valid do we preventDefault and run calculateResult()
         form.addEventListener('submit', function (e) {
@@ -3625,8 +3439,9 @@
                 return;
             }
 
-            // Block submit if any required field (including WBC) is missing; show validation bubbles first
-            if (!this.reportValidity()) {
+            // New applications require the complete panel. Updates fill untouched values
+            // from the athlete's latest result inside calculateResult().
+            if (!isUpdate && !this.reportValidity()) {
                 return;
             }
 

--- a/LongevityWorldCup.Website/wwwroot/onboarding/bortz-age.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/bortz-age.html
@@ -2359,32 +2359,31 @@
 
             // Fill missing biomarker fields on update
             if (isUpdate && athlete?.Biomarkers?.length) {
-                const latestBiomarkerSet = athlete.Biomarkers.reduce((latest, current) => {
-                    return new Date(current.Date) > new Date(latest.Date) ? current : latest;
-                });
+                const latestValue = fieldNames =>
+                    bioageFlow.getLatestBiomarkerValue(athlete, fieldNames)?.value;
                 const biomarkerDefaults = {
-                    lymphocyte_percentage: { val: latestBiomarkerSet.LymPc, unit: '1' },
-                    neutrophil_percentage: { val: latestBiomarkerSet.NeutrophilPc, unit: '1' },
-                    monocyte_percentage: { val: latestBiomarkerSet.MonocytePc, unit: '1' },
-                    rbc: { val: latestBiomarkerSet.Rbc10e12L ?? latestBiomarkerSet.Rbc, unit: '1' },
-                    mcv: { val: latestBiomarkerSet.McvFL, unit: '1' },
-                    mch: { val: latestBiomarkerSet.MchPg ?? latestBiomarkerSet.Mch, unit: '1' },
-                    rdw: { val: latestBiomarkerSet.RdwPc, unit: '1' },
-                    albumin: { val: latestBiomarkerSet.AlbGL, unit: '1' },
-                    urea: { val: latestBiomarkerSet.UreaMmolL ?? latestBiomarkerSet.Urea, unit: '1' },
-                    creatinine: { val: latestBiomarkerSet.CreatUmolL, unit: '1' },
-                    cystatin_c: { val: latestBiomarkerSet.CystatinCMgL ?? latestBiomarkerSet.CystatinC, unit: '1' },
-                    glucose: { val: latestBiomarkerSet.GluMmolL, unit: '1' },
-                    hba1c: { val: latestBiomarkerSet.Hba1cMmolMol ?? latestBiomarkerSet.Hba1c, unit: '1' },
-                    cholesterol: { val: latestBiomarkerSet.CholesterolMmolL ?? latestBiomarkerSet.Cholesterol, unit: '1' },
-                    apoa1: { val: latestBiomarkerSet.ApoA1GL ?? latestBiomarkerSet.ApoA1, unit: '1' },
-                    alt: { val: latestBiomarkerSet.AltUL ?? latestBiomarkerSet.Alt, unit: '1' },
-                    alp: { val: latestBiomarkerSet.AlpUL, unit: '1' },
-                    ggt: { val: latestBiomarkerSet.GgtUL ?? latestBiomarkerSet.Ggt, unit: '1' },
-                    crp: { val: latestBiomarkerSet.CrpMgL, unit: '1' },
-                    shbg: { val: latestBiomarkerSet.ShbgNmolL ?? latestBiomarkerSet.Shbg, unit: '1' },
-                    vitamin_d: { val: latestBiomarkerSet.VitaminDNmolL ?? latestBiomarkerSet.VitaminD, unit: '1' },
-                    wbc: { val: latestBiomarkerSet.Wbc1000cellsuL, unit: '1' }
+                    lymphocyte_percentage: { val: latestValue('LymPc'), unit: '1' },
+                    neutrophil_percentage: { val: latestValue('NeutrophilPc'), unit: '1' },
+                    monocyte_percentage: { val: latestValue('MonocytePc'), unit: '1' },
+                    rbc: { val: latestValue(['Rbc10e12L', 'Rbc']), unit: '1' },
+                    mcv: { val: latestValue('McvFL'), unit: '1' },
+                    mch: { val: latestValue(['MchPg', 'Mch']), unit: '1' },
+                    rdw: { val: latestValue('RdwPc'), unit: '1' },
+                    albumin: { val: latestValue('AlbGL'), unit: '1' },
+                    urea: { val: latestValue(['UreaMmolL', 'Urea']), unit: '1' },
+                    creatinine: { val: latestValue('CreatUmolL'), unit: '1' },
+                    cystatin_c: { val: latestValue(['CystatinCMgL', 'CystatinC']), unit: '1' },
+                    glucose: { val: latestValue('GluMmolL'), unit: '1' },
+                    hba1c: { val: latestValue(['Hba1cMmolMol', 'Hba1c']), unit: '1' },
+                    cholesterol: { val: latestValue(['CholesterolMmolL', 'Cholesterol']), unit: '1' },
+                    apoa1: { val: latestValue(['ApoA1GL', 'ApoA1']), unit: '1' },
+                    alt: { val: latestValue(['AltUL', 'Alt']), unit: '1' },
+                    alp: { val: latestValue('AlpUL'), unit: '1' },
+                    ggt: { val: latestValue(['GgtUL', 'Ggt']), unit: '1' },
+                    crp: { val: latestValue('CrpMgL'), unit: '1' },
+                    shbg: { val: latestValue(['ShbgNmolL', 'Shbg']), unit: '1' },
+                    vitamin_d: { val: latestValue(['VitaminDNmolL', 'VitaminD']), unit: '1' },
+                    wbc: { val: latestValue('Wbc1000cellsuL'), unit: '1' }
                 };
                 Object.entries(biomarkerDefaults).forEach(([id, { val, unit }]) => {
                     const input = document.getElementById(id);

--- a/LongevityWorldCup.Website/wwwroot/onboarding/bortz-age.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/bortz-age.html
@@ -1350,7 +1350,6 @@
                 <i class="fas fa-ambulance" aria-hidden="true"></i> <i class="fas fa-hospital" aria-hidden="true"></i> <i class="fas fa-clinic-medical" aria-hidden="true"></i>
             </div>
             <div id="bortzAgeRankPreview" class="bioage-rank-preview" hidden aria-live="polite"></div>
-            <button type="button" class="bioage-edit-values-button" onclick="editBioageValues()">Edit values</button>
         </div>
 
         <div class="options-container bioage-result-actions flow-action-stack" data-flow-dock="auto" data-flow-dock-when="body.bioage-result-ready" data-aos="fade" data-aos-duration="700" data-aos-delay="450" hidden>
@@ -2204,11 +2203,6 @@
 
         function calculateResultIfResultAlreadyCalculated() {
             if (isResultCalculated) hideCalculatedResult();
-        }
-
-        function editBioageValues() {
-            hideCalculatedResult();
-            lwcSetStep(2);
         }
 
         function correctCorrectableUnits() {

--- a/LongevityWorldCup.Website/wwwroot/onboarding/convergence.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/convergence.html
@@ -1092,8 +1092,15 @@
 
         function clearStoredBiomarkerHandoff() {
             removeSessionItem('biomarkerData');
+            removeSessionItem('bioageClock');
             removeSessionItem('chronoPhenoDifference');
             removeSessionItem('chronoBortzDifference');
+        }
+
+        function clearCompletedBioageState() {
+            clearStoredBiomarkerHandoff();
+            removeSessionItem('bioageDraft:pheno:v1');
+            removeSessionItem('bioageDraft:bortz:v1');
         }
 
         function clearPendingPaymentOffer() {
@@ -1139,10 +1146,10 @@
         const PHENO_RESULT_BIOMARKER_KEYS = ['AlbGL', 'CreatUmolL', 'GluMmolL', 'CrpMgL', 'Wbc1000cellsuL', 'LymPc', 'McvFL', 'RdwPc', 'AlpUL'];
         const BORTZ_RESULT_BIOMARKER_KEYS = ['AlbGL', 'AlpUL', 'UreaMmolL', 'CholesterolMmolL', 'CreatUmolL', 'CystatinCMgL', 'Hba1cMmolMol', 'CrpMgL', 'GgtUL', 'Rbc10e12L', 'McvFL', 'RdwPc', 'Wbc1000cellsuL', 'MonocytePc', 'NeutrophilPc', 'LymPc', 'AltUL', 'ShbgNmolL', 'VitaminDNmolL', 'GluMmolL', 'MchPg', 'ApoA1GL'];
 
-        function hasCompleteSubmittedBiomarkerValues(biomarkerData, chronoPhenoDifference, chronoBortzDifference) {
-            const requiredKeys = chronoBortzDifference
+        function hasCompleteSubmittedBiomarkerValues(biomarkerData, bioageClock) {
+            const requiredKeys = bioageClock === 'bortz'
                 ? BORTZ_RESULT_BIOMARKER_KEYS
-                : chronoPhenoDifference
+                : bioageClock === 'pheno'
                     ? PHENO_RESULT_BIOMARKER_KEYS
                     : null;
 
@@ -1172,6 +1179,25 @@
             }
 
             removeSessionItem(key);
+            return null;
+        }
+
+        function readStoredBioageClock(biomarkerData, chronoPhenoDifference, chronoBortzDifference) {
+            const storedClock = getSessionItem('bioageClock');
+            if (storedClock === 'pheno' || storedClock === 'bortz') return storedClock;
+
+            // Compatibility for applications started before the clock marker existed.
+            const pendingOffer = readPendingPaymentOffer();
+            if (pendingOffer?.offerType === 'pro'
+                && chronoBortzDifference !== null
+                && hasCompleteSubmittedBiomarkerValues(biomarkerData, 'bortz')) return 'bortz';
+            if (pendingOffer?.offerType === 'amateur'
+                && chronoPhenoDifference !== null
+                && hasCompleteSubmittedBiomarkerValues(biomarkerData, 'pheno')) return 'pheno';
+            if (chronoBortzDifference !== null
+                && hasCompleteSubmittedBiomarkerValues(biomarkerData, 'bortz')) return 'bortz';
+            if (chronoPhenoDifference !== null
+                && hasCompleteSubmittedBiomarkerValues(biomarkerData, 'pheno')) return 'pheno';
             return null;
         }
 
@@ -1244,6 +1270,19 @@
         }
 
         function getConvergenceBackDestination() {
+            let biomarkerData = null;
+            try {
+                biomarkerData = JSON.parse(getSessionItem('biomarkerData'));
+            } catch (_) {
+            }
+
+            const storedClock = readStoredBioageClock(
+                biomarkerData,
+                readStoredAgeDifference('chronoPhenoDifference'),
+                readStoredAgeDifference('chronoBortzDifference'));
+            if (storedClock === 'bortz') return '/bortz-age';
+            if (storedClock === 'pheno') return '/pheno-age';
+
             const paymentOffer = readPendingPaymentOffer();
             return paymentOffer && paymentOffer.offerType === 'pro'
                 ? '/bortz-age'
@@ -1306,7 +1345,7 @@
 
             // Get the differences from sessionStorage
             const chronoPhenoDifference = readStoredAgeDifference('chronoPhenoDifference');
-            const chronoBortzDifference = readStoredAgeDifference('chronoBortzDifference');
+            let chronoBortzDifference = readStoredAgeDifference('chronoBortzDifference');
 
             // Use the global variables `profilePic` and `proofPics` directly
             // Get the biomarker data from sessionStorage
@@ -1316,10 +1355,23 @@
             } catch (_) {
                 biomarkerData = null;
             }
-            if (!biomarkerData || !hasStoredDateOfBirth(biomarkerData) || !Array.isArray(biomarkerData.Biomarkers) || !biomarkerData.Biomarkers.length || !hasStoredBiomarkerDates(biomarkerData) || !hasCompleteSubmittedBiomarkerValues(biomarkerData, chronoPhenoDifference, chronoBortzDifference)) {
+            const bioageClock = readStoredBioageClock(
+                biomarkerData,
+                chronoPhenoDifference,
+                chronoBortzDifference);
+            if (bioageClock === 'pheno') chronoBortzDifference = null;
+            const isLegacyUnclockedResult = !bioageClock
+                && getSessionItem('bioageClock') === null
+                && chronoPhenoDifference === null
+                && chronoBortzDifference === null
+                && hasStoredBiomarkerValues(biomarkerData);
+            const hasRequiredAgeDifferences = isLegacyUnclockedResult || (chronoPhenoDifference !== null
+                && (bioageClock === 'pheno' || (bioageClock === 'bortz' && chronoBortzDifference !== null)));
+            if ((!bioageClock && !isLegacyUnclockedResult) || !hasRequiredAgeDifferences || !biomarkerData || !hasStoredDateOfBirth(biomarkerData) || !Array.isArray(biomarkerData.Biomarkers) || !biomarkerData.Biomarkers.length || !hasStoredBiomarkerDates(biomarkerData) || !hasCompleteSubmittedBiomarkerValues(biomarkerData, bioageClock)) {
+                const biomarkerRoute = bioageClock === 'bortz' ? '/bortz-age' : '/pheno-age';
                 clearStoredBiomarkerHandoff();
                 customAlert('Biomarker data is missing. Please complete the biomarker step.')
-                    .then(() => window.location.href = '/onboarding/pheno-age');
+                    .then(() => window.location.href = biomarkerRoute);
                 return;
             }
 
@@ -1989,6 +2041,7 @@
                                     setSessionItem('contactEmail', applicantData.accountEmail);
                                     setLocalItem('contactEmail', applicantData.accountEmail);
                                     removeSessionItem(PENDING_PAYMENT_OFFER_KEY);
+                                    clearCompletedBioageState();
                                     // Clear the image variables
                                     profilePic = null;
                                     proofPics = [];
@@ -2025,6 +2078,7 @@
                                         setSessionItem('contactEmail', applicantData.accountEmail);
                                         setLocalItem('contactEmail', applicantData.accountEmail);
                                         removeSessionItem(PENDING_PAYMENT_OFFER_KEY);
+                                        clearCompletedBioageState();
                                         profilePic = null;
                                         proofPics = [];
                                         removeSessionItem(PENDING_PAYMENT_INVOICE_KEY);

--- a/LongevityWorldCup.Website/wwwroot/onboarding/pheno-age.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/pheno-age.html
@@ -1874,24 +1874,23 @@
 
             // Fill missing biomarker fields on update
             if (isUpdate && athlete?.Biomarkers?.length) {
-                const latestBiomarkerSet = athlete.Biomarkers.reduce((latest, current) => {
-                    return new Date(current.Date) > new Date(latest.Date) ? current : latest;
-                });
+                const latestValue = fieldNames =>
+                    bioageFlow.getLatestBiomarkerValue(athlete, fieldNames)?.value;
                 const biomarkerDefaults = {
-                    wbc: { val: latestBiomarkerSet.Wbc1000cellsuL, unit: '1' },
-                    lymphocyte: { val: latestBiomarkerSet.LymPc, unit: '1' },
-                    mcv: { val: latestBiomarkerSet.McvFL, unit: '1' },
-                    rcdw: { val: latestBiomarkerSet.RdwPc, unit: '1' },
-                    albumin: { val: latestBiomarkerSet.AlbGL, unit: '1' },
-                    ap: { val: latestBiomarkerSet.AlpUL, unit: '1' },
-                    creatinine: { val: latestBiomarkerSet.CreatUmolL, unit: '1' },
-                    glucose: { val: latestBiomarkerSet.GluMmolL, unit: '1' },
-                    crp: { val: latestBiomarkerSet.CrpMgL, unit: '10' }
+                    wbc: { val: latestValue('Wbc1000cellsuL'), unit: '1' },
+                    lymphocyte: { val: latestValue('LymPc'), unit: '1' },
+                    mcv: { val: latestValue('McvFL'), unit: '1' },
+                    rcdw: { val: latestValue('RdwPc'), unit: '1' },
+                    albumin: { val: latestValue('AlbGL'), unit: '1' },
+                    ap: { val: latestValue('AlpUL'), unit: '1' },
+                    creatinine: { val: latestValue('CreatUmolL'), unit: '1' },
+                    glucose: { val: latestValue('GluMmolL'), unit: '1' },
+                    crp: { val: latestValue('CrpMgL'), unit: '10' }
                 };
 
                 Object.entries(biomarkerDefaults).forEach(([id, { val, unit }]) => {
                     const input = document.getElementById(id);
-                    if (!input.value) {
+                    if (hasStoredFiniteBiomarkerValue(val) && !input.value) {
                         input.value = val;
                         document.getElementById(id + 'Unit').value = unit;
                     }

--- a/LongevityWorldCup.Website/wwwroot/onboarding/pheno-age.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/pheno-age.html
@@ -1171,7 +1171,6 @@
                 <i class="fas fa-ambulance" aria-hidden="true"></i> <i class="fas fa-hospital" aria-hidden="true"></i> <i class="fas fa-clinic-medical" aria-hidden="true"></i>
             </div>
             <div id="phenoAgeRankPreview" class="bioage-rank-preview" hidden aria-live="polite"></div>
-            <button type="button" class="bioage-edit-values-button" onclick="editBioageValues()">Edit values</button>
         </div>
 
         <div class="options-container phenoage-result-actions flow-action-stack" data-flow-dock="auto" data-flow-dock-when="body.bioage-result-ready" data-aos="fade" data-aos-duration="700" data-aos-delay="450" hidden>
@@ -1823,11 +1822,6 @@
 
         function calculateResultIfResultAlreadyCalculated() {
             if (isResultCalculated) hideCalculatedResult();
-        }
-
-        function editBioageValues() {
-            hideCalculatedResult();
-            lwcSetStep(2);
         }
 
         function correctCorrectableUnits() {

--- a/LongevityWorldCup.Website/wwwroot/onboarding/pheno-age.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/pheno-age.html
@@ -1158,7 +1158,7 @@
                 </section>
             </form>
         </div>
-        <div id="phenoAgeResult" class="bioageform" data-aos="fade" data-aos-duration="700" data-aos-delay="400">
+        <div id="phenoAgeResult" class="bioageform" data-aos="fade" data-aos-duration="700" data-aos-delay="400" inert aria-hidden="true">
             <div id="validAgeInput">
                 <div>Your biological age is:</div>
                 <div class="bio-age-number-container">
@@ -1171,6 +1171,7 @@
                 <i class="fas fa-ambulance" aria-hidden="true"></i> <i class="fas fa-hospital" aria-hidden="true"></i> <i class="fas fa-clinic-medical" aria-hidden="true"></i>
             </div>
             <div id="phenoAgeRankPreview" class="bioage-rank-preview" hidden aria-live="polite"></div>
+            <button type="button" class="bioage-edit-values-button" onclick="editBioageValues()">Edit values</button>
         </div>
 
         <div class="options-container phenoage-result-actions flow-action-stack" data-flow-dock="auto" data-flow-dock-when="body.bioage-result-ready" data-aos="fade" data-aos-duration="700" data-aos-delay="450" hidden>
@@ -1314,11 +1315,12 @@
                 serializedBiomarkerData = null;
             }
 
+            clearStoredBiomarkerHandoff();
             const stored =
                 !!serializedBiomarkerData
+                && setSessionItem('bioageClock', 'pheno')
                 && setSessionItem('chronoPhenoDifference', chronoPhenoDifference.toFixed(2))
                 && setSessionItem('biomarkerData', serializedBiomarkerData)
-                && setSessionItem('lwcStep', '1')
                 && (!serializedPaymentOffer || setSessionItem(PENDING_PAYMENT_OFFER_KEY, serializedPaymentOffer));
 
             if (!stored) {
@@ -1501,7 +1503,6 @@
             const d = String(todayLocal.getDate()).padStart(2, '0');
             const todayStr = `${y}-${m}-${d}`;
             bloodDrawDateInput.max = todayStr;
-            bloodDrawDateInput.value = todayStr;
 
             // Open the native picker on focus/click (only when supported)
             const lwcOpenDatePickerGuarded = () => {
@@ -1557,20 +1558,6 @@
                 el.addEventListener('input', () => {
                     if (el.value.trim() === '') touchedBiomarkers.delete(id);
                     else touchedBiomarkers.add(id);
-
-                    const card = el.closest('.biomarker-card');
-                    const headerField = card.querySelector('.biomarker-card-header');
-                    const iconField = headerField.querySelector('.toggle-icon');
-                    if (el.value.trim() !== '') {
-                        headerField.style.pointerEvents = 'none';
-                        iconField.style.display = 'none';
-
-                        expandFieldCard(card);
-                    } else if (isUpdate) {
-                        headerField.style.pointerEvents = '';
-                        iconField.style.display = '';
-                    }
-
                 });
             });
 
@@ -1827,10 +1814,20 @@
         updateCalculateButton();
 
         let isResultCalculated = false;
+        function hideCalculatedResult() {
+            isResultCalculated = false;
+            document.getElementById('phenoAgeResult')?.classList.remove('show');
+            document.getElementById('continueButton')?.classList.remove('show');
+            updateCalculateButton();
+        }
+
         function calculateResultIfResultAlreadyCalculated() {
-            if (isResultCalculated) {
-                calculateResult();
-            }
+            if (isResultCalculated) hideCalculatedResult();
+        }
+
+        function editBioageValues() {
+            hideCalculatedResult();
+            lwcSetStep(2);
         }
 
         function correctCorrectableUnits() {
@@ -2032,38 +2029,6 @@
                 validAgeInput.style.display = 'block';
             }
 
-            // Update URL from calculation result (merge so update=1, fake=1 are preserved)
-            (function updateUrlFromPhenoResult() {
-                const PHENO_URL_KEYS = ['Year', 'Month', 'Day', 'Date', 'AlbGL', 'CreatUmolL', 'GluMmolL', 'CrpMgL', 'Wbc1000cellsuL', 'LymPc', 'McvFL', 'RdwPc', 'AlpUL'];
-                const crpMgL = 10 * Math.exp(markerValues[4]);
-                const two = function (n) { return Number.isFinite(n) ? parseFloat(n.toFixed(2)) : n; };
-                const formParams = {
-                    Year: year,
-                    Month: month + 1,
-                    Day: day,
-                    Date: bloodDrawDate,
-                    AlbGL: two(markerValues[1]),
-                    CreatUmolL: two(markerValues[2]),
-                    GluMmolL: two(markerValues[3]),
-                    CrpMgL: two(crpMgL),
-                    Wbc1000cellsuL: two(markerValues[5]),
-                    LymPc: two(markerValues[6]),
-                    McvFL: two(markerValues[7]),
-                    RdwPc: two(markerValues[8]),
-                    AlpUL: two(markerValues[9])
-                };
-                const current = new URLSearchParams(window.location.search);
-                const next = new URLSearchParams();
-                current.forEach(function(val, key) {
-                    if (PHENO_URL_KEYS.indexOf(key) === -1) next.set(key, val);
-                });
-                Object.keys(formParams).forEach(function(k) { next.set(k, String(formParams[k])); });
-                const search = next.toString();
-                const base = '/pheno-age';
-                const hash = window.location.hash || '';
-                history.replaceState({}, '', base + (search ? '?' + search : '') + hash);
-            })();
-
             // Present the complete result immediately; motion must never gate the next action.
             const animatedAgeElement = document.getElementById('animatedAge');
             const yearsTextElement = document.getElementById('yearsText');
@@ -2253,6 +2218,7 @@
         function lwcSetStep(step, options) {
             const shouldFocus = options?.focus !== false;
             lwcCurrentStep = step;
+            bioageFlow.setDraftStep('pheno', step);
             const s1 = document.getElementById('lwc-step-1');
             const s2 = document.getElementById('lwc-step-2');
             const d1 = document.getElementById('lwcDot1');
@@ -2278,6 +2244,14 @@
                         recalcOpenBiomarkerHeightsLwc();
                         // run again on next tick to catch late layout/ fonts
                         setTimeout(recalcOpenBiomarkerHeightsLwc, 60);
+                        if (shouldFocus && window.matchMedia(
+                            '(max-width: 760px), (max-width: 1024px) and (max-height: 600px) and (orientation: landscape)'
+                        ).matches) {
+                            window.scrollTo({
+                                top: Math.max(0, window.scrollY + active.getBoundingClientRect().top - 12),
+                                behavior: 'auto'
+                            });
+                        }
                     }
                 });
             }
@@ -2350,7 +2324,6 @@
                 toStep2Btn.addEventListener('click', () => {
                     if (!lwcValidateStep1()) return;
                     lwcSetStep(2);
-                    setSessionItem('lwcStep', '2');
                 });
             }
             if (toStep1Btn) {
@@ -2360,7 +2333,6 @@
                         return;
                     }
 
-                    setSessionItem('lwcStep', '1');
                     lwcSetStep(1);
                 });
             }
@@ -2369,8 +2341,8 @@
             const dot1 = document.getElementById('lwcDot1');
             const dot2 = document.getElementById('lwcDot2');
 
-            function activateDot1() { lwcSetStep(1); setSessionItem('lwcStep', '1'); }
-            function activateDot2() { if (lwcValidateStep1()) { lwcSetStep(2); setSessionItem('lwcStep', '2'); } }
+            function activateDot1() { lwcSetStep(1); }
+            function activateDot2() { if (lwcValidateStep1()) lwcSetStep(2); }
 
             if (dot1) {
                 dot1.addEventListener('click', activateDot1);
@@ -2434,7 +2406,7 @@
                 hideMainProgress();
 
                 document.getElementById('mainPageTitleH2').textContent = athlete.Name;
-                document.getElementById('mainInstructions').textContent = 'Submit your latest test results. All fields are required and must be from the same day.';
+                document.getElementById('mainInstructions').textContent = 'Enter the blood draw date and at least one new biomarker value. Unchanged values will carry over from your latest result.';
 
                 // Fill out the date of birth because we'll need it for calculations, but hide it as well so the user doesn't wanna change that.
                 document.getElementById('dob-year').value = athlete.DateOfBirth.Year;
@@ -2458,52 +2430,37 @@
             // Also honor CRP-negative checkbox state
             document.getElementById('crp-negative').dispatchEvent(new Event('change'));
 
-            if (isUpdate) {
-                // any card that's .active right now came from code, not the user —
-                // so hide its toggle-icon
-                document
-                    .querySelectorAll('.biomarker-card.active .toggle-icon')
-                    .forEach(icon => icon.style.display = 'none');
-            }
-
             updateModeFormInitializerUnique();
             applyPhenoSubmittedBiomarkerPlaceholders();
             setupPhenoSubmittedBiomarkerComparisons();
             bioageFlow.syncBiomarkerExamplePlaceholders();
+            const hasExplicitBiomarkerPrefill = [
+                'Year', 'Month', 'Day', 'Date', 'AlbGL', 'CreatUmolL', 'GluMmolL',
+                'CrpMgL', 'Wbc1000cellsuL', 'LymPc', 'McvFL', 'RdwPc', 'AlpUL'
+            ].some(key => urlParams.has(key));
+            const biomarkerEntry = bioageFlow.initializeBiomarkerEntry({
+                clock: 'pheno',
+                form: document.getElementById('phenoAgeForm'),
+                isUpdate,
+                restoreDraft: !isFake && !hasExplicitBiomarkerPrefill
+            });
 
             if (isUpdate && hasSelectedAthlete) {
                 hideUpdateModeStepNavigation();
                 lwcSetStep(2, { focus: false });
-                setSessionItem('lwcStep', '2');
                 bioageFlow.resetUpdateModeScroll();
             } else {
                 // Restore step 2 after refresh if user had navigated there and step 1 is valid.
-                let restoredStep = false;
-                try {
-                    if (getSessionItem('lwcStep') === '2' && lwcValidateStep1(true)) {
-                        lwcSetStep(2, { focus: false });
-                        restoredStep = true;
-                    }
-                } catch (e) {}
+                const restoredStep = biomarkerEntry.step === 2 && lwcValidateStep1(true);
+                if (restoredStep) lwcSetStep(2, { focus: false });
                 if (!restoredStep) {
                     lwcSetStep(1, { focus: false });
-                    setSessionItem('lwcStep', '1');
                 }
             }
         });
 
         function updateModeFormInitializerUnique() {
             if (!isUpdate) return;
-
-            if (bloodDrawDateInput) {
-                // In update mode, default the blood draw date to today instead of leaving it blank
-                const todayLocal = new Date();
-                todayLocal.setHours(0, 0, 0, 0);
-                const y = todayLocal.getFullYear();
-                const m = String(todayLocal.getMonth() + 1).padStart(2, '0');
-                const d = String(todayLocal.getDate()).padStart(2, '0');
-                bloodDrawDateInput.value = `${y}-${m}-${d}`;
-            }
 
 
             const idMapUnique = {
@@ -2555,19 +2512,12 @@
                         expandFieldCard(id);
                     }
                 });
-                // hide toggle icons on expanded cards
-                document.querySelectorAll('.biomarker-card.active .toggle-icon')
-                    .forEach(i => i.style.display = 'none');
             }
             // Expand cards for any field filled from URL (when no sessionStorage or in addition)
             ['wbc', 'lymphocyte', 'mcv', 'rcdw', 'albumin', 'ap', 'creatinine', 'glucose', 'crp'].forEach(id => {
                 const el = document.getElementById(id);
                 if (el && el.value.trim() !== '') expandFieldCard(id);
             });
-            if (isUpdate) {
-                document.querySelectorAll('.biomarker-card.active .toggle-icon')
-                    .forEach(i => i.style.display = 'none');
-            }
         }
 
         window.addEventListener('pageshow', () => {
@@ -2575,6 +2525,7 @@
             applyPhenoSubmittedBiomarkerPlaceholders();
             setupPhenoSubmittedBiomarkerComparisons();
             bioageFlow.syncBiomarkerExamplePlaceholders();
+            bioageFlow.updateCalculateButton();
         });
 
         // Detect and apply preferences based on language
@@ -2781,19 +2732,6 @@
 
             bioageFlow.updateBiomarkerExamplePlaceholder(crpUnit);
             calculateResultIfResultAlreadyCalculated();
-
-            const card = document.getElementById('crp').closest('.biomarker-card');
-            const crpHeaderField = card.querySelector('.biomarker-card-header');
-            const crpIconField = crpHeaderField.querySelector('.toggle-icon');
-            if (crpNegativeCheckbox.checked || document.getElementById('crp').value.trim() !== '') {
-                crpHeaderField.style.pointerEvents = 'none';
-                crpIconField.style.display = 'none';
-
-                expandFieldCard(card);
-            } else if (isUpdate) {
-                crpHeaderField.style.pointerEvents = '';
-                crpIconField.style.display = '';
-            }
         }
 
         // Hide month/day & privacy note when age < 18
@@ -2828,112 +2766,8 @@
             );
         document.addEventListener('DOMContentLoaded', checkMinor);
 
-        // Wire up all biomarker‐card headers
-        document.querySelectorAll('.biomarker-card-header').forEach(header => {
-            header.setAttribute('role', 'button');
-            header.setAttribute('tabindex', '0');
-            header.querySelector('.toggle-icon')?.setAttribute('aria-hidden', 'true');
-
-            const toggleCard = function () {
-                const card = header.parentNode;
-                const content = card.querySelector('.biomarker-card-content');
-                const icon = header.querySelector('.toggle-icon');
-
-                if (!isUpdate) {
-                    if (!card.classList.contains('active')) {
-                        card.classList.add('active');
-                        header.setAttribute('aria-expanded', 'true');
-
-                        content.style.maxHeight = content.scrollHeight + 'px';
-                        content.style.paddingTop = '0.75rem';
-                        content.style.paddingBottom = '0.75rem';
-                        header.style.pointerEvents = 'none';
-                        header.style.cursor = 'default';
-                        header.setAttribute('aria-disabled', 'true');
-                        header.setAttribute('tabindex', '-1');
-                        icon.style.display = 'none';
-                    }
-                    return;
-                }
-
-                // update mode: full toggle with icon swap
-                const isActive = card.classList.toggle('active');
-                header.setAttribute('aria-expanded', isActive);
-
-                icon.textContent = isActive ? '−' : '+';
-                icon.style.display = '';
-                if (isActive) {
-                    content.style.maxHeight = content.scrollHeight + 'px';
-                    content.style.paddingTop = '0.75rem';
-                    content.style.paddingBottom = '0.75rem';
-                } else {
-                    content.style.maxHeight = '0';
-                    content.style.paddingTop = '0';
-                    content.style.paddingBottom = '0';
-                }
-            };
-
-            header.addEventListener('click', toggleCard);
-            header.addEventListener('keydown', event => {
-                if (event.key !== 'Enter' && event.key !== ' ') return;
-                event.preventDefault();
-                toggleCard();
-            });
-        });
-
-        /**
-         * Expands the biomarker card containing the given input field.
-         *
-         * @param {string|HTMLElement} field - The ID of the input field, or the field element itself.
-         */
         function expandFieldCard(field) {
-            // Get the input element
-            const input = typeof field === 'string'
-                ? document.getElementById(field)
-                : field;
-            if (!input) return;
-
-            // Find its enclosing card
-            const card = input.closest('.biomarker-card');
-            if (!card) return;
-
-            // If not already expanded, open it
-            if (!card.classList.contains('active')) {
-                const header = card.querySelector('.biomarker-card-header');
-
-                card.classList.add('active');
-                if (header) header.setAttribute('aria-expanded', 'true');
-
-                // Animate the content area open
-                const content = card.querySelector('.biomarker-card-content');
-                content.style.maxHeight = content.scrollHeight + 'px';
-                content.style.paddingTop = '0.75rem';
-                content.style.paddingBottom = '0.75rem';
-
-                // Handle the toggle icon and header behavior
-                const icon = card.querySelector('.toggle-icon');
-
-                if (!isUpdate) {
-                    // In non-update mode: hide the icon and disable further clicks
-                    if (icon) icon.style.display = 'none';
-                    if (header) {
-                        header.style.pointerEvents = 'none';
-                        header.style.cursor = 'default';
-                        header.setAttribute('aria-disabled', 'true');
-                        header.setAttribute('tabindex', '-1');
-                    }
-                } else {
-                    // In update mode: show a minus icon
-                    if (icon) {
-                        icon.textContent = '−';
-                        icon.style.display = '';
-
-                        if (touchedBiomarkers.has(input.id)) {
-                            icon.style.display = 'none';
-                        }
-                    }
-                }
-            }
+            bioageFlow.expandBiomarkerCard(field);
         }
 
         function focusFirstEditableBiomarker(fieldIds) {
@@ -2946,13 +2780,7 @@
             input.focus();
         }
 
-        // Let the browser show its validation bubbles, but expand the card first
         const form = document.getElementById('phenoAgeForm');
-
-        form.addEventListener('invalid', e => {
-            // invalid fires during the capture phase before the bubble appears
-            expandFieldCard(e.target);
-        }, true);
 
         // On submit, defer to browser validation; only when the form is fully valid do we preventDefault and run calculateResult()
         form.addEventListener('submit', function (e) {
@@ -2965,8 +2793,9 @@
                 return;
             }
 
-            // Block submit if any required field is missing; show validation bubbles first
-            if (!this.reportValidity()) {
+            // New applications require the complete panel. Updates fill untouched values
+            // from the athlete's latest result inside calculateResult().
+            if (!isUpdate && !this.reportValidity()) {
                 return;
             }
 

--- a/LongevityWorldCup.Website/wwwroot/play/proof-upload.html
+++ b/LongevityWorldCup.Website/wwwroot/play/proof-upload.html
@@ -716,8 +716,15 @@
 
         function clearStoredBiomarkerHandoff() {
             removeSessionItem('biomarkerData');
+            removeSessionItem('bioageClock');
             removeSessionItem('chronoPhenoDifference');
             removeSessionItem('chronoBortzDifference');
+        }
+
+        function clearCompletedBioageState() {
+            clearStoredBiomarkerHandoff();
+            removeSessionItem('bioageDraft:pheno:v1');
+            removeSessionItem('bioageDraft:bortz:v1');
         }
 
         function clearPendingPaymentOffer() {
@@ -740,10 +747,10 @@
         const PHENO_RESULT_BIOMARKER_KEYS = ['AlbGL', 'CreatUmolL', 'GluMmolL', 'CrpMgL', 'Wbc1000cellsuL', 'LymPc', 'McvFL', 'RdwPc', 'AlpUL'];
         const BORTZ_RESULT_BIOMARKER_KEYS = ['AlbGL', 'AlpUL', 'UreaMmolL', 'CholesterolMmolL', 'CreatUmolL', 'CystatinCMgL', 'Hba1cMmolMol', 'CrpMgL', 'GgtUL', 'Rbc10e12L', 'McvFL', 'RdwPc', 'Wbc1000cellsuL', 'MonocytePc', 'NeutrophilPc', 'LymPc', 'AltUL', 'ShbgNmolL', 'VitaminDNmolL', 'GluMmolL', 'MchPg', 'ApoA1GL'];
 
-        function hasCompleteSubmittedBiomarkerValues(biomarkerData, chronoPhenoDifference, chronoBortzDifference) {
-            const requiredKeys = chronoBortzDifference
+        function hasCompleteSubmittedBiomarkerValues(biomarkerData, bioageClock) {
+            const requiredKeys = bioageClock === 'bortz'
                 ? BORTZ_RESULT_BIOMARKER_KEYS
-                : chronoPhenoDifference
+                : bioageClock === 'pheno'
                     ? PHENO_RESULT_BIOMARKER_KEYS
                     : null;
 
@@ -773,6 +780,25 @@
             }
 
             removeSessionItem(key);
+            return null;
+        }
+
+        function readStoredBioageClock(biomarkerData, chronoPhenoDifference, chronoBortzDifference) {
+            const storedClock = getSessionItem('bioageClock');
+            if (storedClock === 'pheno' || storedClock === 'bortz') return storedClock;
+
+            // Compatibility for result uploads started before the clock marker existed.
+            const pendingOffer = readPendingPaymentOffer();
+            if (pendingOffer?.offerType === 'pro'
+                && chronoBortzDifference !== null
+                && hasCompleteSubmittedBiomarkerValues(biomarkerData, 'bortz')) return 'bortz';
+            if (pendingOffer?.offerType === 'amateur'
+                && chronoPhenoDifference !== null
+                && hasCompleteSubmittedBiomarkerValues(biomarkerData, 'pheno')) return 'pheno';
+            if (chronoBortzDifference !== null
+                && hasCompleteSubmittedBiomarkerValues(biomarkerData, 'bortz')) return 'bortz';
+            if (chronoPhenoDifference !== null
+                && hasCompleteSubmittedBiomarkerValues(biomarkerData, 'pheno')) return 'pheno';
             return null;
         }
 
@@ -973,14 +999,26 @@
                 }
 
                 const chronoPhenoDifference = readStoredAgeDifference('chronoPhenoDifference');
-                const chronoBortzDifference = readStoredAgeDifference('chronoBortzDifference');
+                let chronoBortzDifference = readStoredAgeDifference('chronoBortzDifference');
                 let biomarkerData = null;
                 try {
                     biomarkerData = JSON.parse(getSessionItem('biomarkerData'));
                 } catch (_) {
                     biomarkerData = null;
                 }
-                if (!biomarkerData || !Array.isArray(biomarkerData.Biomarkers) || !biomarkerData.Biomarkers.length || !hasStoredBiomarkerDates(biomarkerData) || !hasCompleteSubmittedBiomarkerValues(biomarkerData, chronoPhenoDifference, chronoBortzDifference)) {
+                const bioageClock = readStoredBioageClock(
+                    biomarkerData,
+                    chronoPhenoDifference,
+                    chronoBortzDifference);
+                if (bioageClock === 'pheno') chronoBortzDifference = null;
+                const isLegacyUnclockedResult = !bioageClock
+                    && getSessionItem('bioageClock') === null
+                    && chronoPhenoDifference === null
+                    && chronoBortzDifference === null
+                    && hasStoredBiomarkerValues(biomarkerData);
+                const hasRequiredAgeDifferences = isLegacyUnclockedResult || (chronoPhenoDifference !== null
+                    && (bioageClock === 'pheno' || (bioageClock === 'bortz' && chronoBortzDifference !== null)));
+                if ((!bioageClock && !isLegacyUnclockedResult) || !hasRequiredAgeDifferences || !biomarkerData || !Array.isArray(biomarkerData.Biomarkers) || !biomarkerData.Biomarkers.length || !hasStoredBiomarkerDates(biomarkerData) || !hasCompleteSubmittedBiomarkerValues(biomarkerData, bioageClock)) {
                     clearStoredBiomarkerHandoff();
                     customAlert('Biomarker data is missing. Please fill out the biomarker form first.')
                         .then(() => window.location.href = '/dashboard');
@@ -1044,6 +1082,7 @@
                                     }
                                     proofPics = [];
                                     removeSessionItem(PENDING_PAYMENT_OFFER_KEY);
+                                    clearCompletedBioageState();
                                     if (checkoutLink) {
                                         if (invoiceId) {
                                             const pendingInvoiceInfo = JSON.stringify({
@@ -1083,6 +1122,7 @@
                                         }
                                         proofPics = [];
                                         removeSessionItem(PENDING_PAYMENT_OFFER_KEY);
+                                        clearCompletedBioageState();
                                         removeSessionItem(PENDING_PAYMENT_INVOICE_KEY);
                                         removeLocalItem(PENDING_PAYMENT_INVOICE_STORAGE_KEY);
                                         setSessionItem("came-from", "proof-upload");


### PR DESCRIPTION
## Why

The Pheno Age and Bortz Age application flows were especially painful on a real phone:

- the soft keyboard shrank the visual viewport while the fixed action dock kept covering inputs;
- entering 9 or 22 biomarkers required repeatedly opening cards;
- there was no durable progress, draft recovery, or safe way to edit a calculated result;
- desktop mobile emulation did not reproduce the keyboard occlusion.

## What changed

- Replaced the mobile accordion workflow with a compact, direct-entry worksheet:
  - all biomarker inputs stay visible;
  - units remain inline;
  - completion progress and validation are immediate;
  - Calculate stays disabled until the required inputs are ready;
  - Enter advances to the next missing biomarker and wraps to earlier gaps.
- Made the shared action dock soft-keyboard aware:
  - detects visual-viewport occlusion only while an editable control is focused;
  - returns the action stack to document flow while the keyboard is open;
  - adds enough scroll range for the final field to clear the keyboard;
  - keeps the focused input inside offset visual viewports;
  - restores the dock when the keyboard closes.
- Added portrait and landscape behavior through 1024 px wide compact devices, including 956×440 flagship-phone coverage.
- Added per-clock session drafts with step, date, biomarker, and unit restoration.
- Removed native spinner controls from biomarker value fields while preserving numeric input behavior.
- Kept collapsed result content outside keyboard navigation and the accessibility tree.
- Stopped copying biomarker values into the URL after calculation.
- Kept update submissions partial: a blood draw date plus one changed biomarker is enough, while each unchanged value carries forward from its latest available historical entry.
- Made Pheno/Bortz handoffs clock-explicit, clear stale cross-clock state, preserve zero-valued differences, and retain compatibility with legacy unclocked result uploads.
- Clear completed handoffs and drafts after successful submission.

## Verification

- `dotnet build LongevityWorldCup.sln --no-restore --verbosity minimal`
  - 0 warnings, 0 errors
- Affected-area regression run:
  - 248 passed, 0 failed
- Keyboard-specific browser coverage:
  - Pheno and Bortz
  - portrait 390×844
  - landscape 844×390
  - landscape 956×440
  - offset visual viewports
  - dock release and restoration
  - final-field clearance
  - Enter wraparound while the simulated soft keyboard remains open
- Responsive boundary inventory and compact-landscape global header checks pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared onboarding session state, apply/convergence validation, and mobile layout for a long user journey; mitigated by broad Playwright coverage and legacy clock inference.
> 
> **Overview**
> **Mobile Pheno/Bortz biomarker entry** is reworked: on compact viewports, biomarkers are shown as a direct worksheet (no accordion), with live progress, draft restore per clock (`bioageDraft:pheno|bortz:v1`), Enter/Tab to advance, and editing after calculate clears stale session handoff keys.
> 
> **Flow action dock** now treats the soft keyboard as a first-class layout: it undocks while an editable field is focused and the visual viewport shrinks, scrolls the focused control into view, and exposes `--flow-input-keyboard-occlusion` for layout. Result reveal no longer auto-scrolls on every resize (rank preview / continuous resizing tests updated accordingly).
> 
> **Onboarding handoff** uses an explicit `bioageClock` in session storage instead of inferring from `lwcStep` or both chrono differences; convergence/apply back navigation and missing-biomarker redirects route to the correct clock page. Legacy sessions without `bioageClock` still infer pheno vs bortz from offer type and panel completeness. Join-game starts clear prior handoff; successful apply clears drafts and handoff.
> 
> **Update mode** only requires blood draw date plus one new biomarker (full HTML5 validity skipped on update); new applications still require the full panel. Bortz no longer writes calculated values into the URL after submit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57dc152315246e045916d53851ffd860b221980d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->