### PR TITLE
Send mention emails after Challenge opt-out

### DIFF
--- a/LongevityWorldCup.Tests/LongevitymaxxingChallengeServiceTests.cs
+++ b/LongevityWorldCup.Tests/LongevitymaxxingChallengeServiceTests.cs
@@ -158,30 +158,32 @@ public sealed class LongevitymaxxingChallengeServiceTests
     }
 
     [Fact]
-    public async Task CheckInMentionsHonorChallengeEmailOptOutAndLimitFanout()
+    public async Task CheckInMentionsIgnoreChallengeEmailOptOut()
     {
         using var fixture = TestChallengeFixture.Create();
         var senderAccess = await fixture.ConfirmParticipantAsync("sender@example.com", "Sender Sam");
-        await fixture.ConfirmParticipantAsync("quiet@example.com", "Quiet Quinn");
-        fixture.Db.Run(sqlite =>
-        {
-            using var update = sqlite.CreateCommand();
-            update.CommandText =
-                """
-                UPDATE LongevitymaxxingParticipants
-                SET StoppedEmailsAtUtc = @stopped
-                WHERE Email = 'quiet@example.com';
-                """;
-            update.Parameters.AddWithValue("@stopped", DateTimeOffset.Parse("2026-06-08T12:00:00Z").ToString("o"));
-            update.ExecuteNonQuery();
-        });
+        var quietAccess = await fixture.ConfirmParticipantAsync("quiet@example.com", "Quiet Quinn");
+        fixture.Service.StopChallengeEmails(quietAccess, DateTimeOffset.Parse("2026-06-08T12:00:00Z"));
+
+        var unsubscribed = fixture.Service.GetPublicState(DateTimeOffset.Parse("2026-06-09T08:04:00Z"))
+            .Leaderboard
+            .Single(row => row.DisplayName == "Quiet Quinn");
+        Assert.True(unsubscribed.ChallengeEmailsStopped);
 
         fixture.Service.SubmitCheckIn(
             new LongevitymaxxingCheckInRequest(senderAccess, 1, 2, 2, 2, 2, "Still visible to @Quiet Quinn."),
             DateTimeOffset.Parse("2026-06-09T08:05:00Z"));
 
-        Assert.Empty(fixture.Email.Mentions);
+        var mention = Assert.Single(fixture.Email.Mentions);
+        Assert.Equal("quiet@example.com", mention.Mention.RecipientEmail);
+        Assert.Equal(quietAccess, ReadQueryToken(mention.Url, "token"));
+    }
 
+    [Fact]
+    public async Task CheckInMentionsLimitFanout()
+    {
+        using var fixture = TestChallengeFixture.Create();
+        var senderAccess = await fixture.ConfirmParticipantAsync("sender@example.com", "Sender Sam");
         var names = Enumerable.Range(1, 6).Select(index => $"Person {index}").ToArray();
         foreach (var name in names)
             fixture.InsertConfirmedParticipant($"{name.Replace(' ', '-').ToLowerInvariant()}@example.com", name);

--- a/LongevityWorldCup.Website/Business/LongevitymaxxingChallengeService.cs
+++ b/LongevityWorldCup.Website/Business/LongevitymaxxingChallengeService.cs
@@ -893,7 +893,7 @@ public sealed class LongevitymaxxingChallengeService
         if (checkIn.Note is null || checkIn.NewMentionRecipients.Count == 0)
             return;
 
-        foreach (var recipient in checkIn.NewMentionRecipients.Where(candidate => candidate.StoppedEmailsAtUtc is null))
+        foreach (var recipient in checkIn.NewMentionRecipients)
         {
             try
             {

--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -34,4 +34,4 @@ Use lowercase pheno age, bortz age, crowd age, age reduction, and effective age 
 - Public community-call social announcements are social-only Custom Events queued about one hour before each selected call; they may include the public video call URL, but never participant access or stop links.
 - Community-call reminder emails have their own opt-out; stopping them does not stop daily Challenge emails.
 - Check-in notes may mention confirmed participants with their unique public display name in the form `@Display Name`. A participant receives the full note by email only when they are newly added to a saved note; self-mentions and repeated saves do not notify. Displayed mentions are visually distinct, and only mentions with an attached Longevity athlete profile link to a profile.
-- A check-in may mention at most five other participants. Challenge email opt-outs also stop mention notifications.
+- A check-in may mention at most five other participants. Daily Challenge email opt-outs do not stop mention notifications; new mentions are still emailed to confirmed participants.


### PR DESCRIPTION
## What changed

- send newly added Challenge mention notifications even when the recipient stopped general Challenge emails
- replace the old opt-out suppression test with end-to-end regression coverage using the real unsubscribe path
- keep the five-recipient fanout test separate
- update the canonical Challenge language

## Why

The mention sender filtered recipients by `StoppedEmailsAtUtc`, so a participant who stopped daily Challenge emails silently missed direct mentions. Mention notifications are transactional person-to-person alerts and should remain independent from the general Challenge email opt-out.

## Impact

Confirmed participants will receive email for newly added `@Display Name` mentions even when daily Challenge emails are stopped. Duplicate mentions, self-mentions, and fanout limits are unchanged.

## Validation

- 5 focused mention tests passed
- all 77 `LongevitymaxxingChallengeServiceTests` passed
- build completed with 0 warnings and 0 errors
- broader repository sweeps exceeded the bounded local runtime without reporting a failure

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow behavioral change to transactional mention mail only; daily Challenge email opt-out behavior is unchanged elsewhere.
> 
> **Overview**
> **Mention notifications are no longer suppressed when a recipient has opted out of daily Challenge emails.** `SendMentionNotificationsAsync` now emails every newly mentioned confirmed participant instead of skipping those with `StoppedEmailsAtUtc` set; daily reminders and other Challenge bulk mail still honor that opt-out.
> 
> Tests were split and tightened: one case unsubscribes via `StopChallengeEmails` and asserts the mention still delivers with the recipient access token; the five-mention cap lives in a separate test. **UBIQUITOUS_LANGUAGE** now states that stopping daily Challenge emails does not block mention emails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 407c8f8a314017bc6be5d10543c3da3cea7bdd33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->