### PR TITLE
Let exceptional radar values overflow

### DIFF
--- a/LongevityWorldCup.Tests/AgeVisualizationRadarTests.cs
+++ b/LongevityWorldCup.Tests/AgeVisualizationRadarTests.cs
@@ -1,0 +1,33 @@
+using static LongevityWorldCup.Tests.FrontendSourceTestHelper;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class AgeVisualizationRadarTests
+{
+    [Fact]
+    public void RadarWeb_EndsAtEightiethPercentile_WhileDataCanReachOneHundred()
+    {
+        var source = ReadFrontendSource("age-visualization.ts");
+
+        Assert.Contains("const RADAR_WEB_BOUNDARY_PERCENTILE = 80;", source);
+        Assert.Contains("const RADAR_SCALE_MAX_PERCENTILE = 100;", source);
+        Assert.Contains("max: RADAR_SCALE_MAX_PERCENTILE", source);
+        Assert.Contains("stepSize: 20", source);
+        Assert.Contains("<= RADAR_WEB_BOUNDARY_PERCENTILE", source);
+        Assert.Contains("angleLines: { display: false }", source);
+    }
+
+    [Fact]
+    public void RadarWeb_DrawsSpokesOnlyToTheEightiethPercentileBoundary()
+    {
+        var source = ReadFrontendSource("age-visualization.ts");
+
+        Assert.Contains("plugins: [radarWebSpokesPlugin]", source);
+        Assert.Contains(
+            "scale.getPointPositionForValue(index, RADAR_WEB_BOUNDARY_PERCENTILE)",
+            source);
+        Assert.Contains("chartContext.lineTo(boundary.x, boundary.y)", source);
+        Assert.Contains("clip: 8", source);
+    }
+}

--- a/LongevityWorldCup.Website/Frontend/age-visualization.ts
+++ b/LongevityWorldCup.Website/Frontend/age-visualization.ts
@@ -46,6 +46,23 @@
         readonly dataIndex: number;
     }
 
+    interface RadarPoint {
+        readonly x: number;
+        readonly y: number;
+    }
+
+    interface RadarScale {
+        readonly xCenter: number;
+        readonly yCenter: number;
+        getPointPositionForValue(index: number, value: number): RadarPoint;
+    }
+
+    interface RadarPluginChart {
+        readonly ctx: CanvasRenderingContext2D;
+        readonly data: { readonly labels?: readonly unknown[] };
+        readonly scales?: { readonly r?: RadarScale };
+    }
+
     // Pheno Age: 5 domains (Immune first for radar; aligned with Best domain badges)
     var PHENO_DOMAINS: readonly PhenoDomain[] = [
         { key: 'immune', label: 'Immune', contributor: 'calculateImmunePhenoAgeContributor' },
@@ -268,6 +285,8 @@
     var radarResizeObserver: ResizeObserver | null = null;
     var radarResizeFrame = 0;
     const RADAR_ANIMATION_DURATION_MS = 220;
+    const RADAR_WEB_BOUNDARY_PERCENTILE = 80;
+    const RADAR_SCALE_MAX_PERCENTILE = 100;
 
     function getRadarAnimationDuration(): number {
         if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
@@ -452,9 +471,31 @@
         var radarPoint = modalStyles ? (modalStyles.getPropertyValue('--athlete-modal-cream').trim() || 'rgba(246,244,237,.92)') : 'rgba(246,244,237,.92)';
         var radarPointHitRadius = window.matchMedia && window.matchMedia('(pointer: coarse)').matches ? 18 : 8;
         var contributors = data.tooltipContributors || [];
+        var radarWebSpokesPlugin = {
+            id: 'radarWebSpokes',
+            beforeDatasetsDraw: function (chart: RadarPluginChart): void {
+                var scale = chart.scales?.r;
+                var labelCount = chart.data.labels?.length ?? 0;
+                if (!scale || labelCount === 0) return;
+
+                var chartContext = chart.ctx;
+                chartContext.save();
+                chartContext.beginPath();
+                for (var index = 0; index < labelCount; index++) {
+                    var boundary = scale.getPointPositionForValue(index, RADAR_WEB_BOUNDARY_PERCENTILE);
+                    chartContext.moveTo(scale.xCenter, scale.yCenter);
+                    chartContext.lineTo(boundary.x, boundary.y);
+                }
+                chartContext.strokeStyle = radarGridColor;
+                chartContext.lineWidth = 1;
+                chartContext.stroke();
+                chartContext.restore();
+            }
+        };
 
         radarChartInstance = new ChartConstructor(ctx, {
             type: 'radar',
+            plugins: [radarWebSpokesPlugin],
             data: {
                 labels: data.labels,
                 datasets: [{
@@ -471,7 +512,8 @@
                     pointHoverBorderWidth: 2,
                     pointRadius: 5,
                     pointHoverRadius: 7,
-                    pointHitRadius: radarPointHitRadius
+                    pointHitRadius: radarPointHitRadius,
+                    clip: 8
                 }]
             },
             options: {
@@ -510,21 +552,28 @@
                 scales: {
                     r: {
                         min: 0,
-                        max: 100,
+                        max: RADAR_SCALE_MAX_PERCENTILE,
                         beginAtZero: true,
                         ticks: {
-                            stepSize: 25,
+                            stepSize: 20,
                             backdropColor: 'transparent',
                             display: false
                         },
                         pointLabels: {
                             font: { family: fontFamily, size: 11, weight: '500' },
                             color: radarLabelColor,
-                            padding: 3,
+                            padding: 8,
                             z: 1
                         },
-                        grid: { color: radarGridColor, lineWidth: 1 },
-                        angleLines: { color: radarGridColor, lineWidth: 1 }
+                        grid: {
+                            color: function (context: { readonly tick?: { readonly value?: number } }): string {
+                                return (context.tick?.value ?? 0) <= RADAR_WEB_BOUNDARY_PERCENTILE
+                                    ? radarGridColor
+                                    : 'transparent';
+                            },
+                            lineWidth: 1
+                        },
+                        angleLines: { display: false }
                     }
                 },
                 animation: { duration: getRadarAnimationDuration() },


### PR DESCRIPTION
## Summary

- make the visible radar web end at the 80th percentile
- keep domain percentiles on their truthful 0–100 scale so values above 80 extend beyond the web
- draw spokes only to the web boundary and preserve room for 100th-percentile markers
- add focused regression coverage for the scale and custom spoke boundary

## Why

The existing radar used the 100th percentile as both the data maximum and the outer grid boundary, so even exceptional domain results could never visually exceed the spiderweb.

The new rendering reserves the surrounding 20% for exceptional values while leaving percentile calculations and tooltip values unchanged. This applies consistently to both bortz age and pheno age charts.

## Validation

- `npm run check`
- `dotnet build LongevityWorldCup.sln --no-restore`
- `dotnet test LongevityWorldCup.Tests/LongevityWorldCup.Tests.csproj --no-build --no-restore --filter FullyQualifiedName~AgeVisualizationRadarTests` (2 passed)
- local browser verification with real Valerie Orsoni and Siim Land athlete data; no browser warnings or errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontend chart styling only; percentile math and tooltips are unchanged.
> 
> **Overview**
> **Athlete age radar charts** (pheno and Bortz) now draw the visible spiderweb only through the **80th percentile**, while the scale and data still use **0–100** so exceptional domains can plot **beyond** the web.
> 
> Implementation adds `RADAR_WEB_BOUNDARY_PERCENTILE` / `RADAR_SCALE_MAX_PERCENTILE`, hides default angle lines, shows concentric grid only up to 80, and uses a custom Chart.js plugin to draw spokes to that boundary. Dataset **`clip: 8`**, tick **stepSize 20**, and slightly more label padding make room for high-percentile markers.
> 
> **`AgeVisualizationRadarTests`** adds source-string regression tests for the scale boundary and spoke plugin behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59a816a5c8c4202f19b8c39c01cafcec4a4307c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->