### PR TITLE
Keep flow navigation available during startup

### DIFF
--- a/LongevityWorldCup.Tests/FlowNavigationReadinessBrowserTests.cs
+++ b/LongevityWorldCup.Tests/FlowNavigationReadinessBrowserTests.cs
@@ -1,0 +1,71 @@
+using Microsoft.Playwright;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+[Collection(BrowserTestCollections.WorkloadB)]
+public sealed class FlowNavigationReadinessBrowserTests(
+    PlaywrightBrowserFixture browserFixture,
+    BrowserTestAppFixture appFixture)
+    : BrowserIntegrationTest(browserFixture, appFixture)
+{
+    [Theory]
+    [InlineData("/apply", "#backButton", "/pheno-age")]
+    [InlineData("/pheno-age", "#bioageStepOneBackButton", "/join")]
+    [InlineData("/bortz-age", "#bioageStepOneBackButton", "/join")]
+    [InlineData("/edit-profile", ".flow-action-stack .back-button", "/dashboard")]
+    [InlineData("/proofs", ".flow-action-stack .back-button", "/dashboard")]
+    public async Task BackNavigation_WorksWhilePageModulesAreStillLoading(
+        string path,
+        string backSelector,
+        string destination)
+    {
+        await using var context = await Browser.NewContextAsync(new()
+        {
+            BaseURL = App.BaseAddress.ToString(),
+            Locale = "en-US",
+            ViewportSize = new() { Width = 390, Height = 844 }
+        });
+        await BrowserTestApp.RouteExternalResourcesAsync(context);
+        await context.AddInitScriptAsync(
+            """
+            sessionStorage.setItem('selectedAthlete', JSON.stringify({
+                Name: 'Browser Test Athlete',
+                DisplayName: 'Browser Test Athlete',
+                Biomarkers: []
+            }));
+            sessionStorage.setItem('biomarkerData', JSON.stringify({
+                Biomarkers: [{ Date: '2026-06-19', AlbGL: 45, GluMmolL: 5.1 }]
+            }));
+            """);
+        var page = await context.NewPageAsync();
+        var errors = new List<string>();
+        page.PageError += (_, error) => errors.Add(error);
+        var moduleRequested = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseModule = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await page.RouteAsync("**/js/misc.js*", async route =>
+        {
+            moduleRequested.TrySetResult();
+            await releaseModule.Task;
+            await route.ContinueAsync();
+        });
+
+        try
+        {
+            await page.GotoAsync(path, new() { WaitUntil = WaitUntilState.DOMContentLoaded });
+            await moduleRequested.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            if (path == "/apply")
+                await Assertions.Expect(page.Locator("#nextButton")).ToBeDisabledAsync();
+
+            await page.Locator(backSelector).ClickAsync();
+            await page.WaitForDomContentLoadedUrlAsync($"**{destination}");
+
+            Assert.Equal(destination, new Uri(page.Url).AbsolutePath);
+            Assert.Empty(errors);
+        }
+        finally
+        {
+            releaseModule.TrySetResult();
+        }
+    }
+}

--- a/LongevityWorldCup.Website/Frontend/README.md
+++ b/LongevityWorldCup.Website/Frontend/README.md
@@ -20,6 +20,8 @@ Keep strict null, unchecked-index, exact-optional-property, and erasable-syntax 
 
 Keep these classic scripts free of imports/exports: `flow-action-dock`, `bioage-flow`, `custom-event-markup`, `longevitymaxxing`, `site-statistics-tracking`, `site-statistics`.
 
+The head partial defines `navigateToFlowDestination` synchronously so inline Back handlers work before the asynchronous modules finish. Application Next starts disabled until initialization binds stage validation.
+
 Shared type-only contracts belong in `types/*.d.ts`. Runtime entry points stay self-contained to preserve request order, cache coverage, and independent failure. Ranking fallbacks and athlete-picture transitions have distinct failure, privacy, and timing behavior; consolidation requires equivalence and browser coverage.
 
 ## Inline Scripts

--- a/LongevityWorldCup.Website/Frontend/misc.ts
+++ b/LongevityWorldCup.Website/Frontend/misc.ts
@@ -775,13 +775,6 @@ window.goBackOrHome = function () {
     }
 }
 
-window.navigateToFlowDestination = function (destination) {
-    const target = typeof destination === 'string' && destination.trim()
-        ? destination
-        : '/';
-    window.location.replace(target);
-}
-
 window.optimizeImageClient = async function (dataUri, options) {
     const settings = options || {};
     const MaxBase64Length = 50 * 1024 * 1024; // 50 MB

--- a/LongevityWorldCup.Website/wwwroot/onboarding/convergence.html
+++ b/LongevityWorldCup.Website/wwwroot/onboarding/convergence.html
@@ -747,7 +747,7 @@
             </fieldset>
 
             <div class="options-container convergence-actions flow-action-stack" data-flow-dock="auto">
-                <button type="button" class="option-button green flow-action" id="nextButton" aria-label="Proceed to the next stage">
+                <button type="button" class="option-button green flow-action" id="nextButton" aria-label="Proceed to the next stage" disabled>
                     <span class="flow-action__label">Next</span><i class="fas fa-arrow-right" aria-hidden="true"></i>
                 </button>
                 <button type="button" class="option-button back-button flow-action flow-action--secondary flow-action--icon-left" id="backButton">

--- a/LongevityWorldCup.Website/wwwroot/partials/head.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/head.html
@@ -56,6 +56,14 @@
 
 <script>
     window.modulesReady = Promise.resolve();
+
+    // Inline Back handlers can run before the asynchronous page modules load.
+    window.navigateToFlowDestination = function (destination) {
+        const target = typeof destination === 'string' && destination.trim()
+            ? destination
+            : '/';
+        window.location.replace(target);
+    };
 </script>
 
 <script>


### PR DESCRIPTION
Clicking Back while the page modules are loading can throw `TypeError: window.navigateToFlowDestination is not a function` and leave the user on the current page. A deliberately delayed `misc.js` request reproduced the intermittent application-to-calculator navigation failure.

Define the shared navigation helper synchronously in the head bootstrap, preserving its destination and history behavior for application, calculator, profile-editing, and proof-upload screens. Application Next starts disabled until initialization binds stage validation, preventing premature advancement during the same loading window. Document these loading requirements in the frontend guide.

Validation: five browser cases hold `misc.js` pending and verify that Back still reaches the correct destination without JavaScript errors. The application case also checks that Next stays disabled before initialization. These cases and all 11 existing onboarding tests pass locally (16 total). [Full CI](https://github.com/nopara73/LongevityWorldCup/actions/runs/33951848596) passes all 1,310 tests with coverage on `66ff101db02315ce80a6ab0701c4d2e89524cec6`, including the normal build, frontend compilation, generated-output verification, and Node-free publish contract. CodeQL, dependency review, and Bugbot also pass.

Related to #856 and #857.
