### PR TITLE
Share filler cooldown lookup

### DIFF
--- a/LongevityWorldCup.Website/Business/FacebookFillerPostLogService.cs
+++ b/LongevityWorldCup.Website/Business/FacebookFillerPostLogService.cs
@@ -201,32 +201,7 @@ public class FacebookFillerPostLogService
 
     public bool IsOnCooldownForType(FillerType type, TimeSpan cooldown, DateTime? nowUtc = null)
     {
-        if (cooldown <= TimeSpan.Zero)
-            return false;
-
-        var lastAt = _db.Run(sqlite =>
-        {
-            using var cmd = sqlite.CreateCommand();
-            cmd.CommandText = $"""
-                SELECT PostedAtUtc
-                FROM {TableName}
-                WHERE Type = @type
-                ORDER BY PostedAtUtc DESC
-                LIMIT 1
-                """;
-            cmd.Parameters.AddWithValue("@type", (int)type);
-            var raw = cmd.ExecuteScalar();
-            if (raw is string s &&
-                DateTime.TryParse(s, null, System.Globalization.DateTimeStyles.RoundtripKind, out var dt))
-                return (DateTime?)dt;
-            return (DateTime?)null;
-        });
-
-        if (!lastAt.HasValue)
-            return false;
-
-        var now = nowUtc ?? DateTime.UtcNow;
-        return now - lastAt.Value < cooldown;
+        return FillerPostLogSchedule.IsOnCooldownForType(_db, TableName, type, cooldown, nowUtc);
     }
 
     public bool IsOnRandomizedCooldownForType(FillerType type, int minDays, int maxDays, DateTime? nowUtc = null)

--- a/LongevityWorldCup.Website/Business/FillerPostLogSchedule.cs
+++ b/LongevityWorldCup.Website/Business/FillerPostLogSchedule.cs
@@ -4,6 +4,24 @@ namespace LongevityWorldCup.Website.Business;
 
 public static class FillerPostLogSchedule
 {
+    public static bool IsOnCooldownForType(
+        DatabaseManager db,
+        string tableName,
+        FillerType type,
+        TimeSpan cooldown,
+        DateTime? nowUtc = null)
+    {
+        if (cooldown <= TimeSpan.Zero)
+            return false;
+
+        var lastAt = GetLastPostedAtForType(db, tableName, type);
+        if (!lastAt.HasValue)
+            return false;
+
+        var now = nowUtc ?? DateTime.UtcNow;
+        return now - lastAt.Value < cooldown;
+    }
+
     public static bool IsOnRandomizedCooldownForType(
         DatabaseManager db,
         string tableName,

--- a/LongevityWorldCup.Website/Business/ThreadsFillerPostLogService.cs
+++ b/LongevityWorldCup.Website/Business/ThreadsFillerPostLogService.cs
@@ -200,32 +200,7 @@ public class ThreadsFillerPostLogService
 
     public bool IsOnCooldownForType(FillerType type, TimeSpan cooldown, DateTime? nowUtc = null)
     {
-        if (cooldown <= TimeSpan.Zero)
-            return false;
-
-        var lastAt = _db.Run(sqlite =>
-        {
-            using var cmd = sqlite.CreateCommand();
-            cmd.CommandText = $"""
-                SELECT PostedAtUtc
-                FROM {TableName}
-                WHERE Type = @type
-                ORDER BY PostedAtUtc DESC
-                LIMIT 1
-                """;
-            cmd.Parameters.AddWithValue("@type", (int)type);
-            var raw = cmd.ExecuteScalar();
-            if (raw is string s &&
-                DateTime.TryParse(s, null, System.Globalization.DateTimeStyles.RoundtripKind, out var dt))
-                return (DateTime?)dt;
-            return (DateTime?)null;
-        });
-
-        if (!lastAt.HasValue)
-            return false;
-
-        var now = nowUtc ?? DateTime.UtcNow;
-        return now - lastAt.Value < cooldown;
+        return FillerPostLogSchedule.IsOnCooldownForType(_db, TableName, type, cooldown, nowUtc);
     }
 
     public bool IsOnRandomizedCooldownForType(FillerType type, int minDays, int maxDays, DateTime? nowUtc = null)

--- a/LongevityWorldCup.Website/Business/XFillerPostLogService.cs
+++ b/LongevityWorldCup.Website/Business/XFillerPostLogService.cs
@@ -258,32 +258,7 @@ public class XFillerPostLogService
 
     public bool IsOnCooldownForType(FillerType type, TimeSpan cooldown, DateTime? nowUtc = null)
     {
-        if (cooldown <= TimeSpan.Zero)
-            return false;
-
-        var lastAt = _db.Run(sqlite =>
-        {
-            using var cmd = sqlite.CreateCommand();
-            cmd.CommandText = $"""
-                SELECT PostedAtUtc
-                FROM {TableName}
-                WHERE Type = @type
-                ORDER BY PostedAtUtc DESC
-                LIMIT 1
-                """;
-            cmd.Parameters.AddWithValue("@type", (int)type);
-            var raw = cmd.ExecuteScalar();
-            if (raw is string s &&
-                DateTime.TryParse(s, null, System.Globalization.DateTimeStyles.RoundtripKind, out var dt))
-                return (DateTime?)dt;
-            return (DateTime?)null;
-        });
-
-        if (!lastAt.HasValue)
-            return false;
-
-        var now = nowUtc ?? DateTime.UtcNow;
-        return now - lastAt.Value < cooldown;
+        return FillerPostLogSchedule.IsOnCooldownForType(_db, TableName, type, cooldown, nowUtc);
     }
 
     public bool IsOnRandomizedCooldownForType(FillerType type, int minDays, int maxDays, DateTime? nowUtc = null)


### PR DESCRIPTION
X, Threads, and Facebook each duplicate the same fixed type-cooldown query and expiry calculation. Delegate them to FillerPostLogSchedule so fixed and randomized cooldowns share the existing latest-post lookup. Preserve separate platform tables, zero/negative cooldown handling, timestamp parsing, and the strict expiry boundary.

Validation: full .NET CI suite, including filler scheduling and social job integration tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor of scheduling checks; platform-specific tables and cooldown semantics are unchanged.
> 
> **Overview**
> Removes duplicated **fixed** filler-type cooldown logic from the Facebook, Threads, and X **filler post log** services and routes `IsOnCooldownForType` through **`FillerPostLogSchedule`**, alongside the existing randomized cooldown path.
> 
> The new shared helper reuses **`GetLastPostedAtForType`** (latest `PostedAtUtc` for a `FillerType` in each platform’s log table) and keeps the same rules: non-positive cooldowns are ignored, missing history means not on cooldown, and expiry still uses a strict `now - lastAt < cooldown` check. Each service still passes its own table name so platform logs stay separate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1cbe8bfbc742832dacd106a1690cd140eda9d08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->