### PR TITLE
Polish profiles, discussions, and supporting pages

### DIFF
--- a/LongevityWorldCup.MarkdownPageGenerator/Program.cs
+++ b/LongevityWorldCup.MarkdownPageGenerator/Program.cs
@@ -698,16 +698,39 @@ static string RenderPage(string title, string documentHtml, string contentsHtml,
                 return ((stickyHeader && stickyHeader.offsetHeight) || 52) + 18;
             };
 
+            let activeLink = null;
+            const revealActiveLink = () => {
+                const link = documentationNav?.querySelector("a:focus") || activeLink;
+                if (!documentationNav || !link || !window.matchMedia("(min-width: 901px)").matches) {
+                    return;
+                }
+
+                const pane = documentationNav.getBoundingClientRect();
+                const target = link.getBoundingClientRect();
+                const padding = parseFloat(getComputedStyle(documentationNav).scrollPaddingTop) || 0;
+                if (target.top < pane.top + padding) {
+                    documentationNav.scrollTop += target.top - pane.top - padding;
+                } else if (target.bottom > pane.bottom - padding) {
+                    documentationNav.scrollTop += target.bottom - pane.bottom + padding;
+                }
+            };
+
             const setActive = id => {
+                const previousActiveLink = activeLink;
+                activeLink = null;
                 navLinks.forEach(link => {
                     const active = decodeURIComponent(link.getAttribute("href").slice(1)) === id;
                     link.classList.toggle("is-active", active);
                     if (active) {
+                        activeLink = link;
                         link.setAttribute("aria-current", "location");
                     } else {
                         link.removeAttribute("aria-current");
                     }
                 });
+                if (activeLink !== previousActiveLink) {
+                    revealActiveLink();
+                }
             };
 
             navLinks.forEach(link => {
@@ -761,6 +784,10 @@ static string RenderPage(string title, string documentHtml, string contentsHtml,
                     ticking = false;
                 });
             }, { passive: true });
+            window.addEventListener("resize", () => {
+                updateActiveFromScroll();
+                revealActiveLink();
+            });
 
             updateActiveFromScroll();
         });

--- a/LongevityWorldCup.MarkdownPageGenerator/Program.cs
+++ b/LongevityWorldCup.MarkdownPageGenerator/Program.cs
@@ -778,9 +778,30 @@ static string RenderPage(string title, string documentHtml, string contentsHtml,
                         break;
                     }
                 }
+                if (window.scrollY > 0 && window.scrollY + window.innerHeight >= document.documentElement.scrollHeight - 1) {
+                    current = headings[headings.length - 1];
+                }
                 if (current) {
                     setActive(current.id);
                 }
+            };
+
+            const synchronizeNavigationFromHash = () => {
+                let id;
+                try {
+                    id = decodeURIComponent(window.location.hash.slice(1));
+                } catch {
+                    id = "";
+                }
+                const target = headings.find(heading => heading.id === id);
+                navigationDestination = null;
+                if (target) {
+                    const bounds = target.getBoundingClientRect();
+                    if (bounds.bottom > getOffset() && bounds.top < window.innerHeight) {
+                        navigationDestination = { target, scrollY: window.scrollY, hash: window.location.hash };
+                    }
+                }
+                updateActiveFromScroll();
             };
 
             let ticking = false;
@@ -799,8 +820,17 @@ static string RenderPage(string title, string documentHtml, string contentsHtml,
                 updateActiveFromScroll();
                 revealActiveLink();
             });
+            window.addEventListener("hashchange", () => window.requestAnimationFrame(synchronizeNavigationFromHash));
+            window.addEventListener("pageshow", event => {
+                if (!event.persisted && window.location.hash) {
+                    synchronizeNavigationFromHash();
+                }
+            });
 
             updateActiveFromScroll();
+            if (window.location.hash) {
+                window.requestAnimationFrame(synchronizeNavigationFromHash);
+            }
         });
     </script>
 </body>

--- a/LongevityWorldCup.MarkdownPageGenerator/Program.cs
+++ b/LongevityWorldCup.MarkdownPageGenerator/Program.cs
@@ -213,8 +213,9 @@ static string RenderPage(string title, string documentHtml, string contentsHtml,
         }
 
         .documentation-nav {
+            --documentation-nav-offset: 4.25rem;
             position: sticky;
-            top: 4.25rem;
+            top: var(--documentation-nav-offset);
             display: grid;
             gap: 0.2rem;
             padding: 0.85rem 0.7rem 0.95rem;
@@ -222,6 +223,18 @@ static string RenderPage(string title, string documentHtml, string contentsHtml,
             border-radius: 0 8px 8px 0;
             background: var(--lwc-surface-muted, #eef2f5);
             box-shadow: none;
+        }
+
+        @media (min-width: 901px) {
+            .documentation-nav {
+                box-sizing: border-box;
+                max-height: calc(100dvh - var(--documentation-nav-offset) - 1rem);
+                overflow-y: auto;
+                overscroll-behavior: contain;
+                scroll-padding-block: var(--lwc-space-2);
+                scrollbar-width: thin;
+                scrollbar-color: var(--lwc-border-strong) transparent;
+            }
         }
 
         .documentation-nav-title {

--- a/LongevityWorldCup.MarkdownPageGenerator/Program.cs
+++ b/LongevityWorldCup.MarkdownPageGenerator/Program.cs
@@ -699,6 +699,7 @@ static string RenderPage(string title, string documentHtml, string contentsHtml,
             };
 
             let activeLink = null;
+            let navigationDestination = null;
             const revealActiveLink = () => {
                 const link = documentationNav?.querySelector("a:focus") || activeLink;
                 if (!documentationNav || !link || !window.matchMedia("(min-width: 901px)").matches) {
@@ -747,6 +748,7 @@ static string RenderPage(string title, string documentHtml, string contentsHtml,
                     const top = target.getBoundingClientRect().top + window.scrollY - getOffset();
                     window.scrollTo({ top, behavior: "instant" });
                     history.pushState(null, "", link.getAttribute("href"));
+                    navigationDestination = { target, scrollY: window.scrollY, hash: window.location.hash };
                     setActive(target.id);
 
                     target.setAttribute("tabindex", "-1");
@@ -756,6 +758,17 @@ static string RenderPage(string title, string documentHtml, string contentsHtml,
 
             const updateActiveFromScroll = () => {
                 const offset = getOffset() + 6;
+                // A section near the page end may be visible without reaching the offset.
+                // Honor that destination until the reader moves away from its landing position.
+                if (navigationDestination && window.scrollY === navigationDestination.scrollY &&
+                    window.location.hash === navigationDestination.hash) {
+                    const bounds = navigationDestination.target.getBoundingClientRect();
+                    if (bounds.bottom > offset && bounds.top < window.innerHeight) {
+                        setActive(navigationDestination.target.id);
+                        return;
+                    }
+                }
+                navigationDestination = null;
                 let current = headings[0];
 
                 for (const heading of headings) {
@@ -765,10 +778,6 @@ static string RenderPage(string title, string documentHtml, string contentsHtml,
                         break;
                     }
                 }
-                if (window.scrollY > 0 && window.scrollY + window.innerHeight >= document.documentElement.scrollHeight - 1) {
-                    current = headings[headings.length - 1];
-                }
-
                 if (current) {
                     setActive(current.id);
                 }

--- a/LongevityWorldCup.MarkdownPageGenerator/Program.cs
+++ b/LongevityWorldCup.MarkdownPageGenerator/Program.cs
@@ -228,9 +228,10 @@ static string RenderPage(string title, string documentHtml, string contentsHtml,
             margin: 0 0 0.35rem;
             padding: 0 0.45rem;
             color: var(--lwc-muted, #526373);
-            font-size: 0.78rem;
+            font-size: var(--lwc-type-sm);
             font-weight: 700;
-            text-transform: uppercase;
+            text-transform: none;
+            line-height: 1.5;
         }
 
         .documentation-nav-toggle {
@@ -244,13 +245,16 @@ static string RenderPage(string title, string documentHtml, string contentsHtml,
         }
 
         .documentation-nav a {
-            display: block;
+            display: flex;
             padding: 0.38rem 0.45rem;
-            border-radius: 6px;
+            border-radius: var(--lwc-radius-sm);
             color: var(--lwc-ink, #334155);
-            font-size: 0.92rem;
-            line-height: 1.25;
+            font-size: var(--lwc-type-sm);
+            line-height: 1.5;
             text-decoration: none;
+            min-height: 44px;
+            box-sizing: border-box;
+            align-items: center;
         }
 
         .documentation-nav .documentation-nav-level-3 {
@@ -258,7 +262,8 @@ static string RenderPage(string title, string documentHtml, string contentsHtml,
             padding-top: 0.28rem;
             padding-bottom: 0.28rem;
             color: var(--lwc-muted, #506176);
-            font-size: 0.86rem;
+            font-size: var(--lwc-type-sm);
+            line-height: 1.5;
         }
 
         .documentation-nav a:hover,
@@ -271,6 +276,7 @@ static string RenderPage(string title, string documentHtml, string contentsHtml,
 
         .documentation-nav a.is-active {
             font-weight: 700;
+            box-shadow: inset 3px 0 0 var(--lwc-accent);
         }
 
         .documentation-nav .documentation-source-link {
@@ -386,6 +392,7 @@ static string RenderPage(string title, string documentHtml, string contentsHtml,
             border-collapse: collapse;
             background: var(--lwc-surface, #ffffff);
             border-radius: 8px;
+            font-variant-numeric: tabular-nums;
         }
 
         .documentation-document th,
@@ -399,7 +406,7 @@ static string RenderPage(string title, string documentHtml, string contentsHtml,
 
         .documentation-document th {
             color: var(--lwc-ink, #111827);
-            background: var(--lwc-accent-soft, rgba(0, 188, 212, 0.1));
+            background: var(--lwc-surface-muted);
             font-weight: 700;
         }
 
@@ -408,8 +415,9 @@ static string RenderPage(string title, string documentHtml, string contentsHtml,
             padding-top: 1rem;
             border-top: 1px solid var(--lwc-border, rgba(0, 0, 0, 0.08));
             color: var(--lwc-muted, #506176);
-            font-size: 0.95rem;
+            font-size: var(--lwc-type-sm);
             text-align: left;
+            line-height: 1.5;
         }
 
         @media (max-width: 900px) {
@@ -438,7 +446,7 @@ static string RenderPage(string title, string documentHtml, string contentsHtml,
                 min-height: 44px;
                 padding: 0.6rem 0.75rem;
                 border: 1px solid var(--lwc-border-strong, #71808d);
-                border-radius: 6px;
+                border-radius: var(--lwc-radius-md);
                 background: var(--lwc-surface, #ffffff);
                 color: var(--lwc-ink, #334155);
                 font: inherit;
@@ -461,6 +469,9 @@ static string RenderPage(string title, string documentHtml, string contentsHtml,
             .documentation-nav-toggle-icon {
                 font-size: 1.25rem;
                 line-height: 1;
+                flex: 0 0 1.5rem;
+                width: 1.5rem;
+                text-align: center;
             }
 
             .documentation-nav-links {
@@ -567,17 +578,18 @@ static string RenderPage(string title, string documentHtml, string contentsHtml,
                 gap: 0.35rem;
                 align-items: baseline;
                 color: var(--lwc-ink, #334155);
-                font-size: 0.86rem;
-                line-height: 1.28;
+                font-size: var(--lwc-type-sm);
+                line-height: 1.5;
             }
 
             .documentation-document tbody td::before {
                 content: attr(data-label);
                 color: var(--lwc-muted, #526373);
-                font-size: 0.68rem;
-                font-weight: 800;
-                text-transform: uppercase;
+                font-size: var(--lwc-type-xs);
+                font-weight: 700;
+                text-transform: none;
                 letter-spacing: 0;
+                line-height: 1.5;
             }
 
             .documentation-document tbody td:first-child {
@@ -590,7 +602,8 @@ static string RenderPage(string title, string documentHtml, string contentsHtml,
                 grid-row: 2;
                 font-size: 0.96rem;
                 font-weight: 700;
-                white-space: nowrap;
+                white-space: normal;
+                overflow-wrap: anywhere;
             }
 
             .documentation-document tbody td:nth-child(2)::before {
@@ -609,6 +622,19 @@ static string RenderPage(string title, string documentHtml, string contentsHtml,
 
             .documentation-document tbody td:last-child::before {
                 white-space: nowrap;
+            }
+        }
+        .documentation-nav a:focus-visible {
+            outline: 2px solid var(--lwc-accent);
+            outline-offset: -2px;
+        }
+        @media (max-width: 600px) {
+            .documentation-document {
+                font-size: var(--lwc-type-body);
+                line-height: 1.65;
+            }
+            .documentation-document :is(p,li) {
+                line-height: 1.65;
             }
         }
     </style>

--- a/LongevityWorldCup.MarkdownPageGenerator/Program.cs
+++ b/LongevityWorldCup.MarkdownPageGenerator/Program.cs
@@ -741,14 +741,13 @@ static string RenderPage(string title, string documentHtml, string contentsHtml,
                     }
 
                     event.preventDefault();
-                    const top = target.getBoundingClientRect().top + window.scrollY - getOffset();
-                    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-                    window.scrollTo({ top, behavior: reducedMotion ? "auto" : "smooth" });
-                    history.pushState(null, "", link.getAttribute("href"));
-                    setActive(target.id);
                     if (window.matchMedia("(max-width: 900px)").matches) {
                         setDocumentationNavOpen(false);
                     }
+                    const top = target.getBoundingClientRect().top + window.scrollY - getOffset();
+                    window.scrollTo({ top, behavior: "instant" });
+                    history.pushState(null, "", link.getAttribute("href"));
+                    setActive(target.id);
 
                     target.setAttribute("tabindex", "-1");
                     target.focus({ preventScroll: true });
@@ -765,6 +764,9 @@ static string RenderPage(string title, string documentHtml, string contentsHtml,
                     } else {
                         break;
                     }
+                }
+                if (window.scrollY > 0 && window.scrollY + window.innerHeight >= document.documentElement.scrollHeight - 1) {
+                    current = headings[headings.length - 1];
                 }
 
                 if (current) {

--- a/LongevityWorldCup.Tests/AestheticSystemBrowserTests.Accessibility.cs
+++ b/LongevityWorldCup.Tests/AestheticSystemBrowserTests.Accessibility.cs
@@ -64,6 +64,58 @@ public sealed class AestheticAccessibilityBrowserTests(
             "Keyboard navigation must reach the source link at the end of the contents.");
     }
 
+    [Theory]
+    [InlineData(720)]
+    [InlineData(350)]
+    public async Task DesktopDocumentationNavigation_FollowsReadingWithoutMovingTheDocument(int height)
+    {
+        await using var context = await NewContextAsync(
+            Browser,
+            App,
+            new BrowserNewContextOptions
+            {
+                ViewportSize = new ViewportSize { Width = 1280, Height = height }
+            });
+        var page = await context.NewPageAsync();
+        await NavigateAndSettleAsync(page, "/history");
+        var navigation = page.Locator(".documentation-nav");
+        var links = navigation.Locator("a[href^='#']");
+        var count = await links.CountAsync();
+
+        foreach (var index in new[] { count - 5, 0 })
+        {
+            var link = links.Nth(index);
+            var href = await link.GetAttributeAsync("href");
+            var requestedScroll = await page.EvaluateAsync<double>(
+                """
+                href => {
+                    const heading = document.getElementById(decodeURIComponent(href.slice(1)));
+                    const top = Math.max(0, heading.getBoundingClientRect().top + scrollY - 70);
+                    window.scrollTo({top, behavior: 'instant'});
+                    return Math.min(top, document.documentElement.scrollHeight - innerHeight);
+                }
+                """, href);
+            await page.WaitForFunctionAsync(
+                "href => document.querySelector('.documentation-nav a.is-active')?.getAttribute('href') === href", href);
+
+            var navBox = await navigation.BoundingBoxAsync();
+            var linkBox = await link.BoundingBoxAsync();
+            Assert.NotNull(navBox);
+            Assert.NotNull(linkBox);
+            Assert.True(linkBox.Y >= Math.Max(0, navBox.Y) &&
+                        linkBox.Y + linkBox.Height <= Math.Min(height, navBox.Y + navBox.Height),
+                $"The current section is outside the contents pane at {height}px height.");
+            Assert.InRange(Math.Abs(await page.EvaluateAsync<double>("scrollY") - requestedScroll), 0, 1);
+
+            // Browsing the contents independently must not snap back on every document scroll event.
+            await navigation.EvaluateAsync("element => element.scrollTop = 0");
+            await page.EvaluateAsync("window.scrollTo({top: scrollY + 1, behavior: 'instant'})");
+            await page.EvaluateAsync(
+                "() => new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))");
+            Assert.Equal(0, await navigation.EvaluateAsync<double>("element => element.scrollTop"));
+        }
+    }
+
     [Fact]
     public async Task MobileDocumentationNavigation_UsesProgressiveDisclosureAndLargeTargets()
     {

--- a/LongevityWorldCup.Tests/AestheticSystemBrowserTests.Accessibility.cs
+++ b/LongevityWorldCup.Tests/AestheticSystemBrowserTests.Accessibility.cs
@@ -116,6 +116,58 @@ public sealed class AestheticAccessibilityBrowserTests(
         }
     }
 
+    [Theory]
+    [InlineData(1280, false)]
+    [InlineData(1280, true)]
+    [InlineData(390, false)]
+    [InlineData(390, true)]
+    public async Task DocumentContentsNavigation_ArrivesAtTheChosenSectionWithoutIntermediatePaneJumps(int width, bool reducedMotion)
+    {
+        await using var context = await NewContextAsync(
+            Browser,
+            App,
+            new BrowserNewContextOptions
+            {
+                ViewportSize = new ViewportSize { Width = width, Height = width > 900 ? 350 : 844 },
+                ReducedMotion = reducedMotion ? ReducedMotion.Reduce : ReducedMotion.NoPreference
+            });
+        var page = await context.NewPageAsync();
+        await NavigateAndSettleAsync(page, "/history");
+        var links = page.Locator(".documentation-nav a[href^='#']");
+        var count = await links.CountAsync();
+        foreach (var index in new[] { count - 5, count - 1, 0 })
+        {
+            if (width <= 900)
+                await page.Locator(".documentation-nav-toggle").ClickAsync();
+            var link = links.Nth(index);
+            var href = await link.GetAttributeAsync("href");
+            await link.ClickAsync();
+
+            var stableArrival = await page.EvaluateAsync<bool>(
+                """
+                async href => {
+                    const heading = document.getElementById(decodeURIComponent(href.slice(1)));
+                    const pane = document.querySelector('.documentation-nav');
+                    const documentY = scrollY;
+                    const paneY = pane.scrollTop;
+                    for (let frame = 0; frame < 10; frame++) {
+                        await new Promise(resolve => requestAnimationFrame(resolve));
+                        const headingBox = heading.getBoundingClientRect();
+                        if (headingBox.top < 69 || headingBox.bottom > innerHeight ||
+                            Math.abs(scrollY - documentY) > 1 || Math.abs(pane.scrollTop - paneY) > 1 ||
+                            document.querySelector('.documentation-nav a.is-active')?.getAttribute('href') !== href ||
+                            document.activeElement !== heading || location.hash !== href) {
+                            return false;
+                        }
+                    }
+                    return true;
+                }
+                """, href);
+            Assert.True(stableArrival,
+                $"Selecting {href} moved through intermediate document or contents positions (width={width}, reducedMotion={reducedMotion}).");
+        }
+    }
+
     [Fact]
     public async Task MobileDocumentationNavigation_UsesProgressiveDisclosureAndLargeTargets()
     {

--- a/LongevityWorldCup.Tests/AestheticSystemBrowserTests.Accessibility.cs
+++ b/LongevityWorldCup.Tests/AestheticSystemBrowserTests.Accessibility.cs
@@ -117,25 +117,33 @@ public sealed class AestheticAccessibilityBrowserTests(
     }
 
     [Theory]
-    [InlineData(1280, false)]
-    [InlineData(1280, true)]
-    [InlineData(390, false)]
-    [InlineData(390, true)]
-    public async Task DocumentContentsNavigation_ArrivesAtTheChosenSectionWithoutIntermediatePaneJumps(int width, bool reducedMotion)
+    [InlineData("/history", 1280, false)]
+    [InlineData("/history", 1280, true)]
+    [InlineData("/history", 390, false)]
+    [InlineData("/history", 390, true)]
+    [InlineData("/about", 1280, false)]
+    [InlineData("/about", 1280, true)]
+    [InlineData("/about", 390, false)]
+    [InlineData("/about", 390, true)]
+    [InlineData("/ruleset", 1280, false)]
+    [InlineData("/ruleset", 1280, true)]
+    [InlineData("/ruleset", 390, false)]
+    [InlineData("/ruleset", 390, true)]
+    public async Task DocumentContentsNavigation_ArrivesAtTheChosenSectionWithoutIntermediatePaneJumps(string path, int width, bool reducedMotion)
     {
         await using var context = await NewContextAsync(
             Browser,
             App,
             new BrowserNewContextOptions
             {
-                ViewportSize = new ViewportSize { Width = width, Height = width > 900 ? 350 : 844 },
+                ViewportSize = new ViewportSize { Width = width, Height = width > 900 ? 900 : 844 },
                 ReducedMotion = reducedMotion ? ReducedMotion.Reduce : ReducedMotion.NoPreference
             });
         var page = await context.NewPageAsync();
-        await NavigateAndSettleAsync(page, "/history");
+        await NavigateAndSettleAsync(page, path);
         var links = page.Locator(".documentation-nav a[href^='#']");
         var count = await links.CountAsync();
-        foreach (var index in new[] { count - 5, count - 1, 0 })
+        foreach (var index in new[] { count / 2, count - 2, count - 1, 0 })
         {
             if (width <= 900)
                 await page.Locator(".documentation-nav-toggle").ClickAsync();
@@ -164,8 +172,15 @@ public sealed class AestheticAccessibilityBrowserTests(
                 }
                 """, href);
             Assert.True(stableArrival,
-                $"Selecting {href} moved through intermediate document or contents positions (width={width}, reducedMotion={reducedMotion}).");
+                $"{path}: selecting {href} moved through intermediate document or contents positions (width={width}, reducedMotion={reducedMotion}).");
         }
+
+        var middleHref = await links.Nth(count / 2).GetAttributeAsync("href");
+        await page.EvaluateAsync(
+            "href => window.scrollTo({top: document.getElementById(decodeURIComponent(href.slice(1))).getBoundingClientRect().top + scrollY - 70, behavior: 'instant'})",
+            middleHref);
+        await page.WaitForFunctionAsync(
+            "href => document.querySelector('.documentation-nav a.is-active')?.getAttribute('href') === href", middleHref);
     }
 
     [Fact]

--- a/LongevityWorldCup.Tests/AestheticSystemBrowserTests.Accessibility.cs
+++ b/LongevityWorldCup.Tests/AestheticSystemBrowserTests.Accessibility.cs
@@ -10,6 +10,60 @@ public sealed class AestheticAccessibilityBrowserTests(
     BrowserTestAppFixture appFixture)
     : BrowserIntegrationTest(browserFixture, appFixture)
 {
+    [Theory]
+    [InlineData("/about", 720)]
+    [InlineData("/about", 350)]
+    [InlineData("/ruleset", 720)]
+    [InlineData("/ruleset", 350)]
+    [InlineData("/history", 720)]
+    [InlineData("/history", 350)]
+    public async Task DesktopDocumentationNavigation_KeepsEveryLinkReachableOnShortScreens(string path, int height)
+    {
+        await using var context = await NewContextAsync(
+            Browser,
+            App,
+            new BrowserNewContextOptions
+            {
+                ViewportSize = new ViewportSize { Width = 1280, Height = height }
+            });
+        var page = await context.NewPageAsync();
+        await NavigateAndSettleAsync(page, path);
+        await page.EvaluateAsync("window.scrollTo({ top: 400, behavior: 'instant' })");
+        await page.EvaluateAsync(
+            "() => new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))");
+
+        var navigation = page.Locator(".documentation-nav");
+        var navigationBox = await navigation.BoundingBoxAsync();
+        Assert.NotNull(navigationBox);
+        Assert.True(navigationBox.Y >= 0 && navigationBox.Y + navigationBox.Height <= height - 8,
+            $"{path} contents extend beyond the {height}px viewport: y={navigationBox.Y}, height={navigationBox.Height}.");
+
+        var links = navigation.Locator("a");
+        var count = await links.CountAsync();
+        Assert.True(count > 1);
+        await links.First.FocusAsync();
+        for (var index = 0; index < count; index++)
+        {
+            if (index > 0)
+                await page.Keyboard.PressAsync("Tab");
+
+            var link = links.Nth(index);
+            Assert.True(await link.EvaluateAsync<bool>("element => element === document.activeElement"),
+                $"{path} contents link {index + 1} was skipped by keyboard navigation.");
+            var linkBox = await link.BoundingBoxAsync();
+            Assert.NotNull(linkBox);
+            navigationBox = await navigation.BoundingBoxAsync();
+            Assert.NotNull(navigationBox);
+            Assert.True(linkBox.Y >= navigationBox.Y - 1 &&
+                        linkBox.Y + linkBox.Height <= Math.Min(height, navigationBox.Y + navigationBox.Height) + 1,
+                $"{path} focused contents link {index + 1} is clipped at {height}px height.");
+        }
+
+        Assert.True(await navigation.Locator(".documentation-source-link")
+            .EvaluateAsync<bool>("element => element === document.activeElement"),
+            "Keyboard navigation must reach the source link at the end of the contents.");
+    }
+
     [Fact]
     public async Task MobileDocumentationNavigation_UsesProgressiveDisclosureAndLargeTargets()
     {

--- a/LongevityWorldCup.Tests/AestheticSystemBrowserTests.Accessibility.cs
+++ b/LongevityWorldCup.Tests/AestheticSystemBrowserTests.Accessibility.cs
@@ -183,6 +183,41 @@ public sealed class AestheticAccessibilityBrowserTests(
             "href => document.querySelector('.documentation-nav a.is-active')?.getAttribute('href') === href", middleHref);
     }
 
+    [Theory]
+    [InlineData("/history")]
+    [InlineData("/about")]
+    [InlineData("/ruleset")]
+    public async Task DocumentContentsNavigation_TracksThePageEndAndFragmentHistory(string path)
+    {
+        await using var context = await NewContextAsync(
+            Browser,
+            App,
+            new BrowserNewContextOptions
+            {
+                ViewportSize = new ViewportSize { Width = 1280, Height = 900 }
+            });
+        var page = await context.NewPageAsync();
+        await NavigateAndSettleAsync(page, path);
+        var links = page.Locator(".documentation-nav a[href^='#']");
+        var lastHref = await links.Last.GetAttributeAsync("href");
+        var previousHref = await links.Nth(await links.CountAsync() - 2).GetAttributeAsync("href");
+
+        await page.EvaluateAsync("window.scrollTo({top: document.documentElement.scrollHeight, behavior: 'instant'})");
+        await page.EvaluateAsync(
+            "() => new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))");
+        Assert.Equal(lastHref, await page.Locator(".documentation-nav a.is-active").GetAttributeAsync("href"));
+
+        await page.GotoAsync(path + previousHref, new PageGotoOptions { WaitUntil = WaitUntilState.Load });
+        await page.WaitForFunctionAsync(
+            "href => document.querySelector('.documentation-nav a.is-active')?.getAttribute('href') === href", previousHref);
+        await links.Last.ClickAsync();
+        Assert.Equal(lastHref, await page.Locator(".documentation-nav a.is-active").GetAttributeAsync("href"));
+
+        await page.GoBackAsync(new PageGoBackOptions { WaitUntil = WaitUntilState.Load });
+        await page.WaitForFunctionAsync(
+            "href => document.querySelector('.documentation-nav a.is-active')?.getAttribute('href') === href", previousHref);
+    }
+
     [Fact]
     public async Task MobileDocumentationNavigation_UsesProgressiveDisclosureAndLargeTargets()
     {

--- a/LongevityWorldCup.Tests/AestheticSystemPageTests.cs
+++ b/LongevityWorldCup.Tests/AestheticSystemPageTests.cs
@@ -138,7 +138,7 @@ public sealed class AestheticSystemPageTests(TestWebApplicationFactory sharedFac
 
         var html = await client.GetStringAsync(path);
 
-        Assert.Contains("/css/error-system.css?v=20260719-1", html);
+        Assert.Contains("/css/error-system.css?v=20260905-1", html);
         Assert.Contains("<figure class=\"visual\">", html);
         Assert.Contains("src=\"/error/herold.png\"", html);
         Assert.Contains("alt=\"Herold waiting through a temporary outage\" width=\"1024\" height=\"1536\"", html);

--- a/LongevityWorldCup.Website/wwwroot/css/bioageform.css
+++ b/LongevityWorldCup.Website/wwwroot/css/bioageform.css
@@ -502,18 +502,18 @@
     }
 
     .bioageform.bioage-biomarker-entry-ready #lwc-step-2 .biomarker-card {
-        margin-bottom: 0.55rem;
+        margin-bottom: var(--lwc-space-3);
         border-color: var(--lwc-border, rgba(148, 163, 184, 0.38));
         border-radius: 8px;
     }
 
     .bioageform.bioage-biomarker-entry-ready #lwc-step-2 .biomarker-card-header {
         min-height: 38px;
-        padding: 0.55rem 0.7rem;
+        padding: var(--lwc-space-2) var(--lwc-space-3);
         cursor: default !important;
         pointer-events: none !important;
-        font-size: 0.9rem;
-        line-height: 1.2;
+        font-size: var(--lwc-type-sm);
+        line-height: 1.5;
     }
 
     .bioageform.bioage-biomarker-entry-ready #lwc-step-2 .toggle-icon {
@@ -548,8 +548,8 @@
         max-height: none !important;
         overflow: visible !important;
         padding: 0.55rem 0.65rem 0.65rem !important;
-        border-top: 1px solid rgba(148, 163, 184, 0.24);
-        background: var(--lwc-surface-muted, #fbfdff);
+        border-top: 1px solid var(--lwc-border);
+        background: var(--lwc-surface);
     }
 
     .bioageform.bioage-biomarker-entry-ready #lwc-step-2 .biomarker-card-content .input-group {
@@ -616,10 +616,11 @@
 .bioage-biomarker-progress {
     margin: 0.4rem 0 0.7rem;
     color: var(--lwc-muted, #526373);
-    font-size: 0.86rem;
+    font-size: var(--lwc-type-sm);
     font-weight: 700;
     text-align: center;
     font-variant-numeric: tabular-nums;
+    line-height: 1.5;
 }
 
 .bioage-biomarker-progress--complete {
@@ -629,9 +630,9 @@
 .bioage-biomarker-error {
     margin: 0.45rem 0 0;
     color: var(--danger-color, #b4233b);
-    font-size: 0.82rem;
-    font-weight: 700;
-    line-height: 1.3;
+    font-size: var(--lwc-type-sm);
+    font-weight: 400;
+    line-height: 1.5;
 }
 
 .bioageform .bioage-update-date-fieldset {
@@ -830,7 +831,7 @@
     padding: 0.85rem 0.8rem;
     box-sizing: border-box;
     border: 1px solid var(--lwc-border, rgba(0, 188, 212, 0.28));
-    border-radius: 6px;
+    border-radius: var(--lwc-radius-md);
     background: var(--lwc-surface-muted, #f4f7f9);
     color: var(--lwc-ink, #2d3748);
     font-size: 0.95rem;
@@ -851,11 +852,11 @@
     min-width: 5.4rem;
     padding: 0.3rem 0.45rem;
     box-sizing: border-box;
-    border-radius: 6px;
+    border-radius: var(--lwc-radius-sm);
     background: var(--lwc-accent-soft, rgba(0, 188, 212, 0.12));
     color: var(--lwc-accent-hover, #087f91);
     font-size: 2rem;
-    font-weight: 800;
+    font-weight: 700;
     line-height: 1.05;
     font-variant-numeric: tabular-nums;
     text-align: center;
@@ -867,17 +868,19 @@
 }
 
 .bioage-rank-label {
-    font-size: 0.72rem;
-    font-weight: 800;
+    font-size: var(--lwc-type-sm);
+    font-weight: 700;
     letter-spacing: 0;
-    text-transform: uppercase;
+    text-transform: none;
     color: var(--lwc-muted, #526373);
+    line-height: 1.5;
 }
 
 .bioage-rank-meta,
 .bioage-rank-percentile {
     font-size: 0.92rem;
-    line-height: 1.35;
+    line-height: 1.5;
+    font-weight: 400;
 }
 
 .bioage-rank-meta {
@@ -886,13 +889,13 @@
 
 .bioage-rank-percentile {
     color: var(--lwc-accent-hover, #087f91);
-    font-weight: 700;
+    font-weight: 400;
 }
 
 .bioage-rank-neighbors {
     margin-top: 0.75rem;
     display: grid;
-    gap: 0.15rem;
+    gap: var(--lwc-space-1);
 }
 
 .bioage-rank-row {
@@ -900,11 +903,11 @@
     grid-template-columns: 3.2rem 24px minmax(0, 1fr) auto;
     align-items: center;
     gap: 0.65rem;
-    min-height: 2.05rem;
+    min-height: 44px;
     padding: 0.2rem 0.45rem;
-    border-radius: 6px;
-    font-size: 0.88rem;
-    line-height: 1.25;
+    border-radius: var(--lwc-radius-sm);
+    font-size: var(--lwc-type-sm);
+    line-height: 1.5;
 }
 
 .bioage-rank-row.current {
@@ -927,10 +930,10 @@
     height: 24px;
     aspect-ratio: 1 / 1;
     overflow: hidden;
-    border: 2px solid var(--lwc-accent, var(--primary-color, #19c3d1));
+    border: 1px solid var(--lwc-border);
     border-radius: 50%;
     background: var(--lwc-surface-muted, #eef3f7);
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+    box-shadow: none;
     box-sizing: border-box;
     pointer-events: none;
 }
@@ -977,7 +980,8 @@
 
 .bioage-rank-loading {
     color: var(--lwc-muted, #526373);
-    font-size: 0.9rem;
+    font-size: var(--lwc-type-body);
+    line-height: 1.5;
 }
 
 .bioage-rank-error {
@@ -1103,22 +1107,23 @@
 .bioage-rank-number {
     min-width: 4.75rem;
     padding: 0.5rem 0.65rem;
-    border-radius: 8px;
+    border-radius: var(--lwc-radius-sm);
     background: var(--lwc-accent-soft, rgba(0, 188, 212, 0.1));
     color: var(--lwc-accent-hover, #007c89);
     font-size: 2rem;
     line-height: 1;
-    font-weight: 800;
+    font-weight: 700;
     text-align: center;
     font-family: 'Roboto', sans-serif;
 }
 
 .bioage-rank-label {
-    font-size: 0.75rem;
-    text-transform: uppercase;
+    font-size: var(--lwc-type-sm);
+    text-transform: none;
     letter-spacing: 0;
     color: var(--lwc-muted, #526373);
     font-weight: 700;
+    line-height: 1.5;
 }
 
 .bioage-rank-context {
@@ -1201,4 +1206,11 @@
         justify-self: start;
         font-size: 0.82rem;
     }
+}
+
+.bioage-rank-row-name a:focus-visible {
+    outline: 2px solid var(--lwc-accent);
+    outline-offset: 2px;
+    border-radius: var(--lwc-radius-sm);
+    text-decoration: underline;
 }

--- a/LongevityWorldCup.Website/wwwroot/css/error-system.css
+++ b/LongevityWorldCup.Website/wwwroot/css/error-system.css
@@ -83,7 +83,7 @@ h1 {
     margin: 0;
     color: var(--error-ink);
     font-size: clamp(2rem, 6vw, 3.25rem);
-    line-height: 1.05;
+    line-height: 1.15;
     text-wrap: initial;
     white-space: nowrap;
 }
@@ -95,6 +95,7 @@ h1 {
 
 .note {
     color: var(--error-muted);
+    line-height: 1.5;
 }
 
 button {
@@ -106,6 +107,9 @@ button {
     box-shadow: none;
     font-weight: 700;
     transition: background-color var(--lwc-duration-fast, 140ms) var(--lwc-ease, cubic-bezier(0.2, 0, 0, 1));
+    font-family: inherit;
+    font-size: 1rem;
+    line-height: 1.5;
 }
 
 button:hover,
@@ -151,7 +155,8 @@ button:focus-visible {
 
     .code {
         margin-left: auto;
-        font-size: .72rem;
+        font-size: 0.875rem;
+        line-height: 1.5;
     }
 
     .card-body {

--- a/LongevityWorldCup.Website/wwwroot/css/longevitymaxxing.css
+++ b/LongevityWorldCup.Website/wwwroot/css/longevitymaxxing.css
@@ -1002,8 +1002,9 @@
 
 .lmx-mention-option strong {
     border-radius: 4px;
-    background: var(--lmx-accent-soft);
-    color: var(--lmx-accent-hover);
+    background: transparent;
+    color: var(--lmx-accent);
+    font-weight: 700;
 }
 
 .lmx-mention-avatar {
@@ -1032,8 +1033,9 @@
     align-items: center;
     padding: 0.55rem;
     color: var(--lmx-muted);
-    font-size: 0.84rem;
-    font-weight: 750;
+    font-size: var(--lwc-type-sm);
+    font-weight: 400;
+    line-height: 1.5;
 }
 
 .lmx-note-photo-field {
@@ -1061,8 +1063,9 @@
 
 .lmx-photo-count {
     color: var(--lmx-muted);
-    font-size: 0.82rem;
-    font-weight: 800;
+    font-size: var(--lwc-type-sm);
+    font-weight: 400;
+    line-height: 1.5;
 }
 
 .lmx-note-photo-grid {
@@ -1094,9 +1097,9 @@
 }
 
 .lmx-note-photo:hover {
-    border-color: rgba(0, 188, 212, 0.58);
-    box-shadow: 0 8px 18px rgba(15, 23, 42, 0.14);
-    transform: translateY(-1px);
+    border-color: var(--lmx-accent);
+    box-shadow: var(--lwc-shadow-sm);
+    transform: none;
 }
 
 .lmx-note-photo:focus-visible {
@@ -1127,8 +1130,8 @@
     position: absolute;
     top: 0.35rem;
     right: 0.35rem;
-    width: 2rem;
-    height: 2rem;
+    width: 44px;
+    height: 44px;
     border: 0;
     border-radius: 999px;
     display: inline-flex;
@@ -1137,6 +1140,8 @@
     background: rgba(15, 23, 42, 0.84);
     color: #ffffff;
     cursor: pointer;
+    min-width: 44px;
+    min-height: 44px;
 }
 
 .lmx-note-photo-remove:focus-visible {
@@ -1483,9 +1488,10 @@
 
 .lmx-profile-identity em {
     color: var(--lmx-muted);
-    font-size: 0.78rem;
+    font-size: var(--lwc-type-sm);
     font-style: normal;
-    font-weight: 800;
+    font-weight: 400;
+    line-height: 1.5;
 }
 
 .lmx-athlete-options {
@@ -1730,9 +1736,9 @@
 .lmx-profile-upload {
     display: grid;
     grid-template-columns: 3.25rem minmax(0, 1fr);
-    gap: 0.65rem;
+    gap: var(--lwc-space-2);
     align-items: center;
-    padding: 0.65rem;
+    padding: var(--lwc-space-3);
     border: 1px solid var(--lmx-border);
     border-radius: 8px;
     background: var(--lmx-surface-muted);
@@ -1741,7 +1747,7 @@
 .lmx-profile-preview {
     width: 3.25rem;
     height: 3.25rem;
-    border: 2px solid var(--secondary-color, #ff4f87);
+    border: 1px solid var(--lmx-border-strong);
     border-radius: 999px;
     background: var(--lmx-surface-muted);
     overflow: hidden;
@@ -1972,11 +1978,11 @@
 }
 
 .lmx-compact-button {
-    min-height: 2.15rem;
+    min-height: 44px;
     padding: 0.32rem 0.62rem;
-    border-radius: 999px;
-    font-size: 0.78rem;
-    font-weight: 900;
+    border-radius: var(--lwc-radius-md);
+    font-size: var(--lwc-type-sm);
+    font-weight: 700;
 }
 
 .lmx-button.slack {
@@ -1989,9 +1995,12 @@
 }
 
 .lmx-button:disabled {
-    opacity: 0.6;
+    opacity: 1;
     cursor: not-allowed;
     box-shadow: none;
+    color: var(--lmx-muted);
+    background: var(--lmx-surface-muted);
+    border: 1px solid var(--lmx-border);
 }
 
 .lmx-button[aria-busy="true"] {
@@ -2478,7 +2487,7 @@ body.lmx-checkin-dialog-open {
 
 .lmx-recent-remark strong {
     color: var(--lmx-ink);
-    font-size: 0.82rem;
+    font-size: var(--lwc-type-sm);
 }
 
 .lmx-recent-remark p {
@@ -2503,7 +2512,7 @@ body.lmx-checkin-dialog-open {
 .lmx-discussion-post-author {
     min-width: 0;
     display: grid;
-    gap: 0.08rem;
+    gap: var(--lwc-space-1);
 }
 
 .lmx-discussion-author-identity {
@@ -2555,10 +2564,10 @@ a.lmx-discussion-author-identity:focus-visible {
 
 .lmx-discussion-post-author small {
     padding-left: 2.45rem;
-    color: var(--lmx-subtle);
-    font-size: 0.74rem;
-    font-weight: 700;
-    line-height: 1.3;
+    color: var(--lmx-muted);
+    font-size: var(--lwc-type-sm);
+    font-weight: 400;
+    line-height: 1.5;
 }
 
 .lmx-discussion-reply {
@@ -2574,8 +2583,8 @@ a.lmx-discussion-author-identity:focus-visible {
     justify-content: center;
     gap: 0.35rem;
     font: inherit;
-    font-size: 0.78rem;
-    font-weight: 850;
+    font-size: var(--lwc-type-sm);
+    font-weight: 700;
     cursor: pointer;
     touch-action: manipulation;
     transition:
@@ -2596,8 +2605,8 @@ a.lmx-discussion-author-identity:focus-visible {
 
 .lmx-discussion-replies {
     margin-top: 0.65rem;
-    padding-left: 0.7rem;
-    border-left: 2px solid rgba(20, 184, 166, 0.3);
+    padding-left: var(--lwc-space-3);
+    border-left: 2px solid var(--lmx-border);
 }
 
 .lmx-discussion-replies-toggle {
@@ -2607,8 +2616,8 @@ a.lmx-discussion-author-identity:focus-visible {
     background: transparent;
     color: var(--lmx-accent-hover);
     font: inherit;
-    font-size: 0.78rem;
-    font-weight: 850;
+    font-size: var(--lwc-type-sm);
+    font-weight: 700;
     cursor: pointer;
 }
 
@@ -2653,7 +2662,7 @@ a.lmx-discussion-author-identity:focus-visible {
     display: inline;
     margin: 0;
     color: var(--lmx-ink);
-    font-size: 0.78rem;
+    font-size: var(--lwc-type-sm);
 }
 
 .lmx-discussion-reply-time {
@@ -2664,9 +2673,10 @@ a.lmx-discussion-author-identity:focus-visible {
 
 .lmx-discussion-reply-meta time,
 .lmx-discussion-edited {
-    color: var(--lmx-subtle);
-    font-size: 0.7rem;
-    font-weight: 700;
+    color: var(--lmx-muted);
+    font-size: var(--lwc-type-sm);
+    font-weight: 400;
+    line-height: 1.5;
 }
 
 .lmx-discussion-edited::before {
@@ -2686,12 +2696,12 @@ a.lmx-discussion-author-identity:focus-visible {
     min-height: 44px;
     padding: 0 0.42rem;
     border: 0;
-    border-radius: 6px;
+    border-radius: var(--lwc-radius-sm);
     background: transparent;
-    color: var(--lmx-subtle);
+    color: var(--lmx-muted);
     font: inherit;
-    font-size: 0.72rem;
-    font-weight: 800;
+    font-size: var(--lwc-type-sm);
+    font-weight: 700;
     cursor: pointer;
 }
 
@@ -2714,12 +2724,13 @@ a.lmx-discussion-author-identity:focus-visible {
     display: block;
     margin: 0.16rem 0 0 2.2rem;
     color: var(--lmx-ink);
-    font-size: 0.84rem;
-    line-height: 1.4;
+    font-size: var(--lwc-type-body);
+    line-height: 1.5;
     overflow: visible;
     white-space: pre-wrap;
     overflow-wrap: anywhere;
     -webkit-line-clamp: unset;
+    margin-top: var(--lwc-space-1);
 }
 
 .lmx-discussion-reply-item [data-discussion-reply-body][hidden] {
@@ -2733,9 +2744,14 @@ a.lmx-discussion-author-identity:focus-visible {
 
 .lmx-discussion-reply-status:not(:empty) {
     margin: 0.25rem 0 0 2.2rem;
-    color: var(--lmx-danger, #b4233b);
-    font-size: 0.75rem;
-    font-weight: 750;
+    color: var(--lmx-ink);
+    font-size: var(--lwc-type-sm);
+    font-weight: 400;
+    line-height: 1.5;
+    padding: var(--lwc-space-2);
+    border-left: 3px solid var(--lmx-danger);
+    border-radius: var(--lwc-radius-sm);
+    background: var(--lmx-surface-muted);
 }
 
 .lmx-discussion-reply-slot:not(:empty) {
@@ -2744,8 +2760,8 @@ a.lmx-discussion-author-identity:focus-visible {
 
 .lmx-discussion-reply-composer {
     display: grid;
-    gap: 0.55rem;
-    padding: 0.65rem;
+    gap: var(--lwc-space-2);
+    padding: var(--lwc-space-3);
     border: 1px solid var(--lmx-border);
     border-radius: 8px;
     background: var(--lmx-surface);
@@ -2755,8 +2771,9 @@ a.lmx-discussion-author-identity:focus-visible {
     display: grid;
     gap: 0.35rem;
     color: var(--lmx-ink);
-    font-size: 0.8rem;
-    font-weight: 850;
+    font-size: var(--lwc-type-sm);
+    font-weight: 700;
+    line-height: 1.5;
 }
 
 .lmx-discussion-reply-composer textarea {
@@ -2771,17 +2788,21 @@ a.lmx-discussion-author-identity:focus-visible {
     color: var(--lmx-ink);
     font: inherit;
     font-weight: 400;
+    font-size: var(--lwc-type-body);
+    line-height: 1.5;
 }
 
 .lmx-discussion-reply-composer textarea:focus {
-    border-color: rgba(0, 188, 212, 0.72);
-    outline: 3px solid rgba(0, 188, 212, 0.22);
+    border-color: var(--lmx-accent);
+    outline: 2px solid var(--lmx-accent);
+    outline-offset: 2px;
 }
 
 .lmx-discussion-reply-actions {
     display: flex;
     justify-content: flex-end;
-    gap: 0.45rem;
+    gap: var(--lwc-space-2);
+    flex-wrap: wrap;
 }
 
 .lmx-discussion-reply-actions .lmx-button {
@@ -2897,9 +2918,9 @@ a.lmx-note-mention:focus-visible {
 
 .lmx-call-when small {
     color: var(--lmx-muted);
-    font-size: 0.82rem;
-    font-weight: 700;
-    line-height: 1.2;
+    font-size: var(--lwc-type-sm);
+    font-weight: 400;
+    line-height: 1.5;
 }
 
 .lmx-call-countdown {
@@ -2912,16 +2933,17 @@ a.lmx-note-mention:focus-visible {
 
 .lmx-call-countdown small {
     color: var(--lmx-muted);
-    font-size: 0.72rem;
-    font-weight: 800;
-    line-height: 1;
+    font-size: var(--lwc-type-sm);
+    font-weight: 400;
+    line-height: 1.5;
 }
 
 .lmx-call-countdown b {
     color: var(--lmx-ink);
-    font-size: 0.9rem;
-    font-weight: 900;
-    line-height: 1;
+    font-size: var(--lwc-type-sm);
+    font-weight: 700;
+    line-height: 1.5;
+    font-variant-numeric: tabular-nums;
 }
 
 .lmx-call-countdown.live {
@@ -3472,8 +3494,9 @@ a.lmx-note-mention:focus-visible {
 
 .lmx-checkin-switcher span {
     color: var(--lmx-muted);
-    font-size: 0.82rem;
-    font-weight: 800;
+    font-size: var(--lwc-type-sm);
+    font-weight: 400;
+    line-height: 1.5;
 }
 
 .lmx-checkin-switcher em {
@@ -3483,10 +3506,11 @@ a.lmx-note-mention:focus-visible {
     border-radius: 999px;
     background: var(--lmx-surface-muted);
     color: var(--lmx-ink);
-    font-size: 0.68rem;
+    font-size: var(--lwc-type-xs);
     font-style: normal;
-    font-weight: 900;
-    text-transform: uppercase;
+    font-weight: 700;
+    text-transform: none;
+    line-height: 1.5;
 }
 
 .lmx-checkin-switcher button[aria-pressed="true"] {
@@ -3532,13 +3556,14 @@ a.lmx-note-mention:focus-visible {
 
 .lmx-practice-note {
     display: grid;
-    gap: 0.15rem;
+    gap: var(--lwc-space-1);
     margin: 0.55rem 0 0.25rem;
     padding: 0.65rem 0.7rem;
-    border: 1px solid rgba(14, 165, 233, 0.24);
+    border: 1px solid var(--lmx-border);
     border-radius: 8px;
-    background: var(--lmx-accent-soft);
+    background: var(--lmx-surface-muted);
     color: var(--lmx-ink);
+    border-left: 3px solid var(--lmx-accent);
 }
 
 .lmx-practice-note strong {
@@ -3607,12 +3632,12 @@ a.lmx-note-mention:focus-visible {
     gap: 0.55rem;
     margin: 0.65rem 0;
     padding: 0.7rem;
-    border: 1px solid rgba(var(--lmx-habit-soft), 0.15);
-    border-radius: 13px;
+    border: 1px solid var(--lmx-border);
+    border-radius: var(--lwc-radius-lg);
     background:
         radial-gradient(circle at 0 0, rgba(var(--lmx-habit-soft), 0.07), transparent 34%),
         var(--lmx-surface);
-    box-shadow: 0 1px 3px rgba(15, 23, 42, 0.04);
+    box-shadow: none;
 }
 
 .lmx-question-label {
@@ -3620,8 +3645,8 @@ a.lmx-note-mention:focus-visible {
     align-items: center;
     gap: 0.6rem;
     color: var(--lmx-ink);
-    font-weight: 900;
-    line-height: 1.35;
+    font-weight: 700;
+    line-height: 1.5;
 }
 
 .lmx-question-label i,
@@ -3632,10 +3657,10 @@ a.lmx-note-mention:focus-visible {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    border-radius: 9px;
+    border-radius: var(--lwc-radius-md);
     background: var(--lmx-habit-accent);
     color: #ffffff;
-    box-shadow: inset 0 0 0 1px rgba(var(--lmx-habit-soft), 0.1);
+    box-shadow: none;
 }
 
 .lmx-question-icon svg {
@@ -4525,4 +4550,9 @@ a.lmx-note-mention:focus-visible {
     .lmx-answer-option > .lmx-answer-face {
         transition: none;
     }
+}
+
+#lmxProfilePictureStatus:empty,
+#lmxEditStatus:empty {
+    display: none;
 }

--- a/LongevityWorldCup.Website/wwwroot/css/play-menu.css
+++ b/LongevityWorldCup.Website/wwwroot/css/play-menu.css
@@ -435,7 +435,7 @@ html.play-panel-transitioning .play-hub-panel--entering {
     top: 30px;
     width: 148px;
     padding: 6px 12px;
-    font-size: 0.7rem;
+    font-size: var(--lwc-type-xs);
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0;
@@ -444,6 +444,7 @@ html.play-panel-transitioning .play-hub-panel--entering {
     background: linear-gradient(135deg, #f7931a 0%, #ffc107 50%, #f7931a 100%);
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
     transform: rotate(45deg);
+    line-height: 1.25;
 }
 
 .play-join-card h2 {
@@ -496,6 +497,7 @@ html.play-panel-transitioning .play-hub-panel--entering {
 .play-join-meta dd {
     margin: 0;
     color: var(--lwc-ink, #1e293b);
+    font-variant-numeric: tabular-nums;
 }
 
 .join-pro-entry-cell {
@@ -520,7 +522,7 @@ html.play-panel-transitioning .play-hub-panel--entering {
 .play-join-biomarkers {
     margin-top: 0.75rem;
     padding: 0.72rem 0.9rem 0.85rem;
-    border-radius: 10px;
+    border-radius: var(--lwc-radius-md);
     border: 1px solid var(--lwc-border, #e2e8f0);
     border-left: 3px solid var(--lwc-muted, #526373);
     background: var(--lwc-surface-muted, #f8fafc);
@@ -528,9 +530,9 @@ html.play-panel-transitioning .play-hub-panel--entering {
 }
 
 .play-join-card--pro .play-join-biomarkers {
-    border-color: var(--lwc-success, #1f7a38);
-    border-left-color: var(--lwc-success, var(--main-action-color, #16a34a));
-    background: var(--lwc-success-soft, #ecfdf5);
+    border-color: var(--lwc-border);
+    border-left-color: var(--lwc-success);
+    background: var(--lwc-surface-muted);
 }
 
 .play-join-biomarkers details {
@@ -545,11 +547,12 @@ html.play-panel-transitioning .play-hub-panel--entering {
     min-height: 44px;
     cursor: pointer;
     list-style: none;
-    font-size: 0.75rem;
+    font-size: var(--lwc-type-sm);
     font-weight: 700;
-    text-transform: uppercase;
+    text-transform: none;
     letter-spacing: 0;
     color: var(--lwc-muted, #526373);
+    line-height: 1.5;
 }
 
 .play-join-card--pro .play-join-biomarkers summary {
@@ -583,8 +586,8 @@ html.play-panel-transitioning .play-hub-panel--entering {
 .play-join-biomarkers ul {
     margin: 0;
     padding-left: 1.1rem;
-    font-size: 0.82rem;
-    line-height: 1.35;
+    font-size: var(--lwc-type-sm);
+    line-height: 1.5;
     color: var(--lwc-ink, #334155);
 }
 
@@ -1618,4 +1621,14 @@ html.play-panel-transitioning .play-hub-panel--entering {
     html.play-panel-transitioning .play-hub-panel--entering {
         animation: none;
     }
+}
+
+.play-join-biomarkers li + li {
+    margin-top: var(--lwc-space-1);
+}
+
+.play-join-biomarkers summary:focus-visible {
+    outline: 3px solid var(--lwc-accent);
+    outline-offset: 3px;
+    border-radius: var(--lwc-radius-sm);
 }

--- a/LongevityWorldCup.Website/wwwroot/error/502.html
+++ b/LongevityWorldCup.Website/wwwroot/error/502.html
@@ -296,7 +296,7 @@
       }
     }
   </style>
-  <link rel="stylesheet" href="/css/error-system.css?v=20260719-1">
+  <link rel="stylesheet" href="/css/error-system.css?v=20260905-1">
 </head>
 <body>
   <main class="error-card" aria-labelledby="page-title">

--- a/LongevityWorldCup.Website/wwwroot/error/503.html
+++ b/LongevityWorldCup.Website/wwwroot/error/503.html
@@ -296,7 +296,7 @@
       }
     }
   </style>
-  <link rel="stylesheet" href="/css/error-system.css?v=20260719-1">
+  <link rel="stylesheet" href="/css/error-system.css?v=20260905-1">
 </head>
 <body>
   <main class="error-card" aria-labelledby="page-title">

--- a/LongevityWorldCup.Website/wwwroot/error/504.html
+++ b/LongevityWorldCup.Website/wwwroot/error/504.html
@@ -296,7 +296,7 @@
       }
     }
   </style>
-  <link rel="stylesheet" href="/css/error-system.css?v=20260719-1">
+  <link rel="stylesheet" href="/css/error-system.css?v=20260905-1">
 </head>
 <body>
   <main class="error-card" aria-labelledby="page-title">

--- a/LongevityWorldCup.Website/wwwroot/misc-pages/about.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/about.html
@@ -628,9 +628,30 @@
                         break;
                     }
                 }
+                if (window.scrollY > 0 && window.scrollY + window.innerHeight >= document.documentElement.scrollHeight - 1) {
+                    current = headings[headings.length - 1];
+                }
                 if (current) {
                     setActive(current.id);
                 }
+            };
+
+            const synchronizeNavigationFromHash = () => {
+                let id;
+                try {
+                    id = decodeURIComponent(window.location.hash.slice(1));
+                } catch {
+                    id = "";
+                }
+                const target = headings.find(heading => heading.id === id);
+                navigationDestination = null;
+                if (target) {
+                    const bounds = target.getBoundingClientRect();
+                    if (bounds.bottom > getOffset() && bounds.top < window.innerHeight) {
+                        navigationDestination = { target, scrollY: window.scrollY, hash: window.location.hash };
+                    }
+                }
+                updateActiveFromScroll();
             };
 
             let ticking = false;
@@ -649,8 +670,17 @@
                 updateActiveFromScroll();
                 revealActiveLink();
             });
+            window.addEventListener("hashchange", () => window.requestAnimationFrame(synchronizeNavigationFromHash));
+            window.addEventListener("pageshow", event => {
+                if (!event.persisted && window.location.hash) {
+                    synchronizeNavigationFromHash();
+                }
+            });
 
             updateActiveFromScroll();
+            if (window.location.hash) {
+                window.requestAnimationFrame(synchronizeNavigationFromHash);
+            }
         });
     </script>
 </body>

--- a/LongevityWorldCup.Website/wwwroot/misc-pages/about.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/about.html
@@ -549,6 +549,7 @@
             };
 
             let activeLink = null;
+            let navigationDestination = null;
             const revealActiveLink = () => {
                 const link = documentationNav?.querySelector("a:focus") || activeLink;
                 if (!documentationNav || !link || !window.matchMedia("(min-width: 901px)").matches) {
@@ -597,6 +598,7 @@
                     const top = target.getBoundingClientRect().top + window.scrollY - getOffset();
                     window.scrollTo({ top, behavior: "instant" });
                     history.pushState(null, "", link.getAttribute("href"));
+                    navigationDestination = { target, scrollY: window.scrollY, hash: window.location.hash };
                     setActive(target.id);
 
                     target.setAttribute("tabindex", "-1");
@@ -606,6 +608,17 @@
 
             const updateActiveFromScroll = () => {
                 const offset = getOffset() + 6;
+                // A section near the page end may be visible without reaching the offset.
+                // Honor that destination until the reader moves away from its landing position.
+                if (navigationDestination && window.scrollY === navigationDestination.scrollY &&
+                    window.location.hash === navigationDestination.hash) {
+                    const bounds = navigationDestination.target.getBoundingClientRect();
+                    if (bounds.bottom > offset && bounds.top < window.innerHeight) {
+                        setActive(navigationDestination.target.id);
+                        return;
+                    }
+                }
+                navigationDestination = null;
                 let current = headings[0];
 
                 for (const heading of headings) {
@@ -615,10 +628,6 @@
                         break;
                     }
                 }
-                if (window.scrollY > 0 && window.scrollY + window.innerHeight >= document.documentElement.scrollHeight - 1) {
-                    current = headings[headings.length - 1];
-                }
-
                 if (current) {
                     setActive(current.id);
                 }

--- a/LongevityWorldCup.Website/wwwroot/misc-pages/about.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/about.html
@@ -17,8 +17,9 @@
         }
 
         .documentation-nav {
+            --documentation-nav-offset: 4.25rem;
             position: sticky;
-            top: 4.25rem;
+            top: var(--documentation-nav-offset);
             display: grid;
             gap: 0.2rem;
             padding: 0.85rem 0.7rem 0.95rem;
@@ -26,6 +27,18 @@
             border-radius: 0 8px 8px 0;
             background: var(--lwc-surface-muted, #eef2f5);
             box-shadow: none;
+        }
+
+        @media (min-width: 901px) {
+            .documentation-nav {
+                box-sizing: border-box;
+                max-height: calc(100dvh - var(--documentation-nav-offset) - 1rem);
+                overflow-y: auto;
+                overscroll-behavior: contain;
+                scroll-padding-block: var(--lwc-space-2);
+                scrollbar-width: thin;
+                scrollbar-color: var(--lwc-border-strong) transparent;
+            }
         }
 
         .documentation-nav-title {

--- a/LongevityWorldCup.Website/wwwroot/misc-pages/about.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/about.html
@@ -548,16 +548,39 @@
                 return ((stickyHeader && stickyHeader.offsetHeight) || 52) + 18;
             };
 
+            let activeLink = null;
+            const revealActiveLink = () => {
+                const link = documentationNav?.querySelector("a:focus") || activeLink;
+                if (!documentationNav || !link || !window.matchMedia("(min-width: 901px)").matches) {
+                    return;
+                }
+
+                const pane = documentationNav.getBoundingClientRect();
+                const target = link.getBoundingClientRect();
+                const padding = parseFloat(getComputedStyle(documentationNav).scrollPaddingTop) || 0;
+                if (target.top < pane.top + padding) {
+                    documentationNav.scrollTop += target.top - pane.top - padding;
+                } else if (target.bottom > pane.bottom - padding) {
+                    documentationNav.scrollTop += target.bottom - pane.bottom + padding;
+                }
+            };
+
             const setActive = id => {
+                const previousActiveLink = activeLink;
+                activeLink = null;
                 navLinks.forEach(link => {
                     const active = decodeURIComponent(link.getAttribute("href").slice(1)) === id;
                     link.classList.toggle("is-active", active);
                     if (active) {
+                        activeLink = link;
                         link.setAttribute("aria-current", "location");
                     } else {
                         link.removeAttribute("aria-current");
                     }
                 });
+                if (activeLink !== previousActiveLink) {
+                    revealActiveLink();
+                }
             };
 
             navLinks.forEach(link => {
@@ -611,6 +634,10 @@
                     ticking = false;
                 });
             }, { passive: true });
+            window.addEventListener("resize", () => {
+                updateActiveFromScroll();
+                revealActiveLink();
+            });
 
             updateActiveFromScroll();
         });

--- a/LongevityWorldCup.Website/wwwroot/misc-pages/about.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/about.html
@@ -32,9 +32,10 @@
             margin: 0 0 0.35rem;
             padding: 0 0.45rem;
             color: var(--lwc-muted, #526373);
-            font-size: 0.78rem;
+            font-size: var(--lwc-type-sm);
             font-weight: 700;
-            text-transform: uppercase;
+            text-transform: none;
+            line-height: 1.5;
         }
 
         .documentation-nav-toggle {
@@ -48,13 +49,16 @@
         }
 
         .documentation-nav a {
-            display: block;
+            display: flex;
             padding: 0.38rem 0.45rem;
-            border-radius: 6px;
+            border-radius: var(--lwc-radius-sm);
             color: var(--lwc-ink, #334155);
-            font-size: 0.92rem;
-            line-height: 1.25;
+            font-size: var(--lwc-type-sm);
+            line-height: 1.5;
             text-decoration: none;
+            min-height: 44px;
+            box-sizing: border-box;
+            align-items: center;
         }
 
         .documentation-nav .documentation-nav-level-3 {
@@ -62,7 +66,8 @@
             padding-top: 0.28rem;
             padding-bottom: 0.28rem;
             color: var(--lwc-muted, #506176);
-            font-size: 0.86rem;
+            font-size: var(--lwc-type-sm);
+            line-height: 1.5;
         }
 
         .documentation-nav a:hover,
@@ -75,6 +80,7 @@
 
         .documentation-nav a.is-active {
             font-weight: 700;
+            box-shadow: inset 3px 0 0 var(--lwc-accent);
         }
 
         .documentation-nav .documentation-source-link {
@@ -190,6 +196,7 @@
             border-collapse: collapse;
             background: var(--lwc-surface, #ffffff);
             border-radius: 8px;
+            font-variant-numeric: tabular-nums;
         }
 
         .documentation-document th,
@@ -203,7 +210,7 @@
 
         .documentation-document th {
             color: var(--lwc-ink, #111827);
-            background: var(--lwc-accent-soft, rgba(0, 188, 212, 0.1));
+            background: var(--lwc-surface-muted);
             font-weight: 700;
         }
 
@@ -212,8 +219,9 @@
             padding-top: 1rem;
             border-top: 1px solid var(--lwc-border, rgba(0, 0, 0, 0.08));
             color: var(--lwc-muted, #506176);
-            font-size: 0.95rem;
+            font-size: var(--lwc-type-sm);
             text-align: left;
+            line-height: 1.5;
         }
 
         @media (max-width: 900px) {
@@ -242,7 +250,7 @@
                 min-height: 44px;
                 padding: 0.6rem 0.75rem;
                 border: 1px solid var(--lwc-border-strong, #71808d);
-                border-radius: 6px;
+                border-radius: var(--lwc-radius-md);
                 background: var(--lwc-surface, #ffffff);
                 color: var(--lwc-ink, #334155);
                 font: inherit;
@@ -265,6 +273,9 @@
             .documentation-nav-toggle-icon {
                 font-size: 1.25rem;
                 line-height: 1;
+                flex: 0 0 1.5rem;
+                width: 1.5rem;
+                text-align: center;
             }
 
             .documentation-nav-links {
@@ -371,17 +382,18 @@
                 gap: 0.35rem;
                 align-items: baseline;
                 color: var(--lwc-ink, #334155);
-                font-size: 0.86rem;
-                line-height: 1.28;
+                font-size: var(--lwc-type-sm);
+                line-height: 1.5;
             }
 
             .documentation-document tbody td::before {
                 content: attr(data-label);
                 color: var(--lwc-muted, #526373);
-                font-size: 0.68rem;
-                font-weight: 800;
-                text-transform: uppercase;
+                font-size: var(--lwc-type-xs);
+                font-weight: 700;
+                text-transform: none;
                 letter-spacing: 0;
+                line-height: 1.5;
             }
 
             .documentation-document tbody td:first-child {
@@ -394,7 +406,8 @@
                 grid-row: 2;
                 font-size: 0.96rem;
                 font-weight: 700;
-                white-space: nowrap;
+                white-space: normal;
+                overflow-wrap: anywhere;
             }
 
             .documentation-document tbody td:nth-child(2)::before {
@@ -413,6 +426,19 @@
 
             .documentation-document tbody td:last-child::before {
                 white-space: nowrap;
+            }
+        }
+        .documentation-nav a:focus-visible {
+            outline: 2px solid var(--lwc-accent);
+            outline-offset: -2px;
+        }
+        @media (max-width: 600px) {
+            .documentation-document {
+                font-size: var(--lwc-type-body);
+                line-height: 1.65;
+            }
+            .documentation-document :is(p,li) {
+                line-height: 1.65;
             }
         }
     </style>

--- a/LongevityWorldCup.Website/wwwroot/misc-pages/about.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/about.html
@@ -591,14 +591,13 @@
                     }
 
                     event.preventDefault();
-                    const top = target.getBoundingClientRect().top + window.scrollY - getOffset();
-                    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-                    window.scrollTo({ top, behavior: reducedMotion ? "auto" : "smooth" });
-                    history.pushState(null, "", link.getAttribute("href"));
-                    setActive(target.id);
                     if (window.matchMedia("(max-width: 900px)").matches) {
                         setDocumentationNavOpen(false);
                     }
+                    const top = target.getBoundingClientRect().top + window.scrollY - getOffset();
+                    window.scrollTo({ top, behavior: "instant" });
+                    history.pushState(null, "", link.getAttribute("href"));
+                    setActive(target.id);
 
                     target.setAttribute("tabindex", "-1");
                     target.focus({ preventScroll: true });
@@ -615,6 +614,9 @@
                     } else {
                         break;
                     }
+                }
+                if (window.scrollY > 0 && window.scrollY + window.innerHeight >= document.documentElement.scrollHeight - 1) {
+                    current = headings[headings.length - 1];
                 }
 
                 if (current) {

--- a/LongevityWorldCup.Website/wwwroot/misc-pages/history.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/history.html
@@ -684,6 +684,7 @@
             };
 
             let activeLink = null;
+            let navigationDestination = null;
             const revealActiveLink = () => {
                 const link = documentationNav?.querySelector("a:focus") || activeLink;
                 if (!documentationNav || !link || !window.matchMedia("(min-width: 901px)").matches) {
@@ -732,6 +733,7 @@
                     const top = target.getBoundingClientRect().top + window.scrollY - getOffset();
                     window.scrollTo({ top, behavior: "instant" });
                     history.pushState(null, "", link.getAttribute("href"));
+                    navigationDestination = { target, scrollY: window.scrollY, hash: window.location.hash };
                     setActive(target.id);
 
                     target.setAttribute("tabindex", "-1");
@@ -741,6 +743,17 @@
 
             const updateActiveFromScroll = () => {
                 const offset = getOffset() + 6;
+                // A section near the page end may be visible without reaching the offset.
+                // Honor that destination until the reader moves away from its landing position.
+                if (navigationDestination && window.scrollY === navigationDestination.scrollY &&
+                    window.location.hash === navigationDestination.hash) {
+                    const bounds = navigationDestination.target.getBoundingClientRect();
+                    if (bounds.bottom > offset && bounds.top < window.innerHeight) {
+                        setActive(navigationDestination.target.id);
+                        return;
+                    }
+                }
+                navigationDestination = null;
                 let current = headings[0];
 
                 for (const heading of headings) {
@@ -750,10 +763,6 @@
                         break;
                     }
                 }
-                if (window.scrollY > 0 && window.scrollY + window.innerHeight >= document.documentElement.scrollHeight - 1) {
-                    current = headings[headings.length - 1];
-                }
-
                 if (current) {
                     setActive(current.id);
                 }

--- a/LongevityWorldCup.Website/wwwroot/misc-pages/history.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/history.html
@@ -17,8 +17,9 @@
         }
 
         .documentation-nav {
+            --documentation-nav-offset: 4.25rem;
             position: sticky;
-            top: 4.25rem;
+            top: var(--documentation-nav-offset);
             display: grid;
             gap: 0.2rem;
             padding: 0.85rem 0.7rem 0.95rem;
@@ -26,6 +27,18 @@
             border-radius: 0 8px 8px 0;
             background: var(--lwc-surface-muted, #eef2f5);
             box-shadow: none;
+        }
+
+        @media (min-width: 901px) {
+            .documentation-nav {
+                box-sizing: border-box;
+                max-height: calc(100dvh - var(--documentation-nav-offset) - 1rem);
+                overflow-y: auto;
+                overscroll-behavior: contain;
+                scroll-padding-block: var(--lwc-space-2);
+                scrollbar-width: thin;
+                scrollbar-color: var(--lwc-border-strong) transparent;
+            }
         }
 
         .documentation-nav-title {

--- a/LongevityWorldCup.Website/wwwroot/misc-pages/history.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/history.html
@@ -763,9 +763,30 @@
                         break;
                     }
                 }
+                if (window.scrollY > 0 && window.scrollY + window.innerHeight >= document.documentElement.scrollHeight - 1) {
+                    current = headings[headings.length - 1];
+                }
                 if (current) {
                     setActive(current.id);
                 }
+            };
+
+            const synchronizeNavigationFromHash = () => {
+                let id;
+                try {
+                    id = decodeURIComponent(window.location.hash.slice(1));
+                } catch {
+                    id = "";
+                }
+                const target = headings.find(heading => heading.id === id);
+                navigationDestination = null;
+                if (target) {
+                    const bounds = target.getBoundingClientRect();
+                    if (bounds.bottom > getOffset() && bounds.top < window.innerHeight) {
+                        navigationDestination = { target, scrollY: window.scrollY, hash: window.location.hash };
+                    }
+                }
+                updateActiveFromScroll();
             };
 
             let ticking = false;
@@ -784,8 +805,17 @@
                 updateActiveFromScroll();
                 revealActiveLink();
             });
+            window.addEventListener("hashchange", () => window.requestAnimationFrame(synchronizeNavigationFromHash));
+            window.addEventListener("pageshow", event => {
+                if (!event.persisted && window.location.hash) {
+                    synchronizeNavigationFromHash();
+                }
+            });
 
             updateActiveFromScroll();
+            if (window.location.hash) {
+                window.requestAnimationFrame(synchronizeNavigationFromHash);
+            }
         });
     </script>
 </body>

--- a/LongevityWorldCup.Website/wwwroot/misc-pages/history.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/history.html
@@ -683,16 +683,39 @@
                 return ((stickyHeader && stickyHeader.offsetHeight) || 52) + 18;
             };
 
+            let activeLink = null;
+            const revealActiveLink = () => {
+                const link = documentationNav?.querySelector("a:focus") || activeLink;
+                if (!documentationNav || !link || !window.matchMedia("(min-width: 901px)").matches) {
+                    return;
+                }
+
+                const pane = documentationNav.getBoundingClientRect();
+                const target = link.getBoundingClientRect();
+                const padding = parseFloat(getComputedStyle(documentationNav).scrollPaddingTop) || 0;
+                if (target.top < pane.top + padding) {
+                    documentationNav.scrollTop += target.top - pane.top - padding;
+                } else if (target.bottom > pane.bottom - padding) {
+                    documentationNav.scrollTop += target.bottom - pane.bottom + padding;
+                }
+            };
+
             const setActive = id => {
+                const previousActiveLink = activeLink;
+                activeLink = null;
                 navLinks.forEach(link => {
                     const active = decodeURIComponent(link.getAttribute("href").slice(1)) === id;
                     link.classList.toggle("is-active", active);
                     if (active) {
+                        activeLink = link;
                         link.setAttribute("aria-current", "location");
                     } else {
                         link.removeAttribute("aria-current");
                     }
                 });
+                if (activeLink !== previousActiveLink) {
+                    revealActiveLink();
+                }
             };
 
             navLinks.forEach(link => {
@@ -746,6 +769,10 @@
                     ticking = false;
                 });
             }, { passive: true });
+            window.addEventListener("resize", () => {
+                updateActiveFromScroll();
+                revealActiveLink();
+            });
 
             updateActiveFromScroll();
         });

--- a/LongevityWorldCup.Website/wwwroot/misc-pages/history.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/history.html
@@ -726,14 +726,13 @@
                     }
 
                     event.preventDefault();
-                    const top = target.getBoundingClientRect().top + window.scrollY - getOffset();
-                    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-                    window.scrollTo({ top, behavior: reducedMotion ? "auto" : "smooth" });
-                    history.pushState(null, "", link.getAttribute("href"));
-                    setActive(target.id);
                     if (window.matchMedia("(max-width: 900px)").matches) {
                         setDocumentationNavOpen(false);
                     }
+                    const top = target.getBoundingClientRect().top + window.scrollY - getOffset();
+                    window.scrollTo({ top, behavior: "instant" });
+                    history.pushState(null, "", link.getAttribute("href"));
+                    setActive(target.id);
 
                     target.setAttribute("tabindex", "-1");
                     target.focus({ preventScroll: true });
@@ -750,6 +749,9 @@
                     } else {
                         break;
                     }
+                }
+                if (window.scrollY > 0 && window.scrollY + window.innerHeight >= document.documentElement.scrollHeight - 1) {
+                    current = headings[headings.length - 1];
                 }
 
                 if (current) {

--- a/LongevityWorldCup.Website/wwwroot/misc-pages/history.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/history.html
@@ -32,9 +32,10 @@
             margin: 0 0 0.35rem;
             padding: 0 0.45rem;
             color: var(--lwc-muted, #526373);
-            font-size: 0.78rem;
+            font-size: var(--lwc-type-sm);
             font-weight: 700;
-            text-transform: uppercase;
+            text-transform: none;
+            line-height: 1.5;
         }
 
         .documentation-nav-toggle {
@@ -48,13 +49,16 @@
         }
 
         .documentation-nav a {
-            display: block;
+            display: flex;
             padding: 0.38rem 0.45rem;
-            border-radius: 6px;
+            border-radius: var(--lwc-radius-sm);
             color: var(--lwc-ink, #334155);
-            font-size: 0.92rem;
-            line-height: 1.25;
+            font-size: var(--lwc-type-sm);
+            line-height: 1.5;
             text-decoration: none;
+            min-height: 44px;
+            box-sizing: border-box;
+            align-items: center;
         }
 
         .documentation-nav .documentation-nav-level-3 {
@@ -62,7 +66,8 @@
             padding-top: 0.28rem;
             padding-bottom: 0.28rem;
             color: var(--lwc-muted, #506176);
-            font-size: 0.86rem;
+            font-size: var(--lwc-type-sm);
+            line-height: 1.5;
         }
 
         .documentation-nav a:hover,
@@ -75,6 +80,7 @@
 
         .documentation-nav a.is-active {
             font-weight: 700;
+            box-shadow: inset 3px 0 0 var(--lwc-accent);
         }
 
         .documentation-nav .documentation-source-link {
@@ -190,6 +196,7 @@
             border-collapse: collapse;
             background: var(--lwc-surface, #ffffff);
             border-radius: 8px;
+            font-variant-numeric: tabular-nums;
         }
 
         .documentation-document th,
@@ -203,7 +210,7 @@
 
         .documentation-document th {
             color: var(--lwc-ink, #111827);
-            background: var(--lwc-accent-soft, rgba(0, 188, 212, 0.1));
+            background: var(--lwc-surface-muted);
             font-weight: 700;
         }
 
@@ -212,8 +219,9 @@
             padding-top: 1rem;
             border-top: 1px solid var(--lwc-border, rgba(0, 0, 0, 0.08));
             color: var(--lwc-muted, #506176);
-            font-size: 0.95rem;
+            font-size: var(--lwc-type-sm);
             text-align: left;
+            line-height: 1.5;
         }
 
         @media (max-width: 900px) {
@@ -242,7 +250,7 @@
                 min-height: 44px;
                 padding: 0.6rem 0.75rem;
                 border: 1px solid var(--lwc-border-strong, #71808d);
-                border-radius: 6px;
+                border-radius: var(--lwc-radius-md);
                 background: var(--lwc-surface, #ffffff);
                 color: var(--lwc-ink, #334155);
                 font: inherit;
@@ -265,6 +273,9 @@
             .documentation-nav-toggle-icon {
                 font-size: 1.25rem;
                 line-height: 1;
+                flex: 0 0 1.5rem;
+                width: 1.5rem;
+                text-align: center;
             }
 
             .documentation-nav-links {
@@ -371,17 +382,18 @@
                 gap: 0.35rem;
                 align-items: baseline;
                 color: var(--lwc-ink, #334155);
-                font-size: 0.86rem;
-                line-height: 1.28;
+                font-size: var(--lwc-type-sm);
+                line-height: 1.5;
             }
 
             .documentation-document tbody td::before {
                 content: attr(data-label);
                 color: var(--lwc-muted, #526373);
-                font-size: 0.68rem;
-                font-weight: 800;
-                text-transform: uppercase;
+                font-size: var(--lwc-type-xs);
+                font-weight: 700;
+                text-transform: none;
                 letter-spacing: 0;
+                line-height: 1.5;
             }
 
             .documentation-document tbody td:first-child {
@@ -394,7 +406,8 @@
                 grid-row: 2;
                 font-size: 0.96rem;
                 font-weight: 700;
-                white-space: nowrap;
+                white-space: normal;
+                overflow-wrap: anywhere;
             }
 
             .documentation-document tbody td:nth-child(2)::before {
@@ -413,6 +426,19 @@
 
             .documentation-document tbody td:last-child::before {
                 white-space: nowrap;
+            }
+        }
+        .documentation-nav a:focus-visible {
+            outline: 2px solid var(--lwc-accent);
+            outline-offset: -2px;
+        }
+        @media (max-width: 600px) {
+            .documentation-document {
+                font-size: var(--lwc-type-body);
+                line-height: 1.65;
+            }
+            .documentation-document :is(p,li) {
+                line-height: 1.65;
             }
         }
     </style>

--- a/LongevityWorldCup.Website/wwwroot/misc-pages/media.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/media.html
@@ -13,9 +13,10 @@
             max-width: 820px;
             margin: 2.25rem auto;
             padding: 1.75rem;
-            background: rgba(255, 255, 255, 0.74);
-            border-radius: 16px;
-            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+            background: var(--lwc-surface);
+            border-radius: var(--lwc-radius-lg);
+            box-shadow: var(--lwc-shadow-sm);
+            border: 1px solid var(--lwc-border);
         }
 
         .media-kit-title {
@@ -48,12 +49,13 @@
             gap: 0.5rem;
             min-height: 44px;
             padding: 0.78rem 1.25rem;
-            border-radius: 999px;
-            background: #0a7c0a;
-            color: #fff;
+            border-radius: var(--lwc-radius-md);
+            background: var(--lwc-accent);
+            color: var(--lwc-on-accent);
             font-weight: 700;
             text-decoration: none;
-            box-shadow: 0 8px 18px rgba(10, 124, 10, 0.16);
+            box-shadow: none;
+            transition: background-color var(--lwc-duration-fast) var(--lwc-ease);
         }
 
         .media-kit-primary-download::before {
@@ -66,8 +68,8 @@
 
         .media-kit-primary-download:hover,
         .media-kit-primary-download:focus-visible {
-            background: #096f09;
-            color: #fff;
+            background: var(--lwc-accent-hover);
+            color: var(--lwc-on-accent);
         }
 
         .media-kit-preview {
@@ -93,20 +95,20 @@
             box-sizing: border-box;
             display: grid;
             grid-template-columns: minmax(0, 1fr) auto;
-            gap: 0.75rem;
+            gap: var(--lwc-space-3);
             align-items: center;
             padding: 0.65rem 0.75rem;
-            border: 1px solid rgba(0, 0, 0, 0.06);
-            border-radius: 10px;
-            background: rgba(248, 250, 252, 0.8);
+            border: 1px solid var(--lwc-border);
+            border-radius: var(--lwc-radius-md);
+            background: var(--lwc-surface-muted);
         }
 
         .media-file-name {
             min-width: 0;
-            color: #243446;
+            color: var(--lwc-ink);
             overflow-wrap: break-word;
             word-break: normal;
-            line-height: 1.35;
+            line-height: 1.5;
         }
 
         .media-file-button {
@@ -117,13 +119,15 @@
             gap: 0.38rem;
             min-height: 44px;
             padding: 0.42rem 0.75rem;
-            border: 1px solid rgba(0, 188, 212, 0.34);
-            border-radius: 7px;
-            background: rgba(255, 255, 255, 0.9);
-            color: var(--primary-color);
+            border: 1px solid var(--lwc-border-strong);
+            border-radius: var(--lwc-radius-md);
+            background: var(--lwc-surface);
+            color: var(--lwc-accent);
             font-weight: 700;
             cursor: pointer;
             white-space: nowrap;
+            font-family: inherit;
+            font-size: var(--lwc-type-sm);
         }
 
         .media-file-button::before {
@@ -220,6 +224,38 @@
                 font-size: 0.95rem;
             }
         }
+        .media-kit-primary-download:focus-visible, .media-file-button:focus-visible {
+            outline: 3px solid var(--lwc-accent);
+            outline-offset: 3px;
+        }
+        @media (max-width: 600px) {
+            .media-kit-panel {
+                border-radius: var(--lwc-radius-lg);
+            }
+            .media-kit-primary-download, .media-file-button, .media-file-name {
+                font-size: var(--lwc-type-sm);
+                line-height: 1.5;
+            }
+            .media-file-button {
+                border-radius: var(--lwc-radius-md);
+                padding-block: var(--lwc-space-2);
+            }
+        }
+        .media-kit-intro {
+            color: var(--lwc-ink);
+        }
+        .media-kit-loading {
+            color: var(--lwc-muted);
+        }
+        .media-kit-fallback {
+            padding: var(--lwc-space-3);
+            border: 1px solid var(--lwc-border);
+            border-left: 3px solid var(--lwc-warning);
+            border-radius: var(--lwc-radius-md);
+            background: var(--lwc-surface-muted);
+            color: var(--lwc-ink);
+            text-align: left;
+        }
     </style>
 </head>
 <body>
@@ -307,6 +343,7 @@
 
                     const btn = document.createElement('button');
                     btn.textContent = 'Download';
+                    btn.setAttribute('aria-label', `Download ${path.split('/').pop()}`);
                     btn.className = 'media-file-button';
                     btn.addEventListener('click', async () => {
                         const file = zip.file(path);

--- a/LongevityWorldCup.Website/wwwroot/misc-pages/ruleset.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/ruleset.html
@@ -650,16 +650,39 @@
                 return ((stickyHeader && stickyHeader.offsetHeight) || 52) + 18;
             };
 
+            let activeLink = null;
+            const revealActiveLink = () => {
+                const link = documentationNav?.querySelector("a:focus") || activeLink;
+                if (!documentationNav || !link || !window.matchMedia("(min-width: 901px)").matches) {
+                    return;
+                }
+
+                const pane = documentationNav.getBoundingClientRect();
+                const target = link.getBoundingClientRect();
+                const padding = parseFloat(getComputedStyle(documentationNav).scrollPaddingTop) || 0;
+                if (target.top < pane.top + padding) {
+                    documentationNav.scrollTop += target.top - pane.top - padding;
+                } else if (target.bottom > pane.bottom - padding) {
+                    documentationNav.scrollTop += target.bottom - pane.bottom + padding;
+                }
+            };
+
             const setActive = id => {
+                const previousActiveLink = activeLink;
+                activeLink = null;
                 navLinks.forEach(link => {
                     const active = decodeURIComponent(link.getAttribute("href").slice(1)) === id;
                     link.classList.toggle("is-active", active);
                     if (active) {
+                        activeLink = link;
                         link.setAttribute("aria-current", "location");
                     } else {
                         link.removeAttribute("aria-current");
                     }
                 });
+                if (activeLink !== previousActiveLink) {
+                    revealActiveLink();
+                }
             };
 
             navLinks.forEach(link => {
@@ -713,6 +736,10 @@
                     ticking = false;
                 });
             }, { passive: true });
+            window.addEventListener("resize", () => {
+                updateActiveFromScroll();
+                revealActiveLink();
+            });
 
             updateActiveFromScroll();
         });

--- a/LongevityWorldCup.Website/wwwroot/misc-pages/ruleset.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/ruleset.html
@@ -17,8 +17,9 @@
         }
 
         .documentation-nav {
+            --documentation-nav-offset: 4.25rem;
             position: sticky;
-            top: 4.25rem;
+            top: var(--documentation-nav-offset);
             display: grid;
             gap: 0.2rem;
             padding: 0.85rem 0.7rem 0.95rem;
@@ -26,6 +27,18 @@
             border-radius: 0 8px 8px 0;
             background: var(--lwc-surface-muted, #eef2f5);
             box-shadow: none;
+        }
+
+        @media (min-width: 901px) {
+            .documentation-nav {
+                box-sizing: border-box;
+                max-height: calc(100dvh - var(--documentation-nav-offset) - 1rem);
+                overflow-y: auto;
+                overscroll-behavior: contain;
+                scroll-padding-block: var(--lwc-space-2);
+                scrollbar-width: thin;
+                scrollbar-color: var(--lwc-border-strong) transparent;
+            }
         }
 
         .documentation-nav-title {

--- a/LongevityWorldCup.Website/wwwroot/misc-pages/ruleset.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/ruleset.html
@@ -651,6 +651,7 @@
             };
 
             let activeLink = null;
+            let navigationDestination = null;
             const revealActiveLink = () => {
                 const link = documentationNav?.querySelector("a:focus") || activeLink;
                 if (!documentationNav || !link || !window.matchMedia("(min-width: 901px)").matches) {
@@ -699,6 +700,7 @@
                     const top = target.getBoundingClientRect().top + window.scrollY - getOffset();
                     window.scrollTo({ top, behavior: "instant" });
                     history.pushState(null, "", link.getAttribute("href"));
+                    navigationDestination = { target, scrollY: window.scrollY, hash: window.location.hash };
                     setActive(target.id);
 
                     target.setAttribute("tabindex", "-1");
@@ -708,6 +710,17 @@
 
             const updateActiveFromScroll = () => {
                 const offset = getOffset() + 6;
+                // A section near the page end may be visible without reaching the offset.
+                // Honor that destination until the reader moves away from its landing position.
+                if (navigationDestination && window.scrollY === navigationDestination.scrollY &&
+                    window.location.hash === navigationDestination.hash) {
+                    const bounds = navigationDestination.target.getBoundingClientRect();
+                    if (bounds.bottom > offset && bounds.top < window.innerHeight) {
+                        setActive(navigationDestination.target.id);
+                        return;
+                    }
+                }
+                navigationDestination = null;
                 let current = headings[0];
 
                 for (const heading of headings) {
@@ -717,10 +730,6 @@
                         break;
                     }
                 }
-                if (window.scrollY > 0 && window.scrollY + window.innerHeight >= document.documentElement.scrollHeight - 1) {
-                    current = headings[headings.length - 1];
-                }
-
                 if (current) {
                     setActive(current.id);
                 }

--- a/LongevityWorldCup.Website/wwwroot/misc-pages/ruleset.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/ruleset.html
@@ -32,9 +32,10 @@
             margin: 0 0 0.35rem;
             padding: 0 0.45rem;
             color: var(--lwc-muted, #526373);
-            font-size: 0.78rem;
+            font-size: var(--lwc-type-sm);
             font-weight: 700;
-            text-transform: uppercase;
+            text-transform: none;
+            line-height: 1.5;
         }
 
         .documentation-nav-toggle {
@@ -48,13 +49,16 @@
         }
 
         .documentation-nav a {
-            display: block;
+            display: flex;
             padding: 0.38rem 0.45rem;
-            border-radius: 6px;
+            border-radius: var(--lwc-radius-sm);
             color: var(--lwc-ink, #334155);
-            font-size: 0.92rem;
-            line-height: 1.25;
+            font-size: var(--lwc-type-sm);
+            line-height: 1.5;
             text-decoration: none;
+            min-height: 44px;
+            box-sizing: border-box;
+            align-items: center;
         }
 
         .documentation-nav .documentation-nav-level-3 {
@@ -62,7 +66,8 @@
             padding-top: 0.28rem;
             padding-bottom: 0.28rem;
             color: var(--lwc-muted, #506176);
-            font-size: 0.86rem;
+            font-size: var(--lwc-type-sm);
+            line-height: 1.5;
         }
 
         .documentation-nav a:hover,
@@ -75,6 +80,7 @@
 
         .documentation-nav a.is-active {
             font-weight: 700;
+            box-shadow: inset 3px 0 0 var(--lwc-accent);
         }
 
         .documentation-nav .documentation-source-link {
@@ -190,6 +196,7 @@
             border-collapse: collapse;
             background: var(--lwc-surface, #ffffff);
             border-radius: 8px;
+            font-variant-numeric: tabular-nums;
         }
 
         .documentation-document th,
@@ -203,7 +210,7 @@
 
         .documentation-document th {
             color: var(--lwc-ink, #111827);
-            background: var(--lwc-accent-soft, rgba(0, 188, 212, 0.1));
+            background: var(--lwc-surface-muted);
             font-weight: 700;
         }
 
@@ -212,8 +219,9 @@
             padding-top: 1rem;
             border-top: 1px solid var(--lwc-border, rgba(0, 0, 0, 0.08));
             color: var(--lwc-muted, #506176);
-            font-size: 0.95rem;
+            font-size: var(--lwc-type-sm);
             text-align: left;
+            line-height: 1.5;
         }
 
         @media (max-width: 900px) {
@@ -242,7 +250,7 @@
                 min-height: 44px;
                 padding: 0.6rem 0.75rem;
                 border: 1px solid var(--lwc-border-strong, #71808d);
-                border-radius: 6px;
+                border-radius: var(--lwc-radius-md);
                 background: var(--lwc-surface, #ffffff);
                 color: var(--lwc-ink, #334155);
                 font: inherit;
@@ -265,6 +273,9 @@
             .documentation-nav-toggle-icon {
                 font-size: 1.25rem;
                 line-height: 1;
+                flex: 0 0 1.5rem;
+                width: 1.5rem;
+                text-align: center;
             }
 
             .documentation-nav-links {
@@ -371,17 +382,18 @@
                 gap: 0.35rem;
                 align-items: baseline;
                 color: var(--lwc-ink, #334155);
-                font-size: 0.86rem;
-                line-height: 1.28;
+                font-size: var(--lwc-type-sm);
+                line-height: 1.5;
             }
 
             .documentation-document tbody td::before {
                 content: attr(data-label);
                 color: var(--lwc-muted, #526373);
-                font-size: 0.68rem;
-                font-weight: 800;
-                text-transform: uppercase;
+                font-size: var(--lwc-type-xs);
+                font-weight: 700;
+                text-transform: none;
                 letter-spacing: 0;
+                line-height: 1.5;
             }
 
             .documentation-document tbody td:first-child {
@@ -394,7 +406,8 @@
                 grid-row: 2;
                 font-size: 0.96rem;
                 font-weight: 700;
-                white-space: nowrap;
+                white-space: normal;
+                overflow-wrap: anywhere;
             }
 
             .documentation-document tbody td:nth-child(2)::before {
@@ -413,6 +426,19 @@
 
             .documentation-document tbody td:last-child::before {
                 white-space: nowrap;
+            }
+        }
+        .documentation-nav a:focus-visible {
+            outline: 2px solid var(--lwc-accent);
+            outline-offset: -2px;
+        }
+        @media (max-width: 600px) {
+            .documentation-document {
+                font-size: var(--lwc-type-body);
+                line-height: 1.65;
+            }
+            .documentation-document :is(p,li) {
+                line-height: 1.65;
             }
         }
     </style>

--- a/LongevityWorldCup.Website/wwwroot/misc-pages/ruleset.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/ruleset.html
@@ -693,14 +693,13 @@
                     }
 
                     event.preventDefault();
-                    const top = target.getBoundingClientRect().top + window.scrollY - getOffset();
-                    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-                    window.scrollTo({ top, behavior: reducedMotion ? "auto" : "smooth" });
-                    history.pushState(null, "", link.getAttribute("href"));
-                    setActive(target.id);
                     if (window.matchMedia("(max-width: 900px)").matches) {
                         setDocumentationNavOpen(false);
                     }
+                    const top = target.getBoundingClientRect().top + window.scrollY - getOffset();
+                    window.scrollTo({ top, behavior: "instant" });
+                    history.pushState(null, "", link.getAttribute("href"));
+                    setActive(target.id);
 
                     target.setAttribute("tabindex", "-1");
                     target.focus({ preventScroll: true });
@@ -717,6 +716,9 @@
                     } else {
                         break;
                     }
+                }
+                if (window.scrollY > 0 && window.scrollY + window.innerHeight >= document.documentElement.scrollHeight - 1) {
+                    current = headings[headings.length - 1];
                 }
 
                 if (current) {

--- a/LongevityWorldCup.Website/wwwroot/misc-pages/ruleset.html
+++ b/LongevityWorldCup.Website/wwwroot/misc-pages/ruleset.html
@@ -730,9 +730,30 @@
                         break;
                     }
                 }
+                if (window.scrollY > 0 && window.scrollY + window.innerHeight >= document.documentElement.scrollHeight - 1) {
+                    current = headings[headings.length - 1];
+                }
                 if (current) {
                     setActive(current.id);
                 }
+            };
+
+            const synchronizeNavigationFromHash = () => {
+                let id;
+                try {
+                    id = decodeURIComponent(window.location.hash.slice(1));
+                } catch {
+                    id = "";
+                }
+                const target = headings.find(heading => heading.id === id);
+                navigationDestination = null;
+                if (target) {
+                    const bounds = target.getBoundingClientRect();
+                    if (bounds.bottom > getOffset() && bounds.top < window.innerHeight) {
+                        navigationDestination = { target, scrollY: window.scrollY, hash: window.location.hash };
+                    }
+                }
+                updateActiveFromScroll();
             };
 
             let ticking = false;
@@ -751,8 +772,17 @@
                 updateActiveFromScroll();
                 revealActiveLink();
             });
+            window.addEventListener("hashchange", () => window.requestAnimationFrame(synchronizeNavigationFromHash));
+            window.addEventListener("pageshow", event => {
+                if (!event.persisted && window.location.hash) {
+                    synchronizeNavigationFromHash();
+                }
+            });
 
             updateActiveFromScroll();
+            if (window.location.hash) {
+                window.requestAnimationFrame(synchronizeNavigationFromHash);
+            }
         });
     </script>
 </body>

--- a/LongevityWorldCup.Website/wwwroot/partials/guess-my-age.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/guess-my-age.html
@@ -488,7 +488,7 @@
         border: none;
         border-radius: 999px;
         cursor: pointer;
-        font-weight: 600;
+        font-weight: 700;
         transition: background var(--lwc-duration-normal, 220ms) var(--lwc-ease, ease), color var(--lwc-duration-normal, 220ms) var(--lwc-ease, ease), transform var(--lwc-duration-fast, 140ms) var(--lwc-ease, ease), box-shadow var(--lwc-duration-fast, 140ms) var(--lwc-ease, ease);
     }
 
@@ -1295,8 +1295,9 @@
         box-shadow: 0 0.55rem 1.35rem rgba(0,0,0,.26);
     }
     #detailsModal .gma-btn:focus-visible {
-        outline: none;
-        box-shadow: var(--athlete-modal-focus, 0 0 0 3px rgba(0,188,212,.34));
+        outline: 3px solid var(--lwc-accent-bright);
+        box-shadow: none;
+        outline-offset: 3px;
     }
     #detailsModal .gma-btn--ghost {
         background: rgba(246,244,237,.06);
@@ -1621,6 +1622,26 @@
 
         #detailsModal .modal-content.guess-mode > .gma-trollface-container {
             bottom: 0;
+        }
+    }
+    #detailsModal .gma-actions {
+        gap: var(--lwc-space-2);
+    }
+
+    #detailsModal #gmaBubble,
+    #detailsModal #gmaRealBubble {
+        font-variant-numeric: tabular-nums;
+    }
+
+    #detailsModal #gmaStatus {
+        font-size: var(--lwc-type-sm);
+        line-height: 1.5;
+    }
+
+    @media (max-width: 420px) {
+        #detailsModal .gma-btn--ghost {
+            font-size: var(--lwc-type-sm);
+            line-height: 1.5;
         }
     }
 </style>

--- a/LongevityWorldCup.Website/wwwroot/play/edit-profile.html
+++ b/LongevityWorldCup.Website/wwwroot/play/edit-profile.html
@@ -56,11 +56,13 @@
             width: 100%;
             max-height: min(12rem, 36vh);
             overflow-y: auto;
-            box-shadow: 0 12px 24px rgba(15, 23, 42, 0.16);
+            box-shadow: var(--lwc-shadow-md);
             box-sizing: border-box;
             z-index: 9999;
             scrollbar-width: thin;
             scrollbar-color: rgba(96, 125, 139, 0.45) transparent;
+            overscroll-behavior: contain;
+            scroll-padding-block: var(--lwc-space-1);
         }
 
             .autocomplete-items div {
@@ -68,12 +70,12 @@
                 align-items: center;
                 min-height: 44px;
                 padding: 0.6rem 0.7rem;
-                border-radius: 6px;
+                border-radius: var(--lwc-radius-sm);
                 box-sizing: border-box;
                 color: var(--lwc-ink, #2d3748);
                 cursor: pointer;
                 font-size: 1rem;
-                line-height: 1.25;
+                line-height: 1.5;
             }
 
                 .autocomplete-items div + div {
@@ -117,7 +119,7 @@
             border-radius: 8px;
             font-size: 1rem;
             font-family: inherit;
-            line-height: 1.35;
+            line-height: 1.5;
             transition: border-color var(--lwc-duration-fast, 140ms) var(--lwc-ease, ease), box-shadow var(--lwc-duration-fast, 140ms) var(--lwc-ease, ease);
             background-color: var(--lwc-surface, #fff);
             color: var(--lwc-ink, #17212b);
@@ -172,13 +174,14 @@
             max-height: calc(100dvh - 1.5rem);
             overflow: auto;
             border: 1px solid var(--lwc-border, rgba(15, 23, 42, 0.12));
-            border-radius: 8px;
-            box-shadow: 0 24px 60px rgba(15, 23, 42, 0.28);
+            border-radius: var(--lwc-radius-lg);
+            box-shadow: var(--lwc-shadow-md);
             display: flex;
             flex-direction: column;
             align-items: center;
             justify-content: center;
             gap: 0.95rem;
+            overscroll-behavior: contain;
         }
 
         .cropper-dialog-title {
@@ -481,7 +484,14 @@
             }
 
             #editOptionsGroup {
-                gap: 0.55rem;
+                gap: var(--lwc-space-2);
+            }
+
+            #flagDisplayInput,
+            #personalLinkInput,
+            #mediaContactInput,
+            #whyDisplayInput {
+                padding-block: var(--lwc-space-2);
             }
         }
 
@@ -555,6 +565,28 @@
             #takeProfileSelfieButton {
                 display: inline-flex;
             }
+        }
+        .edit-profile-main :is(input,select,textarea):focus {
+            border-color: var(--lwc-accent);
+            box-shadow: 0 0 0 3px var(--lwc-accent-soft);
+            outline: 2px solid var(--lwc-accent);
+            outline-offset: 1px;
+        }
+        .edit-profile-main .field-requirement {
+            font-size: var(--lwc-type-sm);
+            line-height: 1.5;
+        }
+        #whyDisplayInput {
+            resize: vertical;
+        }
+        .edit-profile-main .option-button.icon-only {
+            background: var(--lwc-surface-muted);
+            color: var(--lwc-muted);
+            border-color: var(--lwc-border);
+        }
+        .edit-profile-main .option-button.icon-only:hover {
+            background: var(--lwc-accent-soft);
+            color: var(--lwc-accent);
         }
     </style>
 </head>


### PR DESCRIPTION
Small supporting text, inconsistent controls, and crowded form states made profile editing, Challenge discussions, and reference pages harder to use. This applies 100 focused polish refinements using the shared typography, spacing, focus, and surface rules.

- Make media downloads, track details, calculator progress, and rank previews easier to read and operate.
- Refine profile inputs, restore controls, flag suggestions, and photo cropping; keep fields clear of the action dock on short desktop screens.
- Improve Challenge replies, mentions, check-in controls, profile feedback, and community-call details across light and dark themes.
- Improve document reading, contents navigation, and mobile tables through the canonical page generator; regenerate About, Ruleset, and History. Constrain desktop contents to the viewport and reveal the active section within that pane. Immediate section jumps keep the heading, focus, and marker in sync; mobile contents collapse before positioning the destination.
- Polish Guess My Age controls and service-error pages, including the standalone error stylesheet cache version.

Validation: all 1,328 tests passed, including 25 document-navigation checks covering short and tall screens, keyboard reachability, active-section visibility, stable scrolling, section selection, direct fragments, reading to the page end, and Back across all three documents. The repo-owned Playwright runtime also passed 108 local browser scenarios across 390px light, 320px dark, 1280px light, and 1280px dark layouts, with no horizontal overflow. Profile/action-dock regression coverage includes 1280×720. Twenty before/after comparison sheets were generated and reviewed locally; composition preserves every screenshot pixel.

Follow-up to #857. Related to #72.

<details>
<summary>100 polish refinements</summary>

1. Media kit: use the shared neutral card, border, radius and small shadow
2. Media kit: bring the main download into the teal action hierarchy
3. Media kit: use the semantic action hover color
4. Media kit: show an explicit keyboard outline on both download controls
5. Media kit: quiet file rows with neutral surfaces and standard corners
6. Media kit: pair file-name and intro colors with the current theme
7. Media kit: make individual downloads neutral secondary actions
8. Media kit: keep compact filenames and download labels readable at 320px
9. Media kit: group fallback feedback with a visible recovery context
10. Media kit: expose each download filename to assistive technology
11. Track choice: make biomarker disclosure text readable without all caps
12. Track choice: give expanded biomarker lists a readable rhythm
13. Track choice: separate the expanded biomarker names with a small gap
14. Track choice: outline keyboard-focused biomarker disclosures
15. Track choice: regularize the biomarker panel corners
16. Track choice: keep the Pro panel neutral with a semantic leading edge
17. Track choice: align prices and testing-window numerals
18. Track choice: increase the prize ribbon text to the compact badge scale
19. Profile edit: use a standard small radius on flag suggestions
20. Profile edit: use the shared overlay shadow on flag suggestions
21. Profile edit: use one visible teal focus treatment for editable fields
22. Profile edit: keep required and optional metadata readable beside labels
23. Profile edit: give a long motivation comfortable text leading
24. Profile edit: prevent horizontal textarea resizing from breaking the form
25. Profile edit: reduce the crop dialog shadow to the shared overlay elevation
26. Profile edit: style restore controls as quiet secondary actions
27. Calculator: align biomarker progress with the small text scale
28. Calculator: make validation explanations readable over multiple lines
29. Calculator: give biomarker names a clearer header rhythm on mobile
30. Calculator: remove the second tint from biomarker input areas
31. Calculator: space biomarker cards by the shared small gap
32. Calculator: give the rank preview standard card corners
33. Calculator: make the clock rank label readable in sentence case
34. Calculator: use standard small corners for the prominent rank number
35. Calculator: increase rank-neighbor row height for easier scanning
36. Calculator: calm the tiny rank-neighbor portrait frames
37. Calculator: use regular supporting percentile text
38. Calculator: show keyboard focus on rank-neighbor profile links
39. Calculator: make rank loading feedback readable at the body scale
40. Calculator: separate neighboring ranks with the standard small gap
41. Discussion: increase post dates and reply counts to readable small text
42. Discussion: use readable names in the compact recent-discussion list
43. Discussion: make Reply labels readable and use the loaded bold weight
44. Discussion: increase earlier-reply disclosure text to the small type scale
45. Discussion: make reply author names easier to scan
46. Discussion: give reply timestamps and edit markers readable regular text
47. Discussion: clarify edit and delete action labels
48. Discussion: use body-sized text for complete replies
49. Discussion: make composer labels readable without synthetic heavy weight
50. Discussion: keep reply entry at 16px to avoid mobile input zoom
51. Discussion: strengthen reply-field keyboard focus in both themes
52. Discussion: give reply composers consistent internal spacing
53. Discussion: let reply actions wrap cleanly on narrow screens
54. Discussion: group failed reply feedback into a readable error notice
55. Discussion: separate author identity from its timestamp
56. Discussion: use a neutral indentation guide for reply threads
57. Discussion: highlight matching mention text without a second colored tile
58. Discussion: make an empty mention search readable
59. Discussion: enlarge photo removal targets to 44px
60. Discussion: keep photo thumbnails still on hover
61. Challenge controls: keep disabled actions readable
62. Challenge photos: make remaining upload capacity readable
63. Challenge profile: collapse empty picture and save feedback spaces
64. Challenge profile: make identity metadata readable
65. Challenge profile: use a neutral frame for the saved portrait
66. Challenge profile: regularize upload panel spacing
67. Daily check-in: keep question boundaries neutral around category artwork
68. Daily check-in: improve question label rhythm and use real bold weight
69. Daily check-in: align category icon corners to the shared scale
70. Daily check-in: give practice information a neutral panel and teal leading edge
71. Daily check-in: make previous-day switcher dates readable
72. Daily check-in: keep switcher status badges compact and legible
73. Challenge controls: standardize compact action height and corners
74. Challenge home: make community call date and timezone readable
75. Challenge home: make countdown labels readable
76. Challenge home: stabilize countdown numbers and match their text scale
77. Documents: make the contents heading readable in sentence case
78. Documents: make desktop contents links comfortable targets that remain reachable on short screens
79. Documents: regularize the nested contents link typography
80. Documents: keep the current-section marker visible with shape and color as the reader moves
81. Documents: distinguish keyboard focus from the current-section highlight
82. Documents: align mobile contents toggle corners with standard controls
83. Documents: reserve a fixed slot for the contents toggle icon
84. Documents: keep mobile reading text at 16px with generous leading
85. Documents: align numbers in historical and rules tables
86. Documents: use a neutral table header surface
87. Documents: make mobile table labels readable without all caps
88. Documents: give mobile table values readable spacing
89. Documents: allow long names in mobile table cards to wrap
90. Documents: make the source footer a quiet readable secondary element
91. Age guessing: keep Skip labels readable on small phones
92. Age guessing: use the loaded bold weight for game commands
93. Age guessing: give grouped game actions a consistent gap
94. Age guessing: use a clear keyboard outline on game commands
95. Age guessing: stabilize the width of changing age numerals
96. Age guessing: keep retry feedback readable inside the game
97. Service errors: improve heading line spacing when messages wrap
98. Service errors: keep status-code badges legible on mobile
99. Service errors: use comfortable leading for explanation and recovery copy
100. Service errors: inherit the page font for the recovery action

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly CSS and client-side documentation navigation with new browser tests; no auth, payments, or server logic.
> 
> **Overview**
> This PR applies shared typography, spacing, focus, and surface tokens across profile editing, bio-age calculator, Challenge discussions, play/join flows, media kit, Guess My Age, and error pages, plus regenerates About/Ruleset/History from the markdown page generator.
> 
> **Documentation “On this page” navigation** is the largest behavioral change: desktop contents are capped to the viewport with an internal scroll pane, links become 44px targets, and JS now jumps sections instantly (no smooth scroll), keeps the active link visible in the pane, honors hash/back-forward, and marks the last section when scrolled to the page end. Mobile table cards and reading typography are tightened to match.
> 
> **Playwright coverage** adds document-navigation tests for short viewports, keyboard reachability, stable section jumps, and fragment/history sync. Error pages bump `error-system.css` to `?v=20260905-1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d769b3c8fbba5fb54486e0ca80875230882ad537. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->