### PR TITLE
Share circular portrait masking

### DIFF
--- a/LongevityWorldCup.Website/Business/AthleteOgImageService.cs
+++ b/LongevityWorldCup.Website/Business/AthleteOgImageService.cs
@@ -265,7 +265,7 @@ public sealed class AthleteOgImageService
                 Mode = ResizeMode.Crop,
                 Position = AnchorPositionMode.Center
             }));
-            MakeCircular(profile);
+            ImageMasks.MakeCircular(profile);
 
             image.Mutate(ctx =>
             {
@@ -1081,35 +1081,6 @@ public sealed class AthleteOgImageService
         }
 
         return string.IsNullOrWhiteSpace(trimmed) ? ellipsis : trimmed + ellipsis;
-    }
-
-    private static void MakeCircular(Image<Rgba32> image)
-    {
-        var w = image.Width;
-        var h = image.Height;
-        var radius = Math.Min(w, h) / 2f;
-
-        using var mask = new Image<Rgba32>(w, h, Color.Transparent);
-        mask.Mutate(ctx =>
-        {
-            ctx.SetGraphicsOptions(new GraphicsOptions
-            {
-                Antialias = true,
-                AntialiasSubpixelDepth = 16
-            });
-            ctx.Fill(Color.White, new EllipsePolygon(w / 2f, h / 2f, radius));
-        });
-
-        image.Mutate(ctx =>
-        {
-            ctx.SetGraphicsOptions(new GraphicsOptions
-            {
-                AlphaCompositionMode = PixelAlphaCompositionMode.DestIn,
-                Antialias = true,
-                AntialiasSubpixelDepth = 16
-            });
-            ctx.DrawImage(mask, new Point(0, 0), 1f);
-        });
     }
 
     private static void DrawTextShadow(

--- a/LongevityWorldCup.Website/Business/ImageMasks.cs
+++ b/LongevityWorldCup.Website/Business/ImageMasks.cs
@@ -1,0 +1,39 @@
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Drawing;
+using SixLabors.ImageSharp.Drawing.Processing;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+
+namespace LongevityWorldCup.Website.Business;
+
+internal static class ImageMasks
+{
+    public static void MakeCircular(Image<Rgba32> image)
+    {
+        var w = image.Width;
+        var h = image.Height;
+        var radius = Math.Min(w, h) / 2f;
+
+        using var mask = new Image<Rgba32>(w, h, Color.Transparent);
+        mask.Mutate(ctx =>
+        {
+            ctx.SetGraphicsOptions(new GraphicsOptions
+            {
+                Antialias = true,
+                AntialiasSubpixelDepth = 16
+            });
+            ctx.Fill(Color.White, new EllipsePolygon(w / 2f, h / 2f, radius));
+        });
+
+        image.Mutate(ctx =>
+        {
+            ctx.SetGraphicsOptions(new GraphicsOptions
+            {
+                AlphaCompositionMode = PixelAlphaCompositionMode.DestIn,
+                Antialias = true,
+                AntialiasSubpixelDepth = 16
+            });
+            ctx.DrawImage(mask, new Point(0, 0), 1f);
+        });
+    }
+}

--- a/LongevityWorldCup.Website/Business/LeagueOgImageService.cs
+++ b/LongevityWorldCup.Website/Business/LeagueOgImageService.cs
@@ -398,7 +398,7 @@ public sealed class LeagueOgImageService
             Mode = ResizeMode.Crop,
             Position = AnchorPositionMode.Center
         }).Brightness(1.08f).Contrast(1.06f).Saturate(1.05f));
-        MakeCircular(profile);
+        ImageMasks.MakeCircular(profile);
 
         var portraitX = (int)MathF.Round(row.X + 34f);
         var portraitY = (int)MathF.Round(row.Y + ((row.Height - size) / 2f));
@@ -471,35 +471,6 @@ public sealed class LeagueOgImageService
                 HorizontalAlignment = HorizontalAlignment.Left,
                 VerticalAlignment = VerticalAlignment.Top
             }, displayName, nameColor);
-        });
-    }
-
-    private static void MakeCircular(Image<Rgba32> image)
-    {
-        var w = image.Width;
-        var h = image.Height;
-        var radius = Math.Min(w, h) / 2f;
-
-        using var mask = new Image<Rgba32>(w, h, Color.Transparent);
-        mask.Mutate(ctx =>
-        {
-            ctx.SetGraphicsOptions(new GraphicsOptions
-            {
-                Antialias = true,
-                AntialiasSubpixelDepth = 16
-            });
-            ctx.Fill(Color.White, new EllipsePolygon(w / 2f, h / 2f, radius));
-        });
-
-        image.Mutate(ctx =>
-        {
-            ctx.SetGraphicsOptions(new GraphicsOptions
-            {
-                AlphaCompositionMode = PixelAlphaCompositionMode.DestIn,
-                Antialias = true,
-                AntialiasSubpixelDepth = 16
-            });
-            ctx.DrawImage(mask, new Point(0, 0), 1f);
         });
     }
 

--- a/LongevityWorldCup.Website/Business/XImageService.cs
+++ b/LongevityWorldCup.Website/Business/XImageService.cs
@@ -423,7 +423,7 @@ public class XImageService
                 Mode = ResizeMode.Crop,
                 Position = AnchorPositionMode.Center
             }));
-            MakeCircular(profile);
+            ImageMasks.MakeCircular(profile);
 
             var centerX = x + (size / 2f);
             var centerY = y + (size / 2f);
@@ -698,35 +698,6 @@ public class XImageService
         }
 
         return string.IsNullOrWhiteSpace(trimmed) ? ellipsis : trimmed + ellipsis;
-    }
-
-    private static void MakeCircular(Image<Rgba32> image)
-    {
-        var w = image.Width;
-        var h = image.Height;
-        var radius = Math.Min(w, h) / 2f;
-
-        using var mask = new Image<Rgba32>(w, h, Color.Transparent);
-        mask.Mutate(ctx =>
-        {
-            ctx.SetGraphicsOptions(new GraphicsOptions
-            {
-                Antialias = true,
-                AntialiasSubpixelDepth = 16
-            });
-            ctx.Fill(Color.White, new EllipsePolygon(w / 2f, h / 2f, radius));
-        });
-
-        image.Mutate(ctx =>
-        {
-            ctx.SetGraphicsOptions(new GraphicsOptions
-            {
-                AlphaCompositionMode = PixelAlphaCompositionMode.DestIn,
-                Antialias = true,
-                AntialiasSubpixelDepth = 16
-            });
-            ctx.DrawImage(mask, new Point(0, 0), 1f);
-        });
     }
 
     private static void ClipRoundedRectangle(Image<Rgba32> image, float radius)


### PR DESCRIPTION
X post images and athlete/league share previews duplicate circular portrait masking. Move the identical mask operation into ImageMasks and use it from all three renderers, preserving the radius, alpha composition, antialiasing, and temporary-image disposal.

Validation: all 1,305 tests passed in CI, including PNG generation and decoding for social images and share previews. The combined local focused run also passed all 74 tests across the cleanup areas.
