### PR TITLE
Preserve applicant acquisition through submission

### DIFF
--- a/LongevityWorldCup.Tests/NewAthleteOnboardingBrowserTests.cs
+++ b/LongevityWorldCup.Tests/NewAthleteOnboardingBrowserTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Playwright;
+using Microsoft.Extensions.DependencyInjection;
 using LongevityWorldCup.Website.Business;
 using LongevityWorldCup.Website.Tools;
 using System.Globalization;
@@ -125,16 +126,42 @@ public sealed class NewAthleteOnboardingBrowserTests(
         });
     }
 
-    [Fact]
-    public async Task AmateurOnboarding_SubmitsExpectedApplicationPayload()
+    [Theory]
+    [InlineData("https://www.reddit.com/", "social")]
+    [InlineData(null, "campaign")]
+    public async Task AmateurOnboarding_SubmitsExpectedApplicationPayload(string? referrer, string firstSource)
     {
         var bloodDrawDate = DateTime.UtcNow.Date.AddDays(-9).ToString("yyyy-MM-dd");
 
         await RunOnboardingBrowserAsync(async (page, errors) =>
         {
+            var campaign = $"outreach_{Guid.NewGuid():N}";
+            await page.GotoAsync($"/?UTM_Source=newsletter&UTM_MEDIUM=email&UTM_CAMPAIGN={campaign}&ref=keep#top",
+                new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded, Referer = referrer });
             await CompleteAmateurHandoffToApplicationAsync(page, bloodDrawDate);
 
+            var submittedEvent = page.WaitForResponseAsync(response =>
+                response.Url.EndsWith("/api/site-statistics/event", StringComparison.Ordinal) &&
+                (response.Request.PostData?.Contains("\"eventName\":\"application_submit_succeeded\"", StringComparison.Ordinal) ?? false) &&
+                response.Ok);
             var payload = await SubmitFakeApplicationAndCapturePayloadAsync(page);
+            await submittedEvent;
+
+            var statistics = App.Services.GetRequiredService<SiteStatisticsService>();
+            var dashboard = await statistics.GetDashboardAsync(new SiteStatisticsDashboardQuery { Range = "7d", Limit = 5000 });
+            var events = dashboard.Events.Where(ev => ev.FirstCampaign == campaign).ToArray();
+            Assert.Contains(events, ev => ev.EventName == "onboarding_entry_viewed");
+            Assert.Contains(events, ev => ev.EventName == "calculator_result_generated");
+            Assert.Contains(events, ev => ev.EventName == "application_submit_succeeded");
+            Assert.Single(events.Select(ev => ev.SessionHash).Distinct());
+            Assert.All(events, ev =>
+            {
+                Assert.Equal(firstSource, ev.FirstSource);
+                Assert.Equal(referrer is null ? null : "www.reddit.com", ev.FirstReferrerDomain);
+                Assert.Equal("newsletter", ev.FirstUtmSource);
+                Assert.Equal("email", ev.FirstUtmMedium);
+                Assert.StartsWith("/?", ev.LandingRoute);
+            });
 
             AssertSubmittedApplicantBasics(payload, "amateur", 10);
             AssertSubmittedApplicantAgeDifferences(payload, expectBortzDifference: false);
@@ -964,6 +991,7 @@ public sealed class NewAthleteOnboardingBrowserTests(
 
             try
             {
+                Assert.False(string.IsNullOrWhiteSpace(await route.Request.HeaderValueAsync("X-LWC-Stats-Session")));
                 using var document = JsonDocument.Parse(route.Request.PostData ?? "{}");
                 payloadSource.TrySetResult(document.RootElement.Clone());
             }

--- a/LongevityWorldCup.Tests/NewAthleteOnboardingBrowserTests.cs
+++ b/LongevityWorldCup.Tests/NewAthleteOnboardingBrowserTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Playwright;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Http;
 using LongevityWorldCup.Website.Business;
 using LongevityWorldCup.Website.Tools;
 using System.Globalization;
@@ -140,14 +141,18 @@ public sealed class NewAthleteOnboardingBrowserTests(
                 new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded, Referer = referrer });
             await CompleteAmateurHandoffToApplicationAsync(page, bloodDrawDate);
 
-            var submittedEvent = page.WaitForResponseAsync(response =>
-                response.Url.EndsWith("/api/site-statistics/event", StringComparison.Ordinal) &&
-                (response.Request.PostData?.Contains("\"eventName\":\"application_submit_succeeded\"", StringComparison.Ordinal) ?? false) &&
-                response.Ok);
-            var payload = await SubmitFakeApplicationAndCapturePayloadAsync(page);
-            await submittedEvent;
-
             var statistics = App.Services.GetRequiredService<SiteStatisticsService>();
+            var payload = await SubmitFakeApplicationAndCapturePayloadAsync(page, async request =>
+            {
+                // The endpoint is stubbed to avoid mail/payment side effects. Persist its
+                // server-side success event using the actual browser request's correlation headers.
+                var submissionContext = new DefaultHttpContext();
+                submissionContext.Request.Headers["X-LWC-Stats-Session"] =
+                    await request.HeaderValueAsync("X-LWC-Stats-Session");
+                submissionContext.Request.Headers.Referer = await request.HeaderValueAsync("Referer");
+                await statistics.RecordServerEventAsync("application_submit_succeeded", submissionContext,
+                    flow: "application", route: "/api/application/application", outcome: "succeeded");
+            });
             var dashboard = await statistics.GetDashboardAsync(new SiteStatisticsDashboardQuery { Range = "7d", Limit = 5000 });
             var events = dashboard.Events.Where(ev => ev.FirstCampaign == campaign).ToArray();
             Assert.Contains(events, ev => ev.EventName == "onboarding_entry_viewed");
@@ -958,9 +963,10 @@ public sealed class NewAthleteOnboardingBrowserTests(
             markerKeys);
     }
 
-    private static async Task<JsonElement> SubmitFakeApplicationAndCapturePayloadAsync(IPage page)
+    private static async Task<JsonElement> SubmitFakeApplicationAndCapturePayloadAsync(
+        IPage page, Func<IRequest, Task>? onSubmission = null)
     {
-        var payloadTask = await CaptureApplicationPostPayloadAsync(page);
+        var payloadTask = await CaptureApplicationPostPayloadAsync(page, onSubmission);
 
         await GoToFakeApplicationFinalStageAsync(page);
         await page.Locator("#nextButton").ClickAsync();
@@ -968,7 +974,8 @@ public sealed class NewAthleteOnboardingBrowserTests(
         return await payloadTask.WaitAsync(TimeSpan.FromSeconds(10));
     }
 
-    private static async Task<Task<JsonElement>> CaptureApplicationPostPayloadAsync(IPage page)
+    private static async Task<Task<JsonElement>> CaptureApplicationPostPayloadAsync(
+        IPage page, Func<IRequest, Task>? onSubmission = null)
     {
         var payloadSource = new TaskCompletionSource<JsonElement>(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -993,6 +1000,8 @@ public sealed class NewAthleteOnboardingBrowserTests(
             {
                 Assert.False(string.IsNullOrWhiteSpace(await route.Request.HeaderValueAsync("X-LWC-Stats-Session")));
                 using var document = JsonDocument.Parse(route.Request.PostData ?? "{}");
+                if (onSubmission is not null)
+                    await onSubmission(route.Request);
                 payloadSource.TrySetResult(document.RootElement.Clone());
             }
             catch (Exception exception)

--- a/LongevityWorldCup.Tests/SiteStatisticsDashboardBrowserTests.cs
+++ b/LongevityWorldCup.Tests/SiteStatisticsDashboardBrowserTests.cs
@@ -94,7 +94,7 @@ public sealed class SiteStatisticsDashboardBrowserTests(
         var referrers = page.Locator("#detailSections .detail-panel")
             .Filter(new() { Has = page.GetByRole(AriaRole.Heading, new() { Name = "First referrers", Exact = true }) });
         await Assertions.Expect(referrers.Locator("tbody tr").Filter(new() { HasText = "www.reddit.com" }).Locator("td"))
-            .ToHaveTextAsync(["www.reddit.com", "3", "0", "2", "0", "10"]);
+            .ToHaveTextAsync(["www.reddit.com", "3", "2"]);
         var campaigns = page.Locator("#detailSections .detail-panel")
             .Filter(new() { Has = page.GetByRole(AriaRole.Heading, new() { Name = "Campaigns", Exact = true }) });
         await Assertions.Expect(campaigns.Locator("tbody tr").Filter(new() { HasText = "outreach" }).Locator("td"))

--- a/LongevityWorldCup.Tests/SiteStatisticsDashboardBrowserTests.cs
+++ b/LongevityWorldCup.Tests/SiteStatisticsDashboardBrowserTests.cs
@@ -2,6 +2,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using LongevityWorldCup.Website.Business;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Playwright;
 using Xunit;
 
@@ -35,6 +36,69 @@ public sealed class SiteStatisticsDashboardBrowserTests(
         });
 
         await statistics.StartAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task Dashboard_AttributesServerConfirmedApplicationsOncePerSession()
+    {
+        var statistics = App.Services.GetRequiredService<SiteStatisticsService>();
+        foreach (var session in new[] { "server-only", "both-events", "direct-application", "failed-application" })
+        {
+            var direct = session == "direct-application";
+            await statistics.RecordClientEventAsync(new SiteStatisticsEventRequest
+            {
+                EventName = "proof_flow_opened",
+                SessionId = session,
+                Flow = "application",
+                Route = "/apply",
+                LandingRoute = "/join",
+                FirstSource = direct ? "direct" : "social",
+                FirstReferrerDomain = direct ? null : "www.reddit.com",
+                FirstCampaign = direct ? null : "outreach"
+            }, new DefaultHttpContext());
+
+            var submissionContext = new DefaultHttpContext();
+            submissionContext.Request.Headers["X-LWC-Stats-Session"] = session;
+            submissionContext.Request.Headers.Referer = "https://www.longevityworldcup.com/apply";
+            await statistics.RecordServerEventAsync(
+                session == "failed-application" ? "application_submit_failed" : "application_submit_succeeded",
+                submissionContext, flow: "application", component: "application", step: "submit");
+            if (session == "both-events")
+            {
+                await statistics.RecordClientEventAsync(new SiteStatisticsEventRequest
+                {
+                    EventName = "application_submit_succeeded", SessionId = session, Flow = "application"
+                }, new DefaultHttpContext());
+            }
+        }
+
+        await using var context = await Browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            BaseURL = App.BaseAddress.ToString(),
+            ViewportSize = new ViewportSize { Width = 1440, Height = 980 }
+        });
+        await BrowserTestApp.RouteExternalResourcesAsync(context);
+        var page = await context.NewPageAsync();
+        await page.GotoAsync("/internal/site-statistics.html?tab=Source%20Quality");
+
+        var applications = page.Locator("#outcomeStrip .metric-tile")
+            .Filter(new() { HasText = "Applications submitted" }).Locator(".metric-value");
+        await Assertions.Expect(applications).ToHaveTextAsync("3");
+        var sourcePanel = page.Locator("#detailSections .detail-panel")
+            .Filter(new() { Has = page.GetByRole(AriaRole.Heading, new() { Name = "Acquisition quality", Exact = true }) });
+        var social = sourcePanel.Locator("tbody tr").Filter(new() { HasText = "social" });
+        await Assertions.Expect(social.Locator("td")).ToHaveTextAsync(["social", "3", "0", "2", "0", "10"]);
+        var directRow = sourcePanel.Locator("tbody tr").Filter(new() { HasText = "direct" });
+        await Assertions.Expect(directRow.Locator("td")).ToHaveTextAsync(["direct", "1", "0", "1", "0", "5"]);
+
+        var referrers = page.Locator("#detailSections .detail-panel")
+            .Filter(new() { Has = page.GetByRole(AriaRole.Heading, new() { Name = "First referrers", Exact = true }) });
+        await Assertions.Expect(referrers.Locator("tbody tr").Filter(new() { HasText = "www.reddit.com" }).Locator("td"))
+            .ToHaveTextAsync(["www.reddit.com", "3", "0", "2", "0", "10"]);
+        var campaigns = page.Locator("#detailSections .detail-panel")
+            .Filter(new() { Has = page.GetByRole(AriaRole.Heading, new() { Name = "Campaigns", Exact = true }) });
+        await Assertions.Expect(campaigns.Locator("tbody tr").Filter(new() { HasText = "outreach" }).Locator("td"))
+            .ToHaveTextAsync(["outreach", "3", "social", "0", "2"]);
     }
 
     [Fact]

--- a/LongevityWorldCup.Tests/SiteStatisticsServiceTests.cs
+++ b/LongevityWorldCup.Tests/SiteStatisticsServiceTests.cs
@@ -12,6 +12,51 @@ namespace LongevityWorldCup.Tests;
 
 public sealed class SiteStatisticsServiceTests
 {
+    [Theory]
+    [InlineData("direct", false)]
+    [InlineData("direct", true)]
+    [InlineData("campaign", false)]
+    [InlineData("campaign", true)]
+    public async Task Dashboard_PreservesReferrerlessAcquisitionAcrossClientAndServerRequests(
+        string firstSource, bool serverArrivesFirst)
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), "LongevityWorldCup.Tests", $"{Guid.NewGuid():N}.db");
+        Directory.CreateDirectory(Path.GetDirectoryName(dbPath)!);
+        await using var cleanup = new TempDatabaseCleanup(dbPath);
+        using var database = new DatabaseManager(dbPath: dbPath);
+        var service = new SiteStatisticsService(database, NullLogger<SiteStatisticsService>.Instance);
+        var serverContext = new DefaultHttpContext();
+        serverContext.Request.Headers["X-LWC-Stats-Session"] = "referrerless-acquisition";
+        serverContext.Request.Headers.Referer = "https://www.longevityworldcup.com/apply";
+        var clientContext = new DefaultHttpContext();
+        clientContext.Request.Headers.Referer = "https://www.longevityworldcup.com/join";
+
+        Task RecordSubmission() => service.RecordServerEventAsync(
+            "application_submit_succeeded", serverContext, flow: "application", outcome: "succeeded");
+        if (serverArrivesFirst) await RecordSubmission();
+        await service.RecordClientEventAsync(new SiteStatisticsEventRequest
+        {
+            EventName = "onboarding_entry_viewed",
+            SessionId = "referrerless-acquisition",
+            Route = "/join",
+            LandingRoute = "/join",
+            FirstSource = firstSource,
+            FirstReferrerDomain = "",
+            FirstUtmCampaign = firstSource == "campaign" ? "outreach" : null
+        }, clientContext);
+        if (!serverArrivesFirst) await RecordSubmission();
+
+        var dashboard = await service.GetDashboardAsync(new SiteStatisticsDashboardQuery { Range = "7d" });
+        Assert.Equal(2, dashboard.Events.Count);
+        Assert.Single(dashboard.Events.Select(ev => ev.SessionHash).Distinct());
+        Assert.All(dashboard.Events, ev =>
+        {
+            Assert.Equal(firstSource, ev.FirstSource);
+            Assert.Null(ev.FirstReferrerDomain);
+            Assert.Equal("/join", ev.LandingRoute);
+        });
+    }
+
     [Fact]
     public async Task RecordClientEventAsync_RedactsSensitiveValuesFromDashboardProjection()
     {

--- a/LongevityWorldCup.Tests/SiteStatisticsTrackingBrowserTests.cs
+++ b/LongevityWorldCup.Tests/SiteStatisticsTrackingBrowserTests.cs
@@ -11,7 +11,7 @@ public sealed class SiteStatisticsTrackingBrowserTests(
     : BrowserIntegrationTest(browserFixture, appFixture)
 {
     [Fact]
-    public async Task Tracker_KeepsAttributionAndSubmissionSessionWhenStorageAndBeaconAreUnavailable()
+    public async Task Tracker_KeepsCurrentDocumentAttributionWhenStorageAndBeaconAreUnavailable()
     {
         await using var context = await Browser.NewContextAsync(new BrowserNewContextOptions
         {

--- a/LongevityWorldCup.Tests/SiteStatisticsTrackingBrowserTests.cs
+++ b/LongevityWorldCup.Tests/SiteStatisticsTrackingBrowserTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Playwright;
+using System.Text.Json;
 using Xunit;
 
 namespace LongevityWorldCup.Tests;
@@ -9,6 +10,45 @@ public sealed class SiteStatisticsTrackingBrowserTests(
     BrowserTestAppFixture appFixture)
     : BrowserIntegrationTest(browserFixture, appFixture)
 {
+    [Fact]
+    public async Task Tracker_KeepsAttributionAndSubmissionSessionWhenStorageAndBeaconAreUnavailable()
+    {
+        await using var context = await Browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            BaseURL = App.BaseAddress.ToString()
+        });
+        await BrowserTestApp.RouteExternalResourcesAsync(context);
+        await context.AddInitScriptAsync("""
+            Object.defineProperty(window, "sessionStorage", {
+                get() { throw new DOMException("Storage blocked", "SecurityError"); }
+            });
+            navigator.sendBeacon = () => false;
+            """);
+        var page = await context.NewPageAsync();
+        var submissionSession = new TaskCompletionSource<string?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        await page.RouteAsync("**/api/application/application", async route =>
+        {
+            submissionSession.TrySetResult(await route.Request.HeaderValueAsync("X-LWC-Stats-Session"));
+            await route.FulfillAsync(new() { Status = 200, ContentType = "application/json", Body = "{}" });
+        });
+        await page.GotoAsync("/join?utm_source=newsletter&utm_campaign=storage-fallback");
+        var recorded = page.WaitForResponseAsync(response =>
+            response.Url.EndsWith("/api/site-statistics/event", StringComparison.Ordinal) &&
+            (response.Request.PostData?.Contains("\"eventName\":\"acquisition_test\"", StringComparison.Ordinal) ?? false) &&
+            response.Ok);
+        await page.EvaluateAsync("""
+            async () => {
+                await fetch("/api/application/application", { method: "POST" });
+                window.LwcSiteStats.track("acquisition_test");
+            }
+            """);
+        var response = await recorded;
+        using var payload = JsonDocument.Parse(response.Request.PostData!);
+        Assert.Equal(await submissionSession.Task, payload.RootElement.GetProperty("sessionId").GetString());
+        Assert.Equal("storage-fallback", payload.RootElement.GetProperty("firstCampaign").GetString());
+        Assert.Equal("newsletter", payload.RootElement.GetProperty("firstUtmSource").GetString());
+    }
+
     [Fact]
     public async Task Tracker_ForwardsOnlyConfirmedBusinessConversionsToGoogleAnalyticsOnce()
     {

--- a/LongevityWorldCup.Tests/TrackingParamStripperMiddlewareTests.cs
+++ b/LongevityWorldCup.Tests/TrackingParamStripperMiddlewareTests.cs
@@ -9,6 +9,21 @@ namespace LongevityWorldCup.Tests;
 public sealed class TrackingParamStripperMiddlewareTests(TestWebApplicationFactory sharedFactory)
 {
     [Fact]
+    public async Task DocumentNavigation_PreservesCampaignLabelsForBrowserAttribution()
+    {
+        using var client = sharedFactory.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+        using var request = new HttpRequestMessage(HttpMethod.Get,
+            "/join?UTM_Source=newsletter&utm_medium=email&utm_campaign=summer&utm_term=athletes&utm_content=invite&fbclid=abc&ref=keep");
+        request.Headers.Accept.ParseAdd("text/html");
+
+        using var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Null(response.Headers.Location);
+        Assert.Contains("/js/site-statistics-tracking.js?v=", await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
     public async Task TrackingParameters_AreRemovedAndNonTrackingParametersArePreserved()
     {
         var factory = sharedFactory;

--- a/LongevityWorldCup.Website/Business/SiteStatisticsService.cs
+++ b/LongevityWorldCup.Website/Business/SiteStatisticsService.cs
@@ -846,7 +846,7 @@ public sealed class SiteStatisticsService : IHostedService
                     END,
                     FirstReferrerDomain = CASE
                         WHEN @hasExplicitFirstTouch = 1 AND lower(coalesce(SiteStatisticSessions.FirstSource, 'direct')) IN ('direct', 'internal') THEN excluded.FirstReferrerDomain
-                        WHEN excluded.FirstSeenAtUtc < SiteStatisticSessions.FirstSeenAtUtc OR SiteStatisticSessions.FirstReferrerDomain IS NULL THEN COALESCE(excluded.FirstReferrerDomain, SiteStatisticSessions.FirstReferrerDomain)
+                        WHEN excluded.FirstSeenAtUtc < SiteStatisticSessions.FirstSeenAtUtc THEN COALESCE(excluded.FirstReferrerDomain, SiteStatisticSessions.FirstReferrerDomain)
                         ELSE SiteStatisticSessions.FirstReferrerDomain
                     END,
                     FirstSource = CASE
@@ -1080,7 +1080,10 @@ public sealed class SiteStatisticsService : IHostedService
             ? rawRoute
             : request.LandingRoute!;
         var landingRoute = BuildRouteProjection(landingRouteRaw).Route ?? sanitizedRoute;
-        var firstReferrerDomain = SafeDomain(request.FirstReferrerDomain) ?? referrerDomain;
+        // An explicit browser first touch may have no referrer. The telemetry/API
+        // request's Referer is our own page and must not become the acquisition source.
+        var firstReferrerDomain = SafeDomain(request.FirstReferrerDomain)
+            ?? (string.IsNullOrWhiteSpace(request.FirstSource) ? referrerDomain : null);
         var firstUtmSource = SafeCampaignValue(request.FirstUtmSource) ?? QueryValue(landingRouteRaw, "utm_source");
         var firstUtmMedium = SafeCampaignValue(request.FirstUtmMedium) ?? QueryValue(landingRouteRaw, "utm_medium");
         var firstUtmCampaign = SafeCampaignValue(request.FirstUtmCampaign) ?? QueryValue(landingRouteRaw, "utm_campaign");

--- a/LongevityWorldCup.Website/Frontend/site-statistics-tracking.ts
+++ b/LongevityWorldCup.Website/Frontend/site-statistics-tracking.ts
@@ -19,6 +19,8 @@
     const touchedFields = new Set<string>();
     let lastRequiredProgress = -1;
     let lastCheckInKind = "scored";
+    let sessionId: string | null = null;
+    let firstTouch: StoredFirstTouch | null = null;
 
     interface StoredFirstTouch {
         landingRoute?: unknown;
@@ -82,11 +84,12 @@
     }
 
     function getSessionId(): string {
+        if (sessionId) return sessionId;
         const existing = safe(() => sessionStorage.getItem(sessionKey));
-        if (existing) return existing;
+        if (existing) return sessionId = existing;
         const id = createSessionId();
         safe(() => sessionStorage.setItem(sessionKey, id));
-        return id;
+        return sessionId = id;
     }
 
     function route(): string {
@@ -94,12 +97,14 @@
     }
 
     function campaignValue(name: string): string {
-        const value = safe(() => new URLSearchParams(window.location.search).get(name)) || "";
+        const value = safe(() => Array.from(new URLSearchParams(window.location.search))
+            .find(([key]) => key.toLowerCase() === name)?.[1]) || "";
         return safeToken(value, 96);
     }
 
     function hasCampaignParams(): boolean {
-        return !!(campaignValue("campaign") || campaignValue("utm_source") || campaignValue("utm_medium") || campaignValue("utm_campaign"));
+        return !!(campaignValue("campaign") || campaignValue("utm_source") || campaignValue("utm_medium")
+            || campaignValue("utm_campaign") || campaignValue("utm_term") || campaignValue("utm_content"));
     }
 
     function flowFromPath(): string {
@@ -177,10 +182,13 @@
     }
 
     function getFirstTouch(): StoredFirstTouch {
+        if (firstTouch) return firstTouch;
         const existing = safe(() => sessionStorage.getItem(firstTouchKey));
         if (existing) {
             const parsed: unknown = safe(() => JSON.parse(existing));
-            if (parsed && typeof parsed === "object") return parsed as StoredFirstTouch;
+            if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+                return firstTouch = parsed as StoredFirstTouch;
+            }
         }
 
         const touch = {
@@ -195,7 +203,7 @@
             firstUtmContent: campaignValue("utm_content")
         };
         safe(() => sessionStorage.setItem(firstTouchKey, JSON.stringify(touch)));
-        return touch;
+        return firstTouch = touch;
     }
 
     function trackGoogleKeyEvent(eventName: string | null): void {
@@ -240,8 +248,7 @@
             const body = JSON.stringify(payload);
             if (navigator.sendBeacon && body.length < 60000) {
                 const blob = new Blob([body], { type: "application/json" });
-                navigator.sendBeacon(endpoint, blob);
-                return;
+                if (navigator.sendBeacon(endpoint, blob)) return;
             }
 
             originalFetch(endpoint, {
@@ -1084,6 +1091,8 @@
     };
     Reflect.set(window, "LwcSiteStats", siteStatisticsApi);
 
+    // Capture the entry URL before SPA navigation or application requests can change it.
+    safe(getFirstTouch);
     setupFetchTracking();
     setupSpaRouteTracking();
     listen(document, "DOMContentLoaded", () => {

--- a/LongevityWorldCup.Website/Frontend/site-statistics-tracking.ts
+++ b/LongevityWorldCup.Website/Frontend/site-statistics-tracking.ts
@@ -19,6 +19,7 @@
     const touchedFields = new Set<string>();
     let lastRequiredProgress = -1;
     let lastCheckInKind = "scored";
+    // These fallbacks last for this document. Cross-page attribution requires sessionStorage.
     let sessionId: string | null = null;
     let firstTouch: StoredFirstTouch | null = null;
 

--- a/LongevityWorldCup.Website/Frontend/site-statistics.ts
+++ b/LongevityWorldCup.Website/Frontend/site-statistics.ts
@@ -1647,7 +1647,7 @@
                 detailPanel("Acquisition quality", sourceQualityTable(events)),
                 detailPanel("Campaigns", campaignTable(events)),
                 detailPanel("Device split", splitTable(events, e => e.deviceClass || "unknown")),
-                detailPanel("First referrers", sourceQualityTable(events, firstReferrer, "Referrer"))
+                detailPanel("First referrers", referrerQualityTable(events))
             ].join("");
             return;
         }
@@ -2431,19 +2431,24 @@
         ]);
     }
 
-    function sourceQualityTable(
-        events: DashboardEvent[],
-        key: (event: DashboardEvent) => string = acquisitionSource,
-        label = "Source"
-    ): string {
-        const rows: [string, number, number, number, number, number][] = Array.from(groupBy(events, key).entries()).map(([source, items]) => {
+    function sourceQualityTable(events: DashboardEvent[]): string {
+        const rows: [string, number, number, number, number, number][] = Array.from(groupBy(events, acquisitionSource).entries()).map(([source, items]) => {
             const results = uniqueSessionsFor(items, ["calculator_result_generated"]);
             const applications = uniqueSessionsFor(items, ["application_submit_succeeded"]);
             const challenge = uniqueSessionsFor(items, ["challenge_scored_checkin_submitted"]);
             const quality = applications * 5 + challenge * 4 + results;
             return [source, uniqueSessions(items), results, applications, challenge, quality] as [string, number, number, number, number, number];
         }).sort((a, b) => b[5] - a[5]);
-        return table([label, "Sessions", "Results", "Apps", "Challenge", "Quality"], rows.slice(0, 12));
+        return table(["Source", "Sessions", "Results", "Apps", "Challenge", "Quality"], rows.slice(0, 12));
+    }
+
+    function referrerQualityTable(events: DashboardEvent[]): string {
+        const rows = Array.from(groupBy(events, firstReferrer).entries()).map(([referrer, items]) => [
+            referrer,
+            uniqueSessions(items),
+            uniqueSessionsFor(items, ["application_submit_succeeded"])
+        ] as [string, number, number]).sort((a, b) => b[2] - a[2] || b[1] - a[1]);
+        return table(["Referrer", "Sessions", "Apps"], rows.slice(0, 12));
     }
 
     function campaignTable(events: DashboardEvent[]): string {

--- a/LongevityWorldCup.Website/Frontend/site-statistics.ts
+++ b/LongevityWorldCup.Website/Frontend/site-statistics.ts
@@ -1473,7 +1473,9 @@
                 ? uniqueSessions(friction)
                 : label === "Error rate"
                     ? percent(uniqueSessions(friction), uniqueSessions(events))
-                    : tileEvents.length;
+                    : label === "Applications submitted"
+                        ? uniqueSessions(tileEvents)
+                        : tileEvents.length;
             const footer = label === "Friction"
                 ? `${friction.length} events`
                 : label === "Error rate"
@@ -1645,7 +1647,7 @@
                 detailPanel("Acquisition quality", sourceQualityTable(events)),
                 detailPanel("Campaigns", campaignTable(events)),
                 detailPanel("Device split", splitTable(events, e => e.deviceClass || "unknown")),
-                detailPanel("First referrers", splitTable(events, e => e.firstReferrerDomain || e.referrerDomain || acquisitionSource(e)))
+                detailPanel("First referrers", sourceQualityTable(events, firstReferrer, "Referrer"))
             ].join("");
             return;
         }
@@ -2429,15 +2431,19 @@
         ]);
     }
 
-    function sourceQualityTable(events: DashboardEvent[]): string {
-        const rows: [string, number, number, number, number, number][] = Array.from(groupBy(events, acquisitionSource).entries()).map(([source, items]) => {
+    function sourceQualityTable(
+        events: DashboardEvent[],
+        key: (event: DashboardEvent) => string = acquisitionSource,
+        label = "Source"
+    ): string {
+        const rows: [string, number, number, number, number, number][] = Array.from(groupBy(events, key).entries()).map(([source, items]) => {
             const results = uniqueSessionsFor(items, ["calculator_result_generated"]);
             const applications = uniqueSessionsFor(items, ["application_submit_succeeded"]);
             const challenge = uniqueSessionsFor(items, ["challenge_scored_checkin_submitted"]);
             const quality = applications * 5 + challenge * 4 + results;
             return [source, uniqueSessions(items), results, applications, challenge, quality] as [string, number, number, number, number, number];
         }).sort((a, b) => b[5] - a[5]);
-        return table(["Source", "Sessions", "Results", "Apps", "Challenge", "Quality"], rows.slice(0, 12));
+        return table([label, "Sessions", "Results", "Apps", "Challenge", "Quality"], rows.slice(0, 12));
     }
 
     function campaignTable(events: DashboardEvent[]): string {
@@ -2509,7 +2515,9 @@
             source: effectiveSource(event.source, referrerDomain),
             landingRoute: event.landingRoute || "",
             firstReferrerDomain: event.firstReferrerDomain || "",
-            firstSource: effectiveSource(event.firstSource || event.source, event.firstReferrerDomain || referrerDomain),
+            firstSource: event.firstSource
+                ? effectiveSource(event.firstSource, event.firstReferrerDomain)
+                : effectiveSource(event.source, referrerDomain),
             firstCampaign: event.firstCampaign || "",
             firstUtmSource: event.firstUtmSource || "",
             firstUtmMedium: event.firstUtmMedium || "",
@@ -2633,6 +2641,12 @@
 
     function acquisitionSource(event: DashboardEvent): string {
         return event.firstSource || event.source || "direct";
+    }
+
+    function firstReferrer(event: DashboardEvent): string {
+        return event.firstReferrerDomain || (event.landingRoute
+            ? acquisitionSource(event)
+            : event.referrerDomain || acquisitionSource(event));
     }
 
     function campaignLabel(event: DashboardEvent): string {


### PR DESCRIPTION
Direct and campaign arrivals could become “internal” when later tracking or application requests supplied a same-site Referer. Preserve the original source and absent referrer through submission, capture campaign tags at tracker startup with case-insensitive keys, and fall back to fetch when a beacon is rejected.

Source Quality now compares referrers by sessions and applications. Submission totals count each session once when browser and server both record success. Existing route and metadata redaction remains in place.

Validation: [1,607 tests passed in CI](https://github.com/nopara73/LongevityWorldCup/actions/runs/33946242770), with CodeQL, dependency review, and automated review passing. Local acquisition journeys use a stubbed application transport and the real statistics service. After [deployment](https://github.com/nopara73/LongevityWorldCup/actions/runs/33946541776), production health and browser probes passed, including referral/campaign continuity through three documents and the submission request, plus the rendered referrer table. Test telemetry and submission requests were intercepted in the production probe.

Attribution remains scoped to the browser tab through sessionStorage. When that storage is blocked, the in-memory fallback preserves correlation within the current document only.

Closes #246