### PR TITLE
Fix dashboard time window consistency

### DIFF
--- a/LongevityWorldCup.Tests/SiteStatisticsDashboardBrowserTests.cs
+++ b/LongevityWorldCup.Tests/SiteStatisticsDashboardBrowserTests.cs
@@ -164,6 +164,91 @@ public sealed class SiteStatisticsDashboardBrowserTests
     }
 
     [Fact]
+    public async Task Dashboard_DiagnosticsLoadCompleteCurrentAndPreviousWindows()
+    {
+        await using var app = await BrowserTestApp.StartAsync();
+        using var playwright = await Playwright.CreateAsync();
+        await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+        {
+            Headless = true
+        });
+        await using var context = await browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            BaseURL = app.BaseAddress.ToString(),
+            Locale = "en-US",
+            ViewportSize = new ViewportSize { Width = 1440, Height = 980 }
+        });
+        await BrowserTestApp.RouteExternalResourcesAsync(context);
+
+        var page = await context.NewPageAsync();
+        var errors = new List<string>();
+        var paginationRequests = new List<string>();
+        page.Console += (_, message) =>
+        {
+            if (message.Type == "error")
+                errors.Add(message.Text);
+        };
+        page.PageError += (_, error) => errors.Add(error);
+
+        await RoutePagedDashboardAsync(page, paginationRequests);
+
+        await page.GotoAsync(
+            "/internal/site-statistics.html?tab=Onboarding%20Diagnostics",
+            new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
+        await page.Locator("#statsStatus").GetByText("2 current and 2 previous redacted events", new() { Exact = false }).WaitForAsync();
+
+        Assert.Equal(2, paginationRequests.Count);
+        Assert.Contains(paginationRequests, url => url.Contains("cursor=current-cursor", StringComparison.Ordinal));
+        Assert.Contains(paginationRequests, url => url.Contains("cursor=previous-cursor", StringComparison.Ordinal));
+        Assert.Contains(paginationRequests, url => url.Contains("fromUtc=2026-08-08", StringComparison.Ordinal));
+        Assert.Contains(paginationRequests, url => url.Contains("fromUtc=2026-08-01", StringComparison.Ordinal));
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public async Task Dashboard_ExportLoadsCompleteCurrentWindow()
+    {
+        await using var app = await BrowserTestApp.StartAsync();
+        using var playwright = await Playwright.CreateAsync();
+        await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+        {
+            Headless = true
+        });
+        await using var context = await browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            BaseURL = app.BaseAddress.ToString(),
+            Locale = "en-US",
+            ViewportSize = new ViewportSize { Width = 1440, Height = 980 },
+            AcceptDownloads = true
+        });
+        await BrowserTestApp.RouteExternalResourcesAsync(context);
+
+        var page = await context.NewPageAsync();
+        var errors = new List<string>();
+        var paginationRequests = new List<string>();
+        page.Console += (_, message) =>
+        {
+            if (message.Type == "error")
+                errors.Add(message.Text);
+        };
+        page.PageError += (_, error) => errors.Add(error);
+        await RoutePagedDashboardAsync(page, paginationRequests);
+
+        await page.GotoAsync("/internal/site-statistics.html", new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
+        await page.Locator("#trafficOverview").GetByText("Visitor sessions", new() { Exact = true }).WaitForAsync();
+        var downloadTask = page.WaitForDownloadAsync();
+        await page.Locator("#statsExport").ClickAsync();
+        var download = await downloadTask;
+        await page.Locator("#statsStatus").GetByText("Exported 2 redacted events from the complete 7D window.", new() { Exact = true }).WaitForAsync();
+
+        Assert.Equal("site-statistics-redacted.csv", download.SuggestedFilename);
+        var request = Assert.Single(paginationRequests);
+        Assert.Contains("cursor=current-cursor", request, StringComparison.Ordinal);
+        Assert.DoesNotContain("cursor=previous-cursor", request, StringComparison.Ordinal);
+        Assert.Empty(errors);
+    }
+
+    [Fact]
     public async Task ApplyPage_RecordsOnlyTheCoarseApplicationStage()
     {
         await using var app = await BrowserTestApp.StartAsync();
@@ -301,4 +386,115 @@ public sealed class SiteStatisticsDashboardBrowserTests
 
         response.EnsureSuccessStatusCode();
     }
+
+    private static Task RoutePagedDashboardAsync(IPage page, List<string> paginationRequests)
+        => page.RouteAsync("**/api/site-statistics/dashboard**", async route =>
+        {
+            var url = route.Request.Url;
+            if (url.Contains("/dashboard/events", StringComparison.Ordinal))
+            {
+                paginationRequests.Add(url);
+                var previous = url.Contains("fromUtc=2026-08-01", StringComparison.Ordinal);
+                await route.FulfillAsync(new RouteFulfillOptions
+                {
+                    Status = 200,
+                    ContentType = "application/json",
+                    Body = JsonSerializer.Serialize(new
+                    {
+                        events = new[]
+                        {
+                            DashboardEventPayload(
+                                "onboarding_clock_selected",
+                                previous ? "previous-session" : "current-session",
+                                previous ? "2026-08-07T12:00:00Z" : "2026-08-14T12:00:00Z")
+                        },
+                        page = new { hasMore = false, nextCursor = (string?)null }
+                    })
+                });
+                return;
+            }
+
+            await route.FulfillAsync(new RouteFulfillOptions
+            {
+                Status = 200,
+                ContentType = "application/json",
+                Body = JsonSerializer.Serialize(new
+                {
+                    generatedAtUtc = "2026-08-15T00:00:00Z",
+                    filters = new
+                    {
+                        range = "7d",
+                        flow = "all",
+                        device = "all",
+                        source = "all",
+                        fromUtc = "2026-08-08T00:00:00Z",
+                        toUtc = "2026-08-15T00:00:00Z",
+                        previousFromUtc = "2026-08-01T00:00:00Z",
+                        previousToUtc = "2026-08-08T00:00:00Z",
+                        limit = 5000
+                    },
+                    trafficSummary = EmptyTrafficSummaryPayload(),
+                    events = new[] { DashboardEventPayload("onboarding_entry_viewed", "current-session", "2026-08-14T11:00:00Z") },
+                    previousEvents = new[] { DashboardEventPayload("onboarding_entry_viewed", "previous-session", "2026-08-07T11:00:00Z") },
+                    eventsPage = new { hasMore = true, nextCursor = "current-cursor" },
+                    previousEventsPage = new { hasMore = true, nextCursor = "previous-cursor" }
+                })
+            });
+        });
+
+    private static object DashboardEventPayload(string eventName, string sessionHash, string occurredAtUtc)
+        => new
+        {
+            occurredAtUtc,
+            sessionHash,
+            actorHash = (string?)null,
+            eventName,
+            flow = "onboarding",
+            route = "/join",
+            component = "join_game",
+            step = "amateur",
+            outcome = "selected",
+            errorCode = (string?)null,
+            durationMs = (long?)null,
+            deviceClass = "desktop",
+            browserFamily = "Chromium",
+            referrerDomain = (string?)null,
+            source = "direct",
+            landingRoute = "/join",
+            firstReferrerDomain = (string?)null,
+            firstSource = "direct",
+            firstCampaign = (string?)null,
+            firstUtmSource = (string?)null,
+            firstUtmMedium = (string?)null,
+            firstUtmCampaign = (string?)null,
+            firstUtmTerm = (string?)null,
+            firstUtmContent = (string?)null,
+            metadata = new Dictionary<string, string>()
+        };
+
+    private static object EmptyTrafficSummaryPayload()
+        => new
+        {
+            totals = new { sessions = 0, pageViews = 0, events = 0 },
+            previousTotals = new { sessions = 0, pageViews = 0, events = 0 },
+            cleanTotals = new { sessions = 0, pageViews = 0, events = 0 },
+            quality = new
+            {
+                rawSessions = 0,
+                cleanSessions = 0,
+                noisySessions = 0,
+                topSessionEvents = 0,
+                topSessionShare = 0,
+                repeatedPageViewSessions = 0,
+                pageViewDominantSessions = 0,
+                noisyPageViews = 0,
+                noisyPageViewShare = 0
+            },
+            daily = Array.Empty<object>(),
+            topPages = Array.Empty<object>(),
+            sources = Array.Empty<object>(),
+            referrers = Array.Empty<object>(),
+            devices = Array.Empty<object>(),
+            browsers = Array.Empty<object>()
+        };
 }

--- a/LongevityWorldCup.Tests/SiteStatisticsServiceTests.cs
+++ b/LongevityWorldCup.Tests/SiteStatisticsServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json;
 using LongevityWorldCup.Website.Business;
 using Microsoft.AspNetCore.Http;
@@ -152,6 +153,9 @@ public sealed class SiteStatisticsServiceTests
         var dashboard = await service.GetDashboardAsync(new SiteStatisticsDashboardQuery { Range = "7d", Limit = 1 });
 
         Assert.Single(dashboard.Events);
+        Assert.True(dashboard.EventsPage.HasMore);
+        Assert.NotNull(dashboard.EventsPage.NextCursor);
+        Assert.False(dashboard.PreviousEventsPage.HasMore);
         Assert.Equal(5006, dashboard.TrafficSummary.Totals.Events);
         Assert.Equal(5006, dashboard.TrafficSummary.Totals.PageViews);
         Assert.Equal(5006, dashboard.TrafficSummary.Totals.Sessions);
@@ -179,6 +183,107 @@ public sealed class SiteStatisticsServiceTests
         Assert.Equal("search", source.Label);
         var referrer = Assert.Single(searchOnly.TrafficSummary.Referrers);
         Assert.Equal("www.google.com", referrer.Label);
+
+        var stableTo = DateTimeOffset.Parse(dashboard.Filters.ToUtc, CultureInfo.InvariantCulture);
+        InsertDashboardEvent(
+            database,
+            stableTo.AddMilliseconds(1),
+            "S-AFTER-SNAPSHOT",
+            "site_page_viewed",
+            "site",
+            route: "/after-snapshot");
+
+        var continuation = await service.GetDashboardEventsPageAsync(new SiteStatisticsDashboardEventsPageQuery
+        {
+            FromUtc = DateTimeOffset.Parse(dashboard.Filters.FromUtc, CultureInfo.InvariantCulture),
+            ToUtc = stableTo,
+            Flow = dashboard.Filters.Flow,
+            Device = dashboard.Filters.Device,
+            Source = dashboard.Filters.Source,
+            Limit = 5000,
+            Cursor = dashboard.EventsPage.NextCursor
+        });
+        Assert.Equal(5000, continuation.Events.Count);
+        Assert.True(continuation.Page.HasMore);
+        Assert.NotNull(continuation.Page.NextCursor);
+
+        var finalPage = await service.GetDashboardEventsPageAsync(new SiteStatisticsDashboardEventsPageQuery
+        {
+            FromUtc = DateTimeOffset.Parse(dashboard.Filters.FromUtc, CultureInfo.InvariantCulture),
+            ToUtc = stableTo,
+            Flow = dashboard.Filters.Flow,
+            Device = dashboard.Filters.Device,
+            Source = dashboard.Filters.Source,
+            Limit = 5000,
+            Cursor = continuation.Page.NextCursor
+        });
+        Assert.Equal(5, finalPage.Events.Count);
+        Assert.False(finalPage.Page.HasMore);
+        Assert.Null(finalPage.Page.NextCursor);
+        var completeWindow = dashboard.Events.Concat(continuation.Events).Concat(finalPage.Events).ToList();
+        Assert.Equal(5006, completeWindow.Count);
+        Assert.Equal(5006, completeWindow.Select(ev => ev.SessionHash).Distinct(StringComparer.Ordinal).Count());
+        Assert.DoesNotContain(completeWindow, ev => ev.SessionHash == "S-AFTER-SNAPSHOT");
+
+        await Assert.ThrowsAsync<ArgumentException>(() => service.GetDashboardEventsPageAsync(new SiteStatisticsDashboardEventsPageQuery
+        {
+            FromUtc = DateTimeOffset.Parse(dashboard.Filters.FromUtc, CultureInfo.InvariantCulture),
+            ToUtc = stableTo,
+            Flow = dashboard.Filters.Flow,
+            Device = dashboard.Filters.Device,
+            Source = "search",
+            Limit = 5000,
+            Cursor = dashboard.EventsPage.NextCursor
+        }));
+    }
+
+    [Fact]
+    public async Task DashboardEventsEndpoint_PagesStableWindowsAndRejectsInvalidRequests()
+    {
+        await using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+        foreach (var sessionId in new[] { "endpoint-page-a", "endpoint-page-b" })
+        {
+            using var response = await client.PostAsync(
+                "/api/site-statistics/event",
+                JsonContent.Create(new SiteStatisticsEventRequest
+                {
+                    EventName = "site_page_viewed",
+                    SessionId = sessionId,
+                    Flow = "site",
+                    Route = "/",
+                    DeviceClass = "desktop",
+                    Source = "direct"
+                }));
+            response.EnsureSuccessStatusCode();
+        }
+
+        var dashboard = await client.GetFromJsonAsync<SiteStatisticsDashboardResponse>(
+            "/api/site-statistics/dashboard?range=7d&limit=1");
+        Assert.NotNull(dashboard);
+        Assert.True(dashboard.EventsPage.HasMore);
+        Assert.NotNull(dashboard.EventsPage.NextCursor);
+
+        var continuationUrl =
+            $"/api/site-statistics/dashboard/events?fromUtc={Uri.EscapeDataString(dashboard.Filters.FromUtc)}" +
+            $"&toUtc={Uri.EscapeDataString(dashboard.Filters.ToUtc)}" +
+            $"&flow={Uri.EscapeDataString(dashboard.Filters.Flow ?? "all")}" +
+            $"&device={Uri.EscapeDataString(dashboard.Filters.Device ?? "all")}" +
+            $"&source={Uri.EscapeDataString(dashboard.Filters.Source ?? "all")}" +
+            $"&limit=1&cursor={Uri.EscapeDataString(dashboard.EventsPage.NextCursor)}";
+        var continuation = await client.GetFromJsonAsync<SiteStatisticsDashboardEventsPageResponse>(continuationUrl);
+        Assert.NotNull(continuation);
+        Assert.Single(continuation.Events);
+        Assert.False(continuation.Page.HasMore);
+
+        var now = DateTimeOffset.UtcNow;
+
+        using var missingWindow = await client.GetAsync("/api/site-statistics/dashboard/events?cursor=invalid");
+        Assert.Equal(HttpStatusCode.BadRequest, missingWindow.StatusCode);
+
+        var invalidCursorUrl = $"/api/site-statistics/dashboard/events?fromUtc={Uri.EscapeDataString(now.AddDays(-1).ToString("O"))}&toUtc={Uri.EscapeDataString(now.ToString("O"))}&cursor=invalid";
+        using var invalidCursor = await client.GetAsync(invalidCursorUrl);
+        Assert.Equal(HttpStatusCode.BadRequest, invalidCursor.StatusCode);
     }
 
     [Fact]

--- a/LongevityWorldCup.Website/Business/SiteStatisticsService.cs
+++ b/LongevityWorldCup.Website/Business/SiteStatisticsService.cs
@@ -216,22 +216,56 @@ public sealed class SiteStatisticsService : IHostedService
                 GeneratedAtUtc: now.ToString("O", CultureInfo.InvariantCulture),
                 Filters: filters,
                 TrafficSummary: trafficSummary,
-                Events: events,
-                PreviousEvents: previousEvents));
+                Events: events.Events,
+                PreviousEvents: previousEvents.Events,
+                EventsPage: events.Page,
+                PreviousEventsPage: previousEvents.Page));
         }, ct).ConfigureAwait(false);
     }
 
-    private static List<SiteStatisticsDashboardEvent> ReadDashboardEvents(
+    public async Task<SiteStatisticsDashboardEventsPageResponse> GetDashboardEventsPageAsync(
+        SiteStatisticsDashboardEventsPageQuery query,
+        CancellationToken ct = default)
+    {
+        EnsureInitialized();
+        await FlushQueuedEventsAsync(ct).ConfigureAwait(false);
+
+        if (query.FromUtc is null || query.ToUtc is null)
+            throw new ArgumentException("Both fromUtc and toUtc are required.", nameof(query));
+
+        var from = query.FromUtc.Value.ToUniversalTime();
+        var to = query.ToUtc.Value.ToUniversalTime();
+        if (from < AllTimeDashboardStartUtc || from >= to)
+            throw new ArgumentException("The dashboard event window is invalid.", nameof(query));
+
+        var limit = Math.Clamp(query.Limit ?? DefaultDashboardLimit, 1, MaxDashboardLimit);
+        var filters = new SiteStatisticsDashboardQuery
+        {
+            Flow = query.Flow,
+            Device = query.Device,
+            Source = query.Source
+        };
+
+        return await _database.RunAsync(sqlite =>
+        {
+            var page = ReadDashboardEvents(sqlite, from, to, filters, limit, query.Cursor);
+            return Task.FromResult(new SiteStatisticsDashboardEventsPageResponse(page.Events, page.Page));
+        }, ct).ConfigureAwait(false);
+    }
+
+    private static DashboardEventPageResult ReadDashboardEvents(
         SqliteConnection sqlite,
         DateTimeOffset from,
         DateTimeOffset to,
         SiteStatisticsDashboardQuery query,
-        int limit)
+        int limit,
+        string? cursor = null)
     {
+        var decodedCursor = DecodeDashboardEventCursor(cursor, from, to, query);
         using var cmd = sqlite.CreateCommand();
         cmd.CommandText =
             """
-            SELECT e.OccurredAtUtc, e.SessionHash, e.ActorHash, e.EventName, e.Flow, e.Route, e.Component, e.Step, e.Outcome,
+            SELECT e.Id, e.OccurredAtUtc, e.SessionHash, e.ActorHash, e.EventName, e.Flow, e.Route, e.Component, e.Step, e.Outcome,
                    e.ErrorCode, e.DurationMs, e.DeviceClass, e.BrowserFamily, e.ReferrerDomain, e.Source, e.MetadataJson,
                    s.LandingRoute, s.FirstReferrerDomain, s.FirstSource, s.FirstCampaign, s.FirstUtmSource,
                    s.FirstUtmMedium, s.FirstUtmCampaign, s.FirstUtmTerm, s.FirstUtmContent
@@ -239,6 +273,8 @@ public sealed class SiteStatisticsService : IHostedService
             LEFT JOIN SiteStatisticSessions s ON s.SessionHash = e.SessionHash
             WHERE e.OccurredAtUtc >= @from
               AND e.OccurredAtUtc < @to
+              AND (@cursorOccurred = '' OR e.OccurredAtUtc < @cursorOccurred
+                   OR (e.OccurredAtUtc = @cursorOccurred AND e.Id < @cursorId))
               AND (@flow = '' OR e.Flow = @flow)
               AND (@device = '' OR e.DeviceClass = @device)
               AND (@source = '' OR (
@@ -273,25 +309,29 @@ public sealed class SiteStatisticsService : IHostedService
                         ELSE coalesce(e.Source, 'direct')
                     END
                   ) = @source)
-            ORDER BY e.OccurredAtUtc DESC
-            LIMIT @limit;
+            ORDER BY e.OccurredAtUtc DESC, e.Id DESC
+            LIMIT @fetchLimit;
             """;
         Add(cmd, "@from", from.ToString("O", CultureInfo.InvariantCulture));
         Add(cmd, "@to", to.ToString("O", CultureInfo.InvariantCulture));
+        Add(cmd, "@cursorOccurred", decodedCursor?.OccurredAtUtc ?? string.Empty);
+        Add(cmd, "@cursorId", decodedCursor?.Id ?? string.Empty);
         Add(cmd, "@flow", NormalizeFilter(query.Flow));
         Add(cmd, "@device", NormalizeFilter(query.Device));
         Add(cmd, "@source", NormalizeFilter(query.Source));
-        Add(cmd, "@limit", limit);
+        Add(cmd, "@fetchLimit", limit + 1);
 
-        var events = new List<SiteStatisticsDashboardEvent>();
+        var rows = new List<DashboardEventRow>();
         using var reader = cmd.ExecuteReader();
         while (reader.Read())
         {
-            var referrerDomain = ReadNullableString(reader, 13);
-            var firstReferrerDomain = ReadNullableString(reader, 17);
-            var routeProjection = BuildRouteProjection(ReadNullableString(reader, 5));
-            var landingRouteProjection = BuildRouteProjection(ReadNullableString(reader, 16));
-            var metadata = ReadMetadata(ReadNullableString(reader, 15));
+            var id = ReadString(reader, 0);
+            var occurredAtUtc = ReadString(reader, 1);
+            var referrerDomain = ReadNullableString(reader, 14);
+            var firstReferrerDomain = ReadNullableString(reader, 18);
+            var routeProjection = BuildRouteProjection(ReadNullableString(reader, 6));
+            var landingRouteProjection = BuildRouteProjection(ReadNullableString(reader, 17));
+            var metadata = ReadMetadata(ReadNullableString(reader, 16));
             if (!string.IsNullOrWhiteSpace(routeProjection.EntryMode) && !metadata.ContainsKey("entryMode"))
             {
                 metadata = new Dictionary<string, string>(metadata, StringComparer.OrdinalIgnoreCase)
@@ -300,35 +340,46 @@ public sealed class SiteStatisticsService : IHostedService
                 };
             }
 
-            events.Add(new SiteStatisticsDashboardEvent(
-                OccurredAtUtc: RoundToMinute(ReadString(reader, 0)),
-                SessionHash: ReadString(reader, 1),
-                ActorHash: ReadNullableString(reader, 2),
-                EventName: ReadString(reader, 3),
-                Flow: ReadNullableString(reader, 4),
+            rows.Add(new DashboardEventRow(
+                Event: new SiteStatisticsDashboardEvent(
+                OccurredAtUtc: RoundToMinute(occurredAtUtc),
+                SessionHash: ReadString(reader, 2),
+                ActorHash: ReadNullableString(reader, 3),
+                EventName: ReadString(reader, 4),
+                Flow: ReadNullableString(reader, 5),
                 Route: routeProjection.Route,
-                Component: ReadNullableString(reader, 6),
-                Step: ReadNullableString(reader, 7),
-                Outcome: ReadNullableString(reader, 8),
-                ErrorCode: ReadNullableString(reader, 9),
-                DurationMs: reader.IsDBNull(10) ? null : reader.GetInt64(10),
-                DeviceClass: ReadNullableString(reader, 11),
-                BrowserFamily: ReadNullableString(reader, 12),
+                Component: ReadNullableString(reader, 7),
+                Step: ReadNullableString(reader, 8),
+                Outcome: ReadNullableString(reader, 9),
+                ErrorCode: ReadNullableString(reader, 10),
+                DurationMs: reader.IsDBNull(11) ? null : reader.GetInt64(11),
+                DeviceClass: ReadNullableString(reader, 12),
+                BrowserFamily: ReadNullableString(reader, 13),
                 ReferrerDomain: referrerDomain,
-                Source: NormalizeSource(ReadNullableString(reader, 14), referrerDomain),
+                Source: NormalizeSource(ReadNullableString(reader, 15), referrerDomain),
                 LandingRoute: landingRouteProjection.Route,
                 FirstReferrerDomain: firstReferrerDomain,
-                FirstSource: NormalizeSource(ReadNullableString(reader, 18), firstReferrerDomain),
-                FirstCampaign: ReadNullableString(reader, 19),
-                FirstUtmSource: ReadNullableString(reader, 20),
-                FirstUtmMedium: ReadNullableString(reader, 21),
-                FirstUtmCampaign: ReadNullableString(reader, 22),
-                FirstUtmTerm: ReadNullableString(reader, 23),
-                FirstUtmContent: ReadNullableString(reader, 24),
-                Metadata: metadata));
+                FirstSource: NormalizeSource(ReadNullableString(reader, 19), firstReferrerDomain),
+                FirstCampaign: ReadNullableString(reader, 20),
+                FirstUtmSource: ReadNullableString(reader, 21),
+                FirstUtmMedium: ReadNullableString(reader, 22),
+                FirstUtmCampaign: ReadNullableString(reader, 23),
+                FirstUtmTerm: ReadNullableString(reader, 24),
+                FirstUtmContent: ReadNullableString(reader, 25),
+                Metadata: metadata),
+                Cursor: new DashboardEventPosition(occurredAtUtc, id)));
         }
 
-        return events;
+        var hasMore = rows.Count > limit;
+        if (hasMore)
+            rows.RemoveAt(rows.Count - 1);
+
+        var nextCursor = hasMore && rows.Count > 0
+            ? EncodeDashboardEventCursor(rows[^1].Cursor, from, to, query)
+            : null;
+        return new DashboardEventPageResult(
+            rows.Select(static row => row.Event).ToList(),
+            new SiteStatisticsDashboardEventPage(HasMore: hasMore, NextCursor: nextCursor));
     }
 
     private static SiteStatisticsTrafficSummary ReadTrafficSummary(
@@ -1478,6 +1529,64 @@ public sealed class SiteStatisticsService : IHostedService
         return string.IsNullOrWhiteSpace(ua) ? "unknown" : "other";
     }
 
+    private static string EncodeDashboardEventCursor(
+        DashboardEventPosition position,
+        DateTimeOffset from,
+        DateTimeOffset to,
+        SiteStatisticsDashboardQuery query)
+    {
+        var cursor = new DashboardEventCursor(
+            position.OccurredAtUtc,
+            position.Id,
+            from.ToString("O", CultureInfo.InvariantCulture),
+            to.ToString("O", CultureInfo.InvariantCulture),
+            NormalizeFilter(query.Flow),
+            NormalizeFilter(query.Device),
+            NormalizeFilter(query.Source));
+        return WebEncoders.Base64UrlEncode(JsonSerializer.SerializeToUtf8Bytes(cursor, JsonOptions));
+    }
+
+    private static DashboardEventCursor? DecodeDashboardEventCursor(
+        string? cursor,
+        DateTimeOffset from,
+        DateTimeOffset to,
+        SiteStatisticsDashboardQuery query)
+    {
+        if (string.IsNullOrWhiteSpace(cursor))
+            return null;
+
+        try
+        {
+            var decoded = JsonSerializer.Deserialize<DashboardEventCursor>(
+                WebEncoders.Base64UrlDecode(cursor),
+                JsonOptions);
+            if (decoded is null)
+                throw new FormatException();
+
+            if (!DateTimeOffset.TryParse(
+                    decoded.OccurredAtUtc,
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.AssumeUniversal,
+                    out _) ||
+                decoded.Id.Length != 32 ||
+                !decoded.Id.All(Uri.IsHexDigit) ||
+                !string.Equals(decoded.FromUtc, from.ToString("O", CultureInfo.InvariantCulture), StringComparison.Ordinal) ||
+                !string.Equals(decoded.ToUtc, to.ToString("O", CultureInfo.InvariantCulture), StringComparison.Ordinal) ||
+                !string.Equals(decoded.Flow, NormalizeFilter(query.Flow), StringComparison.Ordinal) ||
+                !string.Equals(decoded.Device, NormalizeFilter(query.Device), StringComparison.Ordinal) ||
+                !string.Equals(decoded.Source, NormalizeFilter(query.Source), StringComparison.Ordinal))
+            {
+                throw new FormatException();
+            }
+
+            return decoded;
+        }
+        catch (Exception ex) when (ex is FormatException or ArgumentException or JsonException)
+        {
+            throw new ArgumentException("The dashboard event cursor is invalid.", nameof(cursor), ex);
+        }
+    }
+
     private static DateTimeOffset ResolveFrom(string? range, DateTimeOffset now)
         => (range ?? "30d").Trim().ToLowerInvariant() switch
         {
@@ -1536,6 +1645,25 @@ public sealed class SiteStatisticsService : IHostedService
         long Events,
         long PageViews,
         long LargestRepeatedPageViews);
+
+    private sealed record DashboardEventCursor(
+        string OccurredAtUtc,
+        string Id,
+        string FromUtc,
+        string ToUtc,
+        string Flow,
+        string Device,
+        string Source);
+
+    private sealed record DashboardEventPosition(string OccurredAtUtc, string Id);
+
+    private sealed record DashboardEventRow(
+        SiteStatisticsDashboardEvent Event,
+        DashboardEventPosition Cursor);
+
+    private sealed record DashboardEventPageResult(
+        IReadOnlyList<SiteStatisticsDashboardEvent> Events,
+        SiteStatisticsDashboardEventPage Page);
 }
 
 internal sealed record SessionFirstTouch(
@@ -1616,12 +1744,33 @@ public sealed class SiteStatisticsDashboardQuery
     public int? Limit { get; set; }
 }
 
+public sealed class SiteStatisticsDashboardEventsPageQuery
+{
+    public DateTimeOffset? FromUtc { get; set; }
+    public DateTimeOffset? ToUtc { get; set; }
+    public string? Flow { get; set; }
+    public string? Device { get; set; }
+    public string? Source { get; set; }
+    public int? Limit { get; set; }
+    public string? Cursor { get; set; }
+}
+
 public sealed record SiteStatisticsDashboardResponse(
     string GeneratedAtUtc,
     SiteStatisticsDashboardFilters Filters,
     SiteStatisticsTrafficSummary TrafficSummary,
     IReadOnlyList<SiteStatisticsDashboardEvent> Events,
-    IReadOnlyList<SiteStatisticsDashboardEvent> PreviousEvents);
+    IReadOnlyList<SiteStatisticsDashboardEvent> PreviousEvents,
+    SiteStatisticsDashboardEventPage EventsPage,
+    SiteStatisticsDashboardEventPage PreviousEventsPage);
+
+public sealed record SiteStatisticsDashboardEventsPageResponse(
+    IReadOnlyList<SiteStatisticsDashboardEvent> Events,
+    SiteStatisticsDashboardEventPage Page);
+
+public sealed record SiteStatisticsDashboardEventPage(
+    bool HasMore,
+    string? NextCursor);
 
 public sealed record SiteStatisticsDashboardFilters(
     string Range,

--- a/LongevityWorldCup.Website/Controllers/SiteStatisticsController.cs
+++ b/LongevityWorldCup.Website/Controllers/SiteStatisticsController.cs
@@ -22,4 +22,24 @@ public sealed class SiteStatisticsController(SiteStatisticsService statistics) :
     [HttpGet("dashboard")]
     public async Task<IActionResult> Dashboard([FromQuery] SiteStatisticsDashboardQuery query, CancellationToken ct)
         => Ok(await _statistics.GetDashboardAsync(query, ct).ConfigureAwait(false));
+
+    [HttpGet("dashboard/events")]
+    public async Task<IActionResult> DashboardEvents(
+        [FromQuery] SiteStatisticsDashboardEventsPageQuery query,
+        CancellationToken ct)
+    {
+        try
+        {
+            return Ok(await _statistics.GetDashboardEventsPageAsync(query, ct).ConfigureAwait(false));
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Invalid dashboard event window",
+                Detail = ex.Message,
+                Status = StatusCodes.Status400BadRequest
+            });
+        }
+    }
 }

--- a/LongevityWorldCup.Website/Frontend/site-statistics.ts
+++ b/LongevityWorldCup.Website/Frontend/site-statistics.ts
@@ -140,6 +140,23 @@
         browsers?: RawTrafficBreakdown[] | null;
     }
 
+    interface DashboardFilters {
+        range?: string | null;
+        flow?: string | null;
+        device?: string | null;
+        source?: string | null;
+        fromUtc?: string | null;
+        toUtc?: string | null;
+        previousFromUtc?: string | null;
+        previousToUtc?: string | null;
+        limit?: number | null;
+    }
+
+    interface DashboardEventPage {
+        hasMore?: boolean;
+        nextCursor?: string | null;
+    }
+
     type RawTrafficRecord<T, TextKey extends keyof T = never> =
         { [Key in Exclude<keyof T, TextKey>]?: unknown }
         & { [Key in TextKey]?: string | null };
@@ -151,10 +168,17 @@
 
     interface DashboardPayload {
         generatedAtUtc?: string | null;
-        filters?: { limit?: number | null } | null;
+        filters?: DashboardFilters | null;
         events?: RawDashboardEvent[] | null;
         previousEvents?: RawDashboardEvent[] | null;
+        eventsPage?: DashboardEventPage | null;
+        previousEventsPage?: DashboardEventPage | null;
         trafficSummary?: RawTrafficSummary | null;
+    }
+
+    interface DashboardEventsPagePayload {
+        events?: RawDashboardEvent[] | null;
+        page?: DashboardEventPage | null;
     }
 
     interface DecisionInsight {
@@ -239,7 +263,13 @@
         previousEvents: DashboardEvent[];
         previousDefaultEvents: DashboardEvent[];
         trafficSummary: TrafficSummary;
-        loadedEventLimit: number;
+        filters: DashboardFilters | null;
+        eventsPage: DashboardEventPage | null;
+        previousEventsPage: DashboardEventPage | null;
+        currentWindowComplete: boolean;
+        previousWindowComplete: boolean;
+        diagnosticWindowsLoaded: boolean;
+        generatedAtUtc: string | null;
         decisionActions: DecisionAction[];
         selectedEventName: string | null;
         selectedSession: string | null;
@@ -272,12 +302,19 @@
         previousEvents: [],
         previousDefaultEvents: [],
         trafficSummary: emptyTrafficSummary(),
-        loadedEventLimit: 0,
+        filters: null,
+        eventsPage: null,
+        previousEventsPage: null,
+        currentWindowComplete: false,
+        previousWindowComplete: false,
+        diagnosticWindowsLoaded: false,
+        generatedAtUtc: null,
         decisionActions: [],
         selectedEventName: null,
         selectedSession: null,
         selectedLabel: "all events"
     };
+    let loadGeneration = 0;
 
     function calculatorFunnel(selectionLabel: string): FunnelDefinition[] {
         return [
@@ -459,46 +496,136 @@
     }
 
     async function loadDashboard(): Promise<void> {
+        const generation = ++loadGeneration;
+        const requestedTab = state.tab;
+        const loadCompleteDiagnostics = requestedTab !== trafficOverviewTab;
+        setDashboardLoading(true);
         setStatus("Loading redacted analytics...");
         const params = new URLSearchParams({
             range: el("statsRange").value,
             flow: el("statsFlow").value,
             device: el("statsDevice").value,
             source: el("statsSource").value,
-            limit: String(dashboardEventLimit())
+            limit: String(loadCompleteDiagnostics ? diagnosticEventLimit : trafficOverviewEventLimit)
         });
 
         try {
             const response = await fetch(`/api/site-statistics/dashboard?${params.toString()}`, { headers: { "Accept": "application/json" } });
             if (!response.ok) throw new Error(`HTTP ${response.status}`);
             const payload = await response.json() as DashboardPayload;
-            state.events = Array.isArray(payload.events) ? payload.events.map(normalizeEvent) : [];
-            state.previousEvents = Array.isArray(payload.previousEvents) ? payload.previousEvents.map(normalizeEvent) : [];
+            if (generation !== loadGeneration) return;
+
+            const filters = payload.filters || null;
+            const initialEvents = Array.isArray(payload.events) ? payload.events.map(normalizeEvent) : [];
+            const initialPreviousEvents = Array.isArray(payload.previousEvents) ? payload.previousEvents.map(normalizeEvent) : [];
+            let events = initialEvents;
+            let previousEvents = initialPreviousEvents;
+
+            if (loadCompleteDiagnostics) {
+                setStatus(`Loading the complete ${selectedRangeLabel()} diagnostic windows...`);
+                [events, previousEvents] = await Promise.all([
+                    loadCompleteEventWindow(initialEvents, payload.eventsPage, filters, false, generation),
+                    loadCompleteEventWindow(initialPreviousEvents, payload.previousEventsPage, filters, true, generation)
+                ]);
+                if (generation !== loadGeneration) return;
+            }
+
+            state.events = events;
+            state.previousEvents = previousEvents;
             state.trafficSummary = normalizeTrafficSummary(payload.trafficSummary);
-            state.loadedEventLimit = Number(payload.filters && payload.filters.limit) || dashboardEventLimit();
+            state.filters = filters;
+            state.eventsPage = payload.eventsPage || null;
+            state.previousEventsPage = payload.previousEventsPage || null;
+            state.currentWindowComplete = loadCompleteDiagnostics || !hasMoreEvents(payload.eventsPage);
+            state.previousWindowComplete = loadCompleteDiagnostics || !hasMoreEvents(payload.previousEventsPage);
+            state.diagnosticWindowsLoaded = loadCompleteDiagnostics;
+            state.generatedAtUtc = payload.generatedAtUtc || null;
             state.defaultEvents = collapseRepeatedPageViewBursts(state.events);
             state.previousDefaultEvents = collapseRepeatedPageViewBursts(state.previousEvents);
-            const totals = state.trafficSummary.totals;
-            setStatus(`${formatNumber(totals.sessions)} visitor sessions and ${formatNumber(totals.pageViews)} page views loaded. ${state.events.length} recent diagnostic rows available. Generated ${formatTime(payload.generatedAtUtc)}.`);
+            setDashboardLoading(false);
+            renderLoadedStatus();
             renderAll();
         } catch (error) {
+            if (generation !== loadGeneration) return;
             state.events = [];
             state.defaultEvents = [];
             state.previousEvents = [];
             state.previousDefaultEvents = [];
             state.trafficSummary = emptyTrafficSummary();
-            state.loadedEventLimit = 0;
+            state.filters = null;
+            state.eventsPage = null;
+            state.previousEventsPage = null;
+            state.currentWindowComplete = false;
+            state.previousWindowComplete = false;
+            state.diagnosticWindowsLoaded = false;
+            state.generatedAtUtc = null;
+            setDashboardLoading(false);
             setStatus(`Dashboard data could not be loaded: ${errorMessage(error)}.`, true);
             renderAll();
         }
     }
 
-    function dashboardEventLimit(): number {
-        return state.tab === trafficOverviewTab ? trafficOverviewEventLimit : diagnosticEventLimit;
+    async function loadCompleteEventWindow(
+        initialEvents: DashboardEvent[],
+        initialPage: DashboardEventPage | null | undefined,
+        filters: DashboardFilters | null,
+        previous: boolean,
+        generation: number): Promise<DashboardEvent[]> {
+        const events = initialEvents.slice();
+        let page = initialPage || null;
+        let cursor = page && page.nextCursor;
+        while (hasMoreEvents(page)) {
+            if (!filters || !cursor)
+                throw new Error("The dashboard returned an incomplete event window without a continuation cursor.");
+
+            const fromUtc = previous ? filters.previousFromUtc : filters.fromUtc;
+            const toUtc = previous ? filters.previousToUtc : filters.toUtc;
+            if (!fromUtc || !toUtc)
+                throw new Error("The dashboard returned an incomplete event window without stable boundaries.");
+
+            const params = new URLSearchParams({
+                fromUtc,
+                toUtc,
+                flow: filters.flow || "all",
+                device: filters.device || "all",
+                source: filters.source || "all",
+                limit: String(diagnosticEventLimit),
+                cursor
+            });
+            const response = await fetch(`/api/site-statistics/dashboard/events?${params.toString()}`, { headers: { "Accept": "application/json" } });
+            if (!response.ok) throw new Error(`HTTP ${response.status}`);
+            const payload = await response.json() as DashboardEventsPagePayload;
+            if (generation !== loadGeneration) return [];
+
+            const nextEvents = Array.isArray(payload.events) ? payload.events.map(normalizeEvent) : [];
+            events.push(...nextEvents);
+            page = payload.page || null;
+            const nextCursor = page && page.nextCursor;
+            if (hasMoreEvents(page) && (!nextEvents.length || !nextCursor || nextCursor === cursor))
+                throw new Error("Dashboard event pagination did not advance.");
+            cursor = nextCursor;
+        }
+
+        return events;
+    }
+
+    function hasMoreEvents(page: DashboardEventPage | null | undefined): boolean {
+        return Boolean(page && page.hasMore);
+    }
+
+    function renderLoadedStatus(): void {
+        const totals = state.trafficSummary.totals;
+        setStatus(state.tab !== trafficOverviewTab
+            ? `Complete ${selectedRangeLabel()} diagnostic windows loaded: ${formatNumber(state.events.length)} current and ${formatNumber(state.previousEvents.length)} previous redacted events. Generated ${formatTime(state.generatedAtUtc)}.`
+            : `Complete ${selectedRangeLabel()} traffic window loaded: ${formatNumber(totals.sessions)} visitor sessions and ${formatNumber(totals.pageViews)} page views. ${formatNumber(state.events.length)} recent redacted rows retained for export and drilldown. Generated ${formatTime(state.generatedAtUtc)}.`);
+    }
+
+    function setDashboardLoading(loading: boolean): void {
+        (el("statsExport") as HTMLButtonElement).disabled = loading;
     }
 
     function needsDiagnosticEventReload(): boolean {
-        return state.tab !== trafficOverviewTab && state.loadedEventLimit < diagnosticEventLimit;
+        return state.tab !== trafficOverviewTab && !state.diagnosticWindowsLoaded;
     }
 
     function renderAll(): void {
@@ -1327,7 +1454,10 @@
                 state.selectedEventName = null;
                 state.selectedLabel = `${tab} / all events`;
                 if (needsDiagnosticEventReload()) loadDashboard();
-                else renderAll();
+                else {
+                    renderLoadedStatus();
+                    renderAll();
+                }
             });
             host.appendChild(button);
         });
@@ -2647,7 +2777,31 @@
         host.classList.toggle("error", !!error);
     }
 
-    function exportCsv(): void {
+    async function exportCsv(): Promise<void> {
+        if (!state.currentWindowComplete) {
+            const generation = ++loadGeneration;
+            setDashboardLoading(true);
+            setStatus(`Loading the complete ${selectedRangeLabel()} event window for export...`);
+            try {
+                state.events = await loadCompleteEventWindow(
+                    state.events,
+                    state.eventsPage,
+                    state.filters,
+                    false,
+                    generation);
+                if (generation !== loadGeneration) return;
+                state.defaultEvents = collapseRepeatedPageViewBursts(state.events);
+                state.currentWindowComplete = true;
+                state.eventsPage = { hasMore: false, nextCursor: null };
+                setDashboardLoading(false);
+            } catch (error) {
+                if (generation !== loadGeneration) return;
+                setDashboardLoading(false);
+                setStatus(`The complete event window could not be exported: ${errorMessage(error)}.`, true);
+                return;
+            }
+        }
+
         const events = selectedRawEvents();
         const headers: (keyof RawDashboardEvent)[] = ["occurredAtUtc", "sessionHash", "actorHash", "eventName", "flow", "route", "component", "step", "outcome", "errorCode", "durationMs", "deviceClass", "browserFamily", "referrerDomain", "source", "landingRoute", "firstReferrerDomain", "firstSource", "firstCampaign", "firstUtmSource", "firstUtmMedium", "firstUtmCampaign", "firstUtmTerm", "firstUtmContent"];
         const lines = [headers.join(",")].concat(events.map(e => headers.map(h => csv(e[h])).join(",")));
@@ -2658,6 +2812,7 @@
         a.download = "site-statistics-redacted.csv";
         a.click();
         setTimeout(() => URL.revokeObjectURL(url), 500);
+        setStatus(`Exported ${formatNumber(events.length)} redacted events from the complete ${selectedRangeLabel()} window.`);
     }
 
     async function copyLink(): Promise<void> {


### PR DESCRIPTION
Fixes the statistics dashboard mixing full-period traffic aggregates with newest-only capped diagnostic samples. Adds bounded keyset pagination for redacted events, binds opaque cursors to the original current/previous time boundaries and active filters, and makes diagnostic tabs assemble both complete periods before rendering. Pagination failures now fail closed instead of presenting a partial period, stale loads cannot replace newer filters, and CSV export loads the complete selected current window. Verification: clean .NET/TypeScript build; 48/48 statistics service, page, and browser tests passed; full project run passed 1,425/1,426 with one unrelated bioage animation timing test, which passed immediately on isolated rerun.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches internal analytics API and dashboard data assembly; behavior changes how large event sets are loaded but cursors are validated and traffic aggregates remain separate from event paging.
> 
> **Overview**
> Fixes the site statistics dashboard showing **full-period traffic aggregates** alongside **newest-only capped event samples**, which made diagnostic tabs and exports misleading.
> 
> **Backend:** Dashboard responses now include `eventsPage` / `previousEventsPage` (`hasMore`, `nextCursor`). Redacted events are fetched with **keyset pagination** on `OccurredAtUtc` + `Id`, and opaque cursors are **bound to** `fromUtc`/`toUtc` and active flow/device/source filters. A new **`GET /api/site-statistics/dashboard/events`** endpoint continues a stable window; invalid or mismatched cursors return **400**.
> 
> **Frontend:** On **Onboarding/Challenge Diagnostics**, the UI **follows cursors** for both current and previous periods until each window is complete before rendering. **CSV export** loads the full current window via the same pagination if needed. **Load generation** ignores stale responses when filters change; pagination failures **fail closed** instead of showing a partial period.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e19f04d52309f928d28d5715af8dbb291b9e90ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->