### PR TITLE
Fix proof upload timeouts

### DIFF
--- a/LongevityWorldCup.Documentation/ServerDeployment.md
+++ b/LongevityWorldCup.Documentation/ServerDeployment.md
@@ -223,6 +223,39 @@ The production host must have an SDK compatible with the repository's `global.js
 
 Before changing the live publish tree, deployment stops the service and creates a same-filesystem hard-link snapshot. A failed sync, health check, or byte-for-byte script probe restores that prior release before restarting the service. Every master push schedules the workflow; stale runs skip only when a newer run exists, so an otherwise ignored documentation or test commit cannot strand an earlier website change undeployed.
 
+### Application submission proxy timeout
+
+`POST /api/application/application` has a dedicated five-minute ASP.NET Core timeout because an accepted submission may contain up to 37 proof images that must be validated and packaged. The browser waits 310 seconds. Nginx must allow slightly more response-header time than both layers without extending every other public route.
+
+In `/etc/nginx/sites-available/default`, add this exact-match location to the HTTPS `longevityworldcup.com` server. Sibling locations do not inherit proxy directives, so the block must remain complete:
+
+```nginx
+location = /api/application/application {
+    proxy_pass http://127.0.0.1:5000;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection keep-alive;
+    proxy_set_header Host $host;
+    proxy_cache_bypass $http_upgrade;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_read_timeout 330s;
+
+    add_header Onion-Location http://lwc7tszawiykmkjoq4u2yxramezkwbdys2wxr2fmf6sdr6ug5t36ckqd.onion$request_uri always;
+}
+```
+
+Add the same exact-match location to both onion server blocks in `/etc/nginx/sites-available/tor`, but omit the `Onion-Location` response header. Do not raise `proxy_read_timeout` globally.
+
+Before editing, confirm that the enabled symlinks resolve to those two files and create timestamped backups in `sites-available` (never `sites-enabled`, whose wildcard include would load them). After editing:
+
+1. Run `sudo nginx -t`. If it fails, restore both backups and test again; do not reload invalid configuration.
+2. Run `sudo systemctl reload nginx`, then `sudo systemctl is-active --quiet nginx`. If either fails, restore both backups, retest, and reload.
+3. Inspect `sudo nginx -T`. There must be exactly three `location = /api/application/application` blocks and three `proxy_read_timeout 330s;` directives. The public exact block must include `Onion-Location`; the two onion exact blocks must not.
+4. Verify `/health`, then send an empty JSON `POST /api/application/application` through the public host and both onion listeners (use `127.0.0.1` plus the onion `Host` header for local probes, because curl intentionally refuses `.onion` DNS resolution). Each submission probe must return `400`, proving that the exact location reaches ASP.NET Core validation rather than static handling.
+
+Keep the backups until the application submission path has been verified after deployment.
+
 ### Reverse proxy CORS ownership
 
 ASP.NET Core owns the route-specific CORS policies. The nginx reverse-proxy location must pass those response headers through unchanged: do not add `Access-Control-Allow-*` or `Access-Control-Expose-Headers` directives at the proxy layer, and do not intercept `OPTIONS` requests. Adding CORS headers in both layers produces duplicate values that browsers reject; applying wildcard headers in nginx also bypasses the application's restricted policy for non-public routes.

--- a/LongevityWorldCup.Tests/ApplicationControllerValidationTests.cs
+++ b/LongevityWorldCup.Tests/ApplicationControllerValidationTests.cs
@@ -400,11 +400,33 @@ public sealed class ApplicationControllerValidationTests
         {
             Name = "Applicant Ada",
             Biomarkers = [new BiomarkerData { Date = "2026-02-02", AlbGL = 45 }],
-            ProofPics = Enumerable.Repeat("data:image/png;base64,AA==", 38).ToList()
+            ProofPics = Enumerable.Range(0, 38)
+                .Select(index => $"data:image/png;base64,proof-{index}")
+                .ToList()
         }, CancellationToken.None);
 
         var badRequest = Assert.IsType<BadRequestObjectResult>(result);
         Assert.Equal("You can upload a maximum of 37 proof images.", badRequest.Value);
+    }
+
+    [Fact]
+    public async Task DuplicateProofsAreCollapsedBeforeCountValidation()
+    {
+        using var factory = new TestWebApplicationFactory();
+        var controller = CreateController(factory);
+        var applicant = new ApplicantData
+        {
+            Name = "Applicant Ada",
+            ProofPics = Enumerable.Repeat("data:image/png;base64,AA==", 38)
+                .Append(" ")
+                .ToList()
+        };
+
+        var result = await controller.Application(applicant, CancellationToken.None);
+
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Equal("Biomarker data is required.", badRequest.Value);
+        Assert.Equal("data:image/png;base64,AA==", Assert.Single(applicant.ProofPics!));
     }
 
     [Fact]
@@ -892,6 +914,50 @@ public sealed class ApplicationControllerValidationTests
         Assert.Contains("PaymentRequired: false", freeSubmissionBody);
         Assert.Contains("submissionLease.Complete(freeSubmissionResponse);", freeSubmissionBody);
         Assert.Contains("AuditEmailDelivered={AuditEmailDelivered} ArchivePath={ArchivePath}", freeSubmissionBody);
+    }
+
+    [Fact]
+    public void ApplicationSubmit_TimeoutPreservesACompletedPackageWithAFreshToken()
+    {
+        var source = ReadApplicationControllerSource();
+        var catchStart = source.IndexOf(
+            "catch (OperationCanceledException ex) when (processingTimeout.IsCancellationRequested)",
+            StringComparison.Ordinal);
+        var catchEnd = source.IndexOf(
+            "private Task TrackApplicationSubmitEventAsync",
+            catchStart,
+            StringComparison.Ordinal);
+
+        Assert.True(catchStart >= 0);
+        Assert.True(catchEnd > catchStart);
+
+        var timeoutBody = source[catchStart..catchEnd];
+        Assert.Contains("System.IO.File.Exists(recoverableZipPath)", timeoutBody);
+        Assert.Contains("new CancellationTokenSource(TimeSpan.FromSeconds(30))", timeoutBody);
+        Assert.Contains("PersistApplicationSubmissionArchiveAsync(", timeoutBody);
+        Assert.Contains("archiveTimeout.Token", timeoutBody);
+        Assert.Contains("\"application_processing_timeout\"", timeoutBody);
+        Assert.Contains("StatusCodes.Status504GatewayTimeout", timeoutBody);
+    }
+
+    [Fact]
+    public void ApplicationSubmit_CommitsRetryResponseBeforeOptionalPostAcceptanceWork()
+    {
+        var source = ReadApplicationControllerSource();
+
+        var freeComplete = source.IndexOf("submissionLease.Complete(freeSubmissionResponse);", StringComparison.Ordinal);
+        var freeConfirmation = source.IndexOf("await TrySendSubmissionConfirmationEmailAsync(", freeComplete, StringComparison.Ordinal);
+        var paymentUnavailableComplete = source.IndexOf("submissionLease.Complete(paymentUnavailableResponse);", StringComparison.Ordinal);
+        var paymentUnavailableReport = source.IndexOf("await TryRecordDiscountSignupAsync(", paymentUnavailableComplete, StringComparison.Ordinal);
+        var paidComplete = source.IndexOf("submissionLease.Complete(paidSubmissionResponse);", StringComparison.Ordinal);
+        var paidReport = source.IndexOf("await TryRecordDiscountSignupAsync(", paidComplete, StringComparison.Ordinal);
+
+        Assert.True(freeComplete >= 0);
+        Assert.True(freeConfirmation > freeComplete);
+        Assert.True(paymentUnavailableComplete >= 0);
+        Assert.True(paymentUnavailableReport > paymentUnavailableComplete);
+        Assert.True(paidComplete >= 0);
+        Assert.True(paidReport > paidComplete);
     }
 
     [Fact]

--- a/LongevityWorldCup.Tests/ApplicationImageOptimizationTests.cs
+++ b/LongevityWorldCup.Tests/ApplicationImageOptimizationTests.cs
@@ -6,6 +6,9 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Caching.Memory;
 using System.Net;
 using System.Reflection;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Metadata.Profiles.Exif;
+using SixLabors.ImageSharp.PixelFormats;
 using Xunit;
 
 namespace LongevityWorldCup.Tests;
@@ -13,7 +16,78 @@ namespace LongevityWorldCup.Tests;
 public class ApplicationImageOptimizationTests
 {
     [Fact]
-    public void CorruptButSubmittedPngFallsBackToOriginalBytes()
+    public void BoundedProofPngPassesThroughWithoutReencoding()
+    {
+        using var image = new Image<Rgba32>(32, 24, new Rgba32(255, 255, 255));
+        using var stream = new MemoryStream();
+        image.SaveAsPng(stream);
+        var bytes = stream.ToArray();
+        var controller = CreateController();
+        var method = typeof(ApplicationController).GetMethod("OptimizeProofImage", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.NotNull(method);
+
+        var result = method!.Invoke(controller, [(bytes, "image/png", "png"), "test-submission", 1]);
+
+        Assert.NotNull(result);
+        Assert.True((bool)result!.GetType().GetProperty("Success")!.GetValue(result)!);
+        Assert.Equal("png", result.GetType().GetProperty("Extension")!.GetValue(result));
+        Assert.Equal(bytes, (byte[])result.GetType().GetProperty("Bytes")!.GetValue(result)!);
+    }
+
+    [Fact]
+    public void ProofWithExifMetadataIsReencodedWithoutMetadata()
+    {
+        using var image = new Image<Rgba32>(32, 24, new Rgba32(255, 255, 255));
+        image.Metadata.ExifProfile = new ExifProfile();
+        image.Metadata.ExifProfile.SetValue(ExifTag.ImageDescription, "private proof metadata");
+        using var stream = new MemoryStream();
+        image.SaveAsJpeg(stream);
+        var bytes = stream.ToArray();
+        var controller = CreateController();
+        var method = typeof(ApplicationController).GetMethod("OptimizeProofImage", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.NotNull(method);
+
+        var result = method!.Invoke(controller, [(bytes, "image/jpeg", "jpg"), "test-submission", 1]);
+
+        Assert.NotNull(result);
+        Assert.True((bool)result!.GetType().GetProperty("Success")!.GetValue(result)!);
+        Assert.Equal("webp", result.GetType().GetProperty("Extension")!.GetValue(result));
+        var optimizedBytes = (byte[])result.GetType().GetProperty("Bytes")!.GetValue(result)!;
+        Assert.False(bytes.SequenceEqual(optimizedBytes));
+        using var optimizedImage = Image.Load(optimizedBytes);
+        Assert.Null(optimizedImage.Metadata.ExifProfile);
+    }
+
+    [Fact]
+    public void ExifOrientedProofIsAutoOrientedBeforeMetadataIsRemoved()
+    {
+        using var image = new Image<Rgba32>(40, 20, new Rgba32(255, 255, 255));
+        image.Metadata.ExifProfile = new ExifProfile();
+        image.Metadata.ExifProfile.SetValue(ExifTag.Orientation, (ushort)6);
+        using var stream = new MemoryStream();
+        image.SaveAsJpeg(stream);
+        var controller = CreateController();
+        var method = typeof(ApplicationController).GetMethod("OptimizeProofImage", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.NotNull(method);
+
+        var result = method!.Invoke(
+            controller,
+            [(stream.ToArray(), "image/jpeg", "jpg"), "test-submission", 1]);
+
+        Assert.NotNull(result);
+        Assert.True((bool)result!.GetType().GetProperty("Success")!.GetValue(result)!);
+        var optimizedBytes = (byte[])result.GetType().GetProperty("Bytes")!.GetValue(result)!;
+        using var optimizedImage = Image.Load(optimizedBytes);
+        Assert.Equal(20, optimizedImage.Width);
+        Assert.Equal(40, optimizedImage.Height);
+        Assert.Null(optimizedImage.Metadata.ExifProfile);
+    }
+
+    [Fact]
+    public void CorruptSubmittedProfileImageIsRejected()
     {
         const string corruptTinyPng = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9pQ9JxwAAAAASUVORK5CYII=";
         var bytes = Convert.FromBase64String(corruptTinyPng);
@@ -25,9 +99,7 @@ public class ApplicationImageOptimizationTests
         var result = method!.Invoke(controller, [(bytes, "image/png", "png"), "test-submission"]);
 
         Assert.NotNull(result);
-        Assert.True((bool)result!.GetType().GetProperty("Success")!.GetValue(result)!);
-        Assert.Equal("png", result.GetType().GetProperty("Extension")!.GetValue(result));
-        Assert.Equal(bytes, (byte[])result.GetType().GetProperty("Bytes")!.GetValue(result)!);
+        Assert.False((bool)result!.GetType().GetProperty("Success")!.GetValue(result)!);
     }
 
     [Fact]

--- a/LongevityWorldCup.Tests/ApplicationOnboardingPageTests.cs
+++ b/LongevityWorldCup.Tests/ApplicationOnboardingPageTests.cs
@@ -92,7 +92,7 @@ public sealed class ApplicationOnboardingPageTests
     }
 
     [Fact]
-    public async Task ApplicationSubmissionTimeout_WaitsForServerPublicWorkTimeout()
+    public async Task ApplicationSubmissionTimeout_WaitsForDedicatedServerTimeout()
     {
         using var factory = new TestWebApplicationFactory();
         using var client = factory.CreateClient();
@@ -102,11 +102,11 @@ public sealed class ApplicationOnboardingPageTests
 
         Assert.True(match.Success);
         var timeoutMs = int.Parse(match.Groups[1].Value);
-        Assert.True(timeoutMs > PublicRequestTimeoutPolicies.PublicWorkTimeout.TotalMilliseconds);
+        Assert.True(timeoutMs > PublicRequestTimeoutPolicies.ApplicationSubmissionTimeout.TotalMilliseconds);
     }
 
     [Fact]
-    public async Task ApplicationSubmissionId_IsReusedForAnImmediateRetry()
+    public async Task ApplicationSubmissionId_IsReusedOnlyForTheSamePayload()
     {
         using var factory = new TestWebApplicationFactory();
         using var client = factory.CreateClient();
@@ -114,8 +114,13 @@ public sealed class ApplicationOnboardingPageTests
         var javascript = await client.GetStringAsync("/js/misc.js");
 
         Assert.Contains("window.__pendingApplicationSubmissionId", javascript);
+        Assert.Contains("window.createApplicationSubmissionPayloadKey = function (applicantData)", javascript);
+        Assert.Contains("compactApplicationDataString(proof)", javascript);
+        Assert.Contains("window.__pendingApplicationSubmissionFingerprint === normalizedFingerprint", javascript);
         Assert.Contains("return window.__pendingApplicationSubmissionId;", javascript);
         Assert.Contains("window.__pendingApplicationSubmissionId = submissionId;", javascript);
+        Assert.Contains("delete window.__pendingApplicationSubmissionFingerprint;", javascript);
+        Assert.Contains("window.__pendingApplicationSubmissionFingerprint = normalizedFingerprint;", javascript);
     }
 
     [Fact]
@@ -135,6 +140,9 @@ public sealed class ApplicationOnboardingPageTests
         Assert.Contains("window.setTimeout(() => controller.abort(), timeoutMs)", javascript);
         Assert.Contains("...(controller ? { signal: controller.signal } : {})", javascript);
         Assert.Contains("window.trySendApplicationSubmissionReport = function (applicantData, submissionId, phase, submissionKind, error)", javascript);
+        Assert.Contains("let omittedDataLength = 0;", javascript);
+        Assert.Contains("jsonBodyLength = skeleton.length + omittedDataLength;", javascript);
+        Assert.DoesNotContain("jsonBodyLength = JSON.stringify(data).length;", javascript);
         Assert.Contains("typeof window.buildApplicationSubmissionReport !== 'function'", javascript);
         Assert.Contains("const report = window.buildApplicationSubmissionReport(applicantData, submissionId, phase, submissionKind, error);", javascript);
         Assert.Contains("void window.sendApplicationSubmissionReport(report);", javascript);

--- a/LongevityWorldCup.Tests/ApplicationSubmissionWorkspaceTests.cs
+++ b/LongevityWorldCup.Tests/ApplicationSubmissionWorkspaceTests.cs
@@ -1,0 +1,31 @@
+using LongevityWorldCup.Website.Business;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class ApplicationSubmissionWorkspaceTests
+{
+    [Fact]
+    public void WorkspacesAreUniqueAndRemovedOnDispose()
+    {
+        string firstPath;
+        string secondPath;
+
+        using (var first = ApplicationSubmissionWorkspace.Create())
+        using (var second = ApplicationSubmissionWorkspace.Create())
+        {
+            firstPath = first.RootPath;
+            secondPath = second.RootPath;
+
+            Assert.NotEqual(firstPath, secondPath);
+            Assert.True(Directory.Exists(firstPath));
+            Assert.True(Directory.Exists(secondPath));
+
+            File.WriteAllText(Path.Combine(firstPath, "proof_1.png"), "first");
+            File.WriteAllText(Path.Combine(secondPath, "proof_1.png"), "second");
+        }
+
+        Assert.False(Directory.Exists(firstPath));
+        Assert.False(Directory.Exists(secondPath));
+    }
+}

--- a/LongevityWorldCup.Tests/ProofUploadBrowserTests.cs
+++ b/LongevityWorldCup.Tests/ProofUploadBrowserTests.cs
@@ -137,16 +137,24 @@ public sealed class ProofUploadBrowserTests
 
         await context.AddInitScriptAsync(
             """
+            const originalCanvasToBlob = HTMLCanvasElement.prototype.toBlob;
+            window.__proofCanvasEncodeRequests = { webp: 0, jpeg: 0 };
+            HTMLCanvasElement.prototype.toBlob = function(callback, type, quality) {
+                if (type === 'image/webp') window.__proofCanvasEncodeRequests.webp++;
+                if (type === 'image/jpeg') window.__proofCanvasEncodeRequests.jpeg++;
+                const encodedType = type === 'image/webp' ? 'image/png' : type;
+                return originalCanvasToBlob.call(this, callback, encodedType, quality);
+            };
             window.pdfjsLib = {
                 GlobalWorkerOptions: {},
                 getDocument() {
                     return {
                         promise: Promise.resolve({
-                            numPages: 1,
-                            getPage: async () => ({
+                            numPages: 3,
+                            getPage: async pageNumber => ({
                                 getViewport: () => ({ width: 12, height: 12 }),
                                 render: ({ canvasContext }) => {
-                                    canvasContext.fillStyle = '#ffffff';
+                                    canvasContext.fillStyle = ['#ffffff', '#dddddd', '#bbbbbb'][pageNumber - 1];
                                     canvasContext.fillRect(0, 0, 12, 12);
                                     return { promise: Promise.resolve() };
                                 }
@@ -192,14 +200,22 @@ public sealed class ProofUploadBrowserTests
         await page.WaitForFunctionAsync(
             "() => document.getElementById('uploadProofButton')?.getAttribute('data-listener') === 'true'");
 
-        await page.Locator("#proofPicInput").SetInputFilesAsync(new FilePayload
+        var pdfProof = new FilePayload
         {
             Name = "lab-results.pdf",
             MimeType = "application/pdf",
             Buffer = Encoding.ASCII.GetBytes("%PDF-1.4\n1 0 obj\n<<>>\nendobj\ntrailer\n<<>>\n%%EOF")
-        });
+        };
+        await page.Locator("#proofPicInput").SetInputFilesAsync(pdfProof);
         await page.WaitForFunctionAsync(
-            "() => !document.getElementById('submitButton')?.disabled && document.querySelectorAll('#proofImageContainer img').length === 1");
+            "() => !document.getElementById('submitButton')?.disabled && document.querySelectorAll('#proofImageContainer img').length === 3");
+        await page.Locator("#proofPicInput").SetInputFilesAsync(pdfProof);
+        await page.WaitForFunctionAsync(
+            "() => document.querySelector('#proofImageContainer .proof-upload-notice')?.textContent?.includes('Duplicate proof images were skipped.')");
+        Assert.Equal(3, await page.Locator("#proofImageContainer img").CountAsync());
+        var encodeRequests = await page.EvaluateAsync<JsonElement>("() => window.__proofCanvasEncodeRequests");
+        Assert.Equal(1, encodeRequests.GetProperty("webp").GetInt32());
+        Assert.Equal(3, encodeRequests.GetProperty("jpeg").GetInt32());
         await page.EvaluateAsync(
             """
             () => document.querySelectorAll('.biomarker-checkbox')
@@ -242,10 +258,142 @@ public sealed class ProofUploadBrowserTests
         Assert.Equal("gabor@example.test", payload.GetProperty("accountEmail").GetString());
         Assert.Equal(JsonValueKind.Null, payload.GetProperty("paymentOffer").ValueKind);
         Assert.False(string.IsNullOrWhiteSpace(payload.GetProperty("submissionId").GetString()));
-        var proof = Assert.Single(payload.GetProperty("proofPics").EnumerateArray()).GetString();
-        Assert.StartsWith("data:image/", proof);
-        Assert.Contains(";base64,", proof);
+        var proofs = payload.GetProperty("proofPics").EnumerateArray().ToList();
+        Assert.Equal(3, proofs.Count);
+        Assert.All(proofs, proof =>
+        {
+            Assert.StartsWith("data:image/jpeg;base64,", proof.GetString());
+            Assert.Contains(";base64,", proof.GetString());
+        });
         Assert.Empty(errors);
+    }
+
+    [Fact]
+    public async Task ResultUpload_BoundsLargeNoisyPdfCanvasBeforeKeepingIt()
+    {
+        await using var app = await BrowserTestApp.StartAsync();
+        using var playwright = await Playwright.CreateAsync();
+        await using var browser = await LaunchBrowserAsync(playwright);
+        await using var context = await NewContextAsync(browser, app);
+        await RoutePageDependenciesAsync(context, delayProofHelper: false);
+
+        await context.AddInitScriptAsync(
+            """
+            window.pdfjsLib = {
+                GlobalWorkerOptions: {},
+                getDocument() {
+                    return {
+                        promise: Promise.resolve({
+                            numPages: 1,
+                            getPage: async () => ({
+                                getViewport: () => ({ width: 3000, height: 2200 }),
+                                render: ({ canvasContext }) => {
+                                    const width = canvasContext.canvas.width;
+                                    const height = canvasContext.canvas.height;
+                                    const pixels = canvasContext.createImageData(width, height);
+                                    let state = 0x12345678;
+                                    for (let index = 0; index < pixels.data.length; index += 4) {
+                                        state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+                                        pixels.data[index] = state & 255;
+                                        pixels.data[index + 1] = (state >>> 8) & 255;
+                                        pixels.data[index + 2] = (state >>> 16) & 255;
+                                        pixels.data[index + 3] = 255;
+                                    }
+                                    canvasContext.putImageData(pixels, 0, 0);
+                                    return { promise: Promise.resolve() };
+                                }
+                            })
+                        })
+                    };
+                }
+            };
+            window.sessionStorage.setItem('selectedAthlete', JSON.stringify({
+                Name: 'Canvas Bounds Athlete',
+                DisplayName: 'Canvas Bounds Athlete',
+                Biomarkers: []
+            }));
+            window.sessionStorage.setItem('biomarkerData', JSON.stringify({
+                Biomarkers: [{ Date: '2026-06-19', AlbGL: 45 }]
+            }));
+            """);
+
+        var page = await context.NewPageAsync();
+        await page.GotoAsync("/proofs", new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
+        await page.WaitForFunctionAsync(
+            "() => document.getElementById('uploadProofButton')?.getAttribute('data-listener') === 'true'");
+
+        await page.Locator("#proofPicInput").SetInputFilesAsync(new FilePayload
+        {
+            Name = "large-lab-results.pdf",
+            MimeType = "application/pdf",
+            Buffer = Encoding.ASCII.GetBytes("%PDF-1.4\n%%EOF")
+        });
+        await page.WaitForFunctionAsync(
+            "() => document.querySelectorAll('#proofImageContainer img').length === 1",
+            null,
+            new PageWaitForFunctionOptions { Timeout = 60_000 });
+
+        var dataUrl = await page.Locator("#proofImageContainer img").GetAttributeAsync("src");
+        Assert.NotNull(dataUrl);
+        var separator = dataUrl!.IndexOf(',');
+        Assert.True(separator > 0);
+        var bytes = Convert.FromBase64String(dataUrl[(separator + 1)..]);
+        Assert.True(bytes.Length <= (int)(1.5 * 1024 * 1024), $"Encoded proof was {bytes.Length} bytes.");
+
+        using var stream = new MemoryStream(bytes);
+        var imageInfo = SixLabors.ImageSharp.Image.Identify(stream);
+        Assert.NotNull(imageInfo);
+        Assert.True(Math.Max(imageInfo!.Width, imageInfo.Height) <= 2560);
+    }
+
+    [Fact]
+    public async Task ApplicationSubmissionId_ReusesExactPayloadAndRotatesAfterAnEdit()
+    {
+        await using var app = await BrowserTestApp.StartAsync();
+        using var playwright = await Playwright.CreateAsync();
+        await using var browser = await LaunchBrowserAsync(playwright);
+        await using var context = await NewContextAsync(browser, app);
+        await RoutePageDependenciesAsync(context, delayProofHelper: false);
+
+        var page = await context.NewPageAsync();
+        await page.GotoAsync("/", new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
+        await page.WaitForFunctionAsync("() => typeof window.createApplicationSubmissionId === 'function'");
+
+        var result = await page.EvaluateAsync<JsonElement>(
+            """
+            () => {
+                const largeProof = 'data:image/jpeg;base64,' + 'A'.repeat(2 * 1024 * 1024);
+                const applicantData = { proofPics: [largeProof] };
+                const firstPayload = window.createApplicationSubmissionPayloadKey(applicantData);
+                const editedPayload = window.createApplicationSubmissionPayloadKey({ proofPics: [largeProof, 'proof-b'] });
+                const report = window.buildApplicationSubmissionReport(
+                    applicantData,
+                    'submission-test',
+                    'started',
+                    'result-upload',
+                    null);
+                return {
+                    ids: [
+                        window.createApplicationSubmissionId(firstPayload),
+                        window.createApplicationSubmissionId(firstPayload),
+                        window.createApplicationSubmissionId(editedPayload)
+                    ],
+                    firstKeyLength: firstPayload.length,
+                    retainedKeyLength: window.__pendingApplicationSubmissionFingerprint.length,
+                    reportedBodyLength: report.jsonBodyLength,
+                    actualBodyLength: JSON.stringify(applicantData).length
+                };
+            }
+            """);
+
+        var ids = result.GetProperty("ids").EnumerateArray().Select(value => value.GetString()).ToList();
+        Assert.Equal(ids[0], ids[1]);
+        Assert.NotEqual(ids[0], ids[2]);
+        Assert.True(result.GetProperty("firstKeyLength").GetInt32() < 256);
+        Assert.True(result.GetProperty("retainedKeyLength").GetInt32() < 256);
+        Assert.Equal(
+            result.GetProperty("actualBodyLength").GetInt32(),
+            result.GetProperty("reportedBodyLength").GetInt32());
     }
 
     private static async Task<IBrowser> LaunchBrowserAsync(IPlaywright playwright)

--- a/LongevityWorldCup.Tests/ProofUploadPageTests.cs
+++ b/LongevityWorldCup.Tests/ProofUploadPageTests.cs
@@ -87,10 +87,10 @@ public sealed class ProofUploadPageTests
 
         Assert.Contains("function ensurePdfJsReady(): Promise<PdfJsLibrary>", javascript);
         Assert.Contains("const pdfLib = await ensurePdfJsReady();", javascript);
-        Assert.Contains("const loadingTask = pdfLib.getDocument({ data: arrayBuffer });", javascript);
+        Assert.Contains("const loadingTask = pdfLib.getDocument({ data: fileBytes });", javascript);
         Assert.Contains("const maxProofImages = 37;", javascript);
         Assert.Contains("if (proofPics.length >= maxProofImages)", javascript);
-        Assert.DoesNotContain("const loadingTask = pdfjsLib.getDocument({ data: arrayBuffer });", javascript);
+        Assert.DoesNotContain("const loadingTask = pdfjsLib.getDocument({ data: fileBytes });", javascript);
     }
 
     [Fact]
@@ -101,7 +101,7 @@ public sealed class ProofUploadPageTests
 
         var javascript = await GetProofHelpersTypeScriptAsync(client);
         var handlerStart = javascript.IndexOf("const handleProofFiles = async function (", StringComparison.Ordinal);
-        var readerStart = javascript.IndexOf("const readDataURL: (file: File) => Promise<string>", handlerStart, StringComparison.Ordinal);
+        var readerStart = javascript.IndexOf("const readDataURL: (file: Blob) => Promise<string>", handlerStart, StringComparison.Ordinal);
         var imageCapStart = javascript.IndexOf("if (proofPics.length >= maxProofImages)", readerStart, StringComparison.Ordinal);
 
         Assert.True(handlerStart >= 0);
@@ -116,7 +116,8 @@ public sealed class ProofUploadPageTests
         Assert.Contains("let hitImageLimit = false;", javascript);
         Assert.Contains("hitImageLimit = true;", javascript);
         Assert.Contains("const showProofUploadNotice: (message: string) => void = message =>", javascript);
-        Assert.Contains("showProofUploadNotice('Only the first ' + maxProofImages + ' proof images were kept. Remove one to add another.');", javascript);
+        Assert.Contains("uploadNotices.push('Only the first ' + maxProofImages + ' proof images were kept. Remove one to add another.');", javascript);
+        Assert.Contains("showProofUploadNotice(uploadNotices.join(' '));", javascript);
         Assert.DoesNotContain("customAlert('You can upload a maximum of 37 images.')", javascript);
     }
 
@@ -193,9 +194,48 @@ public sealed class ProofUploadPageTests
         Assert.Contains("return dataUrl || raw;", javascript);
         Assert.Contains("} catch (_) {", javascript);
         Assert.Contains("return raw;", javascript);
-        Assert.Contains("const optimizedPage = await optimizeProofImageOrFallback(rawPage);", javascript);
         Assert.Contains("const dataUrl = await optimizeProofImageOrFallback(raw);", javascript);
-        Assert.DoesNotContain("await window.optimizeImageClient(rawPage, proofOptimizationOptions);", javascript);
+        Assert.DoesNotContain("const rawPage = canvas.toDataURL();", javascript);
+    }
+
+    [Fact]
+    public async Task ProofHelper_EncodesPdfCanvasesWithoutDependingOnImageBitmap()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var javascript = await GetProofHelpersTypeScriptAsync(client);
+
+        Assert.Contains("const encodeProofCanvas: (canvas: HTMLCanvasElement) => Promise<string> = async canvas =>", javascript);
+        Assert.Contains("const getPreferredProofCanvasContentType = (): Promise<'image/webp' | 'image/jpeg'> =>", javascript);
+        Assert.Contains("webpBlob?.type.toLowerCase() === 'image/webp'", javascript);
+        Assert.Contains("const maxDimension = Math.max(canvas.width, canvas.height);", javascript);
+        Assert.Contains("proofOptimizationOptions.maxSize / maxDimension", javascript);
+        Assert.Contains("blob.size <= proofOptimizationOptions.targetMaxBytes", javascript);
+        Assert.Contains("for (let attempt = 0; attempt < 12; attempt++)", javascript);
+        Assert.Contains("const optimizedPage = await encodeProofCanvas(canvas);", javascript);
+        Assert.DoesNotContain("const rawPage = canvas.toDataURL();", javascript);
+    }
+
+    [Fact]
+    public async Task ProofHelper_SkipsDuplicateEncodedProofs()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var javascript = await GetProofHelpersTypeScriptAsync(client);
+
+        Assert.Contains("const knownProofImages = new Set(proofPics);", javascript);
+        Assert.Contains("const proofSourceImages = new Map<string, string>();", javascript);
+        Assert.Contains("const fingerprintProofSource = async (bytes: ArrayBuffer): Promise<string> =>", javascript);
+        Assert.Contains("const sourceKey = `${sourceFingerprint}:page:${pageNum}`;", javascript);
+        Assert.Contains("if (isKnownLiveProofSource(sourceKey))", javascript);
+        Assert.Contains("const addProofImage = (dataUrl: string): boolean =>", javascript);
+        Assert.Contains("if (knownProofImages.has(dataUrl))", javascript);
+        Assert.Contains("duplicateProofs++;", javascript);
+        Assert.Contains("addProofImage(optimizedPage);", javascript);
+        Assert.Contains("if (addProofImage(dataUrl))", javascript);
+        Assert.Contains("uploadNotices.push('Duplicate proof images were skipped.');", javascript);
     }
 
     [Fact]
@@ -448,7 +488,7 @@ public sealed class ProofUploadPageTests
 
         var html = await client.GetStringAsync("/play/proof-upload.html");
         var parseStart = html.IndexOf("let biomarkerData = null;", StringComparison.Ordinal);
-        var parseEnd = html.IndexOf("const submissionId = window.createApplicationSubmissionId();", parseStart, StringComparison.Ordinal);
+        var parseEnd = html.IndexOf("const submissionId = window.createApplicationSubmissionId(submissionPayloadKey);", parseStart, StringComparison.Ordinal);
 
         Assert.True(parseStart >= 0);
         Assert.True(parseEnd > parseStart);
@@ -490,6 +530,27 @@ public sealed class ProofUploadPageTests
         Assert.Contains("removeSessionItem('chronoBortzDifference');", html);
         Assert.Contains("customAlert('Biomarker data is missing. Please fill out the biomarker form first.')", parseBody);
         Assert.Contains(".then(() => window.location.href = '/dashboard');", parseBody);
+    }
+
+    [Fact]
+    public async Task ResultUpload_SnapshotsPayloadAndKeysRetriesByItsContents()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var html = await client.GetStringAsync("/play/proof-upload.html");
+        var applicantStart = html.IndexOf("const applicantData = {", StringComparison.Ordinal);
+        var fetchStart = html.IndexOf("fetchWithTimeout('/api/application/application'", applicantStart, StringComparison.Ordinal);
+
+        Assert.True(applicantStart >= 0);
+        Assert.True(fetchStart > applicantStart);
+
+        var submissionSetup = html[applicantStart..fetchStart];
+        Assert.Contains("const submissionPayloadKey = window.createApplicationSubmissionPayloadKey(applicantData);", submissionSetup);
+        Assert.Contains("const submissionId = window.createApplicationSubmissionId(submissionPayloadKey);", submissionSetup);
+        Assert.Contains("applicantData.submissionId = submissionId;", submissionSetup);
+        Assert.Contains("const submissionBody = JSON.stringify(applicantData);", submissionSetup);
+        Assert.Contains("body: submissionBody", html[fetchStart..]);
     }
 
     [Fact]

--- a/LongevityWorldCup.Tests/PublicRequestTimeoutTests.cs
+++ b/LongevityWorldCup.Tests/PublicRequestTimeoutTests.cs
@@ -24,8 +24,23 @@ public sealed class PublicRequestTimeoutTests
         Assert.NotNull(policy.WriteTimeoutResponse);
     }
 
+    [Fact]
+    public void ApplicationSubmissionTimeoutPolicy_IsConfigured()
+    {
+        using var factory = new TestWebApplicationFactory();
+
+        var options = factory.Services.GetRequiredService<IOptions<RequestTimeoutOptions>>().Value;
+
+        Assert.True(options.Policies.TryGetValue(PublicRequestTimeoutPolicies.ApplicationSubmission, out var policy));
+        Assert.Equal(PublicRequestTimeoutPolicies.ApplicationSubmissionTimeout, policy.Timeout);
+        Assert.Equal(StatusCodes.Status504GatewayTimeout, policy.TimeoutStatusCode);
+        Assert.NotNull(policy.WriteTimeoutResponse);
+        Assert.True(
+            PublicRequestTimeoutPolicies.ApplicationSubmissionWorkTimeout
+            < PublicRequestTimeoutPolicies.ApplicationSubmissionTimeout);
+    }
+
     [Theory]
-    [InlineData("api/Application/application")]
     [InlineData("api/data/hypothetical-rank")]
     [InlineData("api/custom-event-preview/image")]
     [InlineData("api/longevitymaxxing/check-in")]
@@ -49,6 +64,30 @@ public sealed class PublicRequestTimeoutTests
             var timeout = endpoint.Metadata.GetMetadata<RequestTimeoutAttribute>();
             Assert.NotNull(timeout);
             Assert.Equal(PublicRequestTimeoutPolicies.PublicWork, timeout.PolicyName);
+        });
+    }
+
+    [Fact]
+    public void ApplicationSubmissionEndpoint_UsesDedicatedTimeoutPolicy()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var _ = factory.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+
+        var endpoints = factory.Services.GetRequiredService<EndpointDataSource>()
+            .Endpoints
+            .OfType<RouteEndpoint>()
+            .Where(endpoint => string.Equals(
+                endpoint.RoutePattern.RawText,
+                "api/Application/application",
+                StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        Assert.NotEmpty(endpoints);
+        Assert.All(endpoints, endpoint =>
+        {
+            var timeout = endpoint.Metadata.GetMetadata<RequestTimeoutAttribute>();
+            Assert.NotNull(timeout);
+            Assert.Equal(PublicRequestTimeoutPolicies.ApplicationSubmission, timeout.PolicyName);
         });
     }
 }

--- a/LongevityWorldCup.Website/Business/ApplicationSubmissionWorkspace.cs
+++ b/LongevityWorldCup.Website/Business/ApplicationSubmissionWorkspace.cs
@@ -1,0 +1,39 @@
+namespace LongevityWorldCup.Website.Business;
+
+internal sealed class ApplicationSubmissionWorkspace : IDisposable
+{
+    private int _disposed;
+
+    private ApplicationSubmissionWorkspace(string rootPath)
+    {
+        RootPath = rootPath;
+    }
+
+    public string RootPath { get; }
+
+    public static ApplicationSubmissionWorkspace Create()
+    {
+        var rootPath = Path.Combine(
+            Path.GetTempPath(),
+            "LWC",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(rootPath);
+        return new ApplicationSubmissionWorkspace(rootPath);
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        try
+        {
+            if (Directory.Exists(RootPath))
+                Directory.Delete(RootPath, recursive: true);
+        }
+        catch
+        {
+            // The operating system can reclaim a best-effort temporary workspace.
+        }
+    }
+}

--- a/LongevityWorldCup.Website/Controllers/ApplicationController.cs
+++ b/LongevityWorldCup.Website/Controllers/ApplicationController.cs
@@ -5,6 +5,7 @@ using MailKit.Net.Smtp;
 using MailKit.Security;
 using Microsoft.AspNetCore.Mvc;
 using MimeKit;
+using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats.Webp;
 using SixLabors.ImageSharp.Processing;
 using System.Diagnostics;
@@ -178,6 +179,7 @@ namespace LongevityWorldCup.Website.Controllers
         }
 
         [HttpPost("application")]
+        [RequestTimeout(PublicRequestTimeoutPolicies.ApplicationSubmission)]
         public async Task<IActionResult> Application([FromBody] ApplicantData applicantData, CancellationToken ct)
         {
             var startedAt = Stopwatch.GetTimestamp();
@@ -239,9 +241,19 @@ namespace LongevityWorldCup.Website.Controllers
                 return await BadRequestWithStatsAsync("missing_name", "Applicant name is required.").ConfigureAwait(false);
             }
 
+            var submittedProofCount = applicantData.ProofPics?.Count ?? 0;
             applicantData.ProofPics = applicantData.ProofPics?
                 .Where(proof => !string.IsNullOrWhiteSpace(proof))
+                .Distinct(StringComparer.Ordinal)
                 .ToList();
+            var duplicateProofCount = submittedProofCount - (applicantData.ProofPics?.Count ?? 0);
+            if (duplicateProofCount > 0)
+            {
+                _logger.LogInformation(
+                    "Duplicate or blank application proofs were removed before processing. SubmissionId={SubmissionId} RemovedProofCount={RemovedProofCount}",
+                    submissionId,
+                    duplicateProofCount);
+            }
 
             if (applicantData.ProofPics?.Count > MaxProofImages)
             {
@@ -404,317 +416,448 @@ namespace LongevityWorldCup.Website.Controllers
             // Once the complete request body has been accepted, finish the bounded server-side
             // work even if a mobile browser drops its response connection. An identical retry
             // waits on the submission lease and receives the cached successful response.
-            using var processingTimeout = new CancellationTokenSource(PublicRequestTimeoutPolicies.PublicWorkTimeout);
+            using var processingTimeout = new CancellationTokenSource(PublicRequestTimeoutPolicies.ApplicationSubmissionWorkTimeout);
             ct = processingTimeout.Token;
+            using var submissionWorkspace = ApplicationSubmissionWorkspace.Create();
+            string? recoverableZipPath = null;
+            string? recoverableFolderKey = null;
 
-            // Load SMTP configuration
-            Config config;
             try
             {
-                config = await Config.LoadAsync() ?? throw new InvalidOperationException("Loaded configuration is null.");
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Application submission failed before processing because configuration could not be loaded.");
-                return await StatusCodeWithStatsAsync(500, "config_load_failed", $"Failed to load configuration: {ex.Message}").ConfigureAwait(false);
-            }
-
-            var proofLengths = GetDataUrlLengths(applicantData.ProofPics);
-            var profilePicLength = GetDataUrlLength(applicantData.ProfilePic);
-
-            _logger.LogInformation(
-                "Application submission started. SubmissionId={SubmissionId} SubmissionKind={SubmissionKind} ProofCount={ProofCount} ProofDataUrlLengths={ProofDataUrlLengths} ProfilePicDataUrlLength={ProfilePicDataUrlLength}",
-                submissionId,
-                submissionKind,
-                applicantData.ProofPics?.Count ?? 0,
-                string.Join(",", proofLengths),
-                profilePicLength);
-
-            applicantData.FreePass = NormalizeFreePassValue(applicantData.FreePass);
-            applicantData.Discount = NormalizeDiscountValue(applicantData.Discount)
-                ?? NormalizeDiscountValue(applicantData.PaymentOffer?.DiscountCode);
-            if (applicantData.PaymentOffer is not null)
-            {
-                applicantData.PaymentOffer.DiscountCode = applicantData.Discount;
-                applicantData.PaymentOffer.DiscountPercent = applicantData.Discount is null
-                    ? null
-                    : MightyKlausDiscountPercent;
-            }
-            var hasFreePass = applicantData.FreePass is not null;
-
-            // Prepare the email body (excluding the images)
-            // Moved this block after processing images to include paths
-
-            // Create the email message
-            var message = new MimeMessage();
-            message.From.Add(CreateConfiguredFromAddress(config, applicantData.Name));
-            message.To.Add(CreateConfiguredToAddress(config));
-            var applicationSubject = BuildApplicationSubject(applicantData.Name);
-            message.Subject = applicationSubject;
-
-            var builder = new BodyBuilder();
-
-            var correctedPersonalLink = NormalizeSubmittedPersonalLink(applicantData.PersonalLink);
-            var trimmedDisplayName = string.IsNullOrWhiteSpace(applicantData.DisplayName) ? null : applicantData.DisplayName.Trim();
-            var displayNameOrName = trimmedDisplayName ?? applicantData.Name?.Trim();
-
-            // 1) Build a temp folder with profile + proofs + athlete.json
-            var folderKey = SanitizeFileName(applicantData.Name ?? "noname");
-            if ((isResultSubmissionOnly || isEditSubmissionOnly) && string.IsNullOrWhiteSpace(accountEmail))
-            {
-                accountEmail = ResolveExistingAthleteContactEmail(TryReadExistingAthleteFields(_environment, folderKey, applicantData.Name));
-            }
-            AddReplyToIfValid(message, accountEmail, displayNameOrName);
-
-            var tempRoot = Path.Combine(Path.GetTempPath(), "LWC", folderKey);
-            var athleteFolder = Path.Combine(tempRoot, folderKey);
-            Directory.CreateDirectory(athleteFolder);
-
-            // 1a) Write athlete.json
-
-            object? athleteJsonObject;
-            if (isResultSubmissionOnly)
-            {
-                athleteJsonObject = new { applicantData.Name, DisplayName = trimmedDisplayName, applicantData.Biomarkers };
-            }
-            else if (isEditSubmissionOnly)
-            {
-                athleteJsonObject = new
+                // Load SMTP configuration
+                Config config;
+                try
                 {
-                    applicantData.Name,
-                    DisplayName = trimmedDisplayName,
-                    applicantData.MediaContact,
-                    applicantData.Division,
-                    applicantData.Flag,
-                    applicantData.Why,
-                    PersonalLink = correctedPersonalLink
-                };
-            }
-            else
-            {
-                athleteJsonObject = (new
+                    config = await Config.LoadAsync() ?? throw new InvalidOperationException("Loaded configuration is null.");
+                }
+                catch (Exception ex)
                 {
-                    applicantData.Name,
-                    DisplayName = trimmedDisplayName,
-                    applicantData.MediaContact,
-                    applicantData.DateOfBirth,
-                    applicantData.Biomarkers,
-                    applicantData.Division,
-                    applicantData.Flag,
-                    applicantData.Why,
-                    PersonalLink = correctedPersonalLink
-                });
-            }
+                    _logger.LogError(ex, "Application submission failed before processing because configuration could not be loaded.");
+                    return await StatusCodeWithStatsAsync(500, "config_load_failed", $"Failed to load configuration: {ex.Message}").ConfigureAwait(false);
+                }
 
-            var athleteJson = JsonSerializer.Serialize(athleteJsonObject, CachedJsonSerializerOptions);
-            await System.IO.File.WriteAllTextAsync(Path.Combine(athleteFolder, "athlete.json"), athleteJson, ct);
+                var proofLengths = GetDataUrlLengths(applicantData.ProofPics);
+                var profilePicLength = GetDataUrlLength(applicantData.ProfilePic);
 
-            // 1b) Save profile picture
-            var hasSubmittedProfileImage = IsSubmittedImageData(applicantData.ProfilePic);
-            if (!string.IsNullOrWhiteSpace(applicantData.ProfilePic) && !hasSubmittedProfileImage && !isEditSubmissionOnly)
-            {
-                _logger.LogError(
-                    "Application submission rejected because profile image was present but was not image data. SubmissionId={SubmissionId} SubmissionKind={SubmissionKind} ProfilePicDataUrlLength={ProfilePicDataUrlLength}",
+                _logger.LogInformation(
+                    "Application submission started. SubmissionId={SubmissionId} SubmissionKind={SubmissionKind} ProofCount={ProofCount} ProofDataUrlLengths={ProofDataUrlLengths} ProfilePicDataUrlLength={ProfilePicDataUrlLength}",
                     submissionId,
                     submissionKind,
+                    applicantData.ProofPics?.Count ?? 0,
+                    string.Join(",", proofLengths),
                     profilePicLength);
-                return await BadRequestWithStatsAsync("invalid_profile_image", "The profile image could not be read. Please upload a smaller image and try again.").ConfigureAwait(false);
-            }
 
-            if (hasSubmittedProfileImage)
-            {
-                var parsedProfile = ParseBase64Image(applicantData.ProfilePic!);
-                if (parsedProfile.bytes is null)
+                applicantData.FreePass = NormalizeFreePassValue(applicantData.FreePass);
+                applicantData.Discount = NormalizeDiscountValue(applicantData.Discount)
+                    ?? NormalizeDiscountValue(applicantData.PaymentOffer?.DiscountCode);
+                if (applicantData.PaymentOffer is not null)
+                {
+                    applicantData.PaymentOffer.DiscountCode = applicantData.Discount;
+                    applicantData.PaymentOffer.DiscountPercent = applicantData.Discount is null
+                        ? null
+                        : MightyKlausDiscountPercent;
+                }
+                var hasFreePass = applicantData.FreePass is not null;
+
+                // Prepare the email body (excluding the images)
+                // Moved this block after processing images to include paths
+
+                // Create the email message
+                var message = new MimeMessage();
+                message.From.Add(CreateConfiguredFromAddress(config, applicantData.Name));
+                message.To.Add(CreateConfiguredToAddress(config));
+                var applicationSubject = BuildApplicationSubject(applicantData.Name);
+                message.Subject = applicationSubject;
+
+                var builder = new BodyBuilder();
+
+                var correctedPersonalLink = NormalizeSubmittedPersonalLink(applicantData.PersonalLink);
+                var trimmedDisplayName = string.IsNullOrWhiteSpace(applicantData.DisplayName) ? null : applicantData.DisplayName.Trim();
+                var displayNameOrName = trimmedDisplayName ?? applicantData.Name?.Trim();
+
+                // 1) Build a temp folder with profile + proofs + athlete.json
+                var folderKey = SanitizeFileName(applicantData.Name ?? "noname");
+                if ((isResultSubmissionOnly || isEditSubmissionOnly) && string.IsNullOrWhiteSpace(accountEmail))
+                {
+                    accountEmail = ResolveExistingAthleteContactEmail(TryReadExistingAthleteFields(_environment, folderKey, applicantData.Name));
+                }
+                AddReplyToIfValid(message, accountEmail, displayNameOrName);
+
+                var tempRoot = submissionWorkspace.RootPath;
+                var athleteFolder = Path.Combine(tempRoot, folderKey);
+                Directory.CreateDirectory(athleteFolder);
+
+                // 1a) Write athlete.json
+
+                object? athleteJsonObject;
+                if (isResultSubmissionOnly)
+                {
+                    athleteJsonObject = new { applicantData.Name, DisplayName = trimmedDisplayName, applicantData.Biomarkers };
+                }
+                else if (isEditSubmissionOnly)
+                {
+                    athleteJsonObject = new
+                    {
+                        applicantData.Name,
+                        DisplayName = trimmedDisplayName,
+                        applicantData.MediaContact,
+                        applicantData.Division,
+                        applicantData.Flag,
+                        applicantData.Why,
+                        PersonalLink = correctedPersonalLink
+                    };
+                }
+                else
+                {
+                    athleteJsonObject = (new
+                    {
+                        applicantData.Name,
+                        DisplayName = trimmedDisplayName,
+                        applicantData.MediaContact,
+                        applicantData.DateOfBirth,
+                        applicantData.Biomarkers,
+                        applicantData.Division,
+                        applicantData.Flag,
+                        applicantData.Why,
+                        PersonalLink = correctedPersonalLink
+                    });
+                }
+
+                var athleteJson = JsonSerializer.Serialize(athleteJsonObject, CachedJsonSerializerOptions);
+                await System.IO.File.WriteAllTextAsync(Path.Combine(athleteFolder, "athlete.json"), athleteJson, ct);
+
+                // 1b) Save profile picture
+                var hasSubmittedProfileImage = IsSubmittedImageData(applicantData.ProfilePic);
+                if (!string.IsNullOrWhiteSpace(applicantData.ProfilePic) && !hasSubmittedProfileImage && !isEditSubmissionOnly)
                 {
                     _logger.LogError(
-                        "Application submission rejected because profile image could not be parsed. SubmissionId={SubmissionId} ProfilePicDataUrlLength={ProfilePicDataUrlLength}",
+                        "Application submission rejected because profile image was present but was not image data. SubmissionId={SubmissionId} SubmissionKind={SubmissionKind} ProfilePicDataUrlLength={ProfilePicDataUrlLength}",
                         submissionId,
+                        submissionKind,
                         profilePicLength);
-                    return await BadRequestWithStatsAsync("profile_image_parse_failed", "The profile image could not be read. Please upload a smaller image and try again.").ConfigureAwait(false);
+                    return await BadRequestWithStatsAsync("invalid_profile_image", "The profile image could not be read. Please upload a smaller image and try again.").ConfigureAwait(false);
                 }
 
-                var profileImage = OptimizeProfileImage(parsedProfile, submissionId);
-                if (!profileImage.Success)
-                    return await BadRequestWithStatsAsync("profile_image_processing_failed", profileImage.ErrorMessage ?? "The profile image could not be processed.").ConfigureAwait(false);
-
-                await System.IO.File.WriteAllBytesAsync(Path.Combine(athleteFolder, $"{folderKey}.{profileImage.Extension}"), profileImage.Bytes!, ct);
-            }
-
-            // 1c) Save each proof
-            if (applicantData.ProofPics != null)
-            {
-                int idx = 1;
-                foreach (var b64 in applicantData.ProofPics)
+                if (hasSubmittedProfileImage)
                 {
-                    var parsedProof = ParseBase64Image(b64);
-                    if (parsedProof.bytes is null)
+                    var parsedProfile = ParseBase64Image(applicantData.ProfilePic!);
+                    if (parsedProfile.bytes is null)
                     {
                         _logger.LogError(
-                            "Application submission rejected because proof image could not be parsed. SubmissionId={SubmissionId} ProofIndex={ProofIndex} ProofDataUrlLength={ProofDataUrlLength}",
+                            "Application submission rejected because profile image could not be parsed. SubmissionId={SubmissionId} ProfilePicDataUrlLength={ProfilePicDataUrlLength}",
                             submissionId,
-                            idx,
-                            b64?.Length ?? 0);
-                        return await ProofBadRequestWithStatsAsync("proof_parse_failed", $"Proof image {idx} could not be read. Please upload a smaller image or PDF page and try again.", idx).ConfigureAwait(false);
+                            profilePicLength);
+                        return await BadRequestWithStatsAsync("profile_image_parse_failed", "The profile image could not be read. Please upload a smaller image and try again.").ConfigureAwait(false);
                     }
 
-                    var proofImage = OptimizeProofImage(parsedProof, submissionId, idx);
-                    if (!proofImage.Success)
-                        return await ProofBadRequestWithStatsAsync("proof_processing_failed", proofImage.ErrorMessage ?? "Proof image could not be processed.", idx).ConfigureAwait(false);
+                    var profileImage = OptimizeProfileImage(parsedProfile, submissionId);
+                    if (!profileImage.Success)
+                        return await BadRequestWithStatsAsync("profile_image_processing_failed", profileImage.ErrorMessage ?? "The profile image could not be processed.").ConfigureAwait(false);
 
-                    if (proofImage.Bytes != null)
-                    {
-                        var proofName = $"proof_{idx}.{proofImage.Extension}";
-                        await System.IO.File.WriteAllBytesAsync(Path.Combine(athleteFolder, proofName), proofImage.Bytes!, ct);
-                        idx++;
-                    }
+                    await System.IO.File.WriteAllBytesAsync(Path.Combine(athleteFolder, $"{folderKey}.{profileImage.Extension}"), profileImage.Bytes!, ct);
                 }
 
-                await TrackApplicationProofEventAsync(
-                    outcome: "succeeded",
-                    submissionKind: submissionKind,
-                    proofCount: applicantData.ProofPics.Count,
-                    errorCode: null,
-                    proofIndex: null,
-                    durationMs: ElapsedMilliseconds(startedAt),
-                    ct: ct).ConfigureAwait(false);
-            }
-
-            // 2) Zip the folder
-            var zipPath = Path.Combine(tempRoot, $"{folderKey}.zip");
-            if (System.IO.File.Exists(zipPath))
-                System.IO.File.Delete(zipPath);
-            System.IO.Compression.ZipFile.CreateFromDirectory(
-                sourceDirectoryName: athleteFolder,
-                destinationArchiveFileName: zipPath,
-                compressionLevel: System.IO.Compression.CompressionLevel.Optimal,
-                includeBaseDirectory: false
-            );
-            var zipSizeBytes = new FileInfo(zipPath).Length;
-
-            // 3) Attach the ZIP
-            var attachmentFilename = $"{folderKey}.zip";
-            builder.Attachments.Add(attachmentFilename,
-                                    await System.IO.File.ReadAllBytesAsync(zipPath, ct),
-                                    new ContentType("application", "zip"));
-
-            // 3a) Prepare email body based on submission type
-            var paymentAmountUsd = hasFreePass ? 0m : applicantData.PaymentOffer?.AmountUsd ?? 0m;
-            var paymentCurrency = string.IsNullOrWhiteSpace(applicantData.PaymentOffer?.Currency)
-                ? "USD"
-                : applicantData.PaymentOffer!.Currency!.Trim().ToUpperInvariant();
-            var paymentDueText = hasFreePass
-                ? $"free pass ({paymentCurrency})"
-                : paymentAmountUsd <= 0m
-                    ? $"free ({paymentCurrency})"
-                    : $"{paymentCurrency} {paymentAmountUsd:0.##}";
-
-            var emailBody = BuildApplicationAuditEmailBody(
-                applicantData,
-                accountEmail,
-                correctedPersonalLink,
-                folderKey,
-                attachmentFilename,
-                paymentDueText,
-                chronoPhenoDifference,
-                chronoBortzDifference,
-                isResultSubmissionOnly,
-                isEditSubmissionOnly,
-                Request,
-                _environment);
-            builder.TextBody = emailBody;
-
-            message.Body = builder.ToMessageBody();
-
-            // Subscribe to newsletter using accountEmail
-            try
-            {
-                if (!string.IsNullOrWhiteSpace(accountEmail))
+                // 1c) Save each proof
+                if (applicantData.ProofPics != null)
                 {
-                    string email = accountEmail.Trim();
-
-                    // Call the static subscription method
-                    var error = await NewsletterService.SubscribeAsync(email, _logger, _environment, ct);
-
-                    if (error != null)
+                    int idx = 1;
+                    foreach (var b64 in applicantData.ProofPics)
                     {
-                        if (error.Contains("already subscribed", StringComparison.OrdinalIgnoreCase))
+                        var parsedProof = ParseBase64Image(b64);
+                        if (parsedProof.bytes is null)
                         {
-                            // Explicitly ignore "already subscribed" errors
-                            _logger.LogInformation("The applicant email is already subscribed to the newsletter.");
+                            _logger.LogError(
+                                "Application submission rejected because proof image could not be parsed. SubmissionId={SubmissionId} ProofIndex={ProofIndex} ProofDataUrlLength={ProofDataUrlLength}",
+                                submissionId,
+                                idx,
+                                b64?.Length ?? 0);
+                            return await ProofBadRequestWithStatsAsync("proof_parse_failed", $"Proof image {idx} could not be read. Please upload a smaller image or PDF page and try again.", idx).ConfigureAwait(false);
+                        }
+
+                        var proofImage = OptimizeProofImage(parsedProof, submissionId, idx);
+                        if (!proofImage.Success)
+                            return await ProofBadRequestWithStatsAsync("proof_processing_failed", proofImage.ErrorMessage ?? "Proof image could not be processed.", idx).ConfigureAwait(false);
+
+                        if (proofImage.Bytes != null)
+                        {
+                            var proofName = $"proof_{idx}.{proofImage.Extension}";
+                            await System.IO.File.WriteAllBytesAsync(Path.Combine(athleteFolder, proofName), proofImage.Bytes!, ct);
+                            idx++;
+                        }
+                    }
+
+                    await TrackApplicationProofEventAsync(
+                        outcome: "succeeded",
+                        submissionKind: submissionKind,
+                        proofCount: applicantData.ProofPics.Count,
+                        errorCode: null,
+                        proofIndex: null,
+                        durationMs: ElapsedMilliseconds(startedAt),
+                        ct: ct).ConfigureAwait(false);
+                }
+
+                // 2) Zip the folder
+                var zipPath = Path.Combine(tempRoot, $"{folderKey}.zip");
+                if (System.IO.File.Exists(zipPath))
+                    System.IO.File.Delete(zipPath);
+                System.IO.Compression.ZipFile.CreateFromDirectory(
+                    sourceDirectoryName: athleteFolder,
+                    destinationArchiveFileName: zipPath,
+                    compressionLevel: System.IO.Compression.CompressionLevel.Optimal,
+                    includeBaseDirectory: false
+                );
+                recoverableZipPath = zipPath;
+                recoverableFolderKey = folderKey;
+                var zipSizeBytes = new FileInfo(zipPath).Length;
+
+                // 3) Attach the ZIP
+                var attachmentFilename = $"{folderKey}.zip";
+                builder.Attachments.Add(attachmentFilename,
+                                        await System.IO.File.ReadAllBytesAsync(zipPath, ct),
+                                        new ContentType("application", "zip"));
+
+                // 3a) Prepare email body based on submission type
+                var paymentAmountUsd = hasFreePass ? 0m : applicantData.PaymentOffer?.AmountUsd ?? 0m;
+                var paymentCurrency = string.IsNullOrWhiteSpace(applicantData.PaymentOffer?.Currency)
+                    ? "USD"
+                    : applicantData.PaymentOffer!.Currency!.Trim().ToUpperInvariant();
+                var paymentDueText = hasFreePass
+                    ? $"free pass ({paymentCurrency})"
+                    : paymentAmountUsd <= 0m
+                        ? $"free ({paymentCurrency})"
+                        : $"{paymentCurrency} {paymentAmountUsd:0.##}";
+
+                var emailBody = BuildApplicationAuditEmailBody(
+                    applicantData,
+                    accountEmail,
+                    correctedPersonalLink,
+                    folderKey,
+                    attachmentFilename,
+                    paymentDueText,
+                    chronoPhenoDifference,
+                    chronoBortzDifference,
+                    isResultSubmissionOnly,
+                    isEditSubmissionOnly,
+                    Request,
+                    _environment);
+                builder.TextBody = emailBody;
+
+                message.Body = builder.ToMessageBody();
+
+                // Subscribe to newsletter using accountEmail
+                try
+                {
+                    if (!string.IsNullOrWhiteSpace(accountEmail))
+                    {
+                        string email = accountEmail.Trim();
+
+                        // Call the static subscription method
+                        var error = await NewsletterService.SubscribeAsync(email, _logger, _environment, ct);
+
+                        if (error != null)
+                        {
+                            if (error.Contains("already subscribed", StringComparison.OrdinalIgnoreCase))
+                            {
+                                // Explicitly ignore "already subscribed" errors
+                                _logger.LogInformation("The applicant email is already subscribed to the newsletter.");
+                            }
+                            else
+                            {
+                                // Log and ignore any other errors silently
+                                _logger.LogWarning("Failed to subscribe applicant email to the newsletter. Error: {Error}", error);
+                            }
                         }
                         else
                         {
-                            // Log and ignore any other errors silently
-                            _logger.LogWarning("Failed to subscribe applicant email to the newsletter. Error: {Error}", error);
+                            // Subscription successful
+                            _logger.LogInformation("Successfully subscribed applicant email to the newsletter.");
                         }
                     }
-                    else
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    // Log and ignore any other errors silently
+                    _logger.LogWarning(ex, "Failed to subscribe applicant email to the newsletter.");
+                }
+
+                var requestedAmountUsd = hasFreePass ? 0m : applicantData.PaymentOffer?.AmountUsd ?? 0m;
+                var paymentRequired = requestedAmountUsd > 0m;
+                paymentRequiredForStats = paymentRequired;
+                string? archivedSubmissionPath = null;
+                var auditEmailDelivered = false;
+
+                // Send the admin notification email. If email auth is misconfigured, keep the
+                // already-packaged submission on disk and let the applicant continue.
+                try
+                {
+                    await SendEmailThroughSmtpAsync(config, message, ct);
+                    auditEmailDelivered = true;
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    try
                     {
-                        // Subscription successful
-                        _logger.LogInformation("Successfully subscribed applicant email to the newsletter.");
+                        archivedSubmissionPath = await PersistApplicationSubmissionArchiveAsync(zipPath, folderKey, submissionId, ct);
                     }
-                }
-            }
-            catch (Exception ex) when (ex is not OperationCanceledException)
-            {
-                // Log and ignore any other errors silently
-                _logger.LogWarning(ex, "Failed to subscribe applicant email to the newsletter.");
-            }
+                    catch (Exception archiveEx) when (archiveEx is not OperationCanceledException)
+                    {
+                        _logger.LogError(
+                            archiveEx,
+                            "Application submission email failed and archive could not be saved. SubmissionId={SubmissionId} SubmissionKind={SubmissionKind}",
+                            submissionId,
+                            submissionKind);
+                        return await StatusCodeWithStatsAsync(500, "application_archive_failed", "Internal server error: application could not be saved.").ConfigureAwait(false);
+                    }
 
-            var requestedAmountUsd = hasFreePass ? 0m : applicantData.PaymentOffer?.AmountUsd ?? 0m;
-            var paymentRequired = requestedAmountUsd > 0m;
-            paymentRequiredForStats = paymentRequired;
-            string? archivedSubmissionPath = null;
-            var auditEmailDelivered = false;
-
-            // Send the admin notification email. If email auth is misconfigured, keep the
-            // already-packaged submission on disk and let the applicant continue.
-            try
-            {
-                await SendEmailThroughSmtpAsync(config, message, ct);
-                auditEmailDelivered = true;
-            }
-            catch (Exception ex) when (ex is not OperationCanceledException)
-            {
-                try
-                {
-                    archivedSubmissionPath = await PersistApplicationSubmissionArchiveAsync(zipPath, folderKey, submissionId, ct);
-                }
-                catch (Exception archiveEx) when (archiveEx is not OperationCanceledException)
-                {
                     _logger.LogError(
-                        archiveEx,
-                        "Application submission email failed and archive could not be saved. SubmissionId={SubmissionId} SubmissionKind={SubmissionKind}",
+                        ex,
+                        "Application submission email failed after archive was saved. SubmissionId={SubmissionId} SubmissionKind={SubmissionKind} ArchivePath={ArchivePath}",
                         submissionId,
-                        submissionKind);
-                    return await StatusCodeWithStatsAsync(500, "application_archive_failed", "Internal server error: application could not be saved.").ConfigureAwait(false);
+                        submissionKind,
+                        archivedSubmissionPath);
                 }
 
-                _logger.LogError(
-                    ex,
-                    "Application submission email failed after archive was saved. SubmissionId={SubmissionId} SubmissionKind={SubmissionKind} ArchivePath={ArchivePath}",
-                    submissionId,
-                    submissionKind,
-                    archivedSubmissionPath);
-            }
-
-            try
-            {
                 try
                 {
-                    Directory.Delete(tempRoot, recursive: true);
-                }
-                catch { /* ignore */ }
+                    if (!paymentRequired)
+                    {
+                        var freeSubmissionResponse = new ApplicationSubmissionResponse(
+                            Success: true,
+                            PaymentRequired: false,
+                            CheckoutLink: null,
+                            InvoiceId: null);
+                        submissionLease.Complete(freeSubmissionResponse);
 
-                if (!paymentRequired)
-                {
-                    await TrySendSubmissionConfirmationEmailAsync(
+                        await TrySendSubmissionConfirmationEmailAsync(
+                            config,
+                            accountEmail,
+                            displayNameOrName,
+                            isResultSubmissionOnly,
+                            isEditSubmissionOnly,
+                            ct: ct);
+
+                        await TryRecordDiscountSignupAsync(
+                            applicantData,
+                            accountEmail,
+                            folderKey,
+                            submissionId,
+                            submissionKind,
+                            requestedAmountUsd,
+                            paymentCurrency,
+                            paymentRequired: false,
+                            invoiceId: null,
+                            checkoutLink: null,
+                            ct);
+
+                        _logger.LogInformation(
+                            "Application submission succeeded. SubmissionId={SubmissionId} SubmissionKind={SubmissionKind} ProofCount={ProofCount} ZipSizeBytes={ZipSizeBytes} PaymentRequired={PaymentRequired} AuditEmailDelivered={AuditEmailDelivered} ArchivePath={ArchivePath}",
+                            submissionId,
+                            submissionKind,
+                            applicantData.ProofPics?.Count ?? 0,
+                            zipSizeBytes,
+                            false,
+                            auditEmailDelivered,
+                            archivedSubmissionPath);
+
+                        await TrackApplicationSubmitEventAsync(
+                            outcome: "succeeded",
+                            submissionKind: submissionKind,
+                            paymentRequired: false,
+                            errorCode: null,
+                            durationMs: ElapsedMilliseconds(startedAt),
+                            metadata: new Dictionary<string, object?>
+                            {
+                                ["proofCount"] = applicantData.ProofPics?.Count ?? 0,
+                                ["auditEmailDelivered"] = auditEmailDelivered,
+                                ["archivedFallback"] = archivedSubmissionPath is not null
+                            },
+                            ct: ct).ConfigureAwait(false);
+
+                        return Ok(freeSubmissionResponse);
+                    }
+
+                    var invoiceResult = await CreateBtcpayInvoiceAsync(
                         config,
+                        applicantData,
+                        requestedAmountUsd,
                         accountEmail,
-                        displayNameOrName,
                         isResultSubmissionOnly,
                         isEditSubmissionOnly,
-                        ct: ct);
+                        ct);
+
+                    if (!invoiceResult.Success)
+                    {
+                        _logger.LogError(
+                            "Application submission was saved but BTCPay invoice creation failed. SubmissionId={SubmissionId} SubmissionKind={SubmissionKind} ZipSizeBytes={ZipSizeBytes} AuditEmailDelivered={AuditEmailDelivered} ArchivePath={ArchivePath} Error={Error}",
+                            submissionId,
+                            submissionKind,
+                            zipSizeBytes,
+                            auditEmailDelivered,
+                            archivedSubmissionPath,
+                            invoiceResult.Error);
+                        var paymentUnavailableResponse = new ApplicationSubmissionResponse(
+                            Success: true,
+                            PaymentRequired: true,
+                            CheckoutLink: null,
+                            InvoiceId: null,
+                            PaymentUnavailable: true);
+                        submissionLease.Complete(paymentUnavailableResponse);
+
+                        await TryRecordDiscountSignupAsync(
+                            applicantData,
+                            accountEmail,
+                            folderKey,
+                            submissionId,
+                            submissionKind,
+                            requestedAmountUsd,
+                            paymentCurrency,
+                            paymentRequired: true,
+                            invoiceId: null,
+                            checkoutLink: null,
+                            ct);
+
+                        await TrySendSubmissionConfirmationEmailAsync(
+                            config,
+                            accountEmail,
+                            displayNameOrName,
+                            isResultSubmissionOnly,
+                            isEditSubmissionOnly,
+                            paymentUnavailable: true,
+                            ct: ct);
+
+                        await TrackApplicationPaymentEventAsync(
+                            eventName: "payment_unavailable",
+                            outcome: "failed",
+                            submissionKind: submissionKind,
+                            paymentRequired: true,
+                            errorCode: "invoice_create_failed",
+                            durationMs: ElapsedMilliseconds(startedAt),
+                            ct: ct).ConfigureAwait(false);
+
+                        await TrackApplicationSubmitEventAsync(
+                            outcome: "succeeded",
+                            submissionKind: submissionKind,
+                            paymentRequired: true,
+                            errorCode: null,
+                            durationMs: ElapsedMilliseconds(startedAt),
+                            metadata: new Dictionary<string, object?>
+                            {
+                                ["proofCount"] = applicantData.ProofPics?.Count ?? 0,
+                                ["auditEmailDelivered"] = auditEmailDelivered,
+                                ["archivedFallback"] = archivedSubmissionPath is not null,
+                                ["paymentState"] = "unavailable"
+                            },
+                            ct: ct).ConfigureAwait(false);
+
+                        return Ok(paymentUnavailableResponse);
+                    }
+
+                    var paidSubmissionResponse = new ApplicationSubmissionResponse(
+                        Success: true,
+                        PaymentRequired: true,
+                        CheckoutLink: invoiceResult.CheckoutLink,
+                        InvoiceId: invoiceResult.InvoiceId);
+                    submissionLease.Complete(paidSubmissionResponse);
 
                     await TryRecordDiscountSignupAsync(
                         applicantData,
@@ -724,17 +867,19 @@ namespace LongevityWorldCup.Website.Controllers
                         submissionKind,
                         requestedAmountUsd,
                         paymentCurrency,
-                        paymentRequired: false,
-                        invoiceId: null,
-                        checkoutLink: null,
+                        paymentRequired: true,
+                        invoiceResult.InvoiceId,
+                        invoiceResult.CheckoutLink,
                         ct);
 
-                    var freeSubmissionResponse = new ApplicationSubmissionResponse(
-                        Success: true,
-                        PaymentRequired: false,
-                        CheckoutLink: null,
-                        InvoiceId: null);
-                    submissionLease.Complete(freeSubmissionResponse);
+                    await TrySendSubmissionConfirmationEmailAsync(
+                        config,
+                        accountEmail,
+                        displayNameOrName,
+                        isResultSubmissionOnly,
+                        isEditSubmissionOnly,
+                        checkoutLink: invoiceResult.CheckoutLink,
+                        ct: ct);
 
                     _logger.LogInformation(
                         "Application submission succeeded. SubmissionId={SubmissionId} SubmissionKind={SubmissionKind} ProofCount={ProofCount} ZipSizeBytes={ZipSizeBytes} PaymentRequired={PaymentRequired} AuditEmailDelivered={AuditEmailDelivered} ArchivePath={ArchivePath}",
@@ -742,82 +887,16 @@ namespace LongevityWorldCup.Website.Controllers
                         submissionKind,
                         applicantData.ProofPics?.Count ?? 0,
                         zipSizeBytes,
-                        false,
+                        true,
                         auditEmailDelivered,
                         archivedSubmissionPath);
 
-                    await TrackApplicationSubmitEventAsync(
+                    await TrackApplicationPaymentEventAsync(
+                        eventName: "checkout_redirect_started",
                         outcome: "succeeded",
                         submissionKind: submissionKind,
-                        paymentRequired: false,
+                        paymentRequired: true,
                         errorCode: null,
-                        durationMs: ElapsedMilliseconds(startedAt),
-                        metadata: new Dictionary<string, object?>
-                        {
-                            ["proofCount"] = applicantData.ProofPics?.Count ?? 0,
-                            ["auditEmailDelivered"] = auditEmailDelivered,
-                            ["archivedFallback"] = archivedSubmissionPath is not null
-                        },
-                        ct: ct).ConfigureAwait(false);
-
-                    return Ok(freeSubmissionResponse);
-                }
-
-                var invoiceResult = await CreateBtcpayInvoiceAsync(
-                    config,
-                    applicantData,
-                    requestedAmountUsd,
-                    accountEmail,
-                    isResultSubmissionOnly,
-                    isEditSubmissionOnly,
-                    ct);
-
-                if (!invoiceResult.Success)
-                {
-                    _logger.LogError(
-                        "Application submission was saved but BTCPay invoice creation failed. SubmissionId={SubmissionId} SubmissionKind={SubmissionKind} ZipSizeBytes={ZipSizeBytes} AuditEmailDelivered={AuditEmailDelivered} ArchivePath={ArchivePath} Error={Error}",
-                        submissionId,
-                        submissionKind,
-                        zipSizeBytes,
-                        auditEmailDelivered,
-                        archivedSubmissionPath,
-                        invoiceResult.Error);
-                    await TryRecordDiscountSignupAsync(
-                        applicantData,
-                        accountEmail,
-                        folderKey,
-                        submissionId,
-                        submissionKind,
-                        requestedAmountUsd,
-                        paymentCurrency,
-                        paymentRequired: true,
-                        invoiceId: null,
-                        checkoutLink: null,
-                        ct);
-
-                    await TrySendSubmissionConfirmationEmailAsync(
-                        config,
-                        accountEmail,
-                        displayNameOrName,
-                        isResultSubmissionOnly,
-                        isEditSubmissionOnly,
-                        paymentUnavailable: true,
-                        ct: ct);
-
-                    var paymentUnavailableResponse = new ApplicationSubmissionResponse(
-                        Success: true,
-                        PaymentRequired: true,
-                        CheckoutLink: null,
-                        InvoiceId: null,
-                        PaymentUnavailable: true);
-                    submissionLease.Complete(paymentUnavailableResponse);
-
-                    await TrackApplicationPaymentEventAsync(
-                        eventName: "payment_unavailable",
-                        outcome: "failed",
-                        submissionKind: submissionKind,
-                        paymentRequired: true,
-                        errorCode: "invoice_create_failed",
                         durationMs: ElapsedMilliseconds(startedAt),
                         ct: ct).ConfigureAwait(false);
 
@@ -832,90 +911,87 @@ namespace LongevityWorldCup.Website.Controllers
                             ["proofCount"] = applicantData.ProofPics?.Count ?? 0,
                             ["auditEmailDelivered"] = auditEmailDelivered,
                             ["archivedFallback"] = archivedSubmissionPath is not null,
-                            ["paymentState"] = "unavailable"
+                            ["paymentState"] = "checkout_created"
                         },
                         ct: ct).ConfigureAwait(false);
 
-                    return Ok(paymentUnavailableResponse);
+                    return Ok(paidSubmissionResponse);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    _logger.LogError(
+                        ex,
+                        "Application submission failed. SubmissionId={SubmissionId} SubmissionKind={SubmissionKind} ProofCount={ProofCount} ProofDataUrlLengths={ProofDataUrlLengths} ProfilePicDataUrlLength={ProfilePicDataUrlLength} ZipSizeBytes={ZipSizeBytes}",
+                        submissionId,
+                        submissionKind,
+                        applicantData.ProofPics?.Count ?? 0,
+                        string.Join(",", proofLengths),
+                        profilePicLength,
+                        zipSizeBytes);
+                    return await StatusCodeWithStatsAsync(500, "application_processing_failed", $"Internal server error: {ex.Message}").ConfigureAwait(false);
+                }
+            }
+            catch (OperationCanceledException ex) when (processingTimeout.IsCancellationRequested)
+            {
+                string? recoveredArchivePath = null;
+                if (!string.IsNullOrWhiteSpace(recoverableZipPath)
+                    && !string.IsNullOrWhiteSpace(recoverableFolderKey)
+                    && System.IO.File.Exists(recoverableZipPath))
+                {
+                    try
+                    {
+                        using var archiveTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+                        recoveredArchivePath = await PersistApplicationSubmissionArchiveAsync(
+                            recoverableZipPath,
+                            recoverableFolderKey,
+                            submissionId,
+                            archiveTimeout.Token).ConfigureAwait(false);
+                    }
+                    catch (Exception archiveEx)
+                    {
+                        _logger.LogError(
+                            archiveEx,
+                            "Timed-out application package could not be preserved. SubmissionId={SubmissionId} SubmissionKind={SubmissionKind}",
+                            submissionId,
+                            submissionKind);
+                    }
                 }
 
-                await TryRecordDiscountSignupAsync(
-                    applicantData,
-                    accountEmail,
-                    folderKey,
-                    submissionId,
-                    submissionKind,
-                    requestedAmountUsd,
-                    paymentCurrency,
-                    paymentRequired: true,
-                    invoiceResult.InvoiceId,
-                    invoiceResult.CheckoutLink,
-                    ct);
-
-                await TrySendSubmissionConfirmationEmailAsync(
-                    config,
-                    accountEmail,
-                    displayNameOrName,
-                    isResultSubmissionOnly,
-                    isEditSubmissionOnly,
-                    checkoutLink: invoiceResult.CheckoutLink,
-                    ct: ct);
-
-                var paidSubmissionResponse = new ApplicationSubmissionResponse(
-                    Success: true,
-                    PaymentRequired: true,
-                    CheckoutLink: invoiceResult.CheckoutLink,
-                    InvoiceId: invoiceResult.InvoiceId);
-                submissionLease.Complete(paidSubmissionResponse);
-
-                _logger.LogInformation(
-                    "Application submission succeeded. SubmissionId={SubmissionId} SubmissionKind={SubmissionKind} ProofCount={ProofCount} ZipSizeBytes={ZipSizeBytes} PaymentRequired={PaymentRequired} AuditEmailDelivered={AuditEmailDelivered} ArchivePath={ArchivePath}",
-                    submissionId,
-                    submissionKind,
-                    applicantData.ProofPics?.Count ?? 0,
-                    zipSizeBytes,
-                    true,
-                    auditEmailDelivered,
-                    archivedSubmissionPath);
-
-                await TrackApplicationPaymentEventAsync(
-                    eventName: "checkout_redirect_started",
-                    outcome: "succeeded",
-                    submissionKind: submissionKind,
-                    paymentRequired: true,
-                    errorCode: null,
-                    durationMs: ElapsedMilliseconds(startedAt),
-                    ct: ct).ConfigureAwait(false);
-
-                await TrackApplicationSubmitEventAsync(
-                    outcome: "succeeded",
-                    submissionKind: submissionKind,
-                    paymentRequired: true,
-                    errorCode: null,
-                    durationMs: ElapsedMilliseconds(startedAt),
-                    metadata: new Dictionary<string, object?>
-                    {
-                        ["proofCount"] = applicantData.ProofPics?.Count ?? 0,
-                        ["auditEmailDelivered"] = auditEmailDelivered,
-                        ["archivedFallback"] = archivedSubmissionPath is not null,
-                        ["paymentState"] = "checkout_created"
-                    },
-                    ct: ct).ConfigureAwait(false);
-
-                return Ok(paidSubmissionResponse);
-            }
-            catch (Exception ex) when (ex is not OperationCanceledException)
-            {
                 _logger.LogError(
                     ex,
-                    "Application submission failed. SubmissionId={SubmissionId} SubmissionKind={SubmissionKind} ProofCount={ProofCount} ProofDataUrlLengths={ProofDataUrlLengths} ProfilePicDataUrlLength={ProfilePicDataUrlLength} ZipSizeBytes={ZipSizeBytes}",
+                    "Application submission exceeded its processing budget. SubmissionId={SubmissionId} SubmissionKind={SubmissionKind} ProofCount={ProofCount} ArchivePath={ArchivePath}",
                     submissionId,
                     submissionKind,
                     applicantData.ProofPics?.Count ?? 0,
-                    string.Join(",", proofLengths),
-                    profilePicLength,
-                    zipSizeBytes);
-                return await StatusCodeWithStatsAsync(500, "application_processing_failed", $"Internal server error: {ex.Message}").ConfigureAwait(false);
+                    recoveredArchivePath);
+
+                try
+                {
+                    using var statsTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+                    await TrackApplicationSubmitEventAsync(
+                        outcome: "failed",
+                        submissionKind: submissionKind,
+                        paymentRequired: paymentRequiredForStats,
+                        errorCode: "application_processing_timeout",
+                        durationMs: ElapsedMilliseconds(startedAt),
+                        metadata: new Dictionary<string, object?>
+                        {
+                            ["proofCount"] = applicantData.ProofPics?.Count ?? 0,
+                            ["archivedFallback"] = recoveredArchivePath is not null
+                        },
+                        ct: statsTimeout.Token).ConfigureAwait(false);
+                }
+                catch (Exception statsEx)
+                {
+                    _logger.LogWarning(
+                        statsEx,
+                        "Failed to record timed-out application submission statistics. SubmissionId={SubmissionId}",
+                        submissionId);
+                }
+
+                return StatusCode(
+                    StatusCodes.Status504GatewayTimeout,
+                    "The application submission took too long and was canceled.");
             }
         }
 
@@ -2414,6 +2490,7 @@ namespace LongevityWorldCup.Website.Controllers
                 maxDimension: ProfileImageMaxDimension,
                 webpQuality: null,
                 existingWebpPassthroughBytes: ExistingWebpProfilePassthroughBytes,
+                allowBoundedOriginalPassthrough: false,
                 userErrorMessage: "The profile image could not be processed. Please upload a smaller image and try again.");
         }
 
@@ -2426,6 +2503,7 @@ namespace LongevityWorldCup.Website.Controllers
                 maxDimension: ProofImageMaxDimension,
                 webpQuality: 88,
                 existingWebpPassthroughBytes: ExistingWebpProofPassthroughBytes,
+                allowBoundedOriginalPassthrough: true,
                 userErrorMessage: $"Proof image {proofIndex} could not be processed. Please upload a smaller image or PDF page and try again.");
         }
 
@@ -2436,6 +2514,7 @@ namespace LongevityWorldCup.Website.Controllers
             int maxDimension,
             int? webpQuality,
             int existingWebpPassthroughBytes,
+            bool allowBoundedOriginalPassthrough,
             string userErrorMessage)
         {
             if (imageData.bytes == null || imageData.contentType == null || imageData.extension == null)
@@ -2443,14 +2522,14 @@ namespace LongevityWorldCup.Website.Controllers
                 return ImageOptimizationResult.Failure(userErrorMessage);
             }
 
-            if (imageData.extension.Equals("webp", StringComparison.OrdinalIgnoreCase)
-                && imageData.bytes.Length <= existingWebpPassthroughBytes)
-            {
-                return ImageOptimizationResult.Ok(imageData.bytes, imageData.contentType, imageData.extension);
-            }
-
             try
             {
+                if (allowBoundedOriginalPassthrough
+                    && CanPassThroughBoundedOriginalImage(imageData, maxDimension, existingWebpPassthroughBytes))
+                {
+                    return ImageOptimizationResult.Ok(imageData.bytes, imageData.contentType, imageData.extension);
+                }
+
                 // Load the image from bytes
                 using var inputStream = new MemoryStream(imageData.bytes);
                 using var image = SixLabors.ImageSharp.Image.Load(inputStream);
@@ -2459,23 +2538,26 @@ namespace LongevityWorldCup.Website.Controllers
                     ? new WebpEncoder
                     {
                         FileFormat = WebpFileFormatType.Lossy,
-                        Quality = webpQuality.Value
+                        Quality = webpQuality.Value,
+                        SkipMetadata = true
                     }
                     : new WebpEncoder
                     {
-                        FileFormat = WebpFileFormatType.Lossy
+                        FileFormat = WebpFileFormatType.Lossy,
+                        SkipMetadata = true
                     };
 
                 using var outputStream = new MemoryStream();
 
-                image.Mutate(x =>
+                image.Mutate(x => x.AutoOrient());
+                if (Math.Max(image.Width, image.Height) > maxDimension)
                 {
-                    x.Resize(new ResizeOptions
+                    image.Mutate(x => x.Resize(new ResizeOptions
                     {
                         Mode = ResizeMode.Max,
                         Size = new SixLabors.ImageSharp.Size(maxDimension, maxDimension)
-                    });
-                });
+                    }));
+                }
 
                 image.Save(outputStream, webpEncoder);
 
@@ -2483,7 +2565,8 @@ namespace LongevityWorldCup.Website.Controllers
             }
             catch (Exception ex)
             {
-                if (CanSaveOriginalImageAfterOptimizationFailure(imageData, existingWebpPassthroughBytes))
+                if (allowBoundedOriginalPassthrough
+                    && CanPassThroughBoundedOriginalImage(imageData, maxDimension, existingWebpPassthroughBytes))
                 {
                     _logger.LogWarning(
                         "Image optimization failed with {ExceptionType}: {ExceptionMessage}. Saving original submitted image. SubmissionId={SubmissionId} ProofIndex={ProofIndex} ContentType={ContentType} Extension={Extension} Bytes={Bytes}",
@@ -2510,20 +2593,43 @@ namespace LongevityWorldCup.Website.Controllers
             }
         }
 
-        private static bool CanSaveOriginalImageAfterOptimizationFailure(
+        private static bool CanPassThroughBoundedOriginalImage(
             (byte[]? bytes, string? contentType, string? extension) imageData,
-            int maxOriginalBytes)
+            int maxDimension,
+            int maxBytes)
         {
-            if (imageData.bytes is null || imageData.contentType is null || imageData.extension is null)
+            if (imageData.bytes is null
+                || imageData.extension is null
+                || imageData.bytes.Length > maxBytes
+                || !(imageData.extension.Equals("png", StringComparison.OrdinalIgnoreCase)
+                    || imageData.extension.Equals("jpg", StringComparison.OrdinalIgnoreCase)
+                    || imageData.extension.Equals("jpeg", StringComparison.OrdinalIgnoreCase)
+                    || imageData.extension.Equals("webp", StringComparison.OrdinalIgnoreCase)))
+            {
                 return false;
+            }
 
-            if (imageData.bytes.Length > maxOriginalBytes)
+            try
+            {
+                using var inputStream = new MemoryStream(imageData.bytes);
+                var imageInfo = SixLabors.ImageSharp.Image.Identify(inputStream);
+                if (imageInfo is null
+                    || imageInfo.Width > maxDimension
+                    || imageInfo.Height > maxDimension
+                    || imageInfo.Metadata.ExifProfile is not null
+                    || imageInfo.Metadata.IptcProfile is not null
+                    || imageInfo.Metadata.XmpProfile is not null)
+                {
+                    return false;
+                }
+
+                return !imageData.extension.Equals("png", StringComparison.OrdinalIgnoreCase)
+                    || imageInfo.Metadata.GetPngMetadata().TextData.Count == 0;
+            }
+            catch
+            {
                 return false;
-
-            return imageData.extension.Equals("png", StringComparison.OrdinalIgnoreCase)
-                || imageData.extension.Equals("jpg", StringComparison.OrdinalIgnoreCase)
-                || imageData.extension.Equals("jpeg", StringComparison.OrdinalIgnoreCase)
-                || imageData.extension.Equals("webp", StringComparison.OrdinalIgnoreCase);
+            }
         }
 
         [GeneratedRegex(@"data:(?<type>.+?);base64,(?<data>.+)")]

--- a/LongevityWorldCup.Website/Frontend/misc.ts
+++ b/LongevityWorldCup.Website/Frontend/misc.ts
@@ -748,9 +748,40 @@ function getErrorMessage(error: unknown): string | null {
     return error.message.slice(0, 500);
 }
 
-window.createApplicationSubmissionId = function () {
+function compactApplicationDataString(value: string): string {
+    let firstHash = 2166136261;
+    let secondHash = 0x9e3779b9;
+    for (let index = 0; index < value.length; index++) {
+        const code = value.charCodeAt(index);
+        firstHash = Math.imul(firstHash ^ code, 16777619);
+        secondHash = Math.imul(secondHash ^ code, 2246822519);
+    }
+    return `${value.length}:${(firstHash >>> 0).toString(16)}:${(secondHash >>> 0).toString(16)}`;
+}
+
+window.createApplicationSubmissionPayloadKey = function (applicantData: unknown): string {
+    const data = isRecord(applicantData) ? applicantData : {};
+    return JSON.stringify(data, (key, value: unknown) => {
+        if (key === 'proofPics' && Array.isArray(value)) {
+            return value.map(proof => typeof proof === 'string'
+                ? compactApplicationDataString(proof)
+                : proof);
+        }
+        if (key === 'profilePic' && typeof value === 'string') {
+            return compactApplicationDataString(value);
+        }
+        return value;
+    }) ?? '{}';
+};
+
+window.createApplicationSubmissionId = function (payloadFingerprint?: string) {
+    const normalizedFingerprint = typeof payloadFingerprint === 'string'
+        ? payloadFingerprint
+        : undefined;
     if (typeof window.__pendingApplicationSubmissionId === 'string'
-        && window.__pendingApplicationSubmissionId.length > 0) {
+        && window.__pendingApplicationSubmissionId.length > 0
+        && (normalizedFingerprint === undefined
+            || window.__pendingApplicationSubmissionFingerprint === normalizedFingerprint)) {
         return window.__pendingApplicationSubmissionId;
     }
 
@@ -762,10 +793,15 @@ window.createApplicationSubmissionId = function () {
     }
 
     window.__pendingApplicationSubmissionId = submissionId;
+    if (normalizedFingerprint === undefined) {
+        delete window.__pendingApplicationSubmissionFingerprint;
+    } else {
+        window.__pendingApplicationSubmissionFingerprint = normalizedFingerprint;
+    }
     return submissionId;
 };
 
-window.APPLICATION_SUBMISSION_TIMEOUT_MS = 65000;
+window.APPLICATION_SUBMISSION_TIMEOUT_MS = 310000;
 window.APPLICATION_SUBMISSION_REPORT_TIMEOUT_MS = 2500;
 
 window.readApplicationErrorMessage = async function (response) {
@@ -842,7 +878,22 @@ window.buildApplicationSubmissionReport = function (applicantData, submissionId,
         : null;
     let jsonBodyLength = null;
     try {
-        jsonBodyLength = JSON.stringify(data).length;
+        let omittedDataLength = 0;
+        const skeleton = JSON.stringify(data, (key, value: unknown) => {
+            if (key === 'proofPics' && Array.isArray(value)) {
+                return value.map(proof => {
+                    if (typeof proof !== 'string') return proof;
+                    omittedDataLength += proof.length;
+                    return '';
+                });
+            }
+            if (key === 'profilePic' && typeof value === 'string') {
+                omittedDataLength += value.length;
+                return '';
+            }
+            return value;
+        });
+        jsonBodyLength = skeleton.length + omittedDataLength;
     } catch (_) {
         jsonBodyLength = null;
     }

--- a/LongevityWorldCup.Website/Frontend/proof-helpers.ts
+++ b/LongevityWorldCup.Website/Frontend/proof-helpers.ts
@@ -267,6 +267,8 @@ window.setupProofUploadHTML = function (
         targetMaxBytes: 1.5 * 1024 * 1024
     };
     const maxProofImages = 37;
+    const proofSourceImages = new Map<string, string>();
+    let preferredProofCanvasContentType: Promise<'image/webp' | 'image/jpeg'> | null = null;
 
     ensurePdfJsReady().catch(() => {});
 
@@ -342,8 +344,8 @@ window.setupProofUploadHTML = function (
         nextButton.disabled = true;
         window.showLoading();
         try {
-            // helper to read a File as dataURL
-            const readDataURL: (file: File) => Promise<string> = file => new Promise((res, rej) => {
+            // Helper to read a File or encoded canvas Blob as a data URL.
+            const readDataURL: (file: Blob) => Promise<string> = file => new Promise((res, rej) => {
                 const r = new FileReader();
                 r.onload = () => {
                     if (typeof r.result === 'string') {
@@ -366,25 +368,141 @@ window.setupProofUploadHTML = function (
                 }
             };
 
+            const encodeCanvasBlob = (
+                canvas: HTMLCanvasElement,
+                contentType: string,
+                quality: number
+            ): Promise<Blob | null> => new Promise(resolve => canvas.toBlob(resolve, contentType, quality));
+
+            const resizeProofCanvas = (source: HTMLCanvasElement, scale: number): HTMLCanvasElement => {
+                const width = Math.max(1, Math.round(source.width * scale));
+                const height = Math.max(1, Math.round(source.height * scale));
+                if (width === source.width && height === source.height) return source;
+
+                const resized = document.createElement('canvas');
+                resized.width = width;
+                resized.height = height;
+                const context = resized.getContext('2d');
+                if (!context) throw new Error('Canvas context unavailable.');
+                context.drawImage(source, 0, 0, width, height);
+                return resized;
+            };
+
+            const getPreferredProofCanvasContentType = (): Promise<'image/webp' | 'image/jpeg'> => {
+                if (preferredProofCanvasContentType) return preferredProofCanvasContentType;
+
+                preferredProofCanvasContentType = (async () => {
+                    const probe = document.createElement('canvas');
+                    probe.width = 1;
+                    probe.height = 1;
+                    const webpBlob = await encodeCanvasBlob(
+                        probe,
+                        'image/webp',
+                        proofOptimizationOptions.quality);
+                    return webpBlob?.type.toLowerCase() === 'image/webp'
+                        ? 'image/webp'
+                        : 'image/jpeg';
+                })();
+                return preferredProofCanvasContentType;
+            };
+
+            const encodeProofCanvas: (canvas: HTMLCanvasElement) => Promise<string> = async canvas => {
+                const maxDimension = Math.max(canvas.width, canvas.height);
+                let workingCanvas = maxDimension > proofOptimizationOptions.maxSize
+                    ? resizeProofCanvas(canvas, proofOptimizationOptions.maxSize / maxDimension)
+                    : canvas;
+                const contentType = await getPreferredProofCanvasContentType();
+                let lastBlob: Blob | null = null;
+
+                // Try progressively lower quality at each size, then downscale according to
+                // the measured excess. This preserves the same bounds as normal image uploads
+                // without round-tripping a PDF canvas through createImageBitmap.
+                for (let attempt = 0; attempt < 12; attempt++) {
+                    const qualityStep = attempt % 4;
+                    const quality = Math.max(0.43, proofOptimizationOptions.quality - qualityStep * 0.15);
+                    const blob = await encodeCanvasBlob(workingCanvas, contentType, quality);
+                    if (!blob || blob.type.toLowerCase() !== contentType) {
+                        throw new Error('Proof canvas could not be encoded in a bounded image format.');
+                    }
+
+                    lastBlob = blob;
+                    if (blob.size <= proofOptimizationOptions.targetMaxBytes) {
+                        return await readDataURL(blob);
+                    }
+
+                    if (qualityStep === 3) {
+                        const measuredScale = Math.sqrt(proofOptimizationOptions.targetMaxBytes / blob.size) * 0.92;
+                        const nextScale = Math.min(0.8, Math.max(0.45, measuredScale));
+                        workingCanvas = resizeProofCanvas(workingCanvas, nextScale);
+                    }
+                }
+
+                throw new Error(
+                    `Proof canvas remained too large after bounded encoding (${lastBlob?.size ?? 0} bytes).`);
+            };
+
+            const fingerprintProofSource = async (bytes: ArrayBuffer): Promise<string> => {
+                if (window.crypto?.subtle) {
+                    const digest = await window.crypto.subtle.digest('SHA-256', bytes);
+                    return Array.from(new Uint8Array(digest))
+                        .map(value => value.toString(16).padStart(2, '0'))
+                        .join('');
+                }
+
+                // Content-based fallback for older embedded browsers. This is a duplicate
+                // hint, not a security boundary.
+                let hash = 2166136261;
+                for (const value of new Uint8Array(bytes)) {
+                    hash = Math.imul(hash ^ value, 16777619);
+                }
+                return `${bytes.byteLength}:${(hash >>> 0).toString(16)}`;
+            };
+
+            const isKnownLiveProofSource = (sourceKey: string): boolean => {
+                const existingProof = proofSourceImages.get(sourceKey);
+                if (!existingProof) return false;
+                if (proofPics.includes(existingProof)) return true;
+
+                proofSourceImages.delete(sourceKey);
+                return false;
+            };
+
             let failedFiles = 0;
             const failedFileSamples: File[] = [];
             let hitImageLimit = false;
+            let duplicateProofs = 0;
+            const knownProofImages = new Set(proofPics);
+            const addProofImage = (dataUrl: string): boolean => {
+                if (knownProofImages.has(dataUrl)) {
+                    duplicateProofs++;
+                    return false;
+                }
+
+                knownProofImages.add(dataUrl);
+                proofPics.push(dataUrl);
+                return true;
+            };
             // process one by one to preserve order
             for (const file of supportedFiles) {
                 const proofCountBeforeFile = proofPics.length;
                 try {
+                    const fileBytes = await file.arrayBuffer();
+                    const sourceFingerprint = await fingerprintProofSource(fileBytes);
                     if (isProofPdfFile(file)) {
                         const pdfLib = await ensurePdfJsReady();
-                        // read file as arrayBuffer
-                        const arrayBuffer = await file.arrayBuffer();
                         // load PDF
-                        const loadingTask = pdfLib.getDocument({ data: arrayBuffer });
+                        const loadingTask = pdfLib.getDocument({ data: fileBytes });
                         const pdfDoc = await loadingTask.promise;
                         // render each page
                         for (let pageNum = 1; pageNum <= pdfDoc.numPages; pageNum++) {
                             if (proofPics.length >= maxProofImages) {
                                 hitImageLimit = true;
                                 break;
+                            }
+                            const sourceKey = `${sourceFingerprint}:page:${pageNum}`;
+                            if (isKnownLiveProofSource(sourceKey)) {
+                                duplicateProofs++;
+                                continue;
                             }
                             const page = await pdfDoc.getPage(pageNum);
                             const viewport = page.getViewport({ scale: 1.5 });
@@ -394,10 +512,10 @@ window.setupProofUploadHTML = function (
                             const context = canvas.getContext('2d');
                             if (!context) throw new Error('Canvas context unavailable.');
                             await page.render({ canvasContext: context, viewport }).promise;
-                            const rawPage = canvas.toDataURL();
-                            const optimizedPage = await optimizeProofImageOrFallback(rawPage);
+                            const optimizedPage = await encodeProofCanvas(canvas);
                             if (optimizedPage) {
-                                proofPics.push(optimizedPage);
+                                addProofImage(optimizedPage);
+                                proofSourceImages.set(sourceKey, optimizedPage);
                             }
                         }
                         updateProofImageContainer(proofImageContainer, nextButton, proofPics, uploadProofButton, cameraButton, biomarkerChecklistContainer);
@@ -410,13 +528,20 @@ window.setupProofUploadHTML = function (
                         hitImageLimit = true;
                         break;
                     }
+                    const sourceKey = `${sourceFingerprint}:image`;
+                    if (isKnownLiveProofSource(sourceKey)) {
+                        duplicateProofs++;
+                        continue;
+                    }
                     const raw = await readDataURL(file);
                     const dataUrl = await optimizeProofImageOrFallback(raw);
                     if (dataUrl) {
-                        proofPics.push(dataUrl);
-                        updateProofImageContainer(proofImageContainer, nextButton, proofPics, uploadProofButton, cameraButton, biomarkerChecklistContainer);
-                        checkProofImages(nextButton, proofPics, uploadProofButton, cameraButton, biomarkerChecklistContainer);
-                        nextButton.disabled = true;
+                        proofSourceImages.set(sourceKey, dataUrl);
+                        if (addProofImage(dataUrl)) {
+                            updateProofImageContainer(proofImageContainer, nextButton, proofPics, uploadProofButton, cameraButton, biomarkerChecklistContainer);
+                            checkProofImages(nextButton, proofPics, uploadProofButton, cameraButton, biomarkerChecklistContainer);
+                            nextButton.disabled = true;
+                        }
                     } else {
                         failedFiles++;
                         failedFileSamples.push(file);
@@ -441,9 +566,16 @@ window.setupProofUploadHTML = function (
                 window.customAlert('Some proof files could not be processed. Please try them again as images or PDFs.')
                     .then(() => focusProofRetryButton(retryButton));
             }
+            const uploadNotices: string[] = [];
+            if (duplicateProofs > 0) {
+                uploadNotices.push('Duplicate proof images were skipped.');
+            }
             if (hitImageLimit) {
                 updateProofImageContainer(proofImageContainer, nextButton, proofPics, uploadProofButton, cameraButton, biomarkerChecklistContainer);
-                showProofUploadNotice('Only the first ' + maxProofImages + ' proof images were kept. Remove one to add another.');
+                uploadNotices.push('Only the first ' + maxProofImages + ' proof images were kept. Remove one to add another.');
+            }
+            if (uploadNotices.length > 0) {
+                showProofUploadNotice(uploadNotices.join(' '));
             }
         } catch (error) {
             trackProofFileRejected('proof_upload_failed', selectedFiles);

--- a/LongevityWorldCup.Website/Frontend/types/shared.d.ts
+++ b/LongevityWorldCup.Website/Frontend/types/shared.d.ts
@@ -380,7 +380,9 @@ interface Window {
     ): Promise<OptimizedImageResult>;
     PROFILE_IMAGE_OPTIMIZATION_OPTIONS: ImageOptimizationOptions;
     __pendingApplicationSubmissionId?: string;
-    createApplicationSubmissionId(): string;
+    __pendingApplicationSubmissionFingerprint?: string;
+    createApplicationSubmissionPayloadKey(applicantData: unknown): string;
+    createApplicationSubmissionId(payloadFingerprint?: string): string;
     APPLICATION_SUBMISSION_TIMEOUT_MS: number;
     APPLICATION_SUBMISSION_REPORT_TIMEOUT_MS: number;
     readApplicationErrorMessage(response: Response | null | undefined): Promise<string>;

--- a/LongevityWorldCup.Website/Program.cs
+++ b/LongevityWorldCup.Website/Program.cs
@@ -176,6 +176,18 @@ namespace LongevityWorldCup.Website
                             CancellationToken.None);
                     }
                 });
+                options.AddPolicy(PublicRequestTimeoutPolicies.ApplicationSubmission, new RequestTimeoutPolicy
+                {
+                    Timeout = PublicRequestTimeoutPolicies.ApplicationSubmissionTimeout,
+                    TimeoutStatusCode = StatusCodes.Status504GatewayTimeout,
+                    WriteTimeoutResponse = static context =>
+                    {
+                        context.Response.ContentType = "application/json; charset=utf-8";
+                        return context.Response.WriteAsync(
+                            "{\"message\":\"The application submission took too long and was canceled.\"}",
+                            CancellationToken.None);
+                    }
+                });
             });
 
             builder.Services.AddSingleton<AssetVersionProvider>();

--- a/LongevityWorldCup.Website/Tools/PublicRequestTimeoutPolicies.cs
+++ b/LongevityWorldCup.Website/Tools/PublicRequestTimeoutPolicies.cs
@@ -3,5 +3,8 @@ namespace LongevityWorldCup.Website.Tools;
 public static class PublicRequestTimeoutPolicies
 {
     public const string PublicWork = "public-work";
+    public const string ApplicationSubmission = "application-submission";
     public static readonly TimeSpan PublicWorkTimeout = TimeSpan.FromSeconds(60);
+    public static readonly TimeSpan ApplicationSubmissionTimeout = TimeSpan.FromMinutes(5);
+    public static readonly TimeSpan ApplicationSubmissionWorkTimeout = TimeSpan.FromSeconds(270);
 }

--- a/LongevityWorldCup.Website/wwwroot/play/proof-upload.html
+++ b/LongevityWorldCup.Website/wwwroot/play/proof-upload.html
@@ -1028,20 +1028,22 @@
                 const paymentOffer = readAdjustedPendingPaymentOffer();
                 if (paymentOffer === undefined) return;
 
-                const submissionId = window.createApplicationSubmissionId();
                 const submissionKind = 'result-upload';
                 const applicantData = {
                     name: athlete.Name,
                     accountEmail: readResultUploadContactEmail(),
                     chronoPhenoDifference: chronoPhenoDifference,
                     chronoBortzDifference: chronoBortzDifference,
-                    submissionId: submissionId,
                     biomarkers: biomarkerData.Biomarkers,
                     proofPics: proofPics,
                     paymentOffer: paymentOffer,
                     freePass: window.getFreePassValue ? window.getFreePassValue() : null,
                     discount: window.getDiscountValue ? window.getDiscountValue() : null
                 };
+                const submissionPayloadKey = window.createApplicationSubmissionPayloadKey(applicantData);
+                const submissionId = window.createApplicationSubmissionId(submissionPayloadKey);
+                applicantData.submissionId = submissionId;
+                const submissionBody = JSON.stringify(applicantData);
 
                 isResultUploadSubmitting = true;
                 submitButton.disabled = true;
@@ -1055,7 +1057,7 @@
                 fetchWithTimeout('/api/application/application', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify(applicantData)
+                    body: submissionBody
                 }, window.APPLICATION_SUBMISSION_TIMEOUT_MS || 180000)
                     .then(response => {
                         hideLoading();


### PR DESCRIPTION
## What happened

One iPhone result upload retried repeatedly with 31 proof pages and then 37 pages. Safari's PDF path fell back to PNG, the server re-encoded every page sequentially, and the 60-second ASP.NET/Nginx limits expired before a response. Reselecting the PDF appended six duplicate pages. Timed-out attempts also shared an athlete-named temporary directory, so retries could retain or mix stale proof files.

## Fix

- Encode PDF canvases directly to a verified WebP/JPEG format, probe Safari support once, and enforce the existing 2,560 px / 1.5 MiB client bounds.
- Deduplicate proof source pages and encoded output in the browser, then deduplicate again on the server before count validation and fingerprinting.
- Keep retry identifiers stable only for an unchanged compact payload key; avoid retaining/serializing the full 10–12 MB payload for diagnostics.
- Give application submissions a dedicated five-minute request budget, a 270-second server work budget, and a 310-second browser budget.
- Fast-pass bounded metadata-free proof images; auto-orient and strip metadata when re-encoding, without upscaling small images.
- Use one unique, automatically cleaned temporary workspace per attempt. Preserve a completed package on a work timeout and commit retry responses before optional post-acceptance work.
- Document the route-scoped 330-second Nginx configuration and reversible verification procedure. The public and both onion production listeners have already been updated and verified.

## Impact

Application result uploads no longer hit the old one-minute ceiling for legitimate multi-page proofs, duplicate PDF reselection cannot inflate the request, and retries cannot collide through a shared athlete workspace.

## Verification

- `dotnet test LongevityWorldCup.Tests/LongevityWorldCup.Tests.csproj --no-restore`
  - 1,351 passed
  - 0 failed
  - 0 skipped
- Browser regression covers:
  - Safari returning PNG for a WebP canvas request
  - one-time format probing across a multi-page PDF
  - same-source PDF page deduplication
  - a noisy 3,000 × 2,200 canvas bounded below 1.5 MiB and 2,560 px
  - retry ID reuse for an identical payload and rotation after an edit
- Production Nginx:
  - `nginx -t` passed
  - service active
  - exactly three route-specific 330-second locations
  - public, onion HTTP, and onion HTTPS POST probes reach ASP.NET validation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the critical application submission path (packaging, archives, payment responses, and production proxy timeouts); behavior is heavily tested but changes timeout and retry semantics users may rely on after failures.
> 
> **Overview**
> Fixes **multi-page proof uploads** timing out and **duplicate PDF reselection** inflating payloads by tightening client encoding, server handling, and layered timeouts.
> 
> **Client (`proof-helpers.ts`, `misc.ts`, proof upload page):** PDF pages are encoded from canvas via bounded WebP/JPEG (with one-time format probe) instead of PNG `toDataURL`, with duplicate detection by source fingerprint and encoded output. Submission **retry IDs** stay stable only when a **compact payload fingerprint** matches; edits rotate the ID. Browser wait rises to **310s**; diagnostic reports estimate body size without serializing full proof blobs.
> 
> **Server (`ApplicationController`, `ApplicationSubmissionWorkspace`, timeouts):** `POST /api/application/application` uses a **dedicated ~5 minute** request policy and **270s** internal work budget (replacing the generic 60s public work timeout). Proofs are **deduplicated** before the 37-image cap; processing uses a **per-attempt temp workspace** instead of athlete-named shared folders. On work timeout, a finished zip may be **archived** and **504** returned; **`submissionLease.Complete`** runs before optional email/BTCPay follow-up so retries get cached success quickly. Proof images may **passthrough** small metadata-free originals; otherwise **auto-orient**, resize, and **strip metadata** on re-encode; corrupt profile images are rejected (no silent passthrough).
> 
> **Ops:** `ServerDeployment.md` documents route-scoped **330s** Nginx `proxy_read_timeout` for the application endpoint on public and onion vhosts.
> 
> **Tests:** Expanded unit, browser, and source-structure tests for dedup, timeouts, image behavior, and retry ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a8b73113bc5a1b451b057641b15e480003fe49b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->