### PR TITLE
Share image render file handling

### DIFF
--- a/LongevityWorldCup.Website/Business/AthleteOgImageService.cs
+++ b/LongevityWorldCup.Website/Business/AthleteOgImageService.cs
@@ -188,15 +188,15 @@ public sealed class AthleteOgImageService
                 return outputPath;
             }
 
-            var tempPath = BuildTempRenderPath(outputPath);
+            var tempPath = ImageRenderFiles.CreateTempPath(outputPath);
             try
             {
                 await RenderImageAsync(payload, tempPath, ct);
-                PublishTempRender(tempPath, outputPath);
+                ImageRenderFiles.Publish(tempPath, outputPath);
             }
             finally
             {
-                DeleteTempRender(tempPath);
+                ImageRenderFiles.DeleteTemp(tempPath);
             }
 
             CleanupOldRenders(renderPrefix, outputPath);
@@ -423,36 +423,6 @@ public sealed class AthleteOgImageService
         {
             ctx.Fill(new Rgba32(0, 0, 0, 74), new RectangularPolygon(0, 0, CanvasWidth, 72f));
         });
-    }
-
-    private static string BuildTempRenderPath(string outputPath)
-    {
-        return $"{outputPath}.{Guid.NewGuid():N}.tmp";
-    }
-
-    private static void PublishTempRender(string tempPath, string outputPath)
-    {
-        try
-        {
-            File.Move(tempPath, outputPath);
-        }
-        catch (IOException) when (File.Exists(outputPath))
-        {
-            // Another app instance finished the same render first.
-        }
-    }
-
-    private static void DeleteTempRender(string tempPath)
-    {
-        try
-        {
-            if (File.Exists(tempPath))
-                File.Delete(tempPath);
-        }
-        catch
-        {
-            // Best-effort cleanup for abandoned temp renders.
-        }
     }
 
     private FontFamily GetFontFamily()

--- a/LongevityWorldCup.Website/Business/ImageRenderFiles.cs
+++ b/LongevityWorldCup.Website/Business/ImageRenderFiles.cs
@@ -1,0 +1,35 @@
+namespace LongevityWorldCup.Website.Business;
+
+internal static class ImageRenderFiles
+{
+    public static string CreateTempPath(string outputPath)
+    {
+        return $"{outputPath}.{Guid.NewGuid():N}.tmp";
+    }
+
+    public static void Publish(string tempPath, string outputPath)
+    {
+        try
+        {
+            File.Move(tempPath, outputPath);
+        }
+        catch (IOException) when (File.Exists(outputPath))
+        {
+            // Another app instance finished the same render first.
+        }
+    }
+
+    public static void DeleteTemp(string tempPath)
+    {
+        try
+        {
+            if (File.Exists(tempPath))
+                File.Delete(tempPath);
+        }
+        catch
+        {
+            // Best-effort cleanup for abandoned temp renders.
+        }
+    }
+}
+

--- a/LongevityWorldCup.Website/Business/LeagueOgImageService.cs
+++ b/LongevityWorldCup.Website/Business/LeagueOgImageService.cs
@@ -210,15 +210,15 @@ public sealed class LeagueOgImageService
                 return outputPath;
             }
 
-            var tempPath = BuildTempRenderPath(outputPath);
+            var tempPath = ImageRenderFiles.CreateTempPath(outputPath);
             try
             {
                 await RenderImageAsync(payload, tempPath, ct);
-                PublishTempRender(tempPath, outputPath);
+                ImageRenderFiles.Publish(tempPath, outputPath);
             }
             finally
             {
-                DeleteTempRender(tempPath);
+                ImageRenderFiles.DeleteTemp(tempPath);
             }
 
             CleanupOldRenders(payload.InternalSlug, outputPath);
@@ -264,36 +264,6 @@ public sealed class LeagueOgImageService
         });
 
         await image.SaveAsPngAsync(outputPath, ct);
-    }
-
-    private static string BuildTempRenderPath(string outputPath)
-    {
-        return $"{outputPath}.{Guid.NewGuid():N}.tmp";
-    }
-
-    private static void PublishTempRender(string tempPath, string outputPath)
-    {
-        try
-        {
-            File.Move(tempPath, outputPath);
-        }
-        catch (IOException) when (File.Exists(outputPath))
-        {
-            // Another app instance finished the same render first.
-        }
-    }
-
-    private static void DeleteTempRender(string tempPath)
-    {
-        try
-        {
-            if (File.Exists(tempPath))
-                File.Delete(tempPath);
-        }
-        catch
-        {
-            // Best-effort cleanup for abandoned temp renders.
-        }
     }
 
     private async Task DrawBrandAsync(Image<Rgba32> image, FontFamily boldFamily, CancellationToken ct)

--- a/LongevityWorldCup.Website/Business/PageOgImageService.cs
+++ b/LongevityWorldCup.Website/Business/PageOgImageService.cs
@@ -212,15 +212,15 @@ public sealed class PageOgImageService
                 return outputPath;
             }
 
-            var tempPath = BuildTempRenderPath(outputPath);
+            var tempPath = ImageRenderFiles.CreateTempPath(outputPath);
             try
             {
                 await RenderImageAsync(payload, tempPath, ct);
-                PublishTempRender(tempPath, outputPath);
+                ImageRenderFiles.Publish(tempPath, outputPath);
             }
             finally
             {
-                DeleteTempRender(tempPath);
+                ImageRenderFiles.DeleteTemp(tempPath);
             }
 
             CleanupOldRenders(payload.Slug, outputPath);
@@ -472,36 +472,6 @@ public sealed class PageOgImageService
         catch (Exception ex)
         {
             _log.LogDebug(ex, "Failed to cleanup stale page OG renders for {Slug}", slug);
-        }
-    }
-
-    private static string BuildTempRenderPath(string outputPath)
-    {
-        return $"{outputPath}.{Guid.NewGuid():N}.tmp";
-    }
-
-    private static void PublishTempRender(string tempPath, string outputPath)
-    {
-        try
-        {
-            File.Move(tempPath, outputPath);
-        }
-        catch (IOException) when (File.Exists(outputPath))
-        {
-            // Another app instance finished the same render first.
-        }
-    }
-
-    private static void DeleteTempRender(string tempPath)
-    {
-        try
-        {
-            if (File.Exists(tempPath))
-                File.Delete(tempPath);
-        }
-        catch
-        {
-            // Best-effort cleanup for abandoned temp renders.
         }
     }
 


### PR DESCRIPTION
Athlete, league, and page share-image renderers duplicate temporary-file naming, publication, and cleanup. Share those file operations through ImageRenderFiles, preserving unique same-directory temporary paths, the concurrent-render race handling, and cleanup in each renderer's existing finally block.

Validation: full .NET CI suite, including generation and decoding of athlete, league, and page PNG previews.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with no intended behavior change; shared file I/O helpers only affect OG image generation paths.
> 
> **Overview**
> Extracts duplicated **temp PNG render** logic from the athlete, league, and page OG image services into a shared internal helper, `ImageRenderFiles`.
> 
> Each service’s `EnsureRenderedImageAsync` now calls `CreateTempPath`, `Publish`, and `DeleteTemp` instead of identical private methods. Behavior is unchanged: GUID-suffixed temp files beside the final path, `File.Move` with an `IOException` swallow when another instance wins the race, and best-effort temp deletion in `finally`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26b5cc3c735198069be48cfa21ffee69667b370d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->