### PR TITLE
Fix mobile join analytics

### DIFF
--- a/LongevityWorldCup.Tests/PlayAthleteFlowBrowserTests.cs
+++ b/LongevityWorldCup.Tests/PlayAthleteFlowBrowserTests.cs
@@ -38,6 +38,51 @@ public sealed class PlayAthleteFlowBrowserTests
         await ExpectGreenPlayActionAsync(page.Locator("#joinGoProButton"));
     }
 
+    [Theory]
+    [InlineData("joinMobileStartAmateurBtn", "pheno", "amateur")]
+    [InlineData("joinMobileGoProButton", "bortz", "pro")]
+    public async Task MobileJoinTrackActions_RecordClockSelection(
+        string controlId,
+        string expectedFlow,
+        string expectedTrack)
+    {
+        await using var app = await BrowserTestApp.StartAsync();
+        using var playwright = await Playwright.CreateAsync();
+        await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+        {
+            Headless = true
+        });
+        await using var context = await browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            BaseURL = app.BaseAddress.ToString(),
+            Locale = "en-US",
+            ViewportSize = new ViewportSize { Width = 390, Height = 844 }
+        });
+        await BrowserTestApp.RouteExternalResourcesAsync(context);
+
+        var page = await context.NewPageAsync();
+        await page.GotoAsync("/join", new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
+        await page.WaitForFunctionAsync(
+            "controlId => !document.getElementById(controlId)?.disabled",
+            controlId);
+
+        var selectionRequestTask = page.WaitForRequestAsync(request =>
+            request.Url.Contains("/api/site-statistics/event", StringComparison.OrdinalIgnoreCase) &&
+            (request.PostData ?? string.Empty).Contains("\"eventName\":\"onboarding_clock_selected\"", StringComparison.Ordinal));
+
+        await page.Locator($"#{controlId}").ClickAsync();
+        var selectionRequest = await selectionRequestTask;
+        using var payload = JsonDocument.Parse(selectionRequest.PostData ?? "{}");
+        var root = payload.RootElement;
+
+        Assert.Equal("onboarding_clock_selected", root.GetProperty("eventName").GetString());
+        Assert.Equal(expectedFlow, root.GetProperty("flow").GetString());
+        Assert.Equal(expectedTrack, root.GetProperty("step").GetString());
+        Assert.Equal("join_game", root.GetProperty("component").GetString());
+        Assert.Equal("selected", root.GetProperty("outcome").GetString());
+        Assert.Equal(expectedTrack, root.GetProperty("metadata").GetProperty("track").GetString());
+    }
+
     [Fact]
     public async Task PaymentOfferFailures_DistinguishPreparationFromStorage()
     {

--- a/LongevityWorldCup.Tests/SiteStatisticsDashboardPageTests.cs
+++ b/LongevityWorldCup.Tests/SiteStatisticsDashboardPageTests.cs
@@ -88,11 +88,15 @@ public sealed class SiteStatisticsDashboardPageTests
         var tracker = ReadFrontendSource("site-statistics-tracking.ts");
 
         Assert.Contains("id=\"joinStartAmateurBtn\"", menu);
+        Assert.Contains("id=\"joinMobileStartAmateurBtn\"", menu);
         Assert.Contains("id=\"joinGoProButton\"", menu);
+        Assert.Contains("id=\"joinMobileGoProButton\"", menu);
         Assert.Contains("id=\"joinStartChallengeLink\"", menu);
         Assert.Contains("play-join-biomarkers", menu);
         Assert.Contains("joinStartAmateurBtn", tracker);
+        Assert.Contains("joinMobileStartAmateurBtn", tracker);
         Assert.Contains("joinGoProButton", tracker);
+        Assert.Contains("joinMobileGoProButton", tracker);
         Assert.Contains("joinStartChallengeLink", tracker);
         Assert.Contains("onboarding_challenge_selected", tracker);
         Assert.Contains("crypto.getRandomValues(new Uint8Array(16))", tracker);

--- a/LongevityWorldCup.Website/Frontend/site-statistics-tracking.ts
+++ b/LongevityWorldCup.Website/Frontend/site-statistics-tracking.ts
@@ -750,27 +750,47 @@
     }
 
     function setupJoinGameTracking(): void {
-        const amateur = document.getElementById("joinStartAmateurBtn") || document.querySelector("[onclick*='startAmateurApplication']");
-        const pro = document.getElementById("joinGoProButton") || document.querySelector("[onclick*='startProApplication']");
+        function joinTrackControls(controlIds: readonly string[], fallbackSelector: string): Element[] {
+            const controls: Element[] = [];
+            controlIds.forEach(controlId => {
+                const control = document.getElementById(controlId);
+                if (control && !controls.includes(control)) controls.push(control);
+            });
+
+            const fallback = document.querySelector(fallbackSelector);
+            if (fallback && !controls.includes(fallback)) controls.push(fallback);
+            return controls;
+        }
+
+        const amateurControls = joinTrackControls(
+            ["joinStartAmateurBtn", "joinMobileStartAmateurBtn"],
+            "[onclick*='startAmateurApplication']");
+        const proControls = joinTrackControls(
+            ["joinGoProButton", "joinMobileGoProButton"],
+            "[onclick*='startProApplication']");
         const challenge = document.getElementById("joinStartChallengeLink");
-        listen(amateur, "click", () => {
-            track("onboarding_clock_selected", {
-                flow: "pheno",
-                component: "join_game",
-                step: "amateur",
-                outcome: "selected",
-                metadata: { track: "amateur" }
-            });
-        }, { passive: true });
-        listen(pro, "click", () => {
-            track("onboarding_clock_selected", {
-                flow: "bortz",
-                component: "join_game",
-                step: "pro",
-                outcome: "selected",
-                metadata: { track: "pro" }
-            });
-        }, { passive: true });
+        amateurControls.forEach(amateur => {
+            listen(amateur, "click", () => {
+                track("onboarding_clock_selected", {
+                    flow: "pheno",
+                    component: "join_game",
+                    step: "amateur",
+                    outcome: "selected",
+                    metadata: { track: "amateur" }
+                });
+            }, { passive: true });
+        });
+        proControls.forEach(pro => {
+            listen(pro, "click", () => {
+                track("onboarding_clock_selected", {
+                    flow: "bortz",
+                    component: "join_game",
+                    step: "pro",
+                    outcome: "selected",
+                    metadata: { track: "pro" }
+                });
+            }, { passive: true });
+        });
         listen(challenge, "click", () => {
             track("onboarding_challenge_selected", {
                 flow: "challenge",


### PR DESCRIPTION
Fixes missing onboarding_clock_selected events from the mobile Amateur and Pro join controls by registering the desktop and mobile controls through the same tracking path. Retains the legacy selector fallback and adds mobile browser coverage that validates the posted event payload. Tests: dotnet build LongevityWorldCup.Tests/LongevityWorldCup.Tests.csproj --configuration Debug; 48 neighboring tests passed, including the two new mobile analytics cases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only listener wiring with parity to existing desktop behavior; no auth, payment, or data-path changes.
> 
> **Overview**
> **Fixes missing `onboarding_clock_selected` analytics** when users tap the mobile Amateur/Pro join buttons on `/join`.
> 
> `setupJoinGameTracking` now collects **desktop and mobile control IDs** (`joinMobileStartAmateurBtn`, `joinMobileGoProButton`) through a shared `joinTrackControls` helper and attaches the same click handlers as the existing desktop buttons, while keeping the legacy `onclick` fallback selectors.
> 
> **Tests:** a static check ensures `menu.html` and the tracker source list the mobile IDs; new Playwright cases on a mobile viewport assert the posted `/api/site-statistics/event` payload (`eventName`, `flow`, `step`, `metadata.track`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40d3793397cdd592d04b764bab9c667905617006. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->