### PR TITLE
Sanitize application log identifiers

### DIFF
--- a/LongevityWorldCup.Tests/ApplicationControllerValidationTests.cs
+++ b/LongevityWorldCup.Tests/ApplicationControllerValidationTests.cs
@@ -429,6 +429,37 @@ public sealed class ApplicationControllerValidationTests
         Assert.Equal("data:image/png;base64,AA==", Assert.Single(applicant.ProofPics!));
     }
 
+    [Theory]
+    [InlineData("submission-safe", "submission-safe")]
+    [InlineData("submission-\r\nforged", "submission-\\r\\nforged")]
+    [InlineData("  submission-\nline  ", "submission-\\nline")]
+    public void SubmissionIdNormalizationEscapesLogLineBreaks(string submitted, string expected)
+    {
+        var method = typeof(ApplicationController).GetMethod(
+            "NormalizeSubmissionId",
+            BindingFlags.Static | BindingFlags.NonPublic);
+
+        var normalized = Assert.IsType<string>(method!.Invoke(null, [submitted]));
+
+        Assert.Equal(expected, normalized);
+        Assert.DoesNotContain('\r', normalized);
+        Assert.DoesNotContain('\n', normalized);
+    }
+
+    [Fact]
+    public void LogValueNormalizationEscapesLineBreaksBeforeTruncating()
+    {
+        var method = typeof(ApplicationController).GetMethod(
+            "TrimForLog",
+            BindingFlags.Static | BindingFlags.NonPublic);
+
+        var normalized = Assert.IsType<string>(method!.Invoke(null, ["abc\r\ndef", 8]));
+
+        Assert.Equal("abc\\r\\nd", normalized);
+        Assert.DoesNotContain('\r', normalized);
+        Assert.DoesNotContain('\n', normalized);
+    }
+
     [Fact]
     public async Task ResultSubmissionProofValidationRecordsServerStatistics()
     {

--- a/LongevityWorldCup.Tests/ApplicationControllerValidationTests.cs
+++ b/LongevityWorldCup.Tests/ApplicationControllerValidationTests.cs
@@ -447,6 +447,21 @@ public sealed class ApplicationControllerValidationTests
     }
 
     [Fact]
+    public void BlankEquivalentSubmissionIdsReceiveDistinctRetryKeys()
+    {
+        var method = typeof(ApplicationController).GetMethod(
+            "NormalizeSubmissionId",
+            BindingFlags.Static | BindingFlags.NonPublic);
+
+        var first = Assert.IsType<string>(method!.Invoke(null, ["\r\n"]));
+        var second = Assert.IsType<string>(method.Invoke(null, [" \r\n\t"]));
+
+        Assert.True(Guid.TryParseExact(first, "N", out _));
+        Assert.True(Guid.TryParseExact(second, "N", out _));
+        Assert.NotEqual(first, second);
+    }
+
+    [Fact]
     public void LogValueNormalizationEscapesLineBreaksBeforeTruncating()
     {
         var method = typeof(ApplicationController).GetMethod(

--- a/LongevityWorldCup.Website/Controllers/ApplicationController.cs
+++ b/LongevityWorldCup.Website/Controllers/ApplicationController.cs
@@ -2432,10 +2432,11 @@ namespace LongevityWorldCup.Website.Controllers
 
         private static string NormalizeSubmissionId(string? value)
         {
-            var normalized = TrimForLog(value, 80);
-            return string.IsNullOrWhiteSpace(normalized)
-                ? Guid.NewGuid().ToString("N")
-                : normalized;
+            var trimmed = value?.Trim();
+            if (string.IsNullOrWhiteSpace(trimmed))
+                return Guid.NewGuid().ToString("N");
+
+            return TrimForLog(trimmed, 80);
         }
 
         private static string CreateApplicationSubmissionFingerprint(ApplicantData applicantData)

--- a/LongevityWorldCup.Website/Controllers/ApplicationController.cs
+++ b/LongevityWorldCup.Website/Controllers/ApplicationController.cs
@@ -2432,10 +2432,10 @@ namespace LongevityWorldCup.Website.Controllers
 
         private static string NormalizeSubmissionId(string? value)
         {
-            var trimmed = value?.Trim();
-            return string.IsNullOrWhiteSpace(trimmed)
+            var normalized = TrimForLog(value, 80);
+            return string.IsNullOrWhiteSpace(normalized)
                 ? Guid.NewGuid().ToString("N")
-                : trimmed.Length <= 80 ? trimmed : trimmed[..80];
+                : normalized;
         }
 
         private static string CreateApplicationSubmissionFingerprint(ApplicantData applicantData)
@@ -2466,8 +2466,11 @@ namespace LongevityWorldCup.Website.Controllers
 
         private static string TrimForLog(string? value, int maxLength)
         {
-            var trimmed = value?.Trim() ?? "";
-            return trimmed.Length <= maxLength ? trimmed : trimmed[..maxLength];
+            var singleLine = (value ?? "")
+                .Replace("\r", "\\r", StringComparison.Ordinal)
+                .Replace("\n", "\\n", StringComparison.Ordinal)
+                .Trim();
+            return singleLine.Length <= maxLength ? singleLine : singleLine[..maxLength];
         }
 
         private static string? NormalizeFreePassValue(string? value)


### PR DESCRIPTION
## What changed

- Escape CR and LF at the shared application log-normalization boundary.
- Route normalized submission IDs through that boundary before they are used as retry keys or structured log values.
- Preserve the existing fresh-GUID behavior for blank-equivalent IDs before escaping.
- Add regression coverage for forged multi-line IDs, CR/LF-only retry keys, and truncation after escaping.

## Why

Follow-up to the CodeQL review comments on #820. `submissionId` was trimmed and truncated but could still contain embedded line breaks supplied by an HTTP client, allowing forged plain-text log entries at multiple logging sinks.

The three separate CodeQL claims about `auditEmailDelivered` are false positives: the value is a boolean delivery status and contains no address, message body, or other private information.

## Impact

Legitimate UUID and fallback submission IDs are unchanged. Crafted multi-line identifiers are made single-line while remaining deterministic for retry handling. Blank-equivalent IDs continue to receive distinct GUIDs. Other client-report fields using the shared helper now receive the same protection.

## Verification

- Full suite on the initial sanitizer commit: 1,355 passed, 0 failed, 0 skipped; zero build warnings.
- Focused controller suite after the blank-ID review fix: 100 passed, 0 failed; zero build warnings.
- Required GitHub checks rerun on the final commit before merge.