### PR TITLE
Honor canonical athlete slugs in profile dialogs

### DIFF
--- a/LongevityWorldCup.Tests/AthleteDialogLinkBrowserTests.cs
+++ b/LongevityWorldCup.Tests/AthleteDialogLinkBrowserTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Nodes;
 using Microsoft.Playwright;
 using Xunit;
 
@@ -358,6 +359,63 @@ public sealed class AthleteDialogLinkBrowserTests
         await page.Locator("#unknownAthleteLink").ClickAsync();
         await page.WaitForURLAsync("**/athlete/not-a-real-athlete");
         Assert.Equal("/athlete/not-a-real-athlete", new Uri(page.Url).AbsolutePath);
+    }
+
+    [Fact]
+    public async Task CanonicalAthleteSlug_OpensDialogWhenItDiffersFromTheCurrentName()
+    {
+        const string canonicalSlug = "michael-lustgarten-stable";
+
+        await using var app = await BrowserTestApp.StartAsync();
+        using var playwright = await Playwright.CreateAsync();
+        await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+        {
+            Headless = true
+        });
+        await using var context = await NewContextAsync(browser, app, width: 1100, height: 760);
+        await context.RouteAsync("**/api/data/athletes", async route =>
+        {
+            var response = await route.FetchAsync();
+            var athletes = JsonNode.Parse(await response.TextAsync())!.AsArray();
+            var michael = athletes
+                .OfType<JsonObject>()
+                .Single(athlete =>
+                    athlete["Name"]?.GetValue<string>() == "Michael Lustgarten");
+            michael["AthleteSlug"] = canonicalSlug.Replace('-', '_');
+
+            await route.FulfillAsync(new RouteFulfillOptions
+            {
+                Status = response.Status,
+                ContentType = "application/json",
+                Body = athletes.ToJsonString()
+            });
+        });
+
+        var page = await context.NewPageAsync();
+        page.SetDefaultTimeout(15_000);
+        await page.GotoAsync("/about", new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
+        await AssertSharedDialogInstalledAsync(page);
+        await page.EvaluateAsync(
+            """
+            slug => {
+                const link = document.createElement('a');
+                link.id = 'stableCanonicalAthleteLink';
+                link.href = `/athlete/${slug}`;
+                link.textContent = 'Renamed athlete';
+                document.querySelector('.documentation-document').appendChild(link);
+            }
+            """,
+            canonicalSlug);
+
+        await page.Locator("#stableCanonicalAthleteLink").ClickAsync();
+        await WaitForOpenAthleteDialogAsync(page, canonicalSlug);
+        Assert.StartsWith("Michael Lustgarten, PhD", await page.Locator("#athleteName").InnerTextAsync());
+
+        await CloseAthleteDialogAsync(page, "/about");
+        await page.GotoAsync(
+            $"/athlete/{canonicalSlug}",
+            new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
+        await WaitForOpenAthleteDialogAsync(page, canonicalSlug);
     }
 
     [Fact]

--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -4718,6 +4718,7 @@
                     return {
                         name: athlete.Name,
                         displayName: displayName,
+                        athleteSlug: athlete.AthleteSlug,
                         mediaContact: athlete.MediaContact,
                         dateOfBirth: dob,
                         chronologicalAge: chronologicalAgeNow,
@@ -7503,7 +7504,7 @@
     }
 
     function getAthleteData(athleteNameText) {
-        return athleteResults.find(athlete => window.slugifyName(athlete.name) === window.slugifyName(athleteNameText));
+        return findAthleteDataBySlug(athleteNameText);
     }
 
     function normalizeAthleteSlugForLookup(value) {
@@ -7528,9 +7529,12 @@
         if (!normalizedSlug) return null;
 
         return athleteResults.find(athlete => {
+            const canonicalSlug = normalizeAthleteSlugForLookup(athlete.athleteSlug);
             const nameSlug = normalizeAthleteSlugForLookup(athlete.name);
             const displayNameSlug = athlete.displayName ? normalizeAthleteSlugForLookup(athlete.displayName) : '';
-            return nameSlug === normalizedSlug || displayNameSlug === normalizedSlug;
+            return canonicalSlug === normalizedSlug ||
+                nameSlug === normalizedSlug ||
+                displayNameSlug === normalizedSlug;
         }) || null;
     }
 
@@ -7997,7 +8001,9 @@
             return window.__sharedAthletesRequest;
         };
 
-        const athleteSlug = window.slugifyName(athleteNameText, true);
+        const athleteSlug = normalizeAthleteSlugForLookup(
+            athleteData?.athleteSlug || athleteNameText);
+        const normalizedAthleteName = normalizeAthleteSlugForLookup(athleteNameText);
         const suppressGuessMyAge = !!(options && options.suppressGuessMyAge);
         const requestId = ++currentAthleteModalRequestId;
         const modalContent = resetModalForLoading(athleteSlug);
@@ -8005,7 +8011,11 @@
         window.getSharedAthletes()
             .then(athletes => {
                 if (requestId !== currentAthleteModalRequestId) return;
-                const fullAthleteData = athletes.find(a => window.slugifyName(a.Name) === window.slugifyName(athleteNameText));
+                const fullAthleteData = athletes.find(a => {
+                    const canonicalSlug = normalizeAthleteSlugForLookup(a.AthleteSlug);
+                    const nameSlug = normalizeAthleteSlugForLookup(a.Name);
+                    return canonicalSlug === athleteSlug || nameSlug === normalizedAthleteName;
+                });
                 if (!fullAthleteData) {
                     throw new Error(`Full athlete data not found for ${athleteSlug}`);
                 }


### PR DESCRIPTION
## Outcome

Athlete profile links now continue to open the shared dialog when a stable `AthleteSlug` differs from the athlete's current name or display name. The canonical slug is preserved through lookup, modal state, browser history, direct athlete-route hydration, and full-data matching.

## Root cause

PR #806 built the dialog lookup index from name-derived slugs only, even though calculator and public profile URLs use the stable `AthleteSlug`. A renamed athlete therefore fell through to full-page navigation and could miss direct-route hydration as well.

## Verification

- `dotnet test LongevityWorldCup.Tests/LongevityWorldCup.Tests.csproj --filter "FullyQualifiedName~AthleteDialogLinkBrowserTests"` — 13/13 passed
- Added a Playwright regression that rewrites an athlete's stable slug so it differs from the current name, then verifies both delegated link opening and direct canonical navigation
- `git diff --check` — clean

Follow-up to #806.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted front-end lookup and modal routing changes with a new browser test; no auth, data writes, or server API changes.
> 
> **Overview**
> **Athlete profile links and direct `/athlete/{slug}` routes now resolve through the stable `AthleteSlug`**, not only name-derived slugs, so renamed athletes still open the shared dialog and hydrate correctly.
> 
> Leaderboard result objects now carry `athleteSlug` from the API. `findAthleteDataBySlug` and full-data fetch logic prefer the canonical slug (with name/display fallbacks), and modal loading uses that slug for URL state and `/api/data/athletes` matching.
> 
> A Playwright regression stubs an athlete whose `AthleteSlug` differs from the current name and checks delegated link open plus direct canonical navigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db16d3b5b8e0f8a31affe486b0ae1a904dfc32f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->