### PR TITLE
Lock down the 54 g/L albumin cap

### DIFF
--- a/LongevityWorldCup.Tests/AlbuminCapBrowserTests.cs
+++ b/LongevityWorldCup.Tests/AlbuminCapBrowserTests.cs
@@ -1,0 +1,147 @@
+using System.Globalization;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using LongevityWorldCup.Website.Controllers;
+using LongevityWorldCup.Website.Tools;
+using Microsoft.Playwright;
+using Xunit;
+using static Microsoft.Playwright.Assertions;
+
+namespace LongevityWorldCup.Tests;
+
+[Collection(BrowserTestCollections.WorkloadA)]
+public sealed class AlbuminCapBrowserTests(
+    PlaywrightBrowserFixture browserFixture,
+    BrowserTestAppFixture appFixture)
+    : BrowserIntegrationTest(browserFixture, appFixture)
+{
+    [Theory]
+    [InlineData("pheno")]
+    [InlineData("bortz")]
+    public async Task CalculatorAndRankPreview_CapAlbuminAfterUnitConversion(string clock)
+    {
+        await using var context = await Browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            BaseURL = App.BaseAddress.ToString(), Locale = "en-GB", TimezoneId = "UTC",
+            ReducedMotion = ReducedMotion.Reduce
+        });
+        await BrowserTestApp.RouteExternalResourcesAsync(context);
+        var athletes = new JsonArray(AlbuminCapTestData.Athlete(54, "Ada"), AlbuminCapTestData.Athlete(66, "Zed"));
+        await context.AddInitScriptAsync($"window.getSharedAthletes = async () => ({athletes.ToJsonString()});");
+        var page = await context.NewPageAsync();
+        var errors = new List<string>();
+        page.PageError += (_, error) => errors.Add(error);
+        await page.GotoAsync($"/{clock}-age", new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
+        await page.Locator("#dob-year").SelectOptionAsync("1980");
+        await page.Locator("#dob-month").SelectOptionAsync("1");
+        await page.Locator("#dob-day").SelectOptionAsync("1");
+        await page.Locator("#blood-draw-date").FillAsync("2026-01-01");
+        await page.Locator("#lwcToStep2Btn").ClickAsync();
+        await Expect(page.Locator("#lwc-step-2")).ToHaveClassAsync(new System.Text.RegularExpressions.Regex("lwc-step--visible"));
+
+        var fields = FormFields(clock);
+        await page.EvaluateAsync(
+            """
+            fields => {
+                for (const [id, value] of Object.entries(fields)) {
+                    const element = document.getElementById(id);
+                    if (!element) throw new Error(`Missing calculator field: ${id}`);
+                    element.value = value;
+                    element.dispatchEvent(new Event('input', { bubbles: true }));
+                    element.dispatchEvent(new Event('change', { bubbles: true }));
+                }
+            }
+            """, fields);
+        await page.Locator("#calculateBioageButton").ClickAsync();
+
+        using var client = App.CreateClient();
+        var atCap = clock == "pheno"
+            ? PhenoAgeHelper.CalculatePhenoAge(AlbuminCapTestData.PhenoValues(54))
+            : BortzAgeHelper.CalculateBortzAgeFromRaw(AlbuminCapTestData.Age, AlbuminCapTestData.BortzValues(54));
+
+        foreach (var (value, unit, rawAlbumin) in new[]
+        {
+            ("53", "1", 53d), ("54", "1", 54d), ("55", "1", 55d), ("66", "1", 66d),
+            ("5.3", "0.1", 53d), ("5.4", "0.1", 54d), ("6.6", "0.1", 66d)
+        })
+        {
+            await page.EvaluateAsync(
+                """
+                ({value, unit}) => {
+                    document.getElementById('albumin').value = value;
+                    document.getElementById('albuminUnit').value = unit;
+                    calculateResult();
+                }
+                """, new { value, unit });
+
+            var apiAge = await CalculateApiAsync(client, clock, rawAlbumin);
+            var browserAge = await page.EvaluateAsync<double>(clock == "pheno"
+                ? "() => lastCalculatedPhenoAge"
+                : "() => lastCalculatedBortzAge");
+            Assert.Equal(apiAge, browserAge, precision: 10);
+            if (rawAlbumin >= 54)
+                Assert.Equal(atCap, browserAge, precision: 10);
+            else
+                Assert.True(browserAge > atCap);
+
+            // Bortz onboarding also computes pheno age from the same entered laboratory values.
+            Assert.Equal(PhenoAgeHelper.CalculatePhenoAge(AlbuminCapTestData.PhenoValues(rawAlbumin)),
+                await page.EvaluateAsync<double>("() => lastCalculatedPhenoAge"), precision: 10);
+            await Expect(page.Locator("#animatedAge")).ToHaveTextAsync(apiAge.ToString("F1", CultureInfo.InvariantCulture));
+            await Expect(page.Locator("#albumin")).ToHaveValueAsync(value);
+            await Expect(page.Locator("#albuminUnit")).ToHaveValueAsync(unit);
+
+            // Ada (54) and Zed (66) tie. With the same DOB, the established name tie-break places You between them.
+            var preview = page.Locator($"#{clock}AgeRankPreview");
+            await Expect(preview.Locator(".bioage-rank-number")).ToHaveTextAsync(rawAlbumin >= 54 ? "#2" : "#3");
+            var names = await preview.Locator(".bioage-rank-row-name").AllTextContentsAsync();
+            Assert.Equal(rawAlbumin >= 54 ? new[] { "Ada", "You", "Zed" } : new[] { "Ada", "Zed", "You" }, names);
+        }
+
+        await page.Locator("#continueButton").ClickAsync();
+        await page.WaitForDomContentLoadedUrlAsync("**/apply");
+        Assert.Equal(66, await page.EvaluateAsync<double>(
+            "() => JSON.parse(sessionStorage.getItem('biomarkerData')).Biomarkers[0].AlbGL"), precision: 10);
+        Assert.Empty(errors);
+    }
+
+    private static async Task<double> CalculateApiAsync(HttpClient client, string clock, double albumin)
+    {
+        var request = JsonSerializer.SerializeToNode(AlbuminCapTestData.Marker(albumin))!.AsObject();
+        request["ChronologicalAge"] = AlbuminCapTestData.Age;
+        using var response = await client.PostAsJsonAsync($"/api/data/{clock}-age", request);
+        response.EnsureSuccessStatusCode();
+        if (clock == "bortz")
+            return (await response.Content.ReadFromJsonAsync<BortzAgeCalculationResult>())!.BiologicalAge;
+
+        var result = (await response.Content.ReadFromJsonAsync<PhenoAgeCalculationResult>())!;
+        Assert.Equal(PhenoAgeHelper.CalculateLiverPhenoAgeContributor(AlbuminCapTestData.PhenoValues(albumin)),
+            result.DomainContributions.Liver, precision: 10);
+        return result.BiologicalAge;
+    }
+
+    private static Dictionary<string, string> FormFields(string clock)
+    {
+        var fields = new Dictionary<string, string>
+        {
+            ["albumin"] = "53", ["wbc"] = "6.3", ["mcv"] = "96.7", ["creatinine"] = "88.4",
+            ["glucose"] = "5.05", ["crp"] = "0.8",
+            [clock == "pheno" ? "lymphocyte" : "lymphocyte_percentage"] = "25.5",
+            [clock == "pheno" ? "rcdw" : "rdw"] = "12.5",
+            [clock == "pheno" ? "ap" : "alp"] = "51"
+        };
+        if (clock == "bortz")
+        {
+            foreach (var (id, value) in new[]
+            {
+                ("urea", "5.4"), ("cholesterol", "4.8"), ("cystatin_c", "0.85"), ("hba1c", "34"),
+                ("ggt", "22"), ("rbc", "4.7"), ("monocyte_percentage", "7.2"), ("neutrophil_percentage", "58.1"),
+                ("alt", "24"), ("shbg", "45"), ("vitamin_d", "85"), ("mch", "31.5"), ("apoa1", "1.55")
+            }) fields[id] = value;
+        }
+        foreach (var id in fields.Keys.ToArray()) fields[id + "Unit"] = "1";
+        fields["crpUnit"] = clock == "pheno" ? "10" : "1";
+        return fields;
+    }
+}

--- a/LongevityWorldCup.Tests/AlbuminCapTests.cs
+++ b/LongevityWorldCup.Tests/AlbuminCapTests.cs
@@ -1,0 +1,121 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using LongevityWorldCup.Website.Business;
+using LongevityWorldCup.Website.Tools;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class AlbuminCapTests
+{
+    // The approved ceiling is 54 g/L; 66 g/L is the result reported in issue #320.
+    [Theory]
+    [InlineData(54d)]
+    [InlineData(54.001d)]
+    [InlineData(55d)]
+    [InlineData(66d)]
+    [InlineData(108d)]
+    public void BothClocks_StopAlbuminImprovementAt54GramsPerLitre(double albumin)
+    {
+        var atCap = AlbuminCapTestData.PhenoValues(54);
+        var actual = AlbuminCapTestData.PhenoValues(albumin);
+        var belowCap = AlbuminCapTestData.PhenoValues(53.999);
+
+        Assert.Equal(54 * -0.0336 + 51 * 0.0019,
+            PhenoAgeHelper.CalculateLiverScore(actual), precision: 12);
+        Assert.Equal(PhenoAgeHelper.CalculatePhenoAge(atCap),
+            PhenoAgeHelper.CalculatePhenoAge(actual), precision: 12);
+        Assert.Equal(PhenoAgeHelper.CalculateLiverPhenoAgeContributor(atCap),
+            PhenoAgeHelper.CalculateLiverPhenoAgeContributor(actual), precision: 12);
+        Assert.True(PhenoAgeHelper.CalculatePhenoAge(belowCap) > PhenoAgeHelper.CalculatePhenoAge(atCap));
+
+        var bortzAtCap = AlbuminCapTestData.BortzValues(54);
+        var bortzActual = AlbuminCapTestData.BortzValues(albumin);
+        var bortzBelowCap = AlbuminCapTestData.BortzValues(53.999);
+        var feature = Assert.Single(BortzAgeHelper.Features, item => item.Id == "albumin");
+
+        Assert.Equal((54 - 45.1238763) * -0.011331946,
+            BortzAgeHelper.CalculateFeatureContribution(albumin, feature), precision: 12);
+        Assert.Equal(BortzAgeHelper.CalculateBAA(bortzAtCap),
+            BortzAgeHelper.CalculateBAA(bortzActual), precision: 12);
+        Assert.Equal(BortzAgeHelper.CalculateBortzAgeFromRaw(AlbuminCapTestData.Age, bortzAtCap),
+            BortzAgeHelper.CalculateBortzAgeFromRaw(AlbuminCapTestData.Age, bortzActual), precision: 12);
+        Assert.True(BortzAgeHelper.CalculateBAA(bortzBelowCap) > BortzAgeHelper.CalculateBAA(bortzAtCap));
+    }
+
+    [Theory]
+    [InlineData(55d)]
+    [InlineData(66d)]
+    [InlineData(108d)]
+    public void StoredAndSubmittedResults_KeepCappedScoresAndOriginalLaboratoryValues(double albumin)
+    {
+        var atCap = AlbuminCapTestData.Athlete(54);
+        var actual = AlbuminCapTestData.Athlete(albumin);
+        foreach (var athlete in new[] { atCap, actual })
+        {
+            var baseline = AlbuminCapTestData.Marker(45);
+            baseline.Date = "2025-01-01";
+            athlete["Biomarkers"]!.AsArray().Insert(0, JsonSerializer.SerializeToNode(baseline));
+        }
+
+        var expected = PhenoStatsCalculator.Compute(atCap, AlbuminCapTestData.ResultDate);
+        var result = PhenoStatsCalculator.Compute(actual, AlbuminCapTestData.ResultDate);
+
+        Assert.NotNull(result.AgeReduction);
+        Assert.NotNull(result.BortzAgeReduction);
+        Assert.Equal(expected.LowestPhenoAge, result.LowestPhenoAge);
+        Assert.Equal(expected.LowestBortzAge, result.LowestBortzAge);
+        Assert.Equal(expected.AgeReduction, result.AgeReduction);
+        Assert.Equal(expected.BortzAgeReduction, result.BortzAgeReduction);
+        Assert.Equal(expected.PhenoAgeDiffFromBaseline, result.PhenoAgeDiffFromBaseline);
+        Assert.Equal(expected.BortzAgeDiffFromBaseline, result.BortzAgeDiffFromBaseline);
+        Assert.Equal(expected.PhenoAgeImprovementFromWorst, result.PhenoAgeImprovementFromWorst);
+        Assert.Equal(expected.BortzAgeImprovementFromWorst, result.BortzAgeImprovementFromWorst);
+        Assert.Equal(PhenoAgeHelper.CalculateLiverPhenoAgeContributor(expected.BestMarkerValues!),
+            PhenoAgeHelper.CalculateLiverPhenoAgeContributor(result.BestMarkerValues!), precision: 12);
+        Assert.Equal(albumin, result.BestMarkerValues![1]);
+        Assert.Equal(albumin, actual["Biomarkers"]![1]!["AlbGL"]!.GetValue<double>());
+
+        var submitted = SubmittedAgeDifferenceCalculator.Calculate(
+            AlbuminCapTestData.DateOfBirth, [AlbuminCapTestData.Marker(albumin)],
+            includePheno: true, includeBortz: true);
+        var submittedAtCap = SubmittedAgeDifferenceCalculator.Calculate(
+            AlbuminCapTestData.DateOfBirth, [AlbuminCapTestData.Marker(54)],
+            includePheno: true, includeBortz: true);
+        Assert.NotNull(submitted.PhenoDifference);
+        Assert.NotNull(submitted.BortzDifference);
+        Assert.Equal(submittedAtCap, submitted);
+    }
+}
+
+internal static class AlbuminCapTestData
+{
+    public static DateTime ResultDate => new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+    public static DateOfBirthData DateOfBirth => new() { Year = 1980, Month = 1, Day = 1 };
+    public static double Age => (ResultDate - new DateTime(1980, 1, 1, 0, 0, 0, DateTimeKind.Utc)).TotalDays / 365.2425;
+
+    public static BiomarkerData Marker(double albumin) => new()
+    {
+        Date = "2026-01-01", AlbGL = albumin, AlpUL = 51, UreaMmolL = 5.4,
+        CholesterolMmolL = 4.8, CreatUmolL = 88.4, CystatinCMgL = 0.85,
+        Hba1cMmolMol = 34, CrpMgL = 0.8, GgtUL = 22, Rbc10e12L = 4.7,
+        McvFL = 96.7, RdwPc = 12.5, Wbc1000cellsuL = 6.3, MonocytePc = 7.2,
+        NeutrophilPc = 58.1, LymPc = 25.5, AltUL = 24, ShbgNmolL = 45,
+        VitaminDNmolL = 85, GluMmolL = 5.05, MchPg = 31.5, ApoA1GL = 1.55
+    };
+
+    public static JsonObject Athlete(double albumin, string name = "Albumin") => new()
+    {
+        ["AthleteSlug"] = name.ToLowerInvariant(),
+        ["Name"] = name,
+        ["DateOfBirth"] = JsonSerializer.SerializeToNode(DateOfBirth),
+        ["Biomarkers"] = new JsonArray(JsonSerializer.SerializeToNode(Marker(albumin)))
+    };
+
+    public static double[] PhenoValues(double albumin) =>
+        [Age, albumin, 88.4, 5.05, Math.Log(0.8 / 10), 6.3, 25.5, 96.7, 12.5, 51];
+
+    public static double[] BortzValues(double albumin) =>
+        [Age, albumin, 51, 5.4, 4.8, 88.4, 0.85, 34, 0.8, 22, 4.7, 96.7, 12.5,
+         6.3 * 7.2 / 100, 6.3 * 58.1 / 100, 25.5, 24, 45, 85, 5.05, 31.5, 1.55];
+}

--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -10,6 +10,7 @@
 - **Pheno Age**, **Bortz Age**, and **Crowd Age** are distinct clocks/views.
 - **Biological Age Difference** is biological age minus chronological age; lower is better. **Age Reduction** is the favorable public label.
 - Biological age differences use unrounded biological and chronological ages; rounding is presentation-only.
+- Albumin has a ceiling of 54 g/L in both pheno age and bortz age calculations, including domain contributions. Apply the ceiling after converting to g/L; preserve the original laboratory value in stored and displayed results. Values above the ceiling provide no further score or ranking benefit.
 - **Effective Age Reduction** is the Ultimate League score: Bortz for Pro, otherwise pheno.
 - **Crowd Count** is accepted realistic guesses behind Crowd Age.
 - Each Crowd Age guess belongs to the exact published profile-picture content identified by `ProfileImageId`; Crowd Age and Crowd Count use only guesses for the athlete's current image.


### PR DESCRIPTION
Albumin is already capped at 54 g/L in both clocks, following the [approved cap decision](https://github.com/nopara73/LongevityWorldCup/issues/136#issuecomment-3901560157). This adds regression coverage for the 66 g/L case in #320 and records the invariant in the domain documentation.

The tests cover the exact ceiling, behavior just below it, liver contributions, stored leaderboard and improvement scores, submitted results, both calculation APIs, browser calculator unit conversion, ranking ties, and preservation of the original lab value through the application handoff. Model coefficients and cap values are unchanged.

Validation: 30 focused checks passed locally, and [all 1,529 CI tests passed](https://github.com/nopara73/LongevityWorldCup/actions/runs/33944744387), including both new browser scenarios. CodeQL, dependency review, and automated reviews passed. Live production APIs and deployed JavaScript agree at 53, 54, 55, 66, and 108 g/L, with identical calculated ages and hypothetical ranks at and above 54 g/L. Production health is Healthy.

Closes #320. The broader model research in #136 remains open.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and documentation changes with no production logic modifications in the diff.
> 
> **Overview**
> Adds **regression tests and domain documentation** for the existing **54 g/L albumin ceiling** in pheno and bortz age (including the **66 g/L** case from #320). **No calculation coefficients or cap values change** in this diff.
> 
> **`AlbuminCapTests`** asserts capped pheno/bortz scores and liver/feature contributions at and above 54 g/L, behavior just below the cap, and that **`PhenoStatsCalculator`**, **`SubmittedAgeDifferenceCalculator`**, and stored biomarkers keep **capped leaderboard/improvement scores** while **retaining the original `AlbGL`**.
> 
> **`AlbuminCapBrowserTests`** (Playwright) walks the pheno/bortz onboarding calculators through multiple albumin inputs and **unit conversions**, checks ages match **`/api/data/{clock}-age`**, rank preview ties (54 vs 66), and that **sessionStorage** on apply still stores the **uncapped lab value** (e.g. 66).
> 
> **`UBIQUITOUS_LANGUAGE.md`** records the rule: cap after g/L conversion, no extra benefit above 54, preserve displayed/stored lab values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dace6d1f7274da18ee5d41fb8e21cedd71cabdae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->