### PR TITLE
Cover badge Event transitions and verify browser testing

### DIFF
--- a/LongevityWorldCup.Tests/BadgeAwardEventDiffTests.cs
+++ b/LongevityWorldCup.Tests/BadgeAwardEventDiffTests.cs
@@ -1,12 +1,209 @@
 using System.Collections;
 using System.Reflection;
 using LongevityWorldCup.Website.Business;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace LongevityWorldCup.Tests;
 
 public sealed class BadgeAwardEventDiffTests
 {
+    private static readonly DateTime SnapshotTimeUtc = new(2026, 8, 1, 12, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void InitialCurrentSnapshotDoesNotAnnounceExistingAwards()
+    {
+        var events = BuildBadgeAwardEventsForCurrentSnapshotChange(
+            CreateAwardRowList(),
+            CreateAwardRowList(Award("alice"), Award("bob", place: 1)));
+
+        Assert.Empty(events);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(1)]
+    public void UnchangedOwnershipIgnoresRowOrderDuplicatesAndAthleteSlugCasing(int? place)
+    {
+        var events = BuildBadgeAwardEventsForCurrentSnapshotChange(
+            CreateAwardRowList(Award("alice", place), Award("bob", place)),
+            CreateAwardRowList(Award("BOB", place), Award("alice", place), Award("alice", place)));
+
+        Assert.Empty(events);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(1)]
+    public void NewlyAwardedBadgeAnnouncesEachRecipientOnce(int? place)
+    {
+        var existingAward = Award("carol", label: "Podcast");
+        var events = BuildBadgeAwardEventsForCurrentSnapshotChange(
+            CreateAwardRowList(existingAward),
+            CreateAwardRowList(existingAward, Award("bob", place), Award("alice", place), Award("bob", place)));
+
+        Assert.Collection(events,
+            item => AssertAwardEvent(item, "alice", place),
+            item => AssertAwardEvent(item, "bob", place));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(1)]
+    public void LosingAllOwnersDoesNotInventAWinner(int? place)
+    {
+        var events = BuildBadgeAwardEventsForCurrentSnapshotChange(
+            CreateAwardRowList(Award("alice", place), Award("bob", place)),
+            CreateAwardRowList());
+
+        Assert.Empty(events);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(1)]
+    public void SharedAwardRemainingSharedDoesNotReannounceExistingOwners(int? place)
+    {
+        var events = BuildBadgeAwardEventsForCurrentSnapshotChange(
+            CreateAwardRowList(Award("alice", place), Award("bob", place), Award("carol", place)),
+            CreateAwardRowList(Award("alice", place), Award("bob", place)));
+
+        Assert.Empty(events);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(1)]
+    public void JoiningSharedOwnershipDoesNotClaimToReplaceExistingOwners(int? place)
+    {
+        var events = BuildBadgeAwardEventsForCurrentSnapshotChange(
+            CreateAwardRowList(Award("alice", place)),
+            CreateAwardRowList(Award("alice", place), Award("carol", place), Award("bob", place)));
+
+        Assert.Collection(events,
+            item => AssertAwardEvent(item, "bob", place),
+            item => AssertAwardEvent(item, "carol", place));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(1)]
+    public void SharedAwardBecomingSoloNamesTheDepartingOwners(int? place)
+    {
+        var events = BuildBadgeAwardEventsForCurrentSnapshotChange(
+            CreateAwardRowList(Award("carol", place), Award("alice", place), Award("bob", place)),
+            CreateAwardRowList(Award("alice", place)));
+
+        AssertAwardEvent(Assert.Single(events), "alice", place, solo: true, previousOwners: ["bob", "carol"]);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(1)]
+    public void NewOwnerTakingOverAnEntireGroupNamesAllPreviousOwners(int? place)
+    {
+        var events = BuildBadgeAwardEventsForCurrentSnapshotChange(
+            CreateAwardRowList(Award("carol", place), Award("bob", place)),
+            CreateAwardRowList(Award("alice", place)));
+
+        AssertAwardEvent(Assert.Single(events), "alice", place, previousOwners: ["bob", "carol"]);
+    }
+
+    [Fact]
+    public void UnrankedAwardTakeoverNamesTheSinglePreviousOwner()
+    {
+        var events = BuildBadgeAwardEventsForCurrentSnapshotChange(
+            CreateAwardRowList(Award("bob")),
+            CreateAwardRowList(Award("alice")));
+
+        AssertAwardEvent(Assert.Single(events), "alice", previousOwner: "bob");
+    }
+
+    [Fact]
+    public void RankedPromotionsDoNotAnnounceDemotionsOrDescribeAPromotedAthleteAsReplaced()
+    {
+        var events = BuildBadgeAwardEventsForCurrentSnapshotChange(
+            CreateAwardRowList(Award("alice", 1), Award("bob", 2), Award("carol", 3)),
+            CreateAwardRowList(Award("bob", 1), Award("carol", 2), Award("alice", 3)));
+
+        Assert.Collection(events.OrderBy(item => GetProperty(item, "Place")),
+            item => AssertAwardEvent(item, "bob", 1, previousOwner: "alice"),
+            item => AssertAwardEvent(item, "carol", 2));
+    }
+
+    [Theory]
+    [InlineData("Pheno Age best improvement", "Global", null)]
+    [InlineData("Age reduction", "Generation", "Gen X")]
+    [InlineData("Age reduction", "Generation", "Millennials")]
+    public void AwardsInOtherBadgesOrLeaguesDoNotSuppressANewPlacement(
+        string label, string category, string? value)
+    {
+        var existingAward = Award("alice", 1, category: "Generation", value: "Gen Z");
+        var events = BuildBadgeAwardEventsForCurrentSnapshotChange(
+            CreateAwardRowList(existingAward, Award("bob", 1, label, category, value)),
+            CreateAwardRowList(existingAward, Award("alice", 1, label, category, value)));
+
+        AssertAwardEvent(Assert.Single(events), "alice", 1, previousOwner: "bob",
+            label: label, category: category, value: value);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(1)]
+    public void AwardResultDateTakesPriorityOverSnapshotRecalculationTime(int? place)
+    {
+        var resultDate = SnapshotTimeUtc.AddDays(-7);
+        var events = BuildBadgeAwardEventsForCurrentSnapshotChange(
+            CreateAwardRowList(Award("bob", place)),
+            CreateAwardRowList(Award("alice", place, occurredAtUtc: resultDate)));
+
+        AssertAwardEvent(Assert.Single(events), "alice", place, previousOwner: "bob", occurredAtUtc: resultDate);
+    }
+
+    [Theory]
+    [InlineData(true, "slug[alice] badge[Age reduction] cat[Global] val[] place[1] solo[1] prevs[bob,carol]")]
+    [InlineData(false, "slug[alice] badge[Age reduction] cat[Global] val[] place[1] prevs[bob,carol]")]
+    public void GroupTransitionsPersistAndReloadWithoutDuplicatingReplay(bool wasSharedOwner, string expectedText)
+    {
+        using var factory = new TestWebApplicationFactory();
+        var service = factory.Services.GetRequiredService<EventDataService>();
+        var db = factory.Services.GetRequiredService<DatabaseManager>();
+        var before = new List<object> { Award("carol", 1), Award("bob", 1) };
+        if (wasSharedOwner)
+            before.Add(Award("alice", 1));
+
+        var changes = BuildBadgeAwardEventsForCurrentSnapshotChange(
+            CreateAwardRowList(before.ToArray()),
+            CreateAwardRowList(Award("alice", 1)));
+        var payload = changes.Select(item => (
+            AthleteSlug: GetStringProperty(item, "AthleteSlug")!,
+            OccurredAtUtc: Assert.IsType<DateTime>(GetProperty(item, "OccurredAtUtc")),
+            BadgeLabel: GetStringProperty(item, "BadgeLabel")!,
+            LeagueCategory: GetStringProperty(item, "LeagueCategory")!,
+            LeagueValue: GetStringProperty(item, "LeagueValue"),
+            Place: (int?)GetProperty(item, "Place"),
+            BecameSoloOwner: Assert.IsType<bool>(GetProperty(item, "BecameSoloOwner")),
+            ReplacedSlug: GetStringProperty(item, "ReplacedSlug"),
+            ReplacedSlugs: (IReadOnlyList<string>?)GetProperty(item, "ReplacedSlugs"))).ToArray();
+
+        service.CreateBadgeAwardEvents(payload);
+        service.CreateBadgeAwardEvents(payload);
+
+        var savedCount = db.Run(sqlite =>
+        {
+            using var command = sqlite.CreateCommand();
+            command.CommandText = "SELECT COUNT(*) FROM Events WHERE Type=@type AND Text=@text;";
+            command.Parameters.AddWithValue("@type", (int)EventType.BadgeAward);
+            command.Parameters.AddWithValue("@text", expectedText);
+            return Convert.ToInt32(command.ExecuteScalar());
+        });
+        Assert.Equal(1, savedCount);
+        var published = Assert.Single(service.GetEvents(), item => item.Text == expectedText);
+        Assert.Equal(EventType.BadgeAward, published.Type);
+        Assert.Equal(SnapshotTimeUtc, published.OccurredAtUtc);
+        Assert.True(published.VisibleOnWebsite);
+    }
+
     [Fact]
     public void AmateurAgeReductionReplacementKeepsPreviousHolderForNormalHandoff()
     {
@@ -54,7 +251,7 @@ public sealed class BadgeAwardEventDiffTests
         Assert.NotNull(method);
 
         var proSlugs = new HashSet<string>(currentProSlugs, StringComparer.OrdinalIgnoreCase);
-        var result = method.Invoke(null, [before, after, DateTime.UtcNow, proSlugs]);
+        var result = method.Invoke(null, [before, after, SnapshotTimeUtc, proSlugs]);
         var events = Assert.IsAssignableFrom<IEnumerable>(result);
 
         return events.Cast<object>().ToList();
@@ -73,7 +270,8 @@ public sealed class BadgeAwardEventDiffTests
         string leagueCategory,
         string? leagueValue,
         int? place,
-        string athleteSlug)
+        string athleteSlug,
+        DateTime? occurredAtUtc = null)
     {
         var row = Activator.CreateInstance(rowType, nonPublic: true);
         Assert.NotNull(row);
@@ -84,7 +282,7 @@ public sealed class BadgeAwardEventDiffTests
         rowType.GetProperty("Place")!.SetValue(row, place);
         rowType.GetProperty("AthleteSlug")!.SetValue(row, athleteSlug);
         rowType.GetProperty("DefinitionHash")!.SetValue(row, null);
-        rowType.GetProperty("OccurredAtUtc")!.SetValue(row, null);
+        rowType.GetProperty("OccurredAtUtc")!.SetValue(row, occurredAtUtc);
 
         return row;
     }
@@ -98,6 +296,38 @@ public sealed class BadgeAwardEventDiffTests
             list.Add(row);
 
         return list;
+    }
+
+    private static object Award(
+        string slug,
+        int? place = null,
+        string label = "Age reduction",
+        string category = "Global",
+        string? value = null,
+        DateTime? occurredAtUtc = null)
+        => CreateAwardRow(GetAwardRowType(), label, category, value, place, slug, occurredAtUtc);
+
+    private static void AssertAwardEvent(
+        object item,
+        string slug,
+        int? place = null,
+        bool solo = false,
+        string? previousOwner = null,
+        string[]? previousOwners = null,
+        string label = "Age reduction",
+        string category = "Global",
+        string? value = null,
+        DateTime? occurredAtUtc = null)
+    {
+        Assert.Equal(slug, GetStringProperty(item, "AthleteSlug"));
+        Assert.Equal(label, GetStringProperty(item, "BadgeLabel"));
+        Assert.Equal(category, GetStringProperty(item, "LeagueCategory"));
+        Assert.Equal(value, GetStringProperty(item, "LeagueValue"));
+        Assert.Equal(place, (int?)GetProperty(item, "Place"));
+        Assert.Equal(solo, GetProperty(item, "BecameSoloOwner"));
+        Assert.Equal(previousOwner, GetStringProperty(item, "ReplacedSlug"));
+        Assert.Equal(previousOwners, (IReadOnlyList<string>?)GetProperty(item, "ReplacedSlugs"));
+        Assert.Equal(occurredAtUtc ?? SnapshotTimeUtc, GetProperty(item, "OccurredAtUtc"));
     }
 
     private static string? GetStringProperty(object item, string propertyName)


### PR DESCRIPTION
Badge Event ownership transitions lacked direct regression coverage for shared winners, solo ownership, takeovers, and losses. Add 24 cases covering those transitions, new awards, unchanged snapshots, promotions and demotions, badge/league separation, result dates, and SQLite persistence with idempotent replay.

The Playwright infrastructure requested in #453 already runs in CI on pushes and pull requests. Existing browser tests exercise onboarding and submissions, pheno/bortz calculators, leaderboards, athlete profiles and proof uploads, Guess My Age, and the Event board. This change verifies that suite alongside the new Event coverage; application behavior is unchanged.

Validation: 46 focused badge tests passed. The complete local suite passed 1,519 tests with zero failures or skips, including Playwright. The build completed with zero warnings/errors; coverage was 74.24% line and 58.52% branch. [GitHub CI](https://github.com/nopara73/LongevityWorldCup/actions/runs/33944334809) also passed the complete suite, frontend build, NuGet audit, and Node-free publish contract. CodeQL, dependency review, and Bugbot passed; Codex review completed without findings.

[Master CI](https://github.com/nopara73/LongevityWorldCup/actions/runs/33944683210) and [automatic deployment](https://github.com/nopara73/LongevityWorldCup/actions/runs/33944683146) passed for merge commit `6732aa447c53141ad0d1f921d2f9eaabcdce22e0`. Production SSH confirmed that exact commit and an active service; internal/public health checks were Healthy, and `/leaderboard` and `/play` returned HTTP 200.

Closes #341
Closes #453