### PR TITLE
Share social filler option catalog

### DIFF
--- a/LongevityWorldCup.Tests/FlowActionDockBrowserTests.Layout.cs
+++ b/LongevityWorldCup.Tests/FlowActionDockBrowserTests.Layout.cs
@@ -27,7 +27,9 @@ public sealed class FlowActionDockLayoutBrowserTests(
         var page = await context.NewPageAsync();
         var errors = CapturePageErrors(page);
 
-        await page.GotoAsync("/join", new PageGotoOptions { WaitUntil = WaitUntilState.Commit });
+        // The route class appears before the footer is parsed, so wait for the full
+        // document before checking whether page chrome is absent or hidden.
+        await page.GotoAsync("/join", new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
         await page.WaitForFunctionAsync("() => document.body?.classList.contains('play-flow-route')");
 
         var chromeState = await page.EvaluateAsync<PlayWorkflowChromeState>(

--- a/LongevityWorldCup.Website/Business/FacebookFillerPostLogService.cs
+++ b/LongevityWorldCup.Website/Business/FacebookFillerPostLogService.cs
@@ -6,8 +6,6 @@ namespace LongevityWorldCup.Website.Business;
 public class FacebookFillerPostLogService
 {
     private const string TableName = "FacebookFillerPostLog";
-    private static readonly string[] Top3LeagueSlugs = ["ultimate", "amateur", "mens", "womens", "open", "silent-generation", "baby-boomers", "gen-x", "millennials", "gen-z", "gen-alpha", "prosperan"];
-    private static readonly string[] DomainKeys = ["liver", "kidney", "metabolic", "inflammation", "immune", "vitamin_d"];
     private readonly DatabaseManager _db;
 
     public FacebookFillerPostLogService(DatabaseManager db)
@@ -114,15 +112,7 @@ public class FacebookFillerPostLogService
 
     public IReadOnlyList<(FillerType Type, string PayloadText)> GetSuggestedFillersOrdered()
     {
-        var options = new List<(FillerType Type, string Text)>();
-        foreach (var slug in Top3LeagueSlugs)
-            options.Add((FillerType.Top3Leaderboard, $"league[{slug}]"));
-        foreach (var dk in DomainKeys)
-            options.Add((FillerType.DomainTop, $"domain[{dk}]"));
-        options.Add((FillerType.HistoryDocument, ""));
-        options.Add((FillerType.Ruleset, ""));
-        options.Add((FillerType.GitHubRepository, ""));
-        options.Add((FillerType.Donation, ""));
+        var options = FillerPostOptions.Create();
 
         var lastByOption = _db.Run(sqlite =>
         {

--- a/LongevityWorldCup.Website/Business/FillerPostOptions.cs
+++ b/LongevityWorldCup.Website/Business/FillerPostOptions.cs
@@ -1,0 +1,21 @@
+namespace LongevityWorldCup.Website.Business;
+
+internal static class FillerPostOptions
+{
+    private static readonly string[] Top3LeagueSlugs = ["ultimate", "amateur", "mens", "womens", "open", "silent-generation", "baby-boomers", "gen-x", "millennials", "gen-z", "gen-alpha", "prosperan"];
+    private static readonly string[] DomainKeys = ["liver", "kidney", "metabolic", "inflammation", "immune", "vitamin_d"];
+
+    public static List<(FillerType Type, string Text)> Create()
+    {
+        var options = new List<(FillerType Type, string Text)>();
+        foreach (var slug in Top3LeagueSlugs)
+            options.Add((FillerType.Top3Leaderboard, $"league[{slug}]"));
+        foreach (var dk in DomainKeys)
+            options.Add((FillerType.DomainTop, $"domain[{dk}]"));
+        options.Add((FillerType.HistoryDocument, ""));
+        options.Add((FillerType.Ruleset, ""));
+        options.Add((FillerType.GitHubRepository, ""));
+        options.Add((FillerType.Donation, ""));
+        return options;
+    }
+}

--- a/LongevityWorldCup.Website/Business/ThreadsFillerPostLogService.cs
+++ b/LongevityWorldCup.Website/Business/ThreadsFillerPostLogService.cs
@@ -6,8 +6,6 @@ namespace LongevityWorldCup.Website.Business;
 public class ThreadsFillerPostLogService
 {
     private const string TableName = "ThreadsFillerPostLog";
-    private static readonly string[] Top3LeagueSlugs = ["ultimate", "amateur", "mens", "womens", "open", "silent-generation", "baby-boomers", "gen-x", "millennials", "gen-z", "gen-alpha", "prosperan"];
-    private static readonly string[] DomainKeys = ["liver", "kidney", "metabolic", "inflammation", "immune", "vitamin_d"];
     private readonly DatabaseManager _db;
 
     public ThreadsFillerPostLogService(DatabaseManager db)
@@ -114,15 +112,7 @@ public class ThreadsFillerPostLogService
 
     public IReadOnlyList<(FillerType Type, string PayloadText)> GetSuggestedFillersOrdered()
     {
-        var options = new List<(FillerType Type, string Text)>();
-        foreach (var slug in Top3LeagueSlugs)
-            options.Add((FillerType.Top3Leaderboard, $"league[{slug}]"));
-        foreach (var dk in DomainKeys)
-            options.Add((FillerType.DomainTop, $"domain[{dk}]"));
-        options.Add((FillerType.HistoryDocument, ""));
-        options.Add((FillerType.Ruleset, ""));
-        options.Add((FillerType.GitHubRepository, ""));
-        options.Add((FillerType.Donation, ""));
+        var options = FillerPostOptions.Create();
 
         var lastByOption = _db.Run(sqlite =>
         {

--- a/LongevityWorldCup.Website/Business/XFillerPostLogService.cs
+++ b/LongevityWorldCup.Website/Business/XFillerPostLogService.cs
@@ -18,8 +18,6 @@ public enum FillerType
 public class XFillerPostLogService
 {
     private const string TableName = "XFillerPostLog";
-    private static readonly string[] Top3LeagueSlugs = ["ultimate", "amateur", "mens", "womens", "open", "silent-generation", "baby-boomers", "gen-x", "millennials", "gen-z", "gen-alpha", "prosperan"];
-    private static readonly string[] DomainKeys = ["liver", "kidney", "metabolic", "inflammation", "immune", "vitamin_d"];
     private readonly DatabaseManager _db;
 
     public XFillerPostLogService(DatabaseManager db)
@@ -132,15 +130,7 @@ public class XFillerPostLogService
 
     public IReadOnlyList<(FillerType Type, string PayloadText)> GetSuggestedFillersOrdered()
     {
-        var options = new List<(FillerType Type, string Text)>();
-        foreach (var slug in Top3LeagueSlugs)
-            options.Add((FillerType.Top3Leaderboard, $"league[{slug}]"));
-        foreach (var dk in DomainKeys)
-            options.Add((FillerType.DomainTop, $"domain[{dk}]"));
-        options.Add((FillerType.HistoryDocument, ""));
-        options.Add((FillerType.Ruleset, ""));
-        options.Add((FillerType.GitHubRepository, ""));
-        options.Add((FillerType.Donation, ""));
+        var options = FillerPostOptions.Create();
 
         var lastByOption = _db.Run(sqlite =>
         {


### PR DESCRIPTION
X, Threads, and Facebook independently build the same filler-option catalog. Create it in one shared helper, retaining the exact league/domain order and reminder entries. Each platform keeps its existing historical-token matching, latest-post lookup, and stable scheduling sort.

CI exposed an existing browser-test readiness race: the chrome test read the footer once the body route class appeared, while the rest of the document could still be parsing. Wait for DOMContentLoaded before capturing the same asserted state.

Validation: all 14 layout tests passed locally after the readiness fix, and all 1,305 tests passed in the subsequent CI run. Filler scheduling, platform rotation, legacy enum compatibility, and social job integration coverage passed.
