### PR TITLE
Canonicalize Guess My Age state

### DIFF
--- a/LongevityWorldCup.Tests/AthleteDialogLinkBrowserTests.cs
+++ b/LongevityWorldCup.Tests/AthleteDialogLinkBrowserTests.cs
@@ -365,6 +365,7 @@ public sealed class AthleteDialogLinkBrowserTests
     public async Task CanonicalAthleteSlug_OpensDialogWhenItDiffersFromTheCurrentName()
     {
         const string canonicalSlug = "michael-lustgarten-stable";
+        const string legacyNameSlug = "michael-lustgarten";
 
         await using var app = await BrowserTestApp.StartAsync();
         using var playwright = await Playwright.CreateAsync();
@@ -373,6 +374,20 @@ public sealed class AthleteDialogLinkBrowserTests
             Headless = true
         });
         await using var context = await NewContextAsync(browser, app, width: 1100, height: 760);
+        await context.AddInitScriptAsync(
+            """
+            if (!sessionStorage.getItem('canonical-slug-guess-seeded')) {
+                localStorage.setItem('gmaAllGuesses', JSON.stringify({
+                    'michael-lustgarten': {
+                        value: 50,
+                        skipped: false,
+                        first: false,
+                        exact: true
+                    }
+                }));
+                sessionStorage.setItem('canonical-slug-guess-seeded', 'true');
+            }
+            """);
         await context.RouteAsync("**/api/data/athletes", async route =>
         {
             var response = await route.FetchAsync();
@@ -382,6 +397,14 @@ public sealed class AthleteDialogLinkBrowserTests
                 .Single(athlete =>
                     athlete["Name"]?.GetValue<string>() == "Michael Lustgarten");
             michael["AthleteSlug"] = canonicalSlug.Replace('-', '_');
+            michael["DateOfBirth"] = new JsonObject
+            {
+                ["Year"] = 1976,
+                ["Month"] = 1,
+                ["Day"] = 1
+            };
+            michael["CrowdAge"] = 50;
+            michael["CrowdCount"] = 150;
 
             await route.FulfillAsync(new RouteFulfillOptions
             {
@@ -410,12 +433,51 @@ public sealed class AthleteDialogLinkBrowserTests
         await page.Locator("#stableCanonicalAthleteLink").ClickAsync();
         await WaitForOpenAthleteDialogAsync(page, canonicalSlug);
         Assert.StartsWith("Michael Lustgarten, PhD", await page.Locator("#athleteName").InnerTextAsync());
+        var migratedGuess = await page.EvaluateAsync<GuessMigrationDiagnostics>(
+            """
+            slugs => {
+                const guesses = JSON.parse(localStorage.getItem('gmaAllGuesses') || '{}');
+                return {
+                    CanonicalExists: Object.prototype.hasOwnProperty.call(guesses, slugs.canonical),
+                    LegacyExists: Object.prototype.hasOwnProperty.call(guesses, slugs.legacy),
+                    Value: guesses[slugs.canonical]?.value,
+                    Exact: guesses[slugs.canonical]?.exact === true
+                };
+            }
+            """,
+            new { canonical = canonicalSlug, legacy = legacyNameSlug });
+        Assert.True(migratedGuess.CanonicalExists);
+        Assert.False(migratedGuess.LegacyExists);
+        Assert.Equal(50, migratedGuess.Value);
+        Assert.True(migratedGuess.Exact);
+        Assert.False(await page.Locator("#detailsModal .modal-content").EvaluateAsync<bool>(
+            "element => element.classList.contains('guess-mode')"));
+        Assert.Equal(1, await page.Locator("#modalBadgeStrip .fa-bullseye").CountAsync());
 
         await CloseAthleteDialogAsync(page, "/about");
+        await page.EvaluateAsync("localStorage.removeItem('gmaAllGuesses')");
         await page.GotoAsync(
-            $"/athlete/{canonicalSlug}",
+            "/league/crowd",
+            new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
+        await page.WaitForFunctionAsync(
+            """
+            slug => JSON.parse(localStorage.getItem('gmaAllGuesses') || '{}')[slug]?.skipped === true
+            """,
+            canonicalSlug);
+        Assert.False(await page.EvaluateAsync<bool>(
+            """
+            legacySlug => Object.prototype.hasOwnProperty.call(
+                JSON.parse(localStorage.getItem('gmaAllGuesses') || '{}'),
+                legacySlug)
+            """,
+            legacyNameSlug));
+
+        await page.GotoAsync(
+            $"/athlete/{canonicalSlug}?guessmyage=1",
             new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
         await WaitForOpenAthleteDialogAsync(page, canonicalSlug);
+        Assert.False(await page.Locator("#detailsModal .modal-content").EvaluateAsync<bool>(
+            "element => element.classList.contains('guess-mode')"));
     }
 
     [Fact]
@@ -718,6 +780,14 @@ public sealed class AthleteDialogLinkBrowserTests
         public bool Exists { get; set; }
         public bool Skipped { get; set; }
         public bool ValueIsNull { get; set; }
+    }
+
+    private sealed class GuessMigrationDiagnostics
+    {
+        public bool CanonicalExists { get; set; }
+        public bool LegacyExists { get; set; }
+        public int Value { get; set; }
+        public bool Exact { get; set; }
     }
 
     private sealed class NativeActivationDiagnostics

--- a/LongevityWorldCup.Website/Frontend/badges.ts
+++ b/LongevityWorldCup.Website/Frontend/badges.ts
@@ -161,12 +161,16 @@ function styleWithBadgeVars(style: string): string {
 }
 
 function getAthleteProfileSlug(athlete: BadgeAthlete | null | undefined): string {
+    if (window.LwcGuessState) {
+        return window.LwcGuessState.getAthleteSlug(athlete);
+    }
+
     const explicitSlug = athlete && (athlete.AthleteSlug || athlete.athleteSlug || athlete.Slug || athlete.slug);
     const raw = explicitSlug || (athlete && (athlete.name || athlete.Name || athlete.displayName || athlete.DisplayName));
     if (!raw) return '';
 
     if (typeof window.slugifyName === 'function') {
-        return window.slugifyName(String(raw), false);
+        return window.slugifyName(String(raw).replace(/_/g, '-'), false);
     }
 
     let s = String(raw).toLowerCase();
@@ -774,20 +778,11 @@ window.setBadges = function (athlete, athleteCell) {
     serverBadges.forEach(b => items.push(buildServerBadgeHtml(b, athlete)));
 
     try {
-        const rawName = athlete.name || athlete.Name || athlete.displayName || athlete.DisplayName || '';
-        if (rawName) {
-            let slug: string;
-            if (typeof window.slugifyName === 'function') {
-                slug = window.slugifyName(String(rawName), true);
-            } else {
-                let s = String(rawName).toLowerCase();
-                try { s = s.normalize('NFKD'); } catch (_) {}
-                slug = s.replace(/[^\w]+/g, '-').replace(/^-+|-+$/g, '');
-            }
-
+        const slug = getAthleteProfileSlug(athlete);
+        if (slug) {
             const parsedGuesses: unknown = JSON.parse(localStorage.getItem('gmaAllGuesses') || '{}');
             const allGuesses = isRecord(parsedGuesses) ? parsedGuesses : {};
-            const g = allGuesses[slug];
+            const g = window.LwcGuessState?.get(athlete) ?? allGuesses[slug];
             const guessed = (isRecord(g) && g.value != null) ? parseInt(String(g.value), 10) : null;
 
             const chrono = athlete.chronologicalAge ?? athlete.ChronoAge ?? null;

--- a/LongevityWorldCup.Website/Frontend/misc.ts
+++ b/LongevityWorldCup.Website/Frontend/misc.ts
@@ -130,6 +130,185 @@ window.slugifyName = function (name, encode) {
         return decodeURIComponent(normalized);
     }
 }
+
+const GUESS_MY_AGE_STORAGE_KEY = 'gmaAllGuesses';
+
+interface GuessStateIdentity {
+    readonly canonicalSlug: string;
+    readonly aliasSlugs: readonly string[];
+}
+
+interface GuessStateMigration {
+    readonly canonicalSlug: string;
+    readonly state: unknown;
+    readonly changed: boolean;
+}
+
+function firstGuessStateString(values: readonly unknown[]): string {
+    for (const value of values) {
+        if (typeof value === 'string' && value.trim()) {
+            return value;
+        }
+    }
+    return '';
+}
+
+function normalizeGuessStateSlug(value: unknown): string {
+    const routeSlug = String(value || '').replace(/_/g, '-');
+    return routeSlug ? window.slugifyName(routeSlug, true) : '';
+}
+
+function getGuessStateIdentity(athleteOrSlug: unknown): GuessStateIdentity {
+    if (!isRecord(athleteOrSlug)) {
+        return {
+            canonicalSlug: normalizeGuessStateSlug(athleteOrSlug),
+            aliasSlugs: []
+        };
+    }
+
+    const explicitSlug = firstGuessStateString([
+        athleteOrSlug.AthleteSlug,
+        athleteOrSlug.athleteSlug,
+        athleteOrSlug.Slug,
+        athleteOrSlug.slug
+    ]);
+    const name = firstGuessStateString([athleteOrSlug.Name, athleteOrSlug.name]);
+    const displayName = firstGuessStateString([
+        athleteOrSlug.DisplayName,
+        athleteOrSlug.displayName
+    ]);
+    const canonicalSlug = normalizeGuessStateSlug(explicitSlug || name || displayName);
+    const aliasSlugs = [...new Set([name, displayName]
+        .map(normalizeGuessStateSlug)
+        .filter(slug => slug && slug !== canonicalSlug))];
+
+    return { canonicalSlug, aliasSlugs };
+}
+
+function readGuessStateStore(): Record<string, unknown> {
+    try {
+        const parsed: unknown = JSON.parse(
+            localStorage.getItem(GUESS_MY_AGE_STORAGE_KEY) || '{}');
+        return isRecord(parsed) ? parsed : {};
+    } catch (_) {
+        return {};
+    }
+}
+
+function writeGuessStateStore(store: Record<string, unknown>): void {
+    localStorage.setItem(GUESS_MY_AGE_STORAGE_KEY, JSON.stringify(store));
+}
+
+function guessStatePriority(state: unknown): number {
+    if (!isRecord(state)) return 0;
+    if (state.value != null) return 3;
+    if (state.skipped === true) return 2;
+    return 1;
+}
+
+function migrateGuessState(
+    store: Record<string, unknown>,
+    athleteOrSlug: unknown
+): GuessStateMigration {
+    const identity = getGuessStateIdentity(athleteOrSlug);
+    if (!identity.canonicalSlug) {
+        return { canonicalSlug: '', state: null, changed: false };
+    }
+
+    const hasOwn = (key: string) =>
+        Object.prototype.hasOwnProperty.call(store, key);
+    let hasCanonicalState = hasOwn(identity.canonicalSlug);
+    let state = hasCanonicalState ? store[identity.canonicalSlug] : null;
+    let changed = false;
+
+    for (const aliasSlug of identity.aliasSlugs) {
+        if (!hasOwn(aliasSlug)) continue;
+
+        const aliasState = store[aliasSlug];
+        if (!hasCanonicalState ||
+            guessStatePriority(aliasState) > guessStatePriority(state)) {
+            state = aliasState;
+            store[identity.canonicalSlug] = aliasState;
+            hasCanonicalState = true;
+            changed = true;
+        }
+
+        delete store[aliasSlug];
+        changed = true;
+    }
+
+    return { canonicalSlug: identity.canonicalSlug, state, changed };
+}
+
+window.LwcGuessState = {
+    getAthleteSlug(athleteOrSlug) {
+        return getGuessStateIdentity(athleteOrSlug).canonicalSlug;
+    },
+    get(athleteOrSlug) {
+        const store = readGuessStateStore();
+        const migration = migrateGuessState(store, athleteOrSlug);
+        if (migration.changed) {
+            writeGuessStateStore(store);
+        }
+        return isRecord(migration.state)
+            ? migration.state as unknown as GuessMyAgeState
+            : null;
+    },
+    set(athleteOrSlug, state) {
+        const store = readGuessStateStore();
+        const migration = migrateGuessState(store, athleteOrSlug);
+        if (!migration.canonicalSlug) return;
+
+        store[migration.canonicalSlug] = state;
+        writeGuessStateStore(store);
+    },
+    ensureSkipped(athleteOrSlug) {
+        const store = readGuessStateStore();
+        const migration = migrateGuessState(store, athleteOrSlug);
+        if (!migration.canonicalSlug) return null;
+
+        if (isRecord(migration.state)) {
+            if (migration.changed) {
+                writeGuessStateStore(store);
+            }
+            return migration.state as unknown as GuessMyAgeState;
+        }
+
+        const skippedState: GuessMyAgeState = {
+            value: null,
+            skipped: true,
+            first: false,
+            exact: false
+        };
+        store[migration.canonicalSlug] = skippedState;
+        writeGuessStateStore(store);
+        return skippedState;
+    },
+    ensureSkippedMany(athletes) {
+        if (!Array.isArray(athletes) || athletes.length === 0) return;
+
+        const store = readGuessStateStore();
+        let changed = false;
+        for (const athlete of athletes) {
+            const migration = migrateGuessState(store, athlete);
+            changed = changed || migration.changed;
+            if (!migration.canonicalSlug || isRecord(migration.state)) continue;
+
+            store[migration.canonicalSlug] = {
+                value: null,
+                skipped: true,
+                first: false,
+                exact: false
+            };
+            changed = true;
+        }
+
+        if (changed) {
+            writeGuessStateStore(store);
+        }
+    }
+};
+
 function normalizeString(str: string): string {
     return str.normalize('NFKD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
 }

--- a/LongevityWorldCup.Website/Frontend/pro-discounts.ts
+++ b/LongevityWorldCup.Website/Frontend/pro-discounts.ts
@@ -136,6 +136,7 @@ function slugToDisplayName(slug: unknown): string {
 
 function getExactGuessAthleteNames(currentAthlete: BadgeAthlete | null | undefined): string[] {
     try {
+        window.LwcGuessState?.get(currentAthlete);
         const parsed: unknown = JSON.parse(localStorage.getItem("gmaAllGuesses") || "{}");
         const allGuesses = isRecord(parsed) ? parsed : {};
         const exactSlugs = Object.entries(allGuesses)
@@ -149,7 +150,12 @@ function getExactGuessAthleteNames(currentAthlete: BadgeAthlete | null | undefin
         const selectedSlug = String(currentAthlete?.AthleteSlug || currentAthlete?.athleteSlug || "").trim();
         const slugify = typeof window.slugifyName === "function" ? window.slugifyName : null;
         const normalizedSelectedSlug =
-            selectedSlug || (slugify && selectedName ? slugify(selectedName, true) : "");
+            window.LwcGuessState?.getAthleteSlug(currentAthlete) ||
+            (selectedSlug
+                ? selectedSlug.replace(/_/g, "-")
+                : slugify && selectedName
+                    ? slugify(selectedName, true)
+                    : "");
 
         return exactSlugs.map(slug => {
             if (

--- a/LongevityWorldCup.Website/Frontend/types/shared.d.ts
+++ b/LongevityWorldCup.Website/Frontend/types/shared.d.ts
@@ -331,6 +331,21 @@ interface HTMLElement {
     __hypotheticalRankRequestId?: number;
 }
 
+interface GuessMyAgeState {
+    value: unknown;
+    skipped: boolean;
+    first: boolean;
+    exact: boolean;
+}
+
+interface LwcGuessStateApi {
+    getAthleteSlug(athleteOrSlug: unknown): string;
+    get(athleteOrSlug: unknown): GuessMyAgeState | null;
+    set(athleteOrSlug: unknown, state: GuessMyAgeState): void;
+    ensureSkipped(athleteOrSlug: unknown): GuessMyAgeState | null;
+    ensureSkippedMany(athletes: readonly unknown[]): void;
+}
+
 interface Window {
     PhenoAge?: PhenoAgeApi;
     BortzAge?: BortzAgeApi;
@@ -341,6 +356,7 @@ interface Window {
     CustomEventMarkup?: CustomEventMarkupApi;
     __lwcPlayFlowScrollInitialized?: boolean;
     LwcFlowActionDock?: LwcFlowActionDockApi;
+    LwcGuessState?: LwcGuessStateApi;
     getIcon(link: string): string;
     slugifyName(name: string, encode?: boolean): string;
     normalizeString?: ((value: string) => string) | undefined;

--- a/LongevityWorldCup.Website/wwwroot/partials/guess-my-age.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/guess-my-age.html
@@ -1026,13 +1026,18 @@
         let allGuesses = JSON.parse(localStorage.getItem('gmaAllGuesses') || '{}');
         const isSkip = e.currentTarget.classList.contains('gma-btn--ghost');
 
-        allGuesses[athleteSlug] = {
+        const guessState = {
             value: isSkip ? null : guessValue,
             skipped: isSkip,
             first: !isSkip && Boolean(e.isFirstGuess),
             exact: !isSkip && Boolean(e.isExactGuess)
         };
-        localStorage.setItem('gmaAllGuesses', JSON.stringify(allGuesses));
+        if (window.LwcGuessState) {
+            window.LwcGuessState.set(athleteSlug, guessState);
+        } else {
+            allGuesses[athleteSlug] = guessState;
+            localStorage.setItem('gmaAllGuesses', JSON.stringify(allGuesses));
+        }
         updateYourGuess();  // ← Add this line
 
         gmaCard.classList.add('gma-done');

--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -3916,10 +3916,18 @@
             return;
         }
 
+        if (window.LwcGuessState) {
+            window.LwcGuessState.ensureSkipped(athleteSlug);
+            return;
+        }
+
+        const routeSlug = String(athleteSlug).replace(/_/g, '-');
         const normalizedAthleteSlug = typeof window.slugifyName === 'function'
-            ? window.slugifyName(athleteSlug, true)
-            : athleteSlug;
+            ? window.slugifyName(routeSlug, true)
+            : routeSlug;
         const allGuesses = JSON.parse(localStorage.getItem('gmaAllGuesses') || '{}');
+        if (allGuesses[normalizedAthleteSlug]) return;
+
         allGuesses[normalizedAthleteSlug] = { value: null, skipped: true, first: false, exact: false };
         localStorage.setItem('gmaAllGuesses', JSON.stringify(allGuesses));
     }
@@ -3929,15 +3937,22 @@
             return;
         }
 
+        if (window.LwcGuessState) {
+            window.LwcGuessState.ensureSkippedMany(athletes);
+            return;
+        }
+
         const allGuesses = JSON.parse(localStorage.getItem('gmaAllGuesses') || '{}');
         let changed = false;
         athletes.forEach(athlete => {
-            const athleteSlug = athlete && athlete.name;
+            const athleteSlug = athlete &&
+                (athlete.athleteSlug || athlete.AthleteSlug || athlete.name || athlete.Name);
             if (!athleteSlug) return;
 
+            const routeSlug = String(athleteSlug).replace(/_/g, '-');
             const normalizedAthleteSlug = typeof window.slugifyName === 'function'
-                ? window.slugifyName(athleteSlug, true)
-                : athleteSlug;
+                ? window.slugifyName(routeSlug, true)
+                : routeSlug;
             if (allGuesses[normalizedAthleteSlug]) return;
 
             allGuesses[normalizedAthleteSlug] = { value: null, skipped: true, first: false, exact: false };
@@ -8020,6 +8035,12 @@
                     throw new Error(`Full athlete data not found for ${athleteSlug}`);
                 }
 
+                window.LwcGuessState?.get({
+                    ...athleteData,
+                    AthleteSlug: fullAthleteData.AthleteSlug,
+                    Name: fullAthleteData.Name,
+                    DisplayName: fullAthleteData.DisplayName
+                });
                 const rankSummary = computeBestLeagueRank(athleteData);
 
                 // Populate the modal with athlete data
@@ -8120,6 +8141,8 @@
                 gmaCard.classList.remove('gma-done');
                 // read your guesses from localStorage
                 const allGuesses = JSON.parse(localStorage.getItem('gmaAllGuesses') || '{}');
+                const athleteGuessState = window.LwcGuessState?.get(athleteData)
+                    || allGuesses[athleteSlug];
                 // check if the user has hit “Skip All”
                 const skipAll = localStorage.getItem('gmaSkipAll') === 'true';
 
@@ -8133,7 +8156,7 @@
                     // user opted out globally
                     modalContent.classList.remove('guess-mode');
                     gmaCard.classList.add('gma-done');
-                } else if (allGuesses.hasOwnProperty(athleteSlug)) {
+                } else if (athleteGuessState) {
                     // already guessed or skipped this athlete
                     modalContent.classList.remove('guess-mode');
                     gmaCard.classList.add('gma-done');
@@ -9424,7 +9447,7 @@
         const yourGuessSpan = document.getElementById('yourGuess');
         const allGuesses = JSON.parse(localStorage.getItem('gmaAllGuesses') || '{}');
         const athleteSlug = document.querySelector('.modal-content').dataset.athleteSlug;
-        const guessData = allGuesses[athleteSlug];
+        const guessData = window.LwcGuessState?.get(athleteSlug) || allGuesses[athleteSlug];
 
         if (guessData && guessData.value != null) {
             // show the row (use '' so table layout is preserved; mobile CSS overrides tr to block)


### PR DESCRIPTION
## Summary

- centralize Guess My Age local-storage identity around the stable `AthleteSlug`
- migrate current name/display-name keys into the canonical key without overwriting a completed guess with a skip
- align modal prompts, bulk skips, exact-guess badges, and Pro-discount consumers
- normalize underscore-backed data slugs to route-style hyphens

## Root cause

#813 switched the primary modal key to `AthleteSlug`, but several producers and consumers still derived keys from the mutable athlete name. A renamed athlete could therefore be prompted again and lose exact-guess UI state.

Related to #813.

## Validation

- `npm run build`
- 16/16 Athlete Dialog + Guess My Age browser tests
- 56/56 badge, aesthetic, and Pro-discount tests

The browser regression covers legacy exact-guess migration, bullseye rendering, canonical crowd-view skip creation, and suppression of repeat prompts on a canonical direct route.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches client-side persistence and modal UX across leaderboard and athlete dialog; migration logic could mis-merge state if identity resolution is wrong, but scope is localStorage-only with fallbacks and new browser coverage.
> 
> **Overview**
> Introduces **`window.LwcGuessState`** in `misc.ts` as the single place to read/write `gmaAllGuesses`, keyed by the stable **`AthleteSlug`** (with `_` → `-` normalization). On access it **migrates** legacy keys derived from name/display name into the canonical slug and drops aliases, preferring a real guess over a skip when both exist.
> 
> **Modal, leaderboard, badges, and Pro discounts** now route through this API instead of ad hoc slugify/name keys: guess/skip persistence in `guess-my-age.html`, bulk skip on crowd views, modal “already guessed” checks, bullseye badges, and perfect-guess discount naming.
> 
> Browser test **`CanonicalAthleteSlug_OpensDialogWhenItDiffersFromTheCurrentName`** is extended to assert legacy exact-guess migration, bullseye UI, canonical skip creation on crowd league, and no repeat guess prompt when `?guessmyage=1` is used after state exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3530a0a7d64d9d6f4b55da14021b4a173c4044d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->