### PR TITLE
Restore profile picture optional label

### DIFF
--- a/LongevityWorldCup.Tests/LongevitymaxxingChallengePageTests.cs
+++ b/LongevityWorldCup.Tests/LongevitymaxxingChallengePageTests.cs
@@ -310,8 +310,7 @@ public sealed class LongevitymaxxingChallengePageTests
         Assert.DoesNotContain("Choose this only if the participant is already listed as a Longevity athlete.", html);
         Assert.DoesNotContain("Only if you are already listed as an athlete", html);
         Assert.Contains("id=\"lmxProfilePictureField\"", html);
-        Assert.Contains("<span class=\"lmx-label\">Profile picture</span>", html);
-        Assert.DoesNotContain("<span>optional</span>", html);
+        Assert.Contains("<span class=\"lmx-label\">Profile picture <span>optional</span></span>", html);
         Assert.Contains("Upload profile picture", html);
         Assert.Contains("id=\"lmxProfilePictureInput\" type=\"file\" accept=\"image/*\"", html);
         Assert.Contains("id=\"lmxSignupTimeZoneLabel\">Timezone</span>", html);

--- a/LongevityWorldCup.Website/wwwroot/css/longevitymaxxing.css
+++ b/LongevityWorldCup.Website/wwwroot/css/longevitymaxxing.css
@@ -911,6 +911,12 @@
     color: var(--lmx-muted);
 }
 
+.lmx-field label span,
+.lmx-field span.lmx-label span {
+    color: var(--lmx-subtle);
+    font-weight: 800;
+}
+
 .lmx-field-help {
     margin: 0;
     color: var(--lmx-muted);

--- a/LongevityWorldCup.Website/wwwroot/longevitymaxxing/longevitymaxxing.html
+++ b/LongevityWorldCup.Website/wwwroot/longevitymaxxing/longevitymaxxing.html
@@ -220,7 +220,7 @@
                             </div>
                         </div>
                         <div id="lmxProfilePictureField" class="lmx-field lmx-profile-picture-field">
-                            <span class="lmx-label">Profile picture</span>
+                            <span class="lmx-label">Profile picture <span>optional</span></span>
                             <div class="lmx-profile-upload">
                                 <span id="lmxProfilePicturePreview" class="lmx-profile-preview placeholder" aria-hidden="true">
                                     <img id="lmxProfilePictureImage" src="/assets/content-images/headshot.webp" alt="" loading="lazy" decoding="async">


### PR DESCRIPTION
## Summary
- restore the unrelated Profile picture optional label in the participant profile editor
- keep the check-in labels as Remarks and Photos without optional qualifiers
- restore the qualifier styling and correct the rendered-page assertion

## Verification
- dotnet test LongevityWorldCup.Tests/LongevityWorldCup.Tests.csproj --filter FullyQualifiedName~LongevitymaxxingChallengePageTests --artifacts-path .artifacts/restore-profile-picture-optional
- 17 passed, 0 failed

Corrects #839 and preserves the requested discussion copy from #837.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy, styling, and test-only changes on the profile form; no API or auth impact.
> 
> **Overview**
> Restores the **Profile picture** field label in the participant profile editor so it again shows an **optional** qualifier, after a prior change removed it unintentionally.
> 
> Adds CSS so nested `<span>` text inside `.lmx-field` labels uses the subtle muted styling used elsewhere for qualifiers. Updates the longevitymaxxing page render test to assert the combined label markup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e78f09a72990a153abfbf0c32e4ea1baa20e5894. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->