### PR TITLE
Stabilize bioage prefill browser test

### DIFF
--- a/LongevityWorldCup.Tests/NewAthleteOnboardingBrowserTests.cs
+++ b/LongevityWorldCup.Tests/NewAthleteOnboardingBrowserTests.cs
@@ -357,7 +357,7 @@ public sealed class NewAthleteOnboardingBrowserTests
                     Body = approvedRankFieldJson
                 }));
                 await page.GotoAsync(route, new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
-                Assert.Equal("2026-06-01", await page.Locator("#blood-draw-date").InputValueAsync());
+                await Assertions.Expect(page.Locator("#blood-draw-date")).ToHaveValueAsync("2026-06-01");
                 await page.Locator("#lwcToStep2Btn").ClickAsync();
                 await page.WaitForFunctionAsync(
                     "() => document.querySelector('#lwc-step-2')?.classList.contains('lwc-step--visible')");


### PR DESCRIPTION
## What changed

- replace the one-shot xUnit date-field read in the shared Pheno/Bortz result test with Playwright's retrying web assertion

## Why

The `.NET` run for `f179374` failed once because the Bortz case sampled `#blood-draw-date` as calculator startup was still applying the URL prefill. The test immediately compared that transient empty value with xUnit, which does not retry. The application later initialized normally, and the same full workflow passed on the next master run.

This change waits for the user-visible prefilled state that the test actually depends on, while still failing if either calculator never applies the date.

## Validation

- focused Pheno/Bortz result theory passed once after the change
- focused theory passed five additional repetitions (12 parameterized executions total)
- all 10 `NewAthleteOnboardingBrowserTests` passed
- build completed with 0 warnings and 0 errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no production code paths affected.
> 
> **Overview**
> Fixes a flaky failure in **`BioageResults_PreserveApprovedValuesPersonalityAndRankCopy`** (Pheno and Bortz) by asserting on the prefilled blood-draw date with Playwright’s **retrying** expectation instead of a one-shot xUnit compare on `#blood-draw-date`.
> 
> After navigation with query params, the calculator can still be applying URL prefill when the test first reads the field, so an immediate `Assert.Equal` on `InputValueAsync()` could see an empty value even though `2026-06-01` appears moments later. **`Assertions.Expect(...).ToHaveValueAsync("2026-06-01")`** waits for that user-visible state before continuing to step 2.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee4e92db7e2d5cd1b4f0e02c4db5a1d98f11f4ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->