### PR TITLE
Share OAuth callback page rendering

### DIFF
--- a/LongevityWorldCup.Tests/OAuthCallbackTests.cs
+++ b/LongevityWorldCup.Tests/OAuthCallbackTests.cs
@@ -1,0 +1,66 @@
+using LongevityWorldCup.Website.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class OAuthCallbackTests
+{
+    [Theory]
+    [InlineData("Threads")]
+    [InlineData("Facebook")]
+    public void CallbackEscapesKnownQueryValuesAndIgnoresOtherFields(string provider)
+    {
+        var result = RenderCallback(provider,
+            "?code=%3Ccleanup%3E%26%22&code=second&state=a%26b&error=%3Cdenied%3E&error_description=%22no%22&ignored=ignore-me");
+
+        Assert.Equal("text/html; charset=utf-8", result.ContentType);
+        var html = Assert.IsType<string>(result.Content);
+        Assert.Contains("code: <code>&lt;cleanup&gt;&amp;&quot;,second</code>", html, StringComparison.Ordinal);
+        Assert.Contains("state: <code>a&amp;b</code>", html, StringComparison.Ordinal);
+        Assert.Contains("error: <code>&lt;denied&gt;</code>", html, StringComparison.Ordinal);
+        Assert.Contains("error_description: <code>&quot;no&quot;</code>", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("<cleanup>", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("ignore-me", html, StringComparison.Ordinal);
+        Assert.True(html.IndexOf("code: <code>", StringComparison.Ordinal) < html.IndexOf("state: <code>", StringComparison.Ordinal));
+        Assert.True(html.IndexOf("state: <code>", StringComparison.Ordinal) < html.IndexOf("error: <code>", StringComparison.Ordinal));
+        Assert.True(html.IndexOf("error: <code>", StringComparison.Ordinal) < html.IndexOf("error_description: <code>", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("Threads")]
+    [InlineData("Facebook")]
+    public void CallbackWithoutQueryKeepsProviderTextAndOmitsQueryRows(string provider)
+    {
+        var html = Assert.IsType<string>(RenderCallback(provider, "").Content);
+
+        Assert.Contains($"<title>{provider} Callback</title>", html, StringComparison.Ordinal);
+        Assert.Contains($"<h1>{provider} callback received.</h1>", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("<code>", html, StringComparison.Ordinal);
+        Assert.Equal(provider == "Facebook", html.Contains("paste it into the Facebook OAuth helper.", StringComparison.Ordinal));
+    }
+
+    private static ContentResult RenderCallback(string provider, string query)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString(query);
+        var controllerContext = new ControllerContext { HttpContext = context };
+
+        if (provider == "Facebook")
+        {
+            var controller = new FacebookController(NullLogger<FacebookController>.Instance)
+            {
+                ControllerContext = controllerContext
+            };
+            return Assert.IsType<ContentResult>(controller.Callback());
+        }
+
+        var threadsController = new ThreadsController(NullLogger<ThreadsController>.Instance)
+        {
+            ControllerContext = controllerContext
+        };
+        return Assert.IsType<ContentResult>(threadsController.Callback());
+    }
+}

--- a/LongevityWorldCup.Website/Controllers/FacebookController.cs
+++ b/LongevityWorldCup.Website/Controllers/FacebookController.cs
@@ -1,5 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
-using System.Text;
+using LongevityWorldCup.Website.Tools;
 
 namespace LongevityWorldCup.Website.Controllers
 {
@@ -13,44 +13,11 @@ namespace LongevityWorldCup.Website.Controllers
         {
             _logger.LogInformation("Facebook callback hit.");
 
-            var html = new StringBuilder()
-                .AppendLine("<!DOCTYPE html>")
-                .AppendLine("<html lang=\"en\">")
-                .AppendLine("<head>")
-                .AppendLine("    <meta charset=\"utf-8\">")
-                .AppendLine("    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">")
-                .AppendLine("    <title>Facebook Callback</title>")
-                .AppendLine("    <style>")
-                .AppendLine("        * { box-sizing: border-box; }")
-                .AppendLine("        body { margin: 0; min-height: 100vh; padding: clamp(1rem, 4vw, 2rem); display: flex; justify-content: center; align-items: flex-start; font-family: system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", sans-serif; line-height: 1.5; color: #172033; background: #f7f8fb; }")
-                .AppendLine("        .callback-card { width: min(100%, 48rem); padding: clamp(1.25rem, 4vw, 2rem); border: 1px solid rgba(23, 32, 51, 0.12); border-radius: 8px; background: #fff; box-shadow: 0 1rem 2.5rem rgba(23, 32, 51, 0.08); }")
-                .AppendLine("        h1 { margin: 0 0 1rem; font-size: clamp(1.6rem, 7vw, 2.25rem); line-height: 1.1; }")
-                .AppendLine("        p { margin: 0 0 1rem; }")
-                .AppendLine("        code { display: inline-block; max-width: 100%; overflow-wrap: anywhere; word-break: break-word; font-family: ui-monospace, SFMono-Regular, Consolas, \"Liberation Mono\", monospace; }")
-                .AppendLine("    </style>")
-                .AppendLine("</head>")
-                .AppendLine("<body>")
-                .AppendLine("  <main class=\"callback-card\">")
-                .AppendLine("    <h1>Facebook callback received.</h1>")
-                .AppendLine("    <p>Copy the full URL from your browser address bar and paste it into the Facebook OAuth helper.</p>");
-
-            if (Request.Query.TryGetValue("code", out var code))
-                html.AppendLine($"    <p>code: <code>{System.Net.WebUtility.HtmlEncode(code.ToString())}</code></p>");
-
-            if (Request.Query.TryGetValue("state", out var state))
-                html.AppendLine($"    <p>state: <code>{System.Net.WebUtility.HtmlEncode(state.ToString())}</code></p>");
-
-            if (Request.Query.TryGetValue("error", out var error))
-                html.AppendLine($"    <p>error: <code>{System.Net.WebUtility.HtmlEncode(error.ToString())}</code></p>");
-
-            if (Request.Query.TryGetValue("error_description", out var errorDescription))
-                html.AppendLine($"    <p>error_description: <code>{System.Net.WebUtility.HtmlEncode(errorDescription.ToString())}</code></p>");
-
-            html.AppendLine("  </main>")
-                .AppendLine("</body>")
-                .AppendLine("</html>");
-
-            return Content(html.ToString(), "text/html; charset=utf-8");
+            return Content(OAuthCallbackPage.Render(
+                "Facebook",
+                Request.Query,
+                "Copy the full URL from your browser address bar and paste it into the Facebook OAuth helper."),
+                "text/html; charset=utf-8");
         }
     }
 }

--- a/LongevityWorldCup.Website/Controllers/ThreadsController.cs
+++ b/LongevityWorldCup.Website/Controllers/ThreadsController.cs
@@ -1,5 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
-using System.Text;
+using LongevityWorldCup.Website.Tools;
 
 namespace LongevityWorldCup.Website.Controllers
 {
@@ -11,43 +11,7 @@ namespace LongevityWorldCup.Website.Controllers
         [HttpGet("callback")]
         public IActionResult Callback()
         {
-            var html = new StringBuilder()
-                .AppendLine("<!DOCTYPE html>")
-                .AppendLine("<html lang=\"en\">")
-                .AppendLine("<head>")
-                .AppendLine("    <meta charset=\"utf-8\">")
-                .AppendLine("    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">")
-                .AppendLine("    <title>Threads Callback</title>")
-                .AppendLine("    <style>")
-                .AppendLine("        * { box-sizing: border-box; }")
-                .AppendLine("        body { margin: 0; min-height: 100vh; padding: clamp(1rem, 4vw, 2rem); display: flex; justify-content: center; align-items: flex-start; font-family: system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", sans-serif; line-height: 1.5; color: #172033; background: #f7f8fb; }")
-                .AppendLine("        .callback-card { width: min(100%, 48rem); padding: clamp(1.25rem, 4vw, 2rem); border: 1px solid rgba(23, 32, 51, 0.12); border-radius: 8px; background: #fff; box-shadow: 0 1rem 2.5rem rgba(23, 32, 51, 0.08); }")
-                .AppendLine("        h1 { margin: 0 0 1rem; font-size: clamp(1.6rem, 7vw, 2.25rem); line-height: 1.1; }")
-                .AppendLine("        p { margin: 0 0 1rem; }")
-                .AppendLine("        code { display: inline-block; max-width: 100%; overflow-wrap: anywhere; word-break: break-word; font-family: ui-monospace, SFMono-Regular, Consolas, \"Liberation Mono\", monospace; }")
-                .AppendLine("    </style>")
-                .AppendLine("</head>")
-                .AppendLine("<body>")
-                .AppendLine("  <main class=\"callback-card\">")
-                .AppendLine("    <h1>Threads callback received.</h1>");
-
-            if (Request.Query.TryGetValue("code", out var code))
-                html.AppendLine($"    <p>code: <code>{System.Net.WebUtility.HtmlEncode(code.ToString())}</code></p>");
-
-            if (Request.Query.TryGetValue("state", out var state))
-                html.AppendLine($"    <p>state: <code>{System.Net.WebUtility.HtmlEncode(state.ToString())}</code></p>");
-
-            if (Request.Query.TryGetValue("error", out var error))
-                html.AppendLine($"    <p>error: <code>{System.Net.WebUtility.HtmlEncode(error.ToString())}</code></p>");
-
-            if (Request.Query.TryGetValue("error_description", out var errorDescription))
-                html.AppendLine($"    <p>error_description: <code>{System.Net.WebUtility.HtmlEncode(errorDescription.ToString())}</code></p>");
-
-            html.AppendLine("  </main>")
-                .AppendLine("</body>")
-                .AppendLine("</html>");
-
-            return Content(html.ToString(), "text/html; charset=utf-8");
+            return Content(OAuthCallbackPage.Render("Threads", Request.Query), "text/html; charset=utf-8");
         }
 
         [HttpGet("uninstall")]

--- a/LongevityWorldCup.Website/Tools/OAuthCallbackPage.cs
+++ b/LongevityWorldCup.Website/Tools/OAuthCallbackPage.cs
@@ -1,0 +1,48 @@
+using System.Net;
+using System.Text;
+
+namespace LongevityWorldCup.Website.Tools;
+
+internal static class OAuthCallbackPage
+{
+    private static readonly string[] QueryFields = ["code", "state", "error", "error_description"];
+
+    public static string Render(string provider, IQueryCollection query, string? instructions = null)
+    {
+        var encodedProvider = WebUtility.HtmlEncode(provider);
+        var html = new StringBuilder()
+            .AppendLine("<!DOCTYPE html>")
+            .AppendLine("<html lang=\"en\">")
+            .AppendLine("<head>")
+            .AppendLine("    <meta charset=\"utf-8\">")
+            .AppendLine("    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">")
+            .AppendLine($"    <title>{encodedProvider} Callback</title>")
+            .AppendLine("    <style>")
+            .AppendLine("        * { box-sizing: border-box; }")
+            .AppendLine("        body { margin: 0; min-height: 100vh; padding: clamp(1rem, 4vw, 2rem); display: flex; justify-content: center; align-items: flex-start; font-family: system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", sans-serif; line-height: 1.5; color: #172033; background: #f7f8fb; }")
+            .AppendLine("        .callback-card { width: min(100%, 48rem); padding: clamp(1.25rem, 4vw, 2rem); border: 1px solid rgba(23, 32, 51, 0.12); border-radius: 8px; background: #fff; box-shadow: 0 1rem 2.5rem rgba(23, 32, 51, 0.08); }")
+            .AppendLine("        h1 { margin: 0 0 1rem; font-size: clamp(1.6rem, 7vw, 2.25rem); line-height: 1.1; }")
+            .AppendLine("        p { margin: 0 0 1rem; }")
+            .AppendLine("        code { display: inline-block; max-width: 100%; overflow-wrap: anywhere; word-break: break-word; font-family: ui-monospace, SFMono-Regular, Consolas, \"Liberation Mono\", monospace; }")
+            .AppendLine("    </style>")
+            .AppendLine("</head>")
+            .AppendLine("<body>")
+            .AppendLine("  <main class=\"callback-card\">")
+            .AppendLine($"    <h1>{encodedProvider} callback received.</h1>");
+
+        if (instructions is not null)
+            html.AppendLine($"    <p>{WebUtility.HtmlEncode(instructions)}</p>");
+
+        foreach (var field in QueryFields)
+        {
+            if (query.TryGetValue(field, out var value))
+                html.AppendLine($"    <p>{field}: <code>{WebUtility.HtmlEncode(value.ToString())}</code></p>");
+        }
+
+        html.AppendLine("  </main>")
+            .AppendLine("</body>")
+            .AppendLine("</html>");
+
+        return html.ToString();
+    }
+}


### PR DESCRIPTION
Threads and Facebook callback controllers duplicate the same HTML page and query-value rendering. Share the renderer while preserving provider text, styles, query-field order, content type, and HTML escaping. Keep Facebook's helper instruction and existing logging.

Validation: all 1,301 tests passed in CI, including four new callback tests. After deployment, Threads and Facebook responses matched their saved originals byte for byte for both empty queries and encoded/repeated values. Production health checks passed.
