### PR TITLE
Stabilize athlete dialog browser test

### DIFF
--- a/LongevityWorldCup.Tests/AthleteDialogLinkBrowserTests.cs
+++ b/LongevityWorldCup.Tests/AthleteDialogLinkBrowserTests.cs
@@ -558,17 +558,10 @@ public sealed class AthleteDialogLinkBrowserTests
             "/leaderboard",
             new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
         await AssertSharedDialogInstalledAsync(page);
-        await page.WaitForFunctionAsync(
-            """
-            () => [...document.querySelectorAll(
-                '.leaderboard tbody:not(.loading-skeleton) tr[data-athlete-name]')]
-                .some(row => window.slugifyName(row.dataset.athleteName, true) === 'michael-lustgarten'
-                    && row.getBoundingClientRect().width > 0
-                    && row.getBoundingClientRect().height > 0)
-            """);
-
         var leaderboardName = page.Locator(
             ".leaderboard tbody:not(.loading-skeleton) tr[data-athlete-name='Michael Lustgarten'] .athlete-name");
+        await leaderboardName.WaitForAsync(
+            new LocatorWaitForOptions { State = WaitForSelectorState.Visible });
         await leaderboardName.ClickAsync();
         await WaitForOpenAthleteDialogAsync(page, MichaelSlug);
         var leaderboardDialog = await MeasureDialogAsync(page);


### PR DESCRIPTION
## Summary

- wait for the exact visible leaderboard athlete link before clicking it
- remove the wait predicate's dependency on the asynchronously initialized `window.slugifyName` global

## Root cause

The post-merge [master run](https://github.com/nopara73/LongevityWorldCup/actions/runs/30680761198) failed because `LeaderboardAndStandaloneLinks_RenderTheSameDialogStructureAndGeometry` called `window.slugifyName(...)` before the frontend module defining that function had loaded.

The identical test passed in PR #822 and failed on the same code after merge, exposing a nondeterministic module-loading race rather than a radar regression. Waiting on the exact element the test will click preserves the real test invariant without relying on unrelated global initialization.

## Validation

- failing test passed once after rebuilding
- failing test passed 5 additional consecutive runs
- all 13 `AthleteDialogLinkBrowserTests` passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no production behavior or runtime code paths are modified.
> 
> **Overview**
> Fixes flaky failures in **`LeaderboardAndStandaloneLinks_RenderTheSameDialogStructureAndGeometry`** by changing how the test waits on the leaderboard before opening Michael Lustgarten’s dialog.
> 
> The test no longer uses **`WaitForFunctionAsync`** to find a row whose slug matches via **`window.slugifyName`** (which could run before that global is defined). It now waits for the same **`.athlete-name`** locator it clicks to be **visible**, matching the pattern used elsewhere in this test class.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 946325a714fd0d9e06bf52d2f0c57b364cad5c61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->