### PR TITLE
Wait for initialized onboarding controls in browser tests

### DIFF
--- a/LongevityWorldCup.Tests/FlowActionDockBrowserTests.Layout.cs
+++ b/LongevityWorldCup.Tests/FlowActionDockBrowserTests.Layout.cs
@@ -520,7 +520,7 @@ public sealed class FlowActionDockLayoutBrowserTests(
         var scenario = $"{viewportWidth}x{viewportHeight}";
         await page.GotoAsync("/apply?fake=1", new PageGotoOptions { WaitUntil = WaitUntilState.Commit });
         await page.WaitForFunctionAsync(
-            "() => typeof window.goToStage === 'function' && document.body?.dataset.convergenceStage === '1' && !document.getElementById('nextButton')?.disabled");
+            "() => document.getElementById('name')?.dataset.stage1ValidityListener === 'true' && document.body?.dataset.convergenceStage === '1' && !document.getElementById('nextButton')?.disabled");
         await page.EvaluateAsync("() => window.scrollTo({ top: 0, left: 0, behavior: 'auto' })");
         await page.WaitForFunctionAsync(
             """

--- a/LongevityWorldCup.Tests/FlowActionDockBrowserTests.cs
+++ b/LongevityWorldCup.Tests/FlowActionDockBrowserTests.cs
@@ -139,7 +139,10 @@ public sealed class FlowActionDockBrowserTests(
         var errors = CapturePageErrors(page);
 
         await page.GotoAsync("/apply?fake=1", new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
-        await page.WaitForFunctionAsync("() => window.LwcFlowActionDock && typeof window.goToStage === 'function'");
+        // The function and stage attribute exist in the initial HTML. Wait for the
+        // asynchronous bootstrap to bind stage one before selecting the email stage.
+        await page.WaitForFunctionAsync(
+            "() => window.LwcFlowActionDock && document.getElementById('name')?.dataset.stage1ValidityListener === 'true'");
         await page.EvaluateAsync("() => { window.goToStage(7); window.LwcFlowActionDock.refreshNow(); }");
         await ExpectActionStackDockedInViewportAsync(page, ".convergence-actions");
 

--- a/LongevityWorldCup.Tests/NewAthleteOnboardingBrowserTests.cs
+++ b/LongevityWorldCup.Tests/NewAthleteOnboardingBrowserTests.cs
@@ -201,7 +201,7 @@ public sealed class NewAthleteOnboardingBrowserTests(
         await RunOnboardingBrowserAsync(async (page, errors) =>
         {
             await page.GotoAsync("/apply", new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
-            await page.GetByRole(AriaRole.Heading, new() { Name = "1. Enter the arena" }).WaitForAsync();
+            await page.Locator("#name[data-stage1-validity-listener='true']").WaitForAsync();
 
             await page.EvaluateAsync("() => { currentStage = 4; goToStage(4); }");
 


### PR DESCRIPTION
Browser tests could jump to an application stage or click Next while page modules were still loading. The later initialization could reset the email step and discard focus, as seen in [.NET run 33947723646](https://github.com/nopara73/LongevityWorldCup/actions/runs/33947723646).

Wait for the existing stage-one validation listener marker before interacting in three onboarding tests. The function, heading, stage attribute, and initially enabled Next button all exist before initialization completes. This changes only test synchronization; assertions and production behavior are unchanged.

Validation: 41 focused onboarding and dock tests passed. A temporary controlled browser probe held the proof-helper module request and confirmed that the old sequence loses email focus, while waiting for bound controls preserves it. [Full GitHub CI](https://github.com/nopara73/LongevityWorldCup/actions/runs/33949779276) passed all 1,305 tests with coverage on `ec3d6c0b84ea8cc8a27607b2e207976a4a9fedfc`; CodeQL, dependency review, and Bugbot also passed.
