### PR TITLE
Polish entry, filters, and Challenge controls

### DIFF
--- a/LongevityWorldCup.Tests/HomepageChromeRegressionBrowserTests.cs
+++ b/LongevityWorldCup.Tests/HomepageChromeRegressionBrowserTests.cs
@@ -82,7 +82,7 @@ public sealed class HomepageChromeRegressionBrowserTests(
     }
 
     [Fact]
-    public async Task LeaderboardChangedControls_RetainTheMasterAttentionCue()
+    public async Task LeaderboardChangedControls_KeepAttentionCuesDistinctFromSearchFocus()
     {
         var app = App;
         var browser = Browser;
@@ -93,7 +93,7 @@ public sealed class HomepageChromeRegressionBrowserTests(
             "() => document.getElementById('view-bortz')?.checked === true && document.querySelector('.sidebar-toggle')?.classList.contains('has-active-state') === true");
         await page.Locator("#athleteSearch").ClickAsync();
         await page.WaitForFunctionAsync(
-            "() => getComputedStyle(document.getElementById('athleteSearch')).borderColor === 'rgb(255, 64, 129)'");
+            "() => getComputedStyle(document.getElementById('athleteSearch')).borderColor === 'rgb(8, 118, 133)'");
 
         var cueColors = await page.EvaluateAsync<string[]>(
             """
@@ -111,7 +111,7 @@ public sealed class HomepageChromeRegressionBrowserTests(
             }
             """);
 
-        Assert.All(cueColors, color => Assert.Equal("rgb(255, 64, 129)", color));
+        Assert.Equal(["rgb(255, 64, 129)", "rgb(255, 64, 129)", "rgb(8, 118, 133)", "rgb(8, 118, 133)"], cueColors);
     }
 
     [Fact]

--- a/LongevityWorldCup.Website/wwwroot/css/bioageform.css
+++ b/LongevityWorldCup.Website/wwwroot/css/bioageform.css
@@ -401,12 +401,20 @@
     .bioageform {
         width: 100%;
         max-width: calc(100vw - 1.5rem);
-        margin: 1.35rem auto;
+        margin: var(--lwc-space-2) auto;
         padding: 0.9rem;
     }
 
     .bioageform #lwc-step-1.lwc-step--active > fieldset {
         padding: 0.75rem 0.9rem;
+    }
+
+    .bioageform #lwc-step-1.lwc-step--active > fieldset:first-of-type {
+        margin-top: 0;
+    }
+
+    .bioageform .lwc-wizard-nav {
+        margin-bottom: 0;
     }
 
     .bioageform #lwc-step-1.lwc-step--active label {

--- a/LongevityWorldCup.Website/wwwroot/css/bioageform.css
+++ b/LongevityWorldCup.Website/wwwroot/css/bioageform.css
@@ -415,13 +415,13 @@
     }
 
     .bioageform #lwc-step-1.lwc-step--active fieldset > label:first-of-type {
-        margin-top: 0.35rem;
+        margin-top: 0.5rem;
     }
 
     .bioageform #lwc-step-1.lwc-step--active .privacy-note {
-        margin-top: 0.25rem;
-        font-size: 0.78rem;
-        line-height: 1.22;
+        margin-top: var(--lwc-space-2);
+        font-size: var(--lwc-type-sm);
+        line-height: 1.5;
     }
 
     .bioageform #lwc-step-1.lwc-step--active > fieldset:nth-of-type(2) {
@@ -430,7 +430,7 @@
 
     .bioageform #dobFieldset {
         display: grid;
-        grid-template-columns: minmax(0, 0.85fr) minmax(0, 1.25fr) minmax(0, 0.8fr);
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1.5fr) minmax(0, 1fr);
         column-gap: 0.4rem;
         row-gap: 0.3rem;
     }
@@ -478,7 +478,14 @@
         padding-left: 0.38rem;
         padding-right: 1.3rem;
         background-position: right 0.38rem center;
-        font-size: 0.82rem;
+        font-size: var(--lwc-type-body);
+    }
+
+    .bioageform #dobFieldset label span {
+        display: block;
+        color: var(--lwc-muted);
+        font-size: var(--lwc-type-sm);
+        line-height: 1.5;
     }
 
     .bioageform.bioage-biomarker-entry-ready #lwc-step-2 > fieldset {
@@ -621,6 +628,13 @@
 
 .bioageform .bioage-update-date-fieldset {
     margin-top: 0.75rem;
+}
+
+@media (max-width: 360px) {
+    .bioageform #lwc-step-1.lwc-step--active #dobFieldset {
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1.75fr) minmax(0, 1fr);
+        padding-inline: var(--lwc-space-2);
+    }
 }
 
 @media (min-width: 640px) and (max-width: 932px) and (max-height: 480px) and (orientation: landscape) {

--- a/LongevityWorldCup.Website/wwwroot/css/longevitymaxxing.css
+++ b/LongevityWorldCup.Website/wwwroot/css/longevitymaxxing.css
@@ -899,6 +899,24 @@
     color: #ffffff;
 }
 
+.lmx-identity-options label::before {
+    content: '';
+    width: 0.8rem;
+    height: 0.8rem;
+    flex: 0 0 0.8rem;
+}
+
+.lmx-identity-options label:has(input:checked)::before {
+    content: '\2713';
+    line-height: 0.8rem;
+}
+
+.lmx-identity-options label::after {
+    content: '';
+    width: 0.8rem;
+    flex: 0 0 0.8rem;
+}
+
 .lmx-identity-options label:focus-within {
     outline: 3px solid rgba(0, 188, 212, 0.24);
     outline-offset: 2px;
@@ -906,7 +924,7 @@
 
 .lmx-field label,
 .lmx-field span.lmx-label {
-    font-size: 0.84rem;
+    font-size: var(--lwc-type-sm);
     font-weight: 700;
     color: var(--lmx-muted);
 }
@@ -920,8 +938,8 @@
 .lmx-field-help {
     margin: 0;
     color: var(--lmx-muted);
-    font-size: 0.82rem;
-    line-height: 1.35;
+    font-size: var(--lwc-type-sm);
+    line-height: 1.5;
 }
 
 .lmx-field input,
@@ -1562,7 +1580,7 @@
 
 .lmx-timezone-button small {
     color: var(--lmx-muted);
-    font-size: 0.78rem;
+    font-size: var(--lwc-type-sm);
     font-weight: 800;
     white-space: nowrap;
 }
@@ -1652,11 +1670,11 @@
     min-height: 48px;
     height: auto;
     display: grid;
-    gap: 0.04rem;
+    gap: var(--lwc-space-1);
     align-content: center;
     padding: 0.4rem 0.55rem;
     border: 0;
-    border-radius: 6px;
+    border-radius: var(--lwc-radius-sm);
     background: transparent;
     color: var(--lmx-ink);
     font: inherit;
@@ -1675,16 +1693,19 @@
 }
 
 .lmx-timezone-option span {
-    font-weight: 850;
+    font-weight: 700;
     line-height: 1.2;
 }
 
 .lmx-timezone-option small {
+    color: var(--lmx-muted);
+    font-size: var(--lwc-type-sm);
+    font-weight: 400;
+    line-height: 1.5;
+}
+
+.lmx-timezone-option[aria-selected="true"] small {
     color: inherit;
-    opacity: 0.72;
-    font-size: 0.75rem;
-    font-weight: 750;
-    line-height: 1.25;
 }
 
 .lmx-timezone-empty {
@@ -2410,6 +2431,11 @@ body.lmx-checkin-dialog-open {
     min-height: 1.3rem;
     color: var(--lmx-muted);
     font-weight: 700;
+}
+
+#lmxSignupStatus:empty,
+#lmxResendStatus:empty {
+    display: none;
 }
 
 .lmx-status.error {
@@ -4059,7 +4085,7 @@ a.lmx-note-mention:focus-visible {
         min-height: 2.75rem;
         padding: 0 0.65rem;
         border: 1px solid var(--lmx-border);
-        border-radius: 9px;
+        border-radius: var(--lwc-radius-md);
         background: var(--lmx-surface);
         color: var(--lmx-ink);
         box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06);
@@ -4068,8 +4094,8 @@ a.lmx-note-mention:focus-visible {
         justify-content: center;
         gap: 0.42rem;
         font: inherit;
-        font-size: 0.78rem;
-        font-weight: 850;
+        font-size: var(--lwc-type-sm);
+        font-weight: 700;
         cursor: pointer;
         touch-action: manipulation;
     }
@@ -4086,8 +4112,10 @@ a.lmx-note-mention:focus-visible {
     }
 
     .lmx-week-pager button:disabled {
-        opacity: 0.42;
-        cursor: default;
+        opacity: 1;
+        color: var(--lmx-muted);
+        background: var(--lmx-surface-muted);
+        cursor: not-allowed;
         box-shadow: none;
     }
 
@@ -4097,9 +4125,10 @@ a.lmx-note-mention:focus-visible {
         align-items: center;
         justify-content: center;
         color: var(--lmx-ink);
-        font-family: Orbitron, Roboto, sans-serif;
-        font-size: 0.76rem;
-        font-weight: 800;
+        font-family: inherit;
+        font-size: var(--lwc-type-sm);
+        font-variant-numeric: tabular-nums;
+        font-weight: 700;
         line-height: 1.2;
         text-align: center;
     }

--- a/LongevityWorldCup.Website/wwwroot/css/longevitymaxxing.css
+++ b/LongevityWorldCup.Website/wwwroot/css/longevitymaxxing.css
@@ -747,6 +747,8 @@
 
 .lmx-action-card {
     position: sticky;
+    /* Field popovers must sit above the leaderboard's sticky cells. */
+    z-index: 5;
     top: 0.75rem;
     display: grid;
     align-content: start;

--- a/LongevityWorldCup.Website/wwwroot/css/play-athlete-flow.css
+++ b/LongevityWorldCup.Website/wwwroot/css/play-athlete-flow.css
@@ -5,10 +5,10 @@
     aspect-ratio: 1 / 1;
     margin-inline: auto;
     overflow: hidden;
-    border: 4px solid var(--dark-text-color);
+    border: 1px solid var(--lwc-border);
     border-radius: 8px;
-    background: #b9b9b9;
-    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.4);
+    background: var(--lwc-surface-muted);
+    box-shadow: var(--lwc-shadow-sm);
     box-sizing: border-box;
     line-height: 0;
 }

--- a/LongevityWorldCup.Website/wwwroot/css/play-menu.css
+++ b/LongevityWorldCup.Website/wwwroot/css/play-menu.css
@@ -775,7 +775,7 @@ html.play-panel-transitioning .play-hub-panel--entering {
         display: block;
         min-height: 44px;
         padding: 0.6rem 0.7rem;
-        border-radius: 6px;
+        border-radius: var(--lwc-radius-sm);
         box-sizing: border-box;
         color: var(--lwc-ink, #2d3748);
         cursor: pointer;
@@ -796,9 +796,7 @@ html.play-panel-transitioning .play-hub-panel--entering {
 
         .autocomplete-items div strong {
             display: inline;
-            padding: 0 0.12rem;
-            border-radius: 4px;
-            background: var(--lwc-accent-soft, rgba(0, 188, 212, 0.16));
+            font-weight: 700;
             color: var(--lwc-accent-hover, #0f5965);
         }
 

--- a/LongevityWorldCup.Website/wwwroot/onboarding/application-review.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/application-review.html
@@ -73,20 +73,18 @@
             max-width: 560px;
             margin-top: 1rem;
             padding: 0.95rem 1.05rem;
-            border: 1px solid var(--lwc-success, rgba(76, 175, 80, 0.35));
+            border: 1px solid var(--lwc-border);
+            border-inline-start: 4px solid var(--lwc-success);
             border-radius: 8px;
-            background: var(--lwc-success-soft, rgba(240, 253, 244, 0.68));
+            background: var(--lwc-surface-muted);
             font-size: 1.02rem;
             color: var(--lwc-ink, #334155);
             box-sizing: border-box;
         }
 
         .application-review-highlight {
-            color: var(--lwc-success, #2e7d32);
+            color: var(--lwc-ink);
             font-weight: 700;
-            text-decoration: underline;
-            text-decoration-thickness: 1px;
-            text-underline-offset: 0.14em;
         }
 
         #contactEmailPlaceholder {

--- a/LongevityWorldCup.Website/wwwroot/onboarding/bortz-age.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/bortz-age.html
@@ -924,7 +924,7 @@
                         <legend>Date of birth:</legend>
                         <label for="dob-year">Year <span style="font-weight: normal;">(required)</span></label>
                         <select id="dob-year" name="dob-year" required aria-required="true" onchange="calculateResultIfResultAlreadyCalculated()">
-                            <option value="" disabled selected>Select year</option>
+                            <option value="" disabled selected>Year</option>
                             <!-- Generate year options dynamically here -->
                         </select>
 

--- a/LongevityWorldCup.Website/wwwroot/onboarding/pheno-age.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/pheno-age.html
@@ -914,7 +914,7 @@
                         <legend>Date of birth:</legend>
                         <label for="dob-year">Year <span style="font-weight: normal;">(required)</span></label>
                         <select id="dob-year" name="dob-year" required aria-required="true" onchange="calculateResultIfResultAlreadyCalculated()">
-                            <option value="" disabled selected>Select year</option>
+                            <option value="" disabled selected>Year</option>
                             <!-- Generate year options dynamically here -->
                         </select>
 

--- a/LongevityWorldCup.Website/wwwroot/partials/header.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/header.html
@@ -1033,13 +1033,13 @@
         --play-flow-action-hover-color: #17612d;
     }
 
-    body.play-flow-route .option-button.green {
+    body.play-flow-route .option-button.green:not(:disabled):not([aria-disabled="true"]) {
         border-color: transparent;
         background: var(--play-flow-action-color);
         color: #ffffff;
     }
 
-    body.play-flow-route .option-button.green:hover {
+    body.play-flow-route .option-button.green:not(:disabled):not([aria-disabled="true"]):hover {
         background: var(--play-flow-action-hover-color);
     }
 

--- a/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/leaderboard-content.html
@@ -36,7 +36,7 @@
         padding:1.15rem 1rem; border:1px solid rgba(0,188,212,.18); border-radius:14px; background:rgba(0,188,212,.045);
         box-sizing:border-box;
     }
-    .no-results-empty-state p{ margin:0; }
+    .no-results-empty-state p{ margin:0; font-size:var(--lwc-type-body); line-height:1.5; font-weight:400; }
     .show-all-athletes-btn,
     .leaderboard-retry-button{
         min-height:44px; border:1px solid var(--primary-color); border-radius:999px; background:var(--card-bg); color:var(--primary-color);
@@ -403,14 +403,15 @@
         -webkit-background-clip:text; -webkit-text-fill-color:transparent; text-shadow:none; border-radius:5px;
     }
     .sidebar:hover .collapsed-title, .sidebar.expanded .collapsed-title{ display:none; }
-    .sidebar:hover .sidebar-title, .sidebar.expanded .sidebar-title{ width:100%; }
+    .sidebar-heading{ display:flex; align-items:center; gap:var(--lwc-space-2); width:100%; border-bottom:1px solid var(--lwc-border); }
+    .sidebar:hover .sidebar-title, .sidebar.expanded .sidebar-title{ width:auto; }
     .sidebar:hover:not(.button-collapsed) .sidebar-title,
     .sidebar.expanded .sidebar-title{ position:static; justify-content:flex-start; }
 
     .sidebar-title{
-        width:100%; box-sizing:border-box;
+        flex:1; min-width:0; box-sizing:border-box;
         margin:0; padding:1rem 0; text-align:center; font-size:1.2rem; color:var(--primary-color);
-        display:flex; align-items:center; justify-content:center; border-bottom:1px solid var(--lwc-border);
+        display:flex; align-items:center; justify-content:center;
     }
     .sidebar .sidebar-title .sidebar-icon{
         display:inline-flex; align-items:center; justify-content:center; flex:0 0 2.25rem; width:2.25rem; height:2.25rem;
@@ -425,7 +426,7 @@
     .sidebar:hover .sidebar-title .sidebar-title-text,
     .sidebar.expanded .sidebar-title .sidebar-title-text{ display:inline-block; }
     .clear-sidebar-filters{
-        display:none; align-items:center; gap:.35rem; min-height:44px; margin:.6rem 0 1rem; padding:.35rem .65rem;
+        display:none; align-items:center; justify-content:center; flex:0 0 44px; width:44px; height:44px; margin:0; padding:0;
         color:#777; background:rgba(0,0,0,.035); border:1px solid rgba(0,0,0,.07); border-radius:999px;
         font-size:.85rem; font-weight:700; cursor:pointer; line-height:1.2; visibility:hidden; pointer-events:none;
         font-family:inherit; appearance:none; -webkit-appearance:none; box-sizing:border-box;
@@ -434,6 +435,10 @@
     .clear-sidebar-filters .clear-sidebar-filters-icon{
         display:inline-block; width:.85rem; color:inherit; font-size:.85rem; line-height:1; text-align:center; vertical-align:-.05em;
     }
+    .clear-sidebar-filters > span{ position:absolute; width:1px; height:1px; margin:-1px; overflow:hidden; clip-path:inset(50%); white-space:nowrap; }
+    .sidebar:hover:not(.button-collapsed) .clear-sidebar-filters,
+    .sidebar.expanded .clear-sidebar-filters{ display:inline-flex; }
+    .sidebar-heading .sidebar-close{ position:static; flex:0 0 44px; margin:0; }
     .clear-sidebar-filters:hover,
     .clear-sidebar-filters:focus,
     .clear-sidebar-filters:active{
@@ -1655,7 +1660,8 @@
         aspect-ratio:4 / 3;
         background: rgba(255,255,255,.95);
         border: 1px solid var(--athlete-modal-border);
-        box-shadow: 0 14px 30px rgba(0,0,0,.28);
+        border-radius:var(--lwc-radius-md);
+        box-shadow:var(--lwc-shadow-sm);
     }
     #detailsModal .proof-item img{
         width:100%;
@@ -1664,8 +1670,9 @@
         object-fit:contain;
     }
     #detailsModal .proof-item:hover{
-        transform: translateY(-2px);
-        box-shadow: 0 18px 38px rgba(0,0,0,.34);
+        transform:none;
+        border-color:var(--lwc-accent);
+        box-shadow:var(--lwc-shadow-sm);
     }
     #detailsModal .proofs-empty{
         grid-column:1 / -1;
@@ -1824,13 +1831,16 @@
         outline-offset:2px;
     }
     .enlarged-portrait .image-zoom-controls button:disabled{
-        opacity:.42;
-        cursor:default;
+        opacity:1;
+        color:#a4b1bf;
+        background:#17212b;
+        border-color:#465360;
+        cursor:not-allowed;
     }
     .enlarged-portrait .image-zoom-status{
         min-width:3.75rem;
         color:rgba(255,255,255,.96);
-        font-size:.85rem;
+        font-size:var(--lwc-type-sm);
         font-variant-numeric:tabular-nums;
         font-weight:700;
         text-align:center;
@@ -1842,10 +1852,10 @@
         max-width:calc(100% - 2rem);
         margin:0;
         padding:.35rem .65rem;
-        border-radius:6px;
+        border-radius:var(--lwc-radius-sm);
         background:rgba(12,14,14,.88);
         color:rgba(255,255,255,.92);
-        font-size:.78rem;
+        font-size:var(--lwc-type-sm);
         line-height:1.25;
         text-align:center;
         transform:translateX(-50%);
@@ -2029,17 +2039,17 @@
         .sidebar.expanded .filter-section{ display:block; }
         .sidebar .collapsed-title{ display:none; }
         .sidebar .sidebar-close{
-            position:sticky; top:calc(env(safe-area-inset-top) + .9rem); right:auto; margin-left:auto; margin-bottom:-44px;
+            position:static; margin:0;
         }
-        .sidebar .sidebar-title{ width:100%; padding:.75rem 2.75rem .75rem 0; }
-        .sidebar .sidebar-title .sidebar-title-text{ display:inline-block; }
-        .clear-sidebar-filters{ min-height:44px; align-items:center; align-self:flex-start; padding:.45rem .75rem; }
+        .sidebar-heading{ position:sticky; top:-1rem; z-index:10; background:var(--card-bg); }
+        .sidebar .sidebar-title{ width:auto; padding:.75rem 0; }
+        .sidebar .sidebar-title .sidebar-title-text{ display:inline-block; font-size:1.25rem; }
+        .sidebar .sidebar-title .sidebar-icon{ flex-basis:1.5rem; width:1.5rem; height:1.5rem; font-size:1.5rem; }
         .sidebar.has-active-state.expanded .clear-sidebar-filters{
-            display:flex; width:max-content; position:sticky; top:calc(env(safe-area-inset-top) + 4rem); z-index:8; align-self:flex-end; margin-left:auto; margin-right:.75rem;
-            background:var(--lwc-accent-soft, #e7f7f8); box-shadow:0 0 0 8px var(--card-bg), 0 8px 18px rgba(8,118,133,.16);
+            display:flex; background:var(--lwc-accent-soft); box-shadow:none;
         }
         .sidebar.has-active-state.expanded .clear-sidebar-filters:focus-visible{
-            box-shadow:0 0 0 8px var(--card-bg), 0 0 0 12px rgba(8,118,133,.18), 0 8px 18px rgba(8,118,133,.16);
+            outline:3px solid var(--lwc-accent); outline-offset:2px; box-shadow:none;
         }
         .filter-section label{ min-height:44px; padding:.52rem .65rem; }
         .content{ margin-left:0; }
@@ -2847,25 +2857,25 @@
     }
 
     #athleteSearch:focus {
-        border-color: var(--leaderboard-change-cue);
-        box-shadow: 0 0 0 4px rgba(255, 64, 129, .16), 0 4px 10px rgba(0, 0, 0, .08);
+        border-color:var(--lwc-accent);
+        box-shadow:0 0 0 3px var(--lwc-accent-soft);
     }
 
     .search-container:focus-within .search-icon,
     .clear-icon:hover,
     .clear-icon:focus-visible {
-        color: var(--leaderboard-change-cue);
+        color:var(--lwc-accent);
     }
 
     .clear-icon:hover,
     .clear-icon:focus-visible {
-        background: rgba(255, 64, 129, .08);
-        border-color: rgba(255, 64, 129, .22);
+        background:var(--lwc-accent-soft);
+        border-color:var(--lwc-border);
     }
 
     .clear-icon:focus-visible {
-        outline-color: var(--leaderboard-change-cue);
-        box-shadow: 0 0 0 4px rgba(255, 64, 129, .16), 0 4px 10px rgba(0, 0, 0, .1);
+        outline-color:var(--lwc-accent);
+        box-shadow:none;
     }
 
     .ranking-explanation,
@@ -3032,15 +3042,17 @@
 
         <div class="leaderboard">
             <div class="sidebar" id="leaderboardFilters">
-                <button class="sidebar-close" aria-label="Hide league filters" title="Hide league filters"><i class="fa fa-times"></i></button>
+                <div class="sidebar-heading">
                 <h2 class="sidebar-title" data-aos="fade" data-aos-duration="700" data-aos-delay="200">
                     <span class="sidebar-icon"><i class="fa fa-trophy"></i></span>
                     <span class="sidebar-title-text">Leagues</span>
                 </h2>
-                <button type="button" class="clear-sidebar-filters" id="clearSidebarFiltersBtn" tabindex="-1" aria-hidden="true">
-                    <i class="fa fa-times clear-sidebar-filters-icon" aria-hidden="true"></i>
+                <button type="button" class="clear-sidebar-filters" id="clearSidebarFiltersBtn" title="Clear filters" tabindex="-1" aria-hidden="true">
+                    <i class="fa fa-undo clear-sidebar-filters-icon" aria-hidden="true"></i>
                     <span>Clear filters</span>
                 </button>
+                <button class="sidebar-close" aria-label="Hide league filters" title="Hide league filters"><i class="fa fa-times"></i></button>
+                </div>
                 <div class="collapsed-title" data-aos="fade" data-aos-duration="700" data-aos-delay="200">ULTIMATE LEAGUE</div>
                 <div class="filter-section" id="aging-clock-filter-section">
                     <h3>Ranking views</h3>

--- a/LongevityWorldCup.Website/wwwroot/play/proof-upload.html
+++ b/LongevityWorldCup.Website/wwwroot/play/proof-upload.html
@@ -220,7 +220,7 @@
                 padding: 0.45rem 0.75rem !important;
                 background-color: var(--lwc-surface) !important;
                 color: var(--lwc-danger) !important;
-                border: 1px solid var(--lwc-border);
+                border: 1px solid var(--lwc-border) !important;
                 border-radius: var(--lwc-radius-md) !important;
                 box-shadow: none;
                 box-sizing: border-box;

--- a/LongevityWorldCup.Website/wwwroot/play/proof-upload.html
+++ b/LongevityWorldCup.Website/wwwroot/play/proof-upload.html
@@ -173,9 +173,10 @@
                 min-height: 42px;
                 margin: 0 0 0.75rem;
                 padding: 0.6rem 0.85rem;
-                border: 1px solid var(--lwc-success, rgba(22, 163, 74, 0.35));
+                border: 1px solid var(--lwc-border);
+                border-inline-start: 4px solid var(--lwc-success);
                 border-radius: 8px;
-                background: var(--lwc-success-soft, rgba(240, 253, 244, 0.94));
+                background: var(--lwc-surface-muted);
                 box-shadow: none;
                 box-sizing: border-box;
                 color: var(--lwc-ink, #166534);
@@ -205,26 +206,26 @@
                 height: clamp(160px, 46vw, 240px);
                 max-width: 100% !important;
                 border: 0 !important;
-                border-radius: 6px;
+                border-radius: var(--lwc-radius-sm);
                 background: var(--lwc-surface-muted, #f8fafc);
                 object-fit: contain;
             }
 
             #proofImageContainer button {
-                position: absolute;
-                top: 0.75rem !important;
-                right: 0.75rem !important;
+                position: static !important;
+                display: block;
+                margin: var(--lwc-space-2) 0 0 auto;
                 min-height: 44px;
                 min-width: 44px;
                 padding: 0.45rem 0.75rem !important;
-                background-color: #b91c1c !important;
-                color: var(--light-text-color);
-                border: none;
-                border-radius: 999px !important;
-                box-shadow: 0 3px 8px rgba(127, 29, 29, 0.28);
+                background-color: var(--lwc-surface) !important;
+                color: var(--lwc-danger) !important;
+                border: 1px solid var(--lwc-border);
+                border-radius: var(--lwc-radius-md) !important;
+                box-shadow: none;
                 box-sizing: border-box;
                 cursor: pointer;
-                font-size: 0.8rem;
+                font-size: var(--lwc-type-sm);
                 font-weight: 700;
             }
 
@@ -559,6 +560,10 @@
             .proof-upload-primary-action .upload-choice-divider {
                 display: flex;
             }
+        }
+        .proof-upload-main .proof-upload-copy {
+            text-align: left;
+            line-height: 1.5;
         }
     </style>
 </head>


### PR DESCRIPTION
Disabled entry actions were difficult to read, choosing a league filter moved the choices, and proof removal covered uploaded documents. These 21 focused polish passes continue #847 with clearer control states, steadier filter geometry, and more readable forms.

- Improve athlete selection frames and suggestions, date-field legibility down to 320px, proof previews and removal, and confirmation messages.
- Keep reset and close actions together in a stable filter header; clarify search focus and empty results; calm proof-gallery feedback and improve viewer controls.
- Improve Challenge identity selection, timezone details, validation spacing, and week navigation. Keep form popovers above the leaderboard's sticky cells.
- Preserve ranking, scoring, signup, payment, and submission behavior.

Validation:
- Build passed.
- 150 existing automated tests passed across appearance, onboarding, calculators, proof upload/viewing, leaderboard routing, and Challenge interactions. One onboarding navigation timeout passed on an isolated rerun.
- All 33 tests in the final affected Challenge, proof-upload, and mobile-calculator subset passed after the last fixes.
- 64 browser scenarios across 390px light, 320px dark, and 1280px light/dark views passed layout and interaction checks. Checks included filter stability/reset, proof removal, calculator progression, timezone selection and hit testing, and mocked form validation feedback.
- Produced 14 before-and-after comparison pictures using original screenshots, verified pixel-for-pixel after composition.

Related to #72. Follows merged PR #847.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS and markup tweaks with an updated browser assertion; no changes to ranking, scoring, or submission logic.
> 
> **Overview**
> This PR continues visual polish across leaderboard, onboarding calculators, Challenge, and Play proof upload—mostly CSS/HTML with one regression test update.
> 
> **Leaderboard filters and search:** League sidebar gets a stable **`sidebar-heading`** row (title, compact **clear filters** with undo icon, close). Active-filter **pink** cues stay on the toggle/trophy badge while **athlete search focus** moves to the site **teal accent**, with matching test expectations. Empty-state copy and proof thumbnails in the athlete modal use calmer borders/shadows; disabled zoom controls read clearly instead of fading out.
> 
> **Forms and entry:** Bio-age wizards gain tighter mobile **DOB** grids (including **360px**), shared **design tokens** for spacing/type, and a shorter year placeholder (**Year**). Play-flow **green primary buttons** no longer look “enabled” when disabled; athlete portrait frames and autocomplete matches align with the quieter surface system.
> 
> **Challenge and proof upload:** Identity choices show a **checkmark** treatment; sticky action cards **`z-index`** keeps popovers above leaderboard sticky cells; week pager/timezone/disabled controls and empty status lines are tuned. Proof success banners use **left accent bars**; **remove** actions sit **below** previews instead of overlaying documents.
> 
> **Onboarding copy blocks** (application review, proof instructions) shift from heavy green fills to muted surfaces with semantic accent edges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d8d6bc4f28c7fd72ed331dade1869814237276b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->