### PR TITLE
Add profile highlights for each newly accepted test result

### DIFF
--- a/LongevityWorldCup.Tests/AcceptedResultEventTests.cs
+++ b/LongevityWorldCup.Tests/AcceptedResultEventTests.cs
@@ -1,0 +1,220 @@
+using System.Globalization;
+using System.Text.Json.Nodes;
+using LongevityWorldCup.Website.Business;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class AcceptedResultEventTests
+{
+    private const string Slug = "result_history";
+    private static readonly DateTime AcceptedAt = new(2026, 9, 5, 12, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public async Task PublishedNonImprovementCreatesOneHighlightOnReloadAndSurvivesRestart()
+    {
+        using var workspace = new TestWorkspace();
+        workspace.WriteAthlete(Result("2025-01-01", crp: 1));
+        string eventId;
+        using (var factory = workspace.CreateFactory())
+        {
+            var athletes = factory.Services.GetRequiredService<AthleteDataService>();
+            var events = factory.Services.GetRequiredService<EventDataService>();
+            Assert.Empty(events.GetEvents(EventType.TestResultAccepted));
+
+            var reloadCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            void ObserveReload()
+            {
+                if (events.GetEvents(EventType.TestResultAccepted).Count == 1)
+                    reloadCompleted.TrySetResult();
+            }
+            athletes.AthletesChanged += ObserveReload;
+            var before = DateTime.UtcNow;
+            workspace.WriteAthlete(Result("2025-01-01", crp: 1), Result("2026-08-31", crp: 20));
+            try
+            {
+                await reloadCompleted.Task.WaitAsync(TimeSpan.FromSeconds(15));
+            }
+            finally
+            {
+                athletes.AthletesChanged -= ObserveReload;
+            }
+
+            var highlight = Assert.Single(events.GetEvents(EventType.TestResultAccepted));
+            eventId = highlight.Id;
+            Assert.Equal($"slug[{Slug}] date[2026-08-31]", highlight.Text);
+            Assert.InRange(highlight.OccurredAtUtc, before, DateTime.UtcNow);
+            Assert.Empty(events.GetEvents(EventType.BiologicalAgeImproved));
+            Assert.Equal(0, events.SyncAcceptedResultEvents(athletes.GetAthletesSnapshot(), AcceptedAt));
+
+            using var client = factory.CreateClient();
+            var response = JsonNode.Parse(await client.GetStringAsync("/api/events"))!.AsArray();
+            Assert.Single(response.OfType<JsonObject>(), e => e["Type"]!.GetValue<int>() == 13);
+            AssertNoSocialDelivery(factory, highlight.Id);
+        }
+
+        // Corrections and reordering between deployments are the same two tests.
+        workspace.WriteAthlete(Result("2026-08-31", crp: 19), Result("2025-01-01", crp: 1));
+        using var restarted = workspace.CreateFactory();
+        var restartedEvents = restarted.Services.GetRequiredService<EventDataService>();
+        Assert.Equal(eventId, Assert.Single(restartedEvents.GetEvents(EventType.TestResultAccepted)).Id);
+    }
+
+    [Fact]
+    public void StartupRecognizesEveryNewDateIncludingBackfillsAndNewAthletes()
+    {
+        using var workspace = new TestWorkspace();
+        workspace.WriteAthlete(Result("2025-01-01", crp: 20));
+        using (var baseline = workspace.CreateFactory())
+            Assert.Empty(baseline.Services.GetRequiredService<EventDataService>().GetEvents(EventType.TestResultAccepted));
+
+        workspace.WriteAthlete(Result("2024-03-06", crp: 20), Result("2025-01-01", crp: 20), Result("2026-08-31", crp: 0.6));
+        workspace.WriteAthleteFor("new_athlete", Result("2026-08-31"));
+        using (var restarted = workspace.CreateFactory())
+        {
+            var events = restarted.Services.GetRequiredService<EventDataService>();
+            Assert.Equal(3, events.GetEvents(EventType.TestResultAccepted).Count);
+            Assert.Contains(events.GetEvents(EventType.TestResultAccepted), e => e.Text == $"slug[{Slug}] date[2024-03-06]");
+            Assert.Contains(events.GetEvents(EventType.TestResultAccepted), e => e.Text == "slug[new_athlete] date[2026-08-31]");
+            Assert.Contains(events.GetEvents(EventType.BiologicalAgeImproved), e => e.Text.StartsWith($"slug[{Slug}] clock[pheno]", StringComparison.Ordinal));
+        }
+
+        using var again = workspace.CreateFactory();
+        Assert.Equal(3, again.Services.GetRequiredService<EventDataService>().GetEvents(EventType.TestResultAccepted).Count);
+    }
+
+    [Fact]
+    public void SameDatePanelsAndCorrectionsDoNotRepeatAnEventEvenAfterRemovalAndRestoration()
+    {
+        using var workspace = new TestWorkspace();
+        workspace.WriteAthlete(Result("2025-01-01"));
+        using var factory = workspace.CreateFactory();
+        var events = factory.Services.GetRequiredService<EventDataService>();
+
+        var partial = JsonNode.Parse("""{"Date":"2026-8-31","GluMmolL":4.7}""")!.AsObject();
+        var snapshot = Snapshot(partial, partial.DeepClone().AsObject());
+        Assert.Equal(1, events.SyncAcceptedResultEvents(snapshot, AcceptedAt));
+        var highlight = Assert.Single(events.GetEvents(EventType.TestResultAccepted));
+        Assert.Equal(AcceptedAt, highlight.OccurredAtUtc);
+
+        snapshot = Snapshot(Result("2026-08-31", crp: 5), Result("2026-08-31", crp: 2));
+        Assert.Equal(0, events.SyncAcceptedResultEvents(snapshot, AcceptedAt.AddDays(1)));
+        Assert.Equal(0, events.SyncAcceptedResultEvents(Snapshot(), AcceptedAt.AddDays(2)));
+        Assert.Equal(0, events.SyncAcceptedResultEvents(snapshot, AcceptedAt.AddDays(3)));
+        Assert.Equal(highlight, Assert.Single(events.GetEvents(EventType.TestResultAccepted)));
+    }
+
+    [Fact]
+    public void MissingInvalidAndEmptyTestRecordsDoNotCreateHighlights()
+    {
+        using var workspace = new TestWorkspace();
+        using var factory = workspace.CreateFactory();
+        var events = factory.Services.GetRequiredService<EventDataService>();
+        var invalid = new[]
+        {
+            "{}", "{\"Date\":\"2026-08-31\"}", "{\"GluMmolL\":4.7}",
+            "{\"Date\":\"not a date\",\"GluMmolL\":4.7}",
+            "{\"Date\":42,\"GluMmolL\":4.7}", "{\"Date\":\"2026-08-31\",\"GluMmolL\":null}"
+        }.Select(json => JsonNode.Parse(json)!.AsObject()).ToArray();
+        Assert.Equal(0, events.SyncAcceptedResultEvents(Snapshot(invalid), AcceptedAt));
+        Assert.Empty(events.GetEvents(EventType.TestResultAccepted));
+    }
+
+    [Fact]
+    public void FailedEventInsertRollsBackTheAcceptedResultSoRetryCanFinish()
+    {
+        using var workspace = new TestWorkspace();
+        using var factory = workspace.CreateFactory();
+        var events = factory.Services.GetRequiredService<EventDataService>();
+        var database = factory.Services.GetRequiredService<DatabaseManager>();
+        database.Run(sqlite =>
+        {
+            using var command = sqlite.CreateCommand();
+            command.CommandText =
+                """
+                CREATE TRIGGER FailAcceptedEvent BEFORE INSERT ON Events WHEN NEW.Type = 13
+                BEGIN SELECT RAISE(ABORT, 'Simulated event write failure'); END;
+                """;
+            command.ExecuteNonQuery();
+        });
+
+        var snapshot = Snapshot(Result("2026-08-31"));
+        Assert.Throws<SqliteException>(() => events.SyncAcceptedResultEvents(snapshot, AcceptedAt));
+        database.Run(sqlite =>
+        {
+            using var command = sqlite.CreateCommand();
+            command.CommandText = "SELECT COUNT(*) FROM AcceptedAthleteResults;";
+            Assert.Equal(0L, command.ExecuteScalar());
+            command.CommandText = "DROP TRIGGER FailAcceptedEvent;";
+            command.ExecuteNonQuery();
+        });
+        Assert.Equal(1, events.SyncAcceptedResultEvents(snapshot, AcceptedAt));
+        Assert.Single(events.GetEvents(EventType.TestResultAccepted));
+    }
+
+    private static void AssertNoSocialDelivery(TestWebApplicationFactory factory, string eventId)
+    {
+        factory.Services.GetRequiredService<DatabaseManager>().Run(sqlite =>
+        {
+            using var command = sqlite.CreateCommand();
+            command.CommandText = "SELECT VisibleOnWebsite, SlackProcessed, XProcessed, ThreadsProcessed, FacebookProcessed FROM Events WHERE Id=@id;";
+            command.Parameters.AddWithValue("@id", eventId);
+            using var reader = command.ExecuteReader();
+            Assert.True(reader.Read());
+            for (var i = 0; i < 5; i++)
+                Assert.Equal(1, reader.GetInt32(i));
+        });
+    }
+
+    private static JsonArray Snapshot(params JsonObject[] results) => new(new JsonObject
+    {
+        ["AthleteSlug"] = Slug,
+        ["Biomarkers"] = new JsonArray(results.Select(result => result.DeepClone()).ToArray())
+    });
+
+    private static JsonObject Result(string date, double crp = 2) => JsonNode.Parse(
+        $$"""
+        {"Date":"{{date}}","AlbGL":45,"CreatUmolL":95,"GluMmolL":4,"CrpMgL":{{crp.ToString(CultureInfo.InvariantCulture)}},
+         "LymPc":35.2,"McvFL":86.5,"RdwPc":12.5,"AlpUL":50,"Wbc1000cellsuL":5.48}
+        """)!.AsObject();
+
+    private sealed class TestWorkspace : IDisposable
+    {
+        private readonly string _root = Path.Combine(Path.GetTempPath(), "lwc-accepted-results-" + Guid.NewGuid().ToString("N"));
+        private string WebRoot => Path.Combine(_root, "wwwroot");
+        private string DatabasePath => Path.Combine(_root, "test.db");
+
+        public TestWorkspace() => WriteAthlete();
+
+        public void WriteAthlete(params JsonObject[] results) => WriteAthleteFor(Slug, results);
+
+        public void WriteAthleteFor(string slug, params JsonObject[] results)
+        {
+            var directory = Path.Combine(WebRoot, "athletes", slug);
+            Directory.CreateDirectory(directory);
+            var athlete = Snapshot(results)[0]!.DeepClone().AsObject();
+            athlete["Name"] = slug;
+            athlete["DateOfBirth"] = new JsonObject { ["Year"] = 1980, ["Month"] = 1, ["Day"] = 2 };
+            athlete["Division"] = "Open";
+            athlete["Flag"] = "Earth";
+            File.WriteAllText(Path.Combine(directory, "athlete.json"), athlete.ToJsonString());
+        }
+
+        public TestWebApplicationFactory CreateFactory() => new(builder =>
+        {
+            builder.UseWebRoot(WebRoot);
+            builder.ConfigureTestServices(services =>
+            {
+                services.RemoveAll<DatabaseManager>();
+                services.AddSingleton(_ => new DatabaseManager(dbPath: DatabasePath));
+            });
+        });
+
+        public void Dispose() => Directory.Delete(_root, recursive: true);
+    }
+}

--- a/LongevityWorldCup.Tests/EventBoardBrowserTests.cs
+++ b/LongevityWorldCup.Tests/EventBoardBrowserTests.cs
@@ -116,7 +116,7 @@ public sealed class EventBoardBrowserTests(
         page.PageError += (_, error) => errors.Add(error);
 
         await page.GotoAsync(
-            "/event-board-embed.html?athlete=majoros_gabor&rows=all&viewAll=false&linkNames=false&theme=dark",
+            "/event-board-embed.html?athlete=majoros_gabor&rows=all&viewAll=false&linkNames=false&theme=dark&embed=1",
             new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
         await page.WaitForSelectorAsync("#eventsTable tbody tr.main-row .event-message-cell");
 
@@ -165,6 +165,61 @@ public sealed class EventBoardBrowserTests(
         Assert.True(
             Math.Abs(nameTop - wordTop) < 3,
             $"Expected the sentence to continue on the athlete-name line. Diagnostics: {diagnosticsJson}");
+        Assert.Empty(errors);
+    }
+
+    [Theory]
+    [InlineData(635)]
+    [InlineData(360)]
+    public async Task AcceptedTestsAppearOnlyOnTheirAthletesProfileWithTheCorrectTestDate(int width)
+    {
+        await using var context = await Browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            BaseURL = App.BaseAddress.ToString(),
+            Locale = "en-US",
+            TimezoneId = "America/Los_Angeles",
+            ViewportSize = new ViewportSize { Width = width, Height = 480 }
+        });
+        var eventsBody = JsonSerializer.Serialize(new[]
+        {
+            new { Id = "accepted-latest", Type = 13, Text = "slug[majoros_gabor] date[2026-08-31]", OccurredAt = DateTime.UtcNow, Relevance = 5 },
+            new { Id = "accepted-backfill", Type = 13, Text = "slug[majoros_gabor] date[2024-01-01]", OccurredAt = DateTime.UtcNow, Relevance = 5 },
+            new { Id = "accepted-other", Type = 13, Text = "slug[nopara73] date[2026-08-31]", OccurredAt = DateTime.UtcNow, Relevance = 5 },
+            new { Id = "improvement", Type = 10, Text = "slug[majoros_gabor] clock[pheno] from[40] to[35]", OccurredAt = DateTime.UtcNow, Relevance = 9 }
+        });
+        await RouteEventBoardDependenciesAsync(context, eventsBody);
+        var page = await context.NewPageAsync();
+        var errors = new List<string>();
+        page.PageError += (_, error) => errors.Add(error);
+        page.Console += (_, message) =>
+        {
+            if (message.Type == "error" && !message.Text.StartsWith("Error fetching athletes:", StringComparison.Ordinal))
+                errors.Add(message.Text);
+        };
+
+        await page.GotoAsync("/event-board-embed.html?athlete=majoros_gabor&rows=all&viewAll=false&linkNames=false&theme=dark&embed=1");
+        var latest = page.Locator("tr[data-event-id='accepted-latest']");
+        try
+        {
+            await latest.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Visible });
+        }
+        catch (TimeoutException)
+        {
+            throw new Xunit.Sdk.XunitException(string.Join("\n", errors) + "\n" + await page.Locator("body").InnerTextAsync());
+        }
+        Assert.Contains("Majoros Gábor (#99) submitted a new test (Aug 31", (await latest.InnerTextAsync()).Replace('\u00A0', ' '));
+        Assert.Contains("submitted a new test (Jan 1, 2024)", await page.Locator("tr[data-event-id='accepted-backfill']").InnerTextAsync());
+        Assert.Equal(3, await page.Locator("tr.main-row").CountAsync());
+        Assert.Equal(0, await page.Locator("tr[data-event-id='accepted-other']").CountAsync());
+        Assert.Equal(1, await latest.Locator(".avatar-disabled").CountAsync());
+        Assert.False(await page.EvaluateAsync<bool>("() => document.documentElement.scrollWidth > window.innerWidth"));
+
+        foreach (var url in new[] { "/events", "/" })
+        {
+            await page.GotoAsync(url);
+            await page.Locator("tr[data-event-id='improvement']").WaitForAsync();
+            Assert.Equal(0, await page.Locator("tr[data-event-id^='accepted-']").CountAsync());
+        }
         Assert.Empty(errors);
     }
 

--- a/LongevityWorldCup.Tests/EventDataServiceCleanupTests.cs
+++ b/LongevityWorldCup.Tests/EventDataServiceCleanupTests.cs
@@ -23,6 +23,8 @@ public sealed class EventDataServiceCleanupTests(TestWebApplicationFactory share
 
             InsertEvent(sqlite, "valid-rank", EventType.NewRank, "slug[alice] rank[1] prev[bob]");
             InsertEvent(sqlite, "missing-primary", EventType.NewRank, "slug[ghost] rank[1]");
+            InsertEvent(sqlite, "missing-test", EventType.TestResultAccepted, "slug[ghost] date[2026-08-31]");
+            InsertEvent(sqlite, "valid-test", EventType.TestResultAccepted, "slug[alice] date[2026-08-31]");
             InsertEvent(sqlite, "missing-prev", EventType.BadgeAward, "slug[alice] badge[Test] cat[Global] val[] place[1] prev[ghost]");
             InsertEvent(sqlite, "custom", EventType.CustomEvent, "slug[ghost]\n\nEditorial note");
             InsertEvent(sqlite, "milestone", EventType.AthleteCountMilestone, "athletes[100]");
@@ -43,9 +45,11 @@ public sealed class EventDataServiceCleanupTests(TestWebApplicationFactory share
             "judy"
         });
 
-        Assert.Equal(2, hidden);
+        Assert.Equal(3, hidden);
         var visibleIds = events.GetEvents(visibleOnWebsite: true).Select(e => e.Id).ToHashSet(StringComparer.OrdinalIgnoreCase);
         Assert.Contains("valid-rank", visibleIds);
+        Assert.Contains("valid-test", visibleIds);
+        Assert.DoesNotContain("missing-test", visibleIds);
         Assert.Contains("custom", visibleIds);
         Assert.Contains("milestone", visibleIds);
         Assert.Contains("challenge", visibleIds);

--- a/LongevityWorldCup.Tests/SocialEventSkipPolicyTests.cs
+++ b/LongevityWorldCup.Tests/SocialEventSkipPolicyTests.cs
@@ -18,6 +18,7 @@ public sealed class SocialEventSkipPolicyTests
         yield return new object[] { EventType.NewRank, "slug[alice] rank[1]", now.AddDays(-8), 0, freshCutoff, true, true, SocialEventSkipReason.StalePrimaryEvent };
         yield return new object[] { EventType.AthleteCountMilestone, "athletes[100]", now, 8, freshCutoff, true, false, SocialEventSkipReason.None };
         yield return new object[] { EventType.BecamePro, "slug[alice]", now, 8, freshCutoff, true, true, SocialEventSkipReason.UnsupportedEventType };
+        yield return new object[] { EventType.TestResultAccepted, "slug[alice] date[2026-06-06]", now, 99, freshCutoff, true, true, SocialEventSkipReason.UnsupportedEventType };
         yield return new object[] { EventType.BecamePro, "not-a-slug", now, 8, freshCutoff, true, true, SocialEventSkipReason.UnsupportedEventType };
         yield return new object[] { EventType.BiologicalAgeImproved, "slug[alice] clock[pheno] from[44.2] to[41.8]", now, 8, freshCutoff, true, true, SocialEventSkipReason.UnsupportedEventType };
         yield return new object[] { EventType.BiologicalAgeImproved, "slug[alice] clock[pheno] from[41.8] to[44.2]", now, 8, freshCutoff, true, true, SocialEventSkipReason.UnsupportedEventType };
@@ -40,6 +41,7 @@ public sealed class SocialEventSkipPolicyTests
         yield return new object[] { EventType.BadgeAward, true, SocialEventSkipReason.FacebookSupportsCustomEventsOnly };
         yield return new object[] { EventType.AthleteCountMilestone, true, SocialEventSkipReason.FacebookSupportsCustomEventsOnly };
         yield return new object[] { EventType.BecamePro, true, SocialEventSkipReason.FacebookSupportsCustomEventsOnly };
+        yield return new object[] { EventType.TestResultAccepted, true, SocialEventSkipReason.FacebookSupportsCustomEventsOnly };
         yield return new object[] { EventType.BiologicalAgeImproved, true, SocialEventSkipReason.FacebookSupportsCustomEventsOnly };
         yield return new object[] { EventType.CrowdAgeTop10Change, true, SocialEventSkipReason.FacebookSupportsCustomEventsOnly };
         yield return new object[] { EventType.AgeImprovementTop10Change, true, SocialEventSkipReason.FacebookSupportsCustomEventsOnly };
@@ -129,6 +131,10 @@ public sealed class SocialEventSkipPolicyTests
             freshCutoffUtc));
         Assert.True(EventDataService.ShouldSkipSlackNotification(
             EventType.BiologicalAgeImproved,
+            freshCutoffUtc,
+            freshCutoffUtc));
+        Assert.True(EventDataService.ShouldSkipSlackNotification(
+            EventType.TestResultAccepted,
             freshCutoffUtc,
             freshCutoffUtc));
     }

--- a/LongevityWorldCup.Website/Business/AthleteDataService.cs
+++ b/LongevityWorldCup.Website/Business/AthleteDataService.cs
@@ -286,6 +286,8 @@ public class AthleteDataService : IAthleteSnapshotProvider, IDisposable
 
         var newlyJoined = EnsureDbRowsForNewAthletes();
 
+        _eventDataService.SyncAcceptedResultEvents(GetAthletesSnapshot(), _serviceStartUtc);
+
         // Existing guesses predate profile-image versioning. Treat the image that is
         // public at migration time as their continuity baseline; future image changes
         // then create a clean boundary without deleting the historical guesses.
@@ -981,6 +983,8 @@ public class AthleteDataService : IAthleteSnapshotProvider, IDisposable
             {
                 _athletes = reloadedAthletes;
                 var newlyJoined = EnsureDbRowsForNewAthletes();
+
+                _eventDataService.SyncAcceptedResultEvents(GetAthletesSnapshot(), DateTime.UtcNow);
 
                 SyncAgeGuessProfileImageIds(migrateLegacyGuesses: false);
                 ReloadCrowdStatsCore();

--- a/LongevityWorldCup.Website/Business/EventDataService.cs
+++ b/LongevityWorldCup.Website/Business/EventDataService.cs
@@ -33,7 +33,8 @@ public enum EventType
     BecamePro = 9,
     BiologicalAgeImproved = 10,
     CrowdAgeTop10Change = 11,
-    AgeImprovementTop10Change = 12
+    AgeImprovementTop10Change = 12,
+    TestResultAccepted = 13
 }
 
 public sealed record CustomEventDeliveryTargets(
@@ -337,7 +338,7 @@ public sealed class EventDataService : IDisposable
 
     internal static bool ShouldSkipSlackNotification(EventType type, DateTime occurredAtUtc, DateTime freshCutoffUtc)
     {
-        if (type is EventType.BecamePro or EventType.BiologicalAgeImproved)
+        if (type is EventType.BecamePro or EventType.BiologicalAgeImproved or EventType.TestResultAccepted)
             return true;
 
         return type == EventType.AthleteCountMilestone && EnsureUtc(occurredAtUtc) < freshCutoffUtc;
@@ -1024,6 +1025,99 @@ public sealed class EventDataService : IDisposable
         {
             ReloadIntoCache();
         }
+    }
+
+    public int SyncAcceptedResultEvents(JsonArray athletes, DateTime acceptedAtUtc)
+    {
+        ArgumentNullException.ThrowIfNull(athletes);
+        if (athletes.Count == 0)
+            return 0;
+
+        // Published results are identified by athlete and test date, not mutable
+        // biomarker values or array positions. Partial panels also represent tests.
+        var results = new HashSet<(string Slug, string Date)>();
+        foreach (var athlete in athletes.OfType<JsonObject>())
+        {
+            var slug = NormalizeAthleteSlugForEventCleanup(athlete["AthleteSlug"]?.GetValue<string>());
+            if (string.IsNullOrWhiteSpace(slug) || athlete["Biomarkers"] is not JsonArray biomarkers)
+                continue;
+
+            foreach (var result in biomarkers.OfType<JsonObject>())
+            {
+                if (result["Date"] is not JsonValue dateValue ||
+                    !dateValue.TryGetValue<string>(out var dateText) ||
+                    !DateOnly.TryParse(dateText, CultureInfo.InvariantCulture, DateTimeStyles.None, out var date) ||
+                    !result.Any(field => field.Key != "Date" && field.Value is JsonValue value &&
+                        value.TryGetValue<double>(out var number) && double.IsFinite(number)))
+                    continue;
+
+                results.Add((slug, date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)));
+            }
+        }
+
+        var created = _db.Run(sqlite =>
+        {
+            using var tx = sqlite.BeginTransaction();
+            using var schema = sqlite.CreateCommand();
+            schema.Transaction = tx;
+            schema.CommandText = "SELECT 1 FROM sqlite_master WHERE type='table' AND name='AcceptedAthleteResults';";
+            var baseline = schema.ExecuteScalar() is null;
+            schema.CommandText =
+                """
+                CREATE TABLE IF NOT EXISTS AcceptedAthleteResults (
+                    AthleteSlug TEXT NOT NULL,
+                    ResultDate TEXT NOT NULL,
+                    PRIMARY KEY (AthleteSlug, ResultDate)
+                );
+                """;
+            schema.ExecuteNonQuery();
+
+            using var remember = sqlite.CreateCommand();
+            remember.Transaction = tx;
+            remember.CommandText =
+                """
+                INSERT INTO AcceptedAthleteResults (AthleteSlug, ResultDate) VALUES (@slug, @date)
+                ON CONFLICT (AthleteSlug, ResultDate) DO NOTHING;
+                """;
+            var pSlug = remember.Parameters.Add("@slug", SqliteType.Text);
+            var pDate = remember.Parameters.Add("@date", SqliteType.Text);
+
+            using var insert = sqlite.CreateCommand();
+            insert.Transaction = tx;
+            insert.CommandText =
+                """
+                INSERT INTO Events (Id, Type, Text, OccurredAt, Relevance, SlackProcessed, XProcessed, ThreadsProcessed, FacebookProcessed)
+                VALUES (@id, @type, @text, @occurredAt, 5, 1, 1, 1, 1)
+                ON CONFLICT (Id) DO NOTHING;
+                """;
+            var pId = insert.Parameters.Add("@id", SqliteType.Text);
+            var pText = insert.Parameters.Add("@text", SqliteType.Text);
+            insert.Parameters.AddWithValue("@type", (int)EventType.TestResultAccepted);
+            insert.Parameters.AddWithValue("@occurredAt", EnsureUtc(acceptedAtUtc).ToString("o"));
+
+            var count = 0;
+            foreach (var (slug, date) in results.OrderBy(result => result.Slug, StringComparer.Ordinal).ThenBy(result => result.Date, StringComparer.Ordinal))
+            {
+                pSlug.Value = slug;
+                pDate.Value = date;
+                if (remember.ExecuteNonQuery() == 0 || baseline)
+                    continue;
+
+                pId.Value = $"accepted-result:{slug}:{date}";
+                pText.Value = $"slug[{slug}] date[{date}]";
+                count += insert.ExecuteNonQuery();
+            }
+
+            // Creating the ledger and seeding history is one transaction. A failed
+            // first load cannot leave an empty ledger that floods profiles on retry.
+            // Later loads remember results and create their Events atomically too.
+            tx.Commit();
+            return count;
+        });
+
+        if (created > 0)
+            ReloadIntoCache();
+        return created;
     }
 
     public void CreateBiologicalAgeImprovementEvents(
@@ -2216,7 +2310,8 @@ public sealed class EventDataService : IDisposable
             or EventType.BecamePro
             or EventType.BiologicalAgeImproved
             or EventType.CrowdAgeTop10Change
-            or EventType.AgeImprovementTop10Change;
+            or EventType.AgeImprovementTop10Change
+            or EventType.TestResultAccepted;
 
     internal static IReadOnlyList<string> ExtractReferencedAthleteSlugs(string text)
     {

--- a/LongevityWorldCup.Website/Business/SocialEventSkipPolicy.cs
+++ b/LongevityWorldCup.Website/Business/SocialEventSkipPolicy.cs
@@ -47,7 +47,7 @@ public static class SocialEventSkipPolicy
             return false;
         }
 
-        if (type is EventType.BecamePro or EventType.BiologicalAgeImproved)
+        if (type is EventType.BecamePro or EventType.BiologicalAgeImproved or EventType.TestResultAccepted)
         {
             reason = SocialEventSkipReason.UnsupportedEventType;
             return true;

--- a/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/event-board-content.html
@@ -1082,7 +1082,7 @@
             return window.__sharedAthletesRequest;
         };
 
-        const EVENT_TYPE = { General: 0, Joined: 1, NewRank: 2, DonationReceived: 3, AthleteCountMilestone: 4, BadgeAward: 5, CustomEvent: 6, SeasonFinalResult: 7, LongevitymaxxingChallengeResult: 8, BecamePro: 9, BiologicalAgeImproved: 10, CrowdAgeTop10Change: 11, AgeImprovementTop10Change: 12 };
+        const EVENT_TYPE = { General: 0, Joined: 1, NewRank: 2, DonationReceived: 3, AthleteCountMilestone: 4, BadgeAward: 5, CustomEvent: 6, SeasonFinalResult: 7, LongevitymaxxingChallengeResult: 8, BecamePro: 9, BiologicalAgeImproved: 10, CrowdAgeTop10Change: 11, AgeImprovementTop10Change: 12, TestResultAccepted: 13 };
         const EVENT_TYPE_NAME_BY_ID = {};
         Object.keys(EVENT_TYPE).forEach(name => {
             EVENT_TYPE_NAME_BY_ID[String(EVENT_TYPE[name])] = name;
@@ -1637,6 +1637,7 @@
                 const leagueValue = extractLeagueValue(text);
                 const place = extractPlace(text);
 
+                const resultDate = extractToken(text, "date");
                 const seasonId = extractSeason(text);
                 const clockId = extractClock(text);
                 const ageDiff = extractAgeDiff(text);
@@ -1654,7 +1655,7 @@
                 const eventImprovement = extractFloatToken(text, "improvement");
                 const eventAgeReduction = extractFloatToken(text, "ageReduction");
 
-                return { id, type, text, occurredAt, relevance, slugs: slugTokens, primarySlug, prevSlug, prevSlugs, isSolo, badgeBurstKey, rank, sats, milestoneCount, badgeLabel, leagueCategory, leagueValue, place, seasonId, clockId, ageDiff, challengeKey, challengeDisplayName, checkedInDays, totalPoints, challengeDays, challengeCompleted, bioAgeFrom, bioAgeTo, previousPlace, eventCrowdAge, eventCrowdCount, eventImprovement, eventAgeReduction };
+                return { id, type, text, occurredAt, relevance, slugs: slugTokens, primarySlug, prevSlug, prevSlugs, isSolo, badgeBurstKey, rank, sats, milestoneCount, badgeLabel, leagueCategory, leagueValue, place, resultDate, seasonId, clockId, ageDiff, challengeKey, challengeDisplayName, checkedInDays, totalPoints, challengeDays, challengeCompleted, bioAgeFrom, bioAgeTo, previousPlace, eventCrowdAge, eventCrowdCount, eventImprovement, eventAgeReduction };
             });
         }
 
@@ -1908,7 +1909,7 @@
                 const isSelfRow = athletePageTargetSlug && primaryKey===athletePageTargetSlug;
 
                 let avatarHtml = "";
-                const canLinkAvatar = (r.type === EVENT_TYPE.Joined || r.type === EVENT_TYPE.NewRank || r.type === EVENT_TYPE.BadgeAward || r.type === EVENT_TYPE.SeasonFinalResult || r.type === EVENT_TYPE.LongevitymaxxingChallengeResult || r.type === EVENT_TYPE.BecamePro || r.type === EVENT_TYPE.BiologicalAgeImproved || r.type === EVENT_TYPE.CrowdAgeTop10Change || r.type === EVENT_TYPE.AgeImprovementTop10Change)
+                const canLinkAvatar = (r.type === EVENT_TYPE.Joined || r.type === EVENT_TYPE.NewRank || r.type === EVENT_TYPE.BadgeAward || r.type === EVENT_TYPE.SeasonFinalResult || r.type === EVENT_TYPE.LongevitymaxxingChallengeResult || r.type === EVENT_TYPE.BecamePro || r.type === EVENT_TYPE.BiologicalAgeImproved || r.type === EVENT_TYPE.CrowdAgeTop10Change || r.type === EVENT_TYPE.AgeImprovementTop10Change || r.type === EVENT_TYPE.TestResultAccepted)
                     && r.primarySlug
                     && url
                     && !isSelfRow
@@ -1922,7 +1923,7 @@
                     ? ` data-athlete-slug="${esc(primaryKey)}"`
                     : ``;
 
-                if (r.type === EVENT_TYPE.Joined || r.type === EVENT_TYPE.NewRank || r.type === EVENT_TYPE.BadgeAward || r.type === EVENT_TYPE.SeasonFinalResult || r.type === EVENT_TYPE.BecamePro || r.type === EVENT_TYPE.BiologicalAgeImproved || r.type === EVENT_TYPE.CrowdAgeTop10Change || r.type === EVENT_TYPE.AgeImprovementTop10Change || (r.type === EVENT_TYPE.LongevitymaxxingChallengeResult && r.primarySlug)) {
+                if (r.type === EVENT_TYPE.Joined || r.type === EVENT_TYPE.NewRank || r.type === EVENT_TYPE.BadgeAward || r.type === EVENT_TYPE.SeasonFinalResult || r.type === EVENT_TYPE.BecamePro || r.type === EVENT_TYPE.BiologicalAgeImproved || r.type === EVENT_TYPE.CrowdAgeTop10Change || r.type === EVENT_TYPE.AgeImprovementTop10Change || r.type === EVENT_TYPE.TestResultAccepted || (r.type === EVENT_TYPE.LongevitymaxxingChallengeResult && r.primarySlug)) {
                     if (img) {
                         avatarHtml = canLinkAvatar
                             ? `<a href="${url}" class="avatar-link event-athlete-link" title="${esc(name)}" aria-label="${esc(name)}"${avatarModalAttrs}${avatarTargetAttrs}><img class="avatar" src="${esc(img)}" alt="${esc(name)}" ${avatarLoadingAttrs} decoding="async" referrerpolicy="no-referrer"></a>`
@@ -2042,6 +2043,15 @@
                         afterNameWithCurrentRankFor()
                     );
                     msgHtml = `${nameWithRank} went Pro`;
+                } else if (r.type === EVENT_TYPE.TestResultAccepted && r.primarySlug) {
+                    const nameWithRank = renderTextWithSlugLinks(
+                        `slug[${r.primarySlug}]`,
+                        linkNames,
+                        athletesIndex,
+                        afterNameWithCurrentRankFor()
+                    );
+                    const testDate = r.resultDate ? ` (${esc(formatListDate(`${r.resultDate}T00:00:00`))})` : "";
+                    msgHtml = `${nameWithRank} submitted a new test${testDate}`;
                 } else if (r.type === EVENT_TYPE.BiologicalAgeImproved && r.primarySlug) {
                     const nameWithRank = renderTextWithSlugLinks(
                         `slug[${r.primarySlug}]`,
@@ -2770,6 +2780,7 @@
                 }else{
                     rows=rows.filter(r=>
                         r.type!==EVENT_TYPE.SeasonFinalResult &&
+                        r.type!==EVENT_TYPE.TestResultAccepted &&
                         (r.type!==EVENT_TYPE.LongevitymaxxingChallengeResult || isAllowedLongevitymaxxingChallengeResult(r, mode)) &&
                         (r.type!==EVENT_TYPE.NewRank || isTop10Rank(r, athletesIndex)));
                 }

--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -33,6 +33,7 @@ Use lowercase pheno age, bortz age, crowd age, age reduction, and effective age 
 
 ## Events
 
+- Accepted-test Events appear only in the athlete's profile highlights when a dated biomarker result becomes public, including non-improvements, partial panels, and older backfilled tests. Each athlete and test date identifies one result across clocks; same-date corrections, additional markers, reordered records, reloads, and restarts do not create another Event. The Event date is when publication is first observed, and its text identifies the test date. Existing results are silently baselined when tracking is first introduced; subsequent results are remembered and their Events saved atomically, including results first observed at startup. These Events do not enter the shared highlights feed or social queues.
 - Biological-age improvement Events represent chronologically new personal bests, use the result date as the Event date, and are not created when an older backfilled result predates the athlete's previous personal best.
 - Pheno/Bortz best-improvement badges compare the latest eligible result with the first eligible result. Improvement leaderboards and their placement Events compare the latest eligible result with the worst eligible result.
 


### PR DESCRIPTION
Published test results now create a dated entry in the athlete’s profile highlights even when they do not improve a score. Each athlete and test date identifies one result across clocks, so corrections, additional markers, reordered records, reloads, and restarts cannot repeat the entry. New dates are detected both during live reloads and at startup, including older backfills and new athletes.

The acceptance ledger and its Events are written in one SQLite transaction. Its first initialization silently records existing history; subsequent results create profile-only Events with all social delivery flags already processed. Shared highlights and existing improvement Events retain their behavior.

Validation: [all 1,504 CI tests passed](https://github.com/nopara73/LongevityWorldCup/actions/runs/33944613121) on `fdeb24038cd9fc5527f858ad7c576a937bd9748b`, including file-watcher and restart integration tests, non-improvements and personal bests, multiple results and partial panels, rollback/retry, public Events API visibility, missing-athlete cleanup, social exclusion, and desktop/mobile browser checks with a negative UTC offset. Desktop and mobile screenshots were also inspected. CodeQL, dependency review, Cursor Bugbot, and Codex review completed without findings.

Local validation note: the full Windows run reported a missing-statistics-row assertion in the existing `ApplicationControllerValidationTests.ResultSubmissionProofValidationRecordsServerStatistics` test. That test and `SiteStatisticsService` are unchanged in this PR; the same test passed in the full CI run. The local failure is recorded rather than being represented as a clean local full-suite pass.

Closes #288