### PR TITLE
Address CORS deployment reviews

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -253,9 +253,10 @@ jobs:
             cors_headers="$frontend_stage/cors-headers.txt"
             normalized_cors_headers="$frontend_stage/cors-headers.normalized.txt"
             assert_single_public_cors_origin() {
-              origin_count="$(grep -Eic '^access-control-allow-origin:[[:space:]]*\*[[:space:]]*$' "$normalized_cors_headers" || true)"
-              if [ "$origin_count" -ne 1 ]; then
-                echo "Expected exactly one wildcard Access-Control-Allow-Origin header, found $origin_count." >&2
+              origin_count="$(grep -Eic '^access-control-allow-origin:' "$normalized_cors_headers" || true)"
+              wildcard_origin_count="$(grep -Eic '^access-control-allow-origin:[[:space:]]*\*[[:space:]]*$' "$normalized_cors_headers" || true)"
+              if [ "$origin_count" -ne 1 ] || [ "$wildcard_origin_count" -ne 1 ]; then
+                echo "Expected exactly one Access-Control-Allow-Origin header with value '*'; found $origin_count total and $wildcard_origin_count wildcard." >&2
                 cat "$normalized_cors_headers" >&2
                 exit 1
               fi

--- a/LongevityWorldCup.Tests/PublicApiCorsTests.cs
+++ b/LongevityWorldCup.Tests/PublicApiCorsTests.cs
@@ -80,4 +80,17 @@ public sealed class PublicApiCorsTests
             TrustedSiteOrigin,
             Assert.Single(trustedResponse.Headers.GetValues("Access-Control-Allow-Origin")));
     }
+
+    [Fact]
+    public async Task NonPublicNotFound_ReExecutesRoutedErrorEndpoint()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient(
+            new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+
+        using var response = await client.GetAsync("/route-that-does-not-exist");
+
+        Assert.Equal(HttpStatusCode.Found, response.StatusCode);
+        Assert.Equal("/error/404.html", response.Headers.Location?.ToString());
+    }
 }


### PR DESCRIPTION
## Summary

- make the production CORS probe count every `Access-Control-Allow-Origin` header and require the sole value to be `*`
- add integration coverage proving unknown non-public routes still re-execute through the routed 404 endpoint

## Why

This follows up on the post-merge reviews for #804 and #805. The #805 finding was valid: the deploy probe could pass one wildcard header plus an additional conflicting origin header. The #804 claim did not reproduce on the current ASP.NET Core pipeline, so the working middleware order is preserved and covered by a regression test instead.

## Validation

- `dotnet test LongevityWorldCup.Tests/LongevityWorldCup.Tests.csproj --no-restore --no-build -m:1 --filter "FullyQualifiedName~PublicApiCorsTests"` — 5 passed
- shell probe cases: sole wildcard accepted; mixed origins, duplicate wildcard, and specific-only origins rejected
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI deploy validation and a new integration test; no application runtime behavior is modified.
> 
> **Overview**
> **Production deploy CORS checks** now fail if the public API returns more than one `Access-Control-Allow-Origin` header, or if the single header is not exactly `*`. Previously the probe only counted wildcard lines, so a response with one `*` plus an extra origin could still pass.
> 
> Adds **`NonPublicNotFound_ReExecutesRoutedErrorEndpoint`** in `PublicApiCorsTests`, asserting unknown paths return **302** to `/error/404.html` (no auto-redirect), locking in `UseStatusCodePagesWithReExecute` behavior without changing middleware order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c794bdd96bd0a6d8ea6323cbb59c62ecabfaca49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->