### PR TITLE
Fix mobile keyboard scrolling

### DIFF
--- a/LongevityWorldCup.Tests/BioageKeyboardViewportBrowserTests.cs
+++ b/LongevityWorldCup.Tests/BioageKeyboardViewportBrowserTests.cs
@@ -7,12 +7,12 @@ namespace LongevityWorldCup.Tests;
 public sealed class BioageKeyboardViewportBrowserTests
 {
     [Theory]
-    [InlineData("/pheno-age", "#crp", "1", 390, 844, 420, 0)]
-    [InlineData("/bortz-age", "#vitamin_d", "50", 390, 844, 420, 0)]
-    [InlineData("/pheno-age", "#crp", "1", 844, 390, 200, 24)]
-    [InlineData("/bortz-age", "#vitamin_d", "50", 844, 390, 200, 24)]
-    [InlineData("/pheno-age", "#crp", "1", 956, 440, 230, 24)]
-    [InlineData("/bortz-age", "#vitamin_d", "50", 956, 440, 230, 24)]
+    [InlineData("/pheno-age", "#crp", "1", 390, 844, 420, 360)]
+    [InlineData("/bortz-age", "#vitamin_d", "50", 390, 844, 420, 360)]
+    [InlineData("/pheno-age", "#crp", "1", 844, 390, 200, 160)]
+    [InlineData("/bortz-age", "#vitamin_d", "50", 844, 390, 200, 160)]
+    [InlineData("/pheno-age", "#crp", "1", 956, 440, 230, 180)]
+    [InlineData("/bortz-age", "#vitamin_d", "50", 956, 440, 230, 180)]
     public async Task BioageBiomarker_FocusStaysVisibleWhenTheMobileKeyboardOpens(
         string path,
         string inputSelector,
@@ -112,7 +112,9 @@ public sealed class BioageKeyboardViewportBrowserTests
                     InputTop: rect.top,
                     InputBottom: rect.bottom,
                     VisualViewportTop: viewport.offsetTop,
-                    VisualViewportBottom: viewport.offsetTop + viewport.height
+                    VisualViewportBottom: viewport.offsetTop + viewport.height,
+                    KeyboardClearance: parseFloat(getComputedStyle(document.documentElement)
+                        .getPropertyValue('--flow-input-keyboard-occlusion')) || 0
                 };
             }
             """,
@@ -122,11 +124,31 @@ public sealed class BioageKeyboardViewportBrowserTests
         Assert.True(state.BodyKeyboardOpen, "The body should expose the keyboard-open state.");
         Assert.False(state.Docked, "The mobile action dock should return to document flow while the keyboard is open.");
         Assert.True(state.InputFocused, "The biomarker input should retain focus after the visual viewport shrinks.");
+        Assert.InRange(
+            state.KeyboardClearance,
+            viewportHeight - keyboardViewportHeight - 1,
+            viewportHeight - keyboardViewportHeight + 1);
         Assert.True(
             state.InputTop >= state.VisualViewportTop && state.InputBottom <= state.VisualViewportBottom,
             $"The focused biomarker must remain fully visible: input {state.InputTop}-{state.InputBottom}, "
             + $"visual viewport {state.VisualViewportTop}-{state.VisualViewportBottom}.");
         Assert.Equal("next", await biomarker.GetAttributeAsync("enterkeyhint"));
+
+        await page.EvaluateAsync("() => window.scrollTo({ top: 0, behavior: 'instant' })");
+        await page.WaitForTimeoutAsync(250);
+        Assert.InRange(await page.EvaluateAsync<double>("() => window.scrollY"), 0, 1);
+
+        await page.EvaluateAsync(
+            "() => window.scrollTo({ top: document.scrollingElement.scrollHeight, behavior: 'instant' })");
+        await page.WaitForTimeoutAsync(250);
+        var downwardScroll = await page.EvaluateAsync<ManualScrollState>(
+            """
+            () => ({
+                ScrollY: window.scrollY,
+                MaxScrollY: document.scrollingElement.scrollHeight - window.innerHeight
+            })
+            """);
+        Assert.InRange(downwardScroll.MaxScrollY - downwardScroll.ScrollY, 0, 1);
 
         await biomarker.PressAsync("Enter");
         await page.WaitForFunctionAsync(
@@ -191,5 +213,12 @@ public sealed class BioageKeyboardViewportBrowserTests
         public double InputBottom { get; set; }
         public double VisualViewportTop { get; set; }
         public double VisualViewportBottom { get; set; }
+        public double KeyboardClearance { get; set; }
+    }
+
+    private sealed class ManualScrollState
+    {
+        public double ScrollY { get; set; }
+        public double MaxScrollY { get; set; }
     }
 }

--- a/LongevityWorldCup.Website/Frontend/flow-action-dock.ts
+++ b/LongevityWorldCup.Website/Frontend/flow-action-dock.ts
@@ -47,6 +47,7 @@ interface FlowActionDockApi {
     let transitionsReady = false;
     let generatedFormId = 0;
     let keyboardClearFrame = 0;
+    let focusedControlClearanceRequested = false;
     let largestUnobscuredViewportHeight = 0;
     let lastLayoutViewportWidth = window.innerWidth;
     let isKeyboardOpen = false;
@@ -121,7 +122,7 @@ interface FlowActionDockApi {
             && editingControl
             && largestUnobscuredViewportHeight - viewport.height >= keyboardThreshold;
         const keyboardOcclusion = isKeyboardOpen
-            ? Math.max(0, largestUnobscuredViewportHeight - viewport.bottom)
+            ? Math.max(0, largestUnobscuredViewportHeight - viewport.height)
             : 0;
         const occlusionValue = `${Math.ceil(keyboardOcclusion)}px`;
 
@@ -350,6 +351,8 @@ interface FlowActionDockApi {
 
     function refresh(): void {
         refreshFrame = 0;
+        const shouldClearFocusedControl = focusedControlClearanceRequested;
+        focusedControlClearanceRequested = false;
         ensureRegisteredElements();
         syncKeyboardState();
 
@@ -374,11 +377,16 @@ interface FlowActionDockApi {
         const heightValue = hasDockedElement ? `${Math.ceil(dockedHeight)}px` : '0px';
         document.documentElement.style.setProperty('--flow-action-dock-height', heightValue);
         document.body.style.setProperty('--flow-action-dock-height', heightValue);
-        keepFocusedControlInVisualViewport();
+        if (shouldClearFocusedControl) keepFocusedControlInVisualViewport();
     }
 
     function scheduleRefresh(): void {
         if (!refreshFrame) refreshFrame = window.requestAnimationFrame(refresh);
+    }
+
+    function scheduleFocusedControlClearance(): void {
+        focusedControlClearanceRequested = true;
+        scheduleRefresh();
     }
 
     function refreshImmediately(): void {
@@ -464,19 +472,19 @@ interface FlowActionDockApi {
             attributeFilter: ['class']
         });
 
-        window.addEventListener('resize', scheduleRefresh);
-        window.addEventListener('orientationchange', scheduleRefresh);
+        window.addEventListener('resize', scheduleFocusedControlClearance);
+        window.addEventListener('orientationchange', scheduleFocusedControlClearance);
         window.addEventListener('scroll', scheduleRefresh, { passive: true });
         window.addEventListener('load', scheduleRefresh);
         window.addEventListener('pageshow', scheduleRefresh);
-        document.addEventListener('focusin', scheduleRefresh, true);
+        document.addEventListener('focusin', scheduleFocusedControlClearance, true);
         document.addEventListener('focusout', () => window.setTimeout(scheduleRefresh, 0), true);
         mobileMedia.addEventListener?.('change', scheduleRefresh);
         keyboardMedia.addEventListener?.('change', scheduleRefresh);
         coarsePointerMedia.addEventListener?.('change', scheduleRefresh);
 
         if (window.visualViewport) {
-            window.visualViewport.addEventListener('resize', scheduleRefresh);
+            window.visualViewport.addEventListener('resize', scheduleFocusedControlClearance);
             window.visualViewport.addEventListener('scroll', scheduleRefresh);
         }
         document.fonts?.ready.then(scheduleRefresh).catch(() => {});


### PR DESCRIPTION
## What changed

- reserve the full mobile-keyboard height even after Android Chrome pans the visual viewport
- auto-reveal the focused field only when focus or viewport geometry changes
- leave ordinary window and visual-viewport scrolling under the user's control
- extend the Pheno/Bortz keyboard regression to cover panned portrait and landscape viewports and manual scrolling to both page extremes

## Root cause

The shared action-dock controller recalculated keyboard clearance from the bottom of the already-panned visual viewport. As Chrome panned toward the focused input, that clearance collapsed toward zero. The same controller also reran its focus-reveal correction on every scroll event, so a swipe that moved the focused input offscreen was immediately counteracted.

## User impact

With the numeric keyboard open, users can now scroll freely up and down through all biomarker cards, including the final CRP and Bortz fields. Focus changes still reveal the active input once without trapping subsequent manual scrolling.

## Validation

- `BioageKeyboardViewportBrowserTests`: 6 passed
- `BioageMobileUxBrowserTests` + `FlowActionDockBrowserTests`: 99 passed
- frontend TypeScript compilation and output verification passed as part of both test runs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared mobile dock/keyboard behavior used beyond bioage pages; incorrect occlusion or scroll timing could affect other flows, but changes are localized and covered by expanded browser tests.
> 
> **Overview**
> Fixes **mobile keyboard UX** on Pheno/Bortz biomarker flows by correcting how the shared flow action dock computes keyboard space and when it auto-scrolls the focused field.
> 
> **Keyboard clearance** now uses the gap between the largest unobscured layout height and the current visual viewport height (`largestUnobscuredViewportHeight - viewport.height`), instead of measuring from the panned visual viewport bottom. That keeps `--flow-input-keyboard-occlusion` stable when Android Chrome shifts `visualViewport.offsetTop`, so the page still reserves the full keyboard height for scrolling.
> 
> **Focus reveal** runs only when focus or viewport geometry changes (resize, orientation, `visualViewport` resize, `focusin`), not on every window/visual-viewport scroll. Ordinary user scrolling while the keyboard is open is no longer fought by `keepFocusedControlInVisualViewport`.
> 
> **Tests** use non-zero visual viewport offsets for portrait/landscape, assert keyboard clearance matches the height delta, and verify the page can scroll to top and bottom extremes before Enter still advances focus to the next field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c84ddc22bfb5338ad6de9dc022f1919c1ec5d5a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->