### PR TITLE
Retry transient Threads container creation

### DIFF
--- a/LongevityWorldCup.Tests/ThreadsApiClientTests.cs
+++ b/LongevityWorldCup.Tests/ThreadsApiClientTests.cs
@@ -97,6 +97,65 @@ public sealed class ThreadsApiClientTests
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
+    public async Task SendPostAsync_RetriesTransientContainerCreationFailure(bool imagePost)
+    {
+        var responses = new Queue<HttpResponseMessage>(new[]
+        {
+            Json(HttpStatusCode.TooManyRequests, """{"error":{"message":"Application request limit reached","type":"OAuthException","code":613}}"""),
+            Json(HttpStatusCode.OK, """{"id":"creation-1"}"""),
+            Json(HttpStatusCode.OK, """{"id":"creation-1","status":"FINISHED"}"""),
+            Json(HttpStatusCode.OK, """{"id":"threads-post-1"}""")
+        });
+        var requests = new List<RecordedRequest>();
+        var logger = new RecordingLogger<ThreadsApiClient>();
+        var client = CreateClient(responses, requests, logger);
+
+        var postId = imagePost
+            ? await client.SendImagePostAsync("hello Threads", "https://longevityworldcup.com/post.png")
+            : await client.SendPostAsync("hello Threads");
+
+        Assert.Equal("threads-post-1", postId);
+        Assert.Equal(
+            [
+                "/me/threads",
+                "/me/threads",
+                "/creation-1",
+                "/me/threads_publish"
+            ],
+            requests.Select(request => request.RequestUri!.AbsolutePath));
+        Assert.Contains(
+            logger.Entries,
+            entry => entry.Level == LogLevel.Warning &&
+                     entry.Message.Contains("container creation transiently failed", StringComparison.Ordinal));
+        Assert.DoesNotContain(logger.Entries, entry => entry.Level >= LogLevel.Error);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task SendPostAsync_DoesNotRetryPermanentContainerCreationFailure(bool imagePost)
+    {
+        var responses = new Queue<HttpResponseMessage>(new[]
+        {
+            Json(HttpStatusCode.BadRequest, """{"error":{"message":"Invalid parameter","type":"OAuthException","code":100}}""")
+        });
+        var requests = new List<RecordedRequest>();
+        var logger = new RecordingLogger<ThreadsApiClient>();
+        var client = CreateClient(responses, requests, logger);
+
+        var postId = imagePost
+            ? await client.SendImagePostAsync("hello Threads", "https://longevityworldcup.com/post.png")
+            : await client.SendPostAsync("hello Threads");
+
+        Assert.Null(postId);
+        Assert.Single(requests);
+        Assert.Equal("/me/threads", requests[0].RequestUri!.AbsolutePath);
+        Assert.Contains(logger.Entries, entry => entry.Level == LogLevel.Error);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
     public async Task SendPostAsync_RecreatesContainer_WhenMetaLosesFinishedContainer(bool imagePost)
     {
         var responses = new Queue<HttpResponseMessage>(new[]
@@ -211,12 +270,15 @@ public sealed class ThreadsApiClientTests
         Assert.Equal("/me/threads_publish", requests[2].RequestUri!.AbsolutePath);
     }
 
-    [Fact]
-    public void IsTransientThreadsError_ReturnsTrue_ForGraphTransientBody()
+    [Theory]
+    [InlineData(HttpStatusCode.BadRequest, """{"error":{"message":"retry later","type":"OAuthException","is_transient":true,"code":2}}""")]
+    [InlineData(HttpStatusCode.TooManyRequests, "{}")]
+    [InlineData(HttpStatusCode.InternalServerError, "{}")]
+    public void IsTransientThreadsError_ReturnsTrue_ForRetryableResponse(HttpStatusCode statusCode, string responseBody)
     {
         var isTransient = ThreadsApiClient.IsTransientThreadsError(
-            HttpStatusCode.BadRequest,
-            """{"error":{"message":"retry later","type":"OAuthException","is_transient":true,"code":2}}""");
+            statusCode,
+            responseBody);
 
         Assert.True(isTransient);
     }

--- a/LongevityWorldCup.Website/Business/ThreadsApiClient.cs
+++ b/LongevityWorldCup.Website/Business/ThreadsApiClient.cs
@@ -11,6 +11,7 @@ public class ThreadsApiClient
     private const string ContainerFields = "id,status,error_message";
     private const int MaxTextLength = 500;
     private const int MaxContainerAttempts = 2;
+    private const int ContainerCreationRetryDelayMs = 1000;
     private static readonly TimeSpan ProactiveRefreshWindow = TimeSpan.FromDays(14);
     private static readonly TimeSpan UnknownExpiryRefreshRetryInterval = TimeSpan.FromHours(20);
     private static readonly int[] ContainerReadyPollDelaysMs = [1000, 2000, 3000, 5000, 5000, 10000, 10000, 15000];
@@ -137,7 +138,7 @@ public class ThreadsApiClient
             var creation = await createContainer(token);
             if (!creation.Success || string.IsNullOrWhiteSpace(creation.Id))
             {
-                if (creation.ShouldRefreshToken && attempt < MaxContainerAttempts)
+                if (creation.FailureKind == ThreadsFailureKind.RefreshToken && attempt < MaxContainerAttempts)
                 {
                     var refreshed = await TryRefreshAccessTokenAsync();
                     if (refreshed)
@@ -149,6 +150,18 @@ public class ThreadsApiClient
                             continue;
                         }
                     }
+                }
+
+                if (creation.FailureKind == ThreadsFailureKind.Transient && attempt < MaxContainerAttempts)
+                {
+                    _log.LogWarning(
+                        "Threads {PostKind} container creation transiently failed: {StatusCode} {Body}. Retrying in {DelayMs}ms.",
+                        postKind,
+                        creation.StatusCode,
+                        creation.ErrorBody,
+                        ContainerCreationRetryDelayMs);
+                    await Task.Delay(ContainerCreationRetryDelayMs);
+                    continue;
                 }
 
                 if (creation.StatusCode.HasValue)
@@ -167,7 +180,7 @@ public class ThreadsApiClient
             if (publish.Success && !string.IsNullOrWhiteSpace(publish.Id))
                 return publish.Id;
 
-            if (publish.FailureKind == PublishFailureKind.RefreshToken && attempt < MaxContainerAttempts)
+            if (publish.FailureKind == ThreadsFailureKind.RefreshToken && attempt < MaxContainerAttempts)
             {
                 var refreshed = await TryRefreshAccessTokenAsync();
                 if (refreshed)
@@ -181,7 +194,7 @@ public class ThreadsApiClient
                 }
             }
 
-            if (publish.FailureKind == PublishFailureKind.ContainerMissing && attempt < MaxContainerAttempts)
+            if (publish.FailureKind == ThreadsFailureKind.ContainerMissing && attempt < MaxContainerAttempts)
             {
                 _log.LogWarning(
                     "Threads {PostKind} container {CreationId} disappeared during publishing: {StatusCode} {Body}. Creating a replacement container.",
@@ -226,7 +239,7 @@ public class ThreadsApiClient
             return new(
                 false,
                 null,
-                ShouldRefreshToken(res.StatusCode, json),
+                ClassifyThreadsFailure(res.StatusCode, json),
                 res.StatusCode,
                 json);
         }
@@ -235,16 +248,16 @@ public class ThreadsApiClient
         {
             using var doc = JsonDocument.Parse(json);
             if (doc.RootElement.TryGetProperty("id", out var idEl))
-                return new(true, idEl.GetString(), false, null, null);
+                return new(true, idEl.GetString(), ThreadsFailureKind.None, null, null);
         }
         catch (Exception ex)
         {
             _log.LogError(ex, "Threads create container response parse failed: {Json}", json);
-            return new(false, null, false, null, json);
+            return new(false, null, ThreadsFailureKind.Permanent, null, json);
         }
 
         _log.LogWarning("Threads create container returned no id.");
-        return new(false, null, false, null, json);
+        return new(false, null, ThreadsFailureKind.Permanent, null, json);
     }
 
     private async Task<ContainerCreationResult> CreateImageContainerAsync(string text, string imageUrl, string token)
@@ -266,7 +279,7 @@ public class ThreadsApiClient
             return new(
                 false,
                 null,
-                ShouldRefreshToken(res.StatusCode, json),
+                ClassifyThreadsFailure(res.StatusCode, json),
                 res.StatusCode,
                 json);
         }
@@ -275,16 +288,16 @@ public class ThreadsApiClient
         {
             using var doc = JsonDocument.Parse(json);
             if (doc.RootElement.TryGetProperty("id", out var idEl))
-                return new(true, idEl.GetString(), false, null, null);
+                return new(true, idEl.GetString(), ThreadsFailureKind.None, null, null);
         }
         catch (Exception ex)
         {
             _log.LogError(ex, "Threads create image container response parse failed: {Json}", json);
-            return new(false, null, false, null, json);
+            return new(false, null, ThreadsFailureKind.Permanent, null, json);
         }
 
         _log.LogWarning("Threads create image container returned no id.");
-        return new(false, null, false, null, json);
+        return new(false, null, ThreadsFailureKind.Permanent, null, json);
     }
 
     private async Task<ContainerPublishResult> PublishCreatedContainerAsync(string creationId, string token)
@@ -293,12 +306,12 @@ public class ThreadsApiClient
         if (!ready.IsReady)
         {
             if (ready.ShouldRefreshToken)
-                return new(false, null, PublishFailureKind.RefreshToken, null, null);
+                return new(false, null, ThreadsFailureKind.RefreshToken, null, null);
 
             if (ready.IsMissingContainer)
-                return new(false, null, PublishFailureKind.ContainerMissing, null, null);
+                return new(false, null, ThreadsFailureKind.ContainerMissing, null, null);
 
-            return new(false, null, PublishFailureKind.Permanent, null, null);
+            return new(false, null, ThreadsFailureKind.Permanent, null, null);
         }
 
         for (var attempt = 0; attempt <= PublishRetryDelaysMs.Length; attempt++)
@@ -307,10 +320,10 @@ public class ThreadsApiClient
             if (publish.Success && !string.IsNullOrWhiteSpace(publish.Id))
                 return publish;
 
-            if (publish.FailureKind is PublishFailureKind.RefreshToken or PublishFailureKind.ContainerMissing)
+            if (publish.FailureKind is ThreadsFailureKind.RefreshToken or ThreadsFailureKind.ContainerMissing)
                 return publish;
 
-            if (publish.FailureKind == PublishFailureKind.Transient && attempt < PublishRetryDelaysMs.Length)
+            if (publish.FailureKind == ThreadsFailureKind.Transient && attempt < PublishRetryDelaysMs.Length)
             {
                 var delayMs = PublishRetryDelaysMs[attempt];
                 _log.LogWarning(
@@ -326,7 +339,7 @@ public class ThreadsApiClient
             return publish;
         }
 
-        return new(false, null, PublishFailureKind.Permanent, null, null);
+        return new(false, null, ThreadsFailureKind.Permanent, null, null);
     }
 
     private async Task<(bool IsReady, bool ShouldRefreshToken, bool IsMissingContainer)> WaitForContainerReadyAsync(string creationId, string token)
@@ -389,19 +402,10 @@ public class ThreadsApiClient
 
         if (!res.IsSuccessStatusCode)
         {
-            var failureKind =
-                ShouldRefreshToken(res.StatusCode, json)
-                    ? PublishFailureKind.RefreshToken
-                    : IsMissingThreadsContainerError(json)
-                        ? PublishFailureKind.ContainerMissing
-                        : IsTransientThreadsError(res.StatusCode, json)
-                            ? PublishFailureKind.Transient
-                            : PublishFailureKind.Permanent;
-
             return new(
                 false,
                 null,
-                failureKind,
+                ClassifyThreadsFailure(res.StatusCode, json),
                 res.StatusCode,
                 json);
         }
@@ -410,16 +414,16 @@ public class ThreadsApiClient
         {
             using var doc = JsonDocument.Parse(json);
             if (doc.RootElement.TryGetProperty("id", out var idEl))
-                return new(true, idEl.GetString(), PublishFailureKind.None, null, null);
+                return new(true, idEl.GetString(), ThreadsFailureKind.None, null, null);
         }
         catch (Exception ex)
         {
             _log.LogError(ex, "Threads publish response parse failed: {Json}", json);
-            return new(false, null, PublishFailureKind.Permanent, null, json);
+            return new(false, null, ThreadsFailureKind.Permanent, null, json);
         }
 
         _log.LogWarning("Threads publish returned no id.");
-        return new(false, null, PublishFailureKind.Permanent, null, json);
+        return new(false, null, ThreadsFailureKind.Permanent, null, json);
     }
 
     private async Task<(bool IsFinished, bool IsError, bool ShouldRefreshToken, bool IsMissingContainer, string? Status, string? ErrorMessage)> GetContainerStatusAsync(string creationId, string token)
@@ -587,6 +591,19 @@ public class ThreadsApiClient
                responseBody.Contains("Session has expired", StringComparison.OrdinalIgnoreCase);
     }
 
+    private static ThreadsFailureKind ClassifyThreadsFailure(HttpStatusCode statusCode, string? responseBody)
+    {
+        if (ShouldRefreshToken(statusCode, responseBody))
+            return ThreadsFailureKind.RefreshToken;
+
+        if (IsMissingThreadsContainerError(responseBody))
+            return ThreadsFailureKind.ContainerMissing;
+
+        return IsTransientThreadsError(statusCode, responseBody)
+            ? ThreadsFailureKind.Transient
+            : ThreadsFailureKind.Permanent;
+    }
+
     internal static bool IsTransientThreadsError(HttpStatusCode statusCode, string? responseBody)
     {
         if (TryParseThreadsGraphError(responseBody, out var error) &&
@@ -697,14 +714,14 @@ public class ThreadsApiClient
     private readonly record struct ContainerCreationResult(
         bool Success,
         string? Id,
-        bool ShouldRefreshToken,
+        ThreadsFailureKind FailureKind,
         HttpStatusCode? StatusCode,
         string? ErrorBody);
 
     private readonly record struct ContainerPublishResult(
         bool Success,
         string? Id,
-        PublishFailureKind FailureKind,
+        ThreadsFailureKind FailureKind,
         HttpStatusCode? StatusCode,
         string? ErrorBody);
 
@@ -714,7 +731,7 @@ public class ThreadsApiClient
         bool IsTransient,
         string? UserTitle);
 
-    private enum PublishFailureKind
+    private enum ThreadsFailureKind
     {
         None,
         RefreshToken,


### PR DESCRIPTION
## What changed

- classify Threads container-creation failures with the same shared failure model used by publish responses
- retry text and image container creation once for HTTP 429, HTTP 5xx, or Graph responses marked transient
- keep token refresh, transient creation retry, missing-container replacement, and permanent failures as separate paths
- preserve immediate failure for permanent container-creation errors

## Why

Follow-up to #815. That change correctly moved normal Graph-response recovery into `ThreadsApiClient` and removed the service-level blind retry, but container creation did not yet retry transient responses. A temporary `POST /me/threads` failure could therefore postpone a selected social post until a later job run.

## Validation

- 18 focused `ThreadsApiClientTests` passed
- 104 relevant Threads and social integration tests passed
- website and test projects built with 0 warnings and 0 errors
- regression coverage includes text and image creation retries, permanent creation failures, HTTP 429, HTTP 5xx, and Graph `is_transient` classification

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bounded retry logic in the Threads posting client only; no auth, data, or API contract changes beyond more resilient social publishes.
> 
> **Overview**
> **`ThreadsApiClient`** now retries **`POST /me/threads`** once when container creation fails with a transient Graph/HTTP response (429, 5xx, or `is_transient`), after a 1s delay, for both text and image posts. Permanent creation errors still fail immediately with no extra attempt.
> 
> Failure handling is unified: creation and publish paths share **`ClassifyThreadsFailure`** and a single **`ThreadsFailureKind`** enum (replacing publish-only **`PublishFailureKind`** and the creation **`ShouldRefreshToken`** flag), so token refresh, transient retry, missing-container recreation, and permanent failure stay on separate branches inside **`CreateAndPublishAsync`**.
> 
> Tests cover transient creation retry and no-retry on permanent errors for text/image posts, and broaden **`IsTransientThreadsError`** cases (429/5xx with empty bodies).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc21f8c6f7723e4eb6329f6d7b896811201b4c11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->