### PR TITLE
Remove Longevitymaxxing optional label qualifiers

### DIFF
--- a/LongevityWorldCup.Tests/LongevitymaxxingChallengePageTests.cs
+++ b/LongevityWorldCup.Tests/LongevitymaxxingChallengePageTests.cs
@@ -310,6 +310,8 @@ public sealed class LongevitymaxxingChallengePageTests
         Assert.DoesNotContain("Choose this only if the participant is already listed as a Longevity athlete.", html);
         Assert.DoesNotContain("Only if you are already listed as an athlete", html);
         Assert.Contains("id=\"lmxProfilePictureField\"", html);
+        Assert.Contains("<span class=\"lmx-label\">Profile picture</span>", html);
+        Assert.DoesNotContain("<span>optional</span>", html);
         Assert.Contains("Upload profile picture", html);
         Assert.Contains("id=\"lmxProfilePictureInput\" type=\"file\" accept=\"image/*\"", html);
         Assert.Contains("id=\"lmxSignupTimeZoneLabel\">Timezone</span>", html);
@@ -897,9 +899,9 @@ public sealed class LongevitymaxxingChallengePageTests
         Assert.Contains("formData.append(\"profilePicture\", uploadFile, uploadFile.name || \"profile-picture.jpg\");", javascript);
         Assert.DoesNotContain("Profile picture must be 8 MB or smaller.", javascript);
         Assert.Contains("const MAX_NOTE_PHOTOS = 4;", javascript);
-        Assert.Contains("Remarks <span>optional</span>", javascript);
-        Assert.Contains("Photos <span>optional</span>", javascript);
-        Assert.Contains(".lmx-field span.lmx-label span", css);
+        Assert.Contains("<label for=\"lmx-note-${day.challengeDay}\">Remarks</label>", javascript);
+        Assert.Contains("<span class=\"lmx-label\">Photos</span>", javascript);
+        Assert.DoesNotContain("<span>optional</span>", javascript);
         Assert.Contains("                Save", javascript);
         Assert.DoesNotContain("Participant note <span>optional</span>", javascript);
         Assert.DoesNotContain("Note photos <span>optional</span>", javascript);

--- a/LongevityWorldCup.Website/Frontend/longevitymaxxing.ts
+++ b/LongevityWorldCup.Website/Frontend/longevitymaxxing.ts
@@ -2500,12 +2500,12 @@ const TIME_ZONE_COUNTRY_DATA = "Europe/Andorra=AD|Asia/Dubai=AE|Asia/Kabul=AF|Am
             ${practice ? `<div class="lmx-practice-note"><strong>Practice check-in.</strong><span>Counts for checked-in days and streak, not points.</span></div>` : ""}
             ${questions}
             <div class="lmx-field lmx-mention-field">
-                <label for="lmx-note-${day.challengeDay}">Remarks <span>optional</span></label>
+                <label for="lmx-note-${day.challengeDay}">Remarks</label>
                 <textarea id="lmx-note-${day.challengeDay}" maxlength="240" placeholder="Visible publicly" data-mention-input role="combobox" aria-autocomplete="list" aria-haspopup="listbox" aria-expanded="false" aria-controls="lmx-mentions-${day.challengeDay}">${esc(note)}</textarea>
                 <div id="lmx-mentions-${day.challengeDay}" class="lmx-mention-options" role="listbox" aria-label="Mention a participant" hidden></div>
             </div>
             <div class="lmx-field lmx-note-photo-field" data-photo-slots="${photoSlotsLeft}">
-                <span class="lmx-label">Photos <span>optional</span></span>
+                <span class="lmx-label">Photos</span>
                 ${savedImageHtml}
                 <div class="lmx-note-photo-picker">
                     <button class="lmx-button secondary" type="button" data-photo-button${photoSlotsLeft <= 0 ? " disabled" : ""}>

--- a/LongevityWorldCup.Website/wwwroot/css/longevitymaxxing.css
+++ b/LongevityWorldCup.Website/wwwroot/css/longevitymaxxing.css
@@ -911,12 +911,6 @@
     color: var(--lmx-muted);
 }
 
-.lmx-field label span,
-.lmx-field span.lmx-label span {
-    color: var(--lmx-subtle);
-    font-weight: 800;
-}
-
 .lmx-field-help {
     margin: 0;
     color: var(--lmx-muted);

--- a/LongevityWorldCup.Website/wwwroot/longevitymaxxing/longevitymaxxing.html
+++ b/LongevityWorldCup.Website/wwwroot/longevitymaxxing/longevitymaxxing.html
@@ -220,7 +220,7 @@
                             </div>
                         </div>
                         <div id="lmxProfilePictureField" class="lmx-field lmx-profile-picture-field">
-                            <span class="lmx-label">Profile picture <span>optional</span></span>
+                            <span class="lmx-label">Profile picture</span>
                             <div class="lmx-profile-upload">
                                 <span id="lmxProfilePicturePreview" class="lmx-profile-preview placeholder" aria-hidden="true">
                                     <img id="lmxProfilePictureImage" src="/assets/content-images/headshot.webp" alt="" loading="lazy" decoding="async">


### PR DESCRIPTION
## Summary
- show the check-in fields as Remarks and Photos without redundant optional qualifiers
- show Profile picture without the optional qualifier
- remove the now-unused nested qualifier styling and guard the copy with tests

## Verification
- dotnet test LongevityWorldCup.Tests/LongevityWorldCup.Tests.csproj --filter FullyQualifiedName~LongevitymaxxingChallengePageTests --artifacts-path .artifacts/remove-optional-labels
- 17 passed, 0 failed

Related to #837.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and CSS-only label changes with no validation or API behavior changes; risk is limited to minor UI wording.
> 
> **Overview**
> Removes redundant **optional** text from Longevitymaxxing form labels so fields read as plain **Profile picture**, **Remarks**, and **Photos** on the profile editor and daily check-in UI.
> 
> Deletes the nested `span` qualifier styles in `longevitymaxxing.css` and updates page/script tests to assert the new copy and that generic `<span>optional</span>` no longer appears in rendered HTML or check-in markup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d625fc41a6e152b15f6e30a54bad06ee3e8364d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->