### PR TITLE
Simplify SHA-256 hashing

### DIFF
--- a/LongevityWorldCup.Website/Business/AthleteDataService.cs
+++ b/LongevityWorldCup.Website/Business/AthleteDataService.cs
@@ -3490,12 +3490,9 @@ public class AthleteDataService : IAthleteSnapshotProvider, IDisposable
 
     private static string Sha256Hex(string input)
     {
-        using var sha = SHA256.Create();
         var bytes = Encoding.UTF8.GetBytes(input ?? "");
-        var hash = sha.ComputeHash(bytes);
-        var sb = new StringBuilder(hash.Length * 2);
-        foreach (var b in hash) sb.Append(b.ToString("x2", CultureInfo.InvariantCulture));
-        return sb.ToString();
+        var hash = SHA256.HashData(bytes);
+        return Convert.ToHexString(hash).ToLowerInvariant();
     }
 
     private static string NormalizeAthleteSlug(string? slug)

--- a/LongevityWorldCup.Website/Business/BadgeDataService.cs
+++ b/LongevityWorldCup.Website/Business/BadgeDataService.cs
@@ -656,11 +656,7 @@ VALUES (@bl, @lc, @lv, @p, @a, @dh, @u);";
     private static string BuildEditorialRuleHash(string label, string? note = null)
     {
         string sig = $"label={label}|category=Global|type=editorial|note={note ?? "n/a"}";
-        using var sha = SHA256.Create();
-        var bytes = sha.ComputeHash(Encoding.UTF8.GetBytes(sig));
-        var sb = new StringBuilder(bytes.Length * 2);
-        foreach (var b in bytes) sb.Append(b.ToString("x2", CultureInfo.InvariantCulture));
-        return sb.ToString();
+        return ComputeRuleHash(sig);
     }
 
     private void AddEditorialAwards(
@@ -931,9 +927,8 @@ VALUES (@bl, @lc, @lv, @p, @a, @dh, @u);";
 
     private static string ComputeRuleHash(string signature)
     {
-        using var sha = SHA256.Create();
-        var bytes = sha.ComputeHash(Encoding.UTF8.GetBytes(signature));
-        return BitConverter.ToString(bytes).Replace("-", "").ToLowerInvariant();
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(signature));
+        return Convert.ToHexString(bytes).ToLowerInvariant();
     }
 
     private static string BuildRankedRuleHash(

--- a/LongevityWorldCup.Website/Tools/AssetVersionProvider.cs
+++ b/LongevityWorldCup.Website/Tools/AssetVersionProvider.cs
@@ -66,8 +66,7 @@ public sealed class AssetVersionProvider
     private static string ComputeHash(string fullPath)
     {
         using var stream = File.OpenRead(fullPath);
-        using var sha256 = SHA256.Create();
-        var hash = sha256.ComputeHash(stream);
+        var hash = SHA256.HashData(stream);
         return Convert.ToHexString(hash[..8]).ToLowerInvariant();
     }
 


### PR DESCRIPTION
Asset versions, athlete fingerprints, and badge rule signatures allocate disposable SHA-256 instances for individual hashes. Use the one-shot hashing API, reuse the badge signature helper for editorial rules, and use consistent lowercase hex formatting while preserving every input and hash format.

Validation: existing full .NET and browser test suite in CI, including asset-version and badge-event coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Hash outputs drive biomarker change detection, badge definition identity, and cache-busting URLs—any subtle hex-format drift would cause unnecessary reloads or badge snapshot churn, though the change is a straight API swap with tests in CI.
> 
> **Overview**
> Replaces disposable `SHA256.Create()` + `ComputeHash` loops with the **one-shot** `SHA256.HashData` API for athlete biomarker fingerprints, badge rule `DefinitionHash` values, and static asset cache-bust versions.
> 
> Hex output is normalized via **`Convert.ToHexString(...).ToLowerInvariant()`** instead of manual `StringBuilder` / `BitConverter` formatting. **Editorial badge rules** now route through shared **`ComputeRuleHash`** instead of duplicating hash logic inline.
> 
> Behavior is intended to stay the same (same inputs → same hashes); CI includes asset-version and badge coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e198edc39b7bacc8d16981795fc5a17e2eb8ede. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->