### PR TITLE
Address mobile bioage review feedback

### DIFF
--- a/LongevityWorldCup.Tests/BioageKeyboardViewportBrowserTests.cs
+++ b/LongevityWorldCup.Tests/BioageKeyboardViewportBrowserTests.cs
@@ -6,6 +6,53 @@ namespace LongevityWorldCup.Tests;
 
 public sealed class BioageKeyboardViewportBrowserTests
 {
+    [Fact]
+    public async Task FocusedInput_InWindowedViewportDoesNotTreatUnusedScreenSpaceAsAKeyboard()
+    {
+        await using var app = await BrowserTestApp.StartAsync();
+        using var playwright = await Playwright.CreateAsync();
+        await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+        {
+            Headless = true
+        });
+        await using var context = await browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            BaseURL = app.BaseAddress.ToString(),
+            Locale = "en-US",
+            IsMobile = true,
+            HasTouch = true,
+            ViewportSize = new ViewportSize { Width = 390, Height = 500 },
+            ScreenSize = new ScreenSize { Width = 390, Height = 844 }
+        });
+        await BrowserTestApp.RouteExternalResourcesAsync(context);
+
+        var page = await context.NewPageAsync();
+        await page.GotoAsync("/pheno-age", new PageGotoOptions
+        {
+            WaitUntil = WaitUntilState.DOMContentLoaded
+        });
+        await page.WaitForFunctionAsync("() => window.LwcFlowActionDock");
+        await page.Locator("#blood-draw-date").FocusAsync();
+        await page.EvaluateAsync("() => window.LwcFlowActionDock.refreshNow()");
+
+        var state = await page.EvaluateAsync<WindowedViewportState>(
+            """
+            () => ({
+                KeyboardOpen: document.documentElement.classList.contains('flow-input-keyboard-open'),
+                KeyboardClearance: parseFloat(getComputedStyle(document.documentElement)
+                    .getPropertyValue('--flow-input-keyboard-occlusion')) || 0,
+                ScreenHeight: window.screen.height,
+                ViewportHeight: window.visualViewport?.height || window.innerHeight
+            })
+            """);
+
+        Assert.True(
+            state.ScreenHeight - state.ViewportHeight >= 300,
+            $"The test requires a substantially taller physical screen: {state.ScreenHeight} vs {state.ViewportHeight}.");
+        Assert.False(state.KeyboardOpen);
+        Assert.Equal(0, state.KeyboardClearance);
+    }
+
     [Theory]
     [InlineData("/pheno-age", "#crp", "1", 390, 844, 420, 360)]
     [InlineData("/bortz-age", "#vitamin_d", "50", 390, 844, 420, 360)]
@@ -220,5 +267,13 @@ public sealed class BioageKeyboardViewportBrowserTests
     {
         public double ScrollY { get; set; }
         public double MaxScrollY { get; set; }
+    }
+
+    private sealed class WindowedViewportState
+    {
+        public bool KeyboardOpen { get; set; }
+        public double KeyboardClearance { get; set; }
+        public double ScreenHeight { get; set; }
+        public double ViewportHeight { get; set; }
     }
 }

--- a/LongevityWorldCup.Tests/BioageMobileUxBrowserTests.cs
+++ b/LongevityWorldCup.Tests/BioageMobileUxBrowserTests.cs
@@ -5,6 +5,71 @@ namespace LongevityWorldCup.Tests;
 
 public sealed class BioageMobileUxBrowserTests
 {
+    [Theory]
+    [InlineData("/pheno-age", "pheno")]
+    [InlineData("/bortz-age", "bortz")]
+    public async Task CompletedDraftClear_IsNotUndoneByCachedCalculator(string path, string clock)
+    {
+        await using var app = await BrowserTestApp.StartAsync();
+        using var playwright = await Playwright.CreateAsync();
+        await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+        {
+            Headless = true
+        });
+        await using var context = await browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            BaseURL = app.BaseAddress.ToString(),
+            Locale = "en-US",
+            IsMobile = true,
+            HasTouch = true,
+            ViewportSize = new ViewportSize { Width = 390, Height = 844 }
+        });
+        await BrowserTestApp.RouteExternalResourcesAsync(context);
+
+        var page = await context.NewPageAsync();
+        await page.GotoAsync(path, new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
+        await page.WaitForFunctionAsync(
+            "() => document.querySelector('.bioageform')?.classList.contains('bioage-biomarker-entry-ready')");
+
+        var draftKey = $"bioageDraft:{clock}:v1";
+        await page.EvaluateAsync(
+            """
+            () => {
+                const input = document.querySelector('#wbc');
+                input.value = '6.54';
+                input.dispatchEvent(new Event('input', { bubbles: true }));
+            }
+            """);
+        await page.WaitForFunctionAsync(
+            "key => sessionStorage.getItem(key)?.includes('6.54') === true",
+            draftKey);
+
+        await page.EvaluateAsync(
+            """
+            key => {
+                window.dispatchEvent(new PageTransitionEvent('pagehide', { persisted: true }));
+                sessionStorage.removeItem(key);
+                window.dispatchEvent(new PageTransitionEvent('pageshow', { persisted: true }));
+            }
+            """,
+            draftKey);
+        await page.EvaluateAsync(
+            """
+            () => {
+                const input = document.querySelector('#wbc');
+                input.value = '6.55';
+                input.dispatchEvent(new Event('input', { bubbles: true }));
+            }
+            """);
+        await page.WaitForTimeoutAsync(250);
+        await page.EvaluateAsync(
+            "() => window.dispatchEvent(new PageTransitionEvent('pagehide', { persisted: true }))");
+
+        Assert.Null(await page.EvaluateAsync<string?>(
+            "key => sessionStorage.getItem(key)",
+            draftKey));
+    }
+
     [Fact]
     public async Task RestoredDraftEdit_InvalidatesThePreviouslyCalculatedHandoff()
     {

--- a/LongevityWorldCup.Website/Frontend/bioage-flow.ts
+++ b/LongevityWorldCup.Website/Frontend/bioage-flow.ts
@@ -66,7 +66,9 @@ interface BioageDraft {
 
 interface BioageBiomarkerEntryController {
     clock: BioageClock;
+    draftPersistenceSuppressed: boolean;
     form: HTMLFormElement;
+    hasPersistedDraft: boolean;
     inputs: HTMLInputElement[];
     invalidBatchActive: boolean;
     isUpdate: boolean;
@@ -577,7 +579,10 @@ interface Window {
         const clocks: BioageClock[] = clock ? [clock] : ['pheno', 'bortz'];
         clocks.forEach(draftClock => {
             const controller = biomarkerEntryControllers.get(draftClock);
-            if (controller?.saveTimer) window.clearTimeout(controller.saveTimer);
+            if (controller) {
+                controller.draftPersistenceSuppressed = true;
+                if (controller.saveTimer) window.clearTimeout(controller.saveTimer);
+            }
             biomarkerEntryControllers.delete(draftClock);
             removeSessionItem(getBioageDraftKey(draftClock));
         });
@@ -606,10 +611,22 @@ interface Window {
         return fields;
     }
 
+    function canPersistBioageDraft(controller: BioageBiomarkerEntryController): boolean {
+        if (controller.isUpdate || controller.restoring || controller.draftPersistenceSuppressed) return false;
+
+        if (controller.hasPersistedDraft && getSessionItem(getBioageDraftKey(controller.clock)) === null) {
+            controller.draftPersistenceSuppressed = true;
+            if (controller.saveTimer) window.clearTimeout(controller.saveTimer);
+            controller.saveTimer = 0;
+            return false;
+        }
+
+        return true;
+    }
+
     function saveBioageDraft(controller: BioageBiomarkerEntryController): void {
         controller.saveTimer = 0;
-        if (controller.isUpdate || controller.restoring) return;
-
+        if (!canPersistBioageDraft(controller)) return;
         const draft: BioageDraft = {
             version: BIOAGE_DRAFT_VERSION,
             clock: controller.clock,
@@ -617,14 +634,12 @@ interface Window {
             fields: serializeDraftFields(controller.form)
         };
 
-        try {
-            setSessionItem(getBioageDraftKey(controller.clock), JSON.stringify(draft));
-        } catch (_) {
-        }
+        setSessionItem(getBioageDraftKey(controller.clock), JSON.stringify(draft));
+        controller.hasPersistedDraft = getSessionItem(getBioageDraftKey(controller.clock)) !== null;
     }
 
     function scheduleBioageDraftSave(controller: BioageBiomarkerEntryController): void {
-        if (controller.isUpdate || controller.restoring) return;
+        if (!canPersistBioageDraft(controller)) return;
         if (controller.saveTimer) window.clearTimeout(controller.saveTimer);
         controller.saveTimer = window.setTimeout(() => saveBioageDraft(controller), 100);
     }
@@ -661,6 +676,7 @@ interface Window {
         const draft = readBioageDraft(controller.clock);
         if (!draft) return false;
 
+        controller.hasPersistedDraft = true;
         controller.restoring = true;
         try {
             applyDraftField(controller.form, draft.fields, 'dob-year');
@@ -1040,7 +1056,9 @@ interface Window {
 
         const controller: BioageBiomarkerEntryController = {
             clock: options.clock,
+            draftPersistenceSuppressed: false,
             form: options.form,
+            hasPersistedDraft: false,
             inputs: Array.from(options.form.querySelectorAll<HTMLInputElement>(
                 '.biomarker-card input[type="number"][required]'
             )),

--- a/LongevityWorldCup.Website/Frontend/flow-action-dock.ts
+++ b/LongevityWorldCup.Website/Frontend/flow-action-dock.ts
@@ -37,7 +37,6 @@ interface FlowActionDockApi {
     const backPrimaryActionClass = 'flow-action-stack--back-primary-action';
     const mobileMedia = window.matchMedia('(max-width: 760px)');
     const keyboardMedia = window.matchMedia('(max-width: 760px), (pointer: coarse)');
-    const coarsePointerMedia = window.matchMedia('(pointer: coarse)');
     const reducedMotionMedia = window.matchMedia('(prefers-reduced-motion: reduce)');
     const states = new Map<HTMLElement, DockState>();
     let refreshFrame = 0;
@@ -85,36 +84,29 @@ interface FlowActionDockApi {
         ].includes(element.type);
     }
 
-    function getEstimatedLayoutViewportHeight(viewport: VisualViewportBounds): number {
-        const orientationType = window.screen?.orientation?.type || '';
-        const isLandscape = orientationType.startsWith('landscape')
-            || (!orientationType && window.innerWidth > window.innerHeight);
-        const screenWidth = Number(window.screen?.width);
-        const screenHeight = Number(window.screen?.height);
-        const orientedScreenHeight = coarsePointerMedia.matches
-            && Number.isFinite(screenWidth)
-            && Number.isFinite(screenHeight)
-            ? isLandscape
-                ? Math.min(screenWidth, screenHeight)
-                : Math.max(screenWidth, screenHeight)
-            : 0;
-
-        return Math.max(viewport.height, window.innerHeight, orientedScreenHeight);
+    function getObservedAppViewportHeight(viewport: VisualViewportBounds): number {
+        return Math.max(viewport.height, window.innerHeight);
     }
 
     function syncKeyboardState(): void {
         const viewport = getVisualViewportBounds();
+        const editingControl = isKeyboardEditingControl(document.activeElement);
         const viewportWidth = window.innerWidth;
         if (Math.abs(viewportWidth - lastLayoutViewportWidth) > 48) {
             lastLayoutViewportWidth = viewportWidth;
-            largestUnobscuredViewportHeight = getEstimatedLayoutViewportHeight(viewport);
+            largestUnobscuredViewportHeight = 0;
         }
 
-        const editingControl = isKeyboardEditingControl(document.activeElement);
+        const observedAppViewportHeight = getObservedAppViewportHeight(viewport);
         if (!editingControl) {
-            largestUnobscuredViewportHeight = getEstimatedLayoutViewportHeight(viewport);
+            largestUnobscuredViewportHeight = observedAppViewportHeight;
         } else if (!largestUnobscuredViewportHeight) {
-            largestUnobscuredViewportHeight = getEstimatedLayoutViewportHeight(viewport);
+            largestUnobscuredViewportHeight = observedAppViewportHeight;
+        } else {
+            largestUnobscuredViewportHeight = Math.max(
+                largestUnobscuredViewportHeight,
+                observedAppViewportHeight
+            );
         }
 
         const keyboardThreshold = Math.max(120, largestUnobscuredViewportHeight * 0.22);
@@ -481,7 +473,6 @@ interface FlowActionDockApi {
         document.addEventListener('focusout', () => window.setTimeout(scheduleRefresh, 0), true);
         mobileMedia.addEventListener?.('change', scheduleRefresh);
         keyboardMedia.addEventListener?.('change', scheduleRefresh);
-        coarsePointerMedia.addEventListener?.('change', scheduleRefresh);
 
         if (window.visualViewport) {
             window.visualViewport.addEventListener('resize', scheduleFocusedControlClearance);


### PR DESCRIPTION
## What changed

This follow-up addresses both unresolved P2 review threads posted after #807 had already merged:

- keyboard detection now learns its baseline only from an observed unobscured **application viewport**; it no longer compares a split-screen/windowed app against the full physical screen
- bioage draft controllers now remember when they have persisted a draft and permanently suppress stale writes when the submission flow clears that shared draft, preventing a BFCache-restored calculator from recreating completed values
- same-document `clearBioageDraft` calls also suppress any retained `pagehide` listener before removing the storage entry

## Root causes

1. `window.screen` was treated as an app-layout measurement, so unused physical screen space could satisfy the keyboard shrink threshold.
2. The calculator’s `pagehide` listener retained its populated controller across BFCache restoration and could not distinguish a deliberately cleared completed draft from a never-saved draft.

## User impact

- split-screen and windowed mobile sessions keep their action dock unless the app viewport itself actually shrinks for a keyboard
- completed Pheno/Bortz applications no longer reappear as resumable drafts after back/forward navigation

## Validation

- focused bioage, keyboard viewport, and stored-biomarker tests: **70 passed**
- shared flow-action-dock and visual-viewport tests: **94 passed**
- frontend TypeScript compilation and generated-output verification passed in both runs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mobile keyboard detection and sessionStorage draft lifecycle on bioage flows; behavior is UX-critical but localized and covered by new browser tests.
> 
> **Overview**
> Fixes two mobile bioage regressions from post-merge review: **false keyboard-open state** in split-screen/windowed layouts, and **completed drafts reappearing** after BFCache navigation.
> 
> **Flow action dock** no longer uses `window.screen` or orientation heuristics for the keyboard baseline. It learns **unobscured height** only from the observed app viewport (`visualViewport` / `innerHeight`), resets that baseline on large width changes, and still opens the keyboard state only when shrink exceeds the threshold while a text field is focused.
> 
> **Bioage draft saving** adds `canPersistBioageDraft`: `clearBioageDraft` sets **draft persistence suppressed** on active controllers before removing session storage; controllers track **hasPersistedDraft** and stop scheduling saves if storage was cleared elsewhere (e.g. after submit) so a BFCache-restored page cannot rewrite the draft on `pagehide` or debounced input.
> 
> Playwright coverage adds a **short viewport vs tall screen** keyboard case and a **pagehide/pageshow + sessionStorage remove** draft case for pheno and bortz.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4babacd02b8afe010bbf0902a30ca70ea7ce08a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->