### PR TITLE
Simplify Markdown responses and tracking queries

### DIFF
--- a/LongevityWorldCup.Website/Controllers/AiController.cs
+++ b/LongevityWorldCup.Website/Controllers/AiController.cs
@@ -11,36 +11,26 @@ namespace LongevityWorldCup.Website.Controllers;
 public sealed class AiController(LeaderboardFactsService facts) : Controller
 {
     [HttpGet("leaderboard.md")]
-    public IActionResult GetLeaderboardFacts()
-    {
-        var document = facts.GetLeaderboardMarkdown();
-        var eTag = PublicGetCacheHeaders.BuildWeakContentETag(document.Markdown);
-
-        PublicGetCacheHeaders.Apply(Response, PublicGetCacheHeaders.AiFactsCacheControl, PublicGetCacheHeaders.AiFactsMaxAgeSeconds, eTag, document.LastModifiedUtc);
-        Response.Headers["X-Robots-Tag"] = "index, follow";
-        if (PublicGetCacheHeaders.RequestHasMatchingETag(Request.Headers, eTag))
-            return StatusCode(StatusCodes.Status304NotModified);
-
-        return Content(document.Markdown, "text/markdown; charset=utf-8");
-    }
+    public IActionResult GetLeaderboardFacts() => RenderMarkdown(facts.GetLeaderboardMarkdown());
 
     [HttpGet("athlete-names.md")]
-    public IActionResult GetAthleteNames()
-    {
-        var document = facts.GetAthleteNamesMarkdown();
-        var eTag = PublicGetCacheHeaders.BuildWeakContentETag(document.Markdown);
-
-        PublicGetCacheHeaders.Apply(Response, PublicGetCacheHeaders.AiFactsCacheControl, PublicGetCacheHeaders.AiFactsMaxAgeSeconds, eTag, document.LastModifiedUtc);
-        Response.Headers["X-Robots-Tag"] = "index, follow";
-        if (PublicGetCacheHeaders.RequestHasMatchingETag(Request.Headers, eTag))
-            return StatusCode(StatusCodes.Status304NotModified);
-
-        return Content(document.Markdown, "text/markdown; charset=utf-8");
-    }
+    public IActionResult GetAthleteNames() => RenderMarkdown(facts.GetAthleteNamesMarkdown());
 
     [HttpGet("athletes.md")]
     public IActionResult RedirectAthletes()
     {
         return RedirectPermanent("/ai/leaderboard.md");
+    }
+
+    private IActionResult RenderMarkdown(LeaderboardFactsDocument document)
+    {
+        var eTag = PublicGetCacheHeaders.BuildWeakContentETag(document.Markdown);
+
+        PublicGetCacheHeaders.Apply(Response, PublicGetCacheHeaders.AiFactsCacheControl, PublicGetCacheHeaders.AiFactsMaxAgeSeconds, eTag, document.LastModifiedUtc);
+        Response.Headers["X-Robots-Tag"] = "index, follow";
+        if (PublicGetCacheHeaders.RequestHasMatchingETag(Request.Headers, eTag))
+            return StatusCode(StatusCodes.Status304NotModified);
+
+        return Content(document.Markdown, "text/markdown; charset=utf-8");
     }
 }

--- a/LongevityWorldCup.Website/Middleware/TrackingParamStripperMiddleware.cs
+++ b/LongevityWorldCup.Website/Middleware/TrackingParamStripperMiddleware.cs
@@ -31,18 +31,18 @@ namespace LongevityWorldCup.Website.Middleware
                 return;
             }
 
-            var qs = context.Request.QueryString.Value;
-            if (string.IsNullOrEmpty(qs))
+            var queryString = context.Request.QueryString.Value;
+            if (string.IsNullOrEmpty(queryString))
             {
                 await _next(context);
                 return;
             }
 
-            var dict = QueryHelpers.ParseQuery(qs);
+            var queryParameters = QueryHelpers.ParseQuery(queryString);
             var removed = false;
 
-            foreach (var k in StripKeys.ToArray())
-                removed |= dict.Remove(k);
+            foreach (var key in StripKeys)
+                removed |= queryParameters.Remove(key);
 
             if (!removed)
             {
@@ -51,12 +51,12 @@ namespace LongevityWorldCup.Website.Middleware
             }
 
             // rebuild query string
-            var pairs = dict.SelectMany(kvp =>
+            var pairs = queryParameters.SelectMany(kvp =>
                 kvp.Value.Count == 0
                     ? new[] { Uri.EscapeDataString(kvp.Key ?? "") }
                     : kvp.Value.Select(v => $"{Uri.EscapeDataString(kvp.Key ?? "")}={Uri.EscapeDataString(v ?? "")}"));
 
-            var newQuery = pairs.Any() ? "?" + string.Join("&", pairs) : string.Empty;
+            var newQuery = queryParameters.Count > 0 ? "?" + string.Join("&", pairs) : string.Empty;
             var newUrl = context.Request.PathBase.Add(context.Request.Path).ToString() + newQuery;
 
             context.Response.Redirect(newUrl, permanent: true);


### PR DESCRIPTION
Shares Markdown response handling between the two AI document endpoints and removes unnecessary collection copying and repeated query enumeration from tracking-parameter stripping. Response headers, query encoding, and the GET/HEAD request guard stay the same.

Validation: all 1,599 tests passed in GitHub Actions. Frontend build, Node-free publish verification, CodeQL, and dependency review also passed.
