### PR TITLE
Share social post retry handling

### DIFF
--- a/LongevityWorldCup.Tests/SocialJobIntegrationTests.cs
+++ b/LongevityWorldCup.Tests/SocialJobIntegrationTests.cs
@@ -227,6 +227,92 @@ public sealed class SocialJobIntegrationTests
         Assert.Equal(2, fixture.FacebookRequests.Count);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task XSend_RetriesMissingPostIdWithTheSameTextAndMedia(bool retrySucceeds)
+    {
+        var attempts = 0;
+        using var fixture = SocialJobFixture.Create(responseOverride: _ =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(++attempts == 2 && retrySucceeds
+                    ? """{"data":{"id":"tweet-1"}}"""
+                    : "{}")
+            });
+
+        var sent = await fixture.XEvents.TrySendAsync("Keep the original caption", ["media-1"]);
+
+        Assert.Equal(retrySucceeds, sent);
+        Assert.Equal(2, attempts);
+        foreach (var request in fixture.XRequests)
+        {
+            Assert.Equal("/2/tweets", request.RequestUri?.AbsolutePath);
+            var body = await request.Content!.ReadAsStringAsync();
+            Assert.Contains("\"text\":\"Keep the original caption\"", body, StringComparison.Ordinal);
+            Assert.Contains("\"media_ids\":[\"media-1\"]", body, StringComparison.Ordinal);
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ThreadsSend_DoesNotRestartAfterPermanentClientFailure(bool imagePost)
+    {
+        using var fixture = SocialJobFixture.Create(
+            enableThreads: true,
+            responseOverride: _ => new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent("""{"error":{"message":"Invalid parameter","code":100}}""")
+            });
+
+        var sent = imagePost
+            ? await fixture.ThreadsEvents.TrySendImageAsync("Keep the original caption", " https://example.test/image.png ")
+            : await fixture.ThreadsEvents.TrySendAsync("Keep the original caption");
+
+        Assert.False(sent);
+        var request = Assert.Single(fixture.ThreadsRequests);
+        Assert.Equal("/me/threads", request.RequestUri?.AbsolutePath);
+        var body = await request.Content!.ReadAsStringAsync();
+        Assert.Contains(imagePost ? "media_type=IMAGE" : "media_type=TEXT", body, StringComparison.Ordinal);
+        if (imagePost)
+            Assert.Contains("image_url=https%3A%2F%2Fexample.test%2Fimage.png", body, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task FacebookSend_RetriesMissingPostIdWithTheSamePayload(bool imagePost, bool retrySucceeds)
+    {
+        var attempts = 0;
+        using var fixture = SocialJobFixture.Create(
+            seedLeaderboardAssets: imagePost,
+            responseOverride: _ => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(++attempts == 2 && retrySucceeds
+                    ? """{"id":"facebook-1"}"""
+                    : "{}")
+            });
+
+        // A long title selects image mode while keeping the rendered body small.
+        var sent = imagePost
+            ? await fixture.FacebookEvents.TrySendEventAsync(
+                EventType.CustomEvent,
+                new string('a', 63207) + "\n\nRead [details](https://example.test).",
+                "retry-image")
+            : await fixture.FacebookEvents.TrySendAsync("Keep the original caption");
+
+        Assert.Equal(retrySucceeds, sent);
+        Assert.Equal(2, attempts);
+        Assert.All(fixture.FacebookRequests, request =>
+            Assert.Equal(imagePost ? "/v23.0/page-id/photos" : "/v23.0/page-id/feed", request.RequestUri?.AbsolutePath));
+        var firstBody = await fixture.FacebookRequests[0].Content!.ReadAsStringAsync();
+        Assert.Equal(firstBody, await fixture.FacebookRequests[1].Content!.ReadAsStringAsync());
+        Assert.Contains(imagePost ? "retry-image.png" : "message=Keep+the+original+caption", firstBody, StringComparison.Ordinal);
+    }
+
     [Fact]
     public async Task FacebookJob_CustomEventClaimPreventsImmediateDispatchDuplicate()
     {
@@ -353,7 +439,9 @@ public sealed class SocialJobIntegrationTests
             bool facebookSendSucceeds = true,
             Action? onFacebookRequest = null,
             bool seedLeaderboardAssets = false,
-            bool xMediaUploadSucceeds = true)
+            bool xMediaUploadSucceeds = true,
+            bool enableThreads = false,
+            Func<HttpRequestMessage, HttpResponseMessage>? responseOverride = null)
         {
             var root = Path.Combine(Path.GetTempPath(), "lwc-social-job-" + Guid.NewGuid().ToString("N"));
             Directory.CreateDirectory(Path.Combine(root, "athletes"));
@@ -370,7 +458,7 @@ public sealed class SocialJobIntegrationTests
                 XConsumerSecret = "x-consumer-secret",
                 XUserAccessToken = "x-user-token",
                 XUserAccessTokenSecret = "x-user-token-secret",
-                ThreadsAccessToken = null,
+                ThreadsAccessToken = enableThreads ? "threads-token" : null,
                 ThreadsAccessTokenExpiresAtUtc = DateTimeOffset.UtcNow.AddDays(60).ToString("o"),
                 FacebookPageId = "page-id",
                 FacebookPageAccessToken = "facebook-token"
@@ -391,13 +479,13 @@ public sealed class SocialJobIntegrationTests
 
             var xClient = new XApiClient(
                 new HttpClient(new RecordingHttpHandler(
-                    request => request.RequestUri?.AbsolutePath == "/1.1/media/upload.json"
+                    request => responseOverride?.Invoke(request) ?? (request.RequestUri?.AbsolutePath == "/1.1/media/upload.json"
                         ? xMediaUploadSucceeds
                             ? new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("""{"media_id_string":"media-1"}""") }
                             : new HttpResponseMessage(HttpStatusCode.InternalServerError) { Content = new StringContent("""{"error":"media boom"}""") }
                         : xSendSucceeds
                             ? new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("""{"data":{"id":"tweet-1"}}""") }
-                            : new HttpResponseMessage(HttpStatusCode.InternalServerError) { Content = new StringContent("""{"error":"boom"}""") },
+                            : new HttpResponseMessage(HttpStatusCode.InternalServerError) { Content = new StringContent("""{"error":"boom"}""") }),
                     xRequests)),
                 config,
                 env,
@@ -405,18 +493,18 @@ public sealed class SocialJobIntegrationTests
                 new XDevPreviewService(NullLogger<XDevPreviewService>.Instance, httpFactory, appConfig));
             var threadsClient = new ThreadsApiClient(
                 new HttpClient(new RecordingHttpHandler(
-                    _ => new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("""{"id":"threads-1","status":"FINISHED"}""") },
+                    request => responseOverride?.Invoke(request) ?? new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("""{"id":"threads-1","status":"FINISHED"}""") },
                     threadsRequests)),
                 config,
                 NullLogger<ThreadsApiClient>.Instance);
             var facebookClient = new FacebookApiClient(
                 new HttpClient(new RecordingHttpHandler(
-                    _ =>
+                    request =>
                     {
                         onFacebookRequest?.Invoke();
-                        return facebookSendSucceeds
+                        return responseOverride?.Invoke(request) ?? (facebookSendSucceeds
                             ? new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("""{"id":"facebook-1"}""") }
-                            : new HttpResponseMessage(HttpStatusCode.InternalServerError) { Content = new StringContent("""{"error":"boom"}""") };
+                            : new HttpResponseMessage(HttpStatusCode.InternalServerError) { Content = new StringContent("""{"error":"boom"}""") });
                     },
                     facebookRequests)),
                 config,
@@ -548,6 +636,7 @@ public sealed class SocialJobIntegrationTests
             foreach (var relativePath in new[]
                      {
                          Path.Combine("assets", "HdLogo.png"),
+                         Path.Combine("assets", "custom_event.png"),
                          Path.Combine("assets", "fonts", "Poppins-Bold.ttf"),
                          Path.Combine("assets", "fonts", "Poppins-Regular.ttf")
                      })
@@ -605,10 +694,10 @@ public sealed class SocialJobIntegrationTests
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             var recorded = new HttpRequestMessage(request.Method, request.RequestUri);
-            if (string.Equals(request.Content?.Headers.ContentType?.MediaType, "application/json", StringComparison.OrdinalIgnoreCase))
+            if (request.Content?.Headers.ContentType?.MediaType is "application/json" or "application/x-www-form-urlencoded")
             {
                 var body = await request.Content!.ReadAsStringAsync(cancellationToken);
-                recorded.Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json");
+                recorded.Content = new StringContent(body, System.Text.Encoding.UTF8, request.Content.Headers.ContentType.MediaType);
             }
             else if (request.Content?.Headers.ContentType is { } contentType)
             {

--- a/LongevityWorldCup.Tests/SocialPostRetryTests.cs
+++ b/LongevityWorldCup.Tests/SocialPostRetryTests.cs
@@ -1,0 +1,131 @@
+using LongevityWorldCup.Website.Business;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed class SocialPostRetryTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task SuccessfulSend_StopsAfterOneAttempt(bool retryMissingPostId)
+    {
+        var attempts = 0;
+        var logger = new RecordingLogger();
+
+        var sent = await SocialPostRetry.TrySendAsync(
+            () => Task.FromResult<string?>($"post-{++attempts}"),
+            logger, "Test send", "caption", retryMissingPostId);
+
+        Assert.True(sent);
+        Assert.Equal(1, attempts);
+        Assert.Empty(logger.Entries);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" \t")]
+    public async Task MissingPostId_DoesNotRetryWhenTheClientOwnsRetries(string? postId)
+    {
+        var attempts = 0;
+        var logger = new RecordingLogger();
+
+        var sent = await SocialPostRetry.TrySendAsync(
+            () =>
+            {
+                attempts++;
+                return Task.FromResult(postId);
+            },
+            logger, "Threads image send", "caption", retryMissingPostId: false);
+
+        Assert.False(sent);
+        Assert.Equal(1, attempts);
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Null(entry.Exception);
+        Assert.Equal("Threads image send", entry.Properties["Operation"]);
+        Assert.Equal("caption", entry.Properties["Text"]);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ThrownSend_RetriesAndCanSucceedRegardlessOfMissingIdPolicy(bool retryMissingPostId)
+    {
+        var failure = new HttpRequestException("Connection interrupted");
+        var attempts = 0;
+        var logger = new RecordingLogger();
+
+        var sent = await SocialPostRetry.TrySendAsync(
+            () => ++attempts == 1 ? throw failure : Task.FromResult<string?>("post-2"),
+            logger, "Test send", "caption", retryMissingPostId);
+
+        Assert.True(sent);
+        Assert.Equal(2, attempts);
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Same(failure, entry.Exception);
+        Assert.Equal(1, entry.Properties["Attempt"]);
+        Assert.Equal(2, entry.Properties["MaxAttempts"]);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task FaultedSends_StopAfterTwoAttemptsAndLogTheFinalException(bool retryMissingPostId)
+    {
+        var failures = new[] { new HttpRequestException("First failure"), new HttpRequestException("Final failure") };
+        var attempts = 0;
+        var logger = new RecordingLogger();
+
+        var sent = await SocialPostRetry.TrySendAsync(
+            () => Task.FromException<string?>(failures[attempts++]),
+            logger, "Test send", "caption", retryMissingPostId);
+
+        Assert.False(sent);
+        Assert.Equal(2, attempts);
+        Assert.Equal([LogLevel.Warning, LogLevel.Error], logger.Entries.Select(entry => entry.Level));
+        Assert.Same(failures[0], logger.Entries[0].Exception);
+        Assert.Same(failures[1], logger.Entries[1].Exception);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task MissingIdAndException_ShareOneRetryBudget(bool exceptionFirst)
+    {
+        var failure = new HttpRequestException("Send failed");
+        var attempts = 0;
+        var logger = new RecordingLogger();
+
+        var sent = await SocialPostRetry.TrySendAsync(
+            () => (++attempts == 1) == exceptionFirst
+                ? Task.FromException<string?>(failure)
+                : Task.FromResult<string?>(null),
+            logger, "Test send", "caption", retryMissingPostId: true);
+
+        Assert.False(sent);
+        Assert.Equal(2, attempts);
+        Assert.Equal(LogLevel.Warning, logger.Entries[0].Level);
+        Assert.Equal(exceptionFirst ? LogLevel.Warning : LogLevel.Error, logger.Entries[1].Level);
+        Assert.Same(failure, logger.Entries[exceptionFirst ? 0 : 1].Exception);
+    }
+
+    private sealed record LogEntry(LogLevel Level, Exception? Exception, Dictionary<string, object?> Properties);
+
+    private sealed class RecordingLogger : ILogger
+    {
+        public List<LogEntry> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            var properties = Assert.IsAssignableFrom<IEnumerable<KeyValuePair<string, object?>>>(state).ToDictionary();
+            Entries.Add(new LogEntry(logLevel, exception, properties));
+        }
+    }
+}

--- a/LongevityWorldCup.Website/Business/FacebookEventService.cs
+++ b/LongevityWorldCup.Website/Business/FacebookEventService.cs
@@ -38,44 +38,14 @@ public class FacebookEventService
         _ = await TrySendAsync(text);
     }
 
-    public async Task<bool> TrySendAsync(string text)
+    public Task<bool> TrySendAsync(string text)
     {
-        const int maxAttempts = 2;
-        const int retryDelayMs = 750;
-
-        for (var attempt = 1; attempt <= maxAttempts; attempt++)
-        {
-            try
-            {
-                var postId = await _facebook.SendPostAsync(text);
-                if (!string.IsNullOrWhiteSpace(postId))
-                    return true;
-
-                if (attempt < maxAttempts)
-                {
-                    _log.LogWarning("Facebook send returned no post id, retrying ({Attempt}/{MaxAttempts}): {Text}", attempt, maxAttempts, text);
-                    await Task.Delay(retryDelayMs);
-                    continue;
-                }
-
-                _log.LogWarning("Facebook send returned no post id after retries: {Text}", text);
-                return false;
-            }
-            catch (Exception ex)
-            {
-                if (attempt < maxAttempts)
-                {
-                    _log.LogWarning(ex, "Facebook send failed (attempt {Attempt}/{MaxAttempts}), retrying: {Text}", attempt, maxAttempts, text);
-                    await Task.Delay(retryDelayMs);
-                    continue;
-                }
-
-                _log.LogError(ex, "Facebook send failed after retries: {Text}", text);
-                return false;
-            }
-        }
-
-        return false;
+        return SocialPostRetry.TrySendAsync(
+            () => _facebook.SendPostAsync(text),
+            _log,
+            "Facebook send",
+            text,
+            retryMissingPostId: true);
     }
 
     public async Task SendEventAsync(EventType type, string rawText)
@@ -128,41 +98,12 @@ public class FacebookEventService
             imageAsset.Value.PublicUrl,
             plan.PostText.Length);
 
-        const int maxAttempts = 2;
-        const int retryDelayMs = 750;
-        for (var attempt = 1; attempt <= maxAttempts; attempt++)
-        {
-            try
-            {
-                var postId = await _facebook.SendPhotoPostAsync(plan.PostText, imageAsset.Value.PublicUrl);
-                if (!string.IsNullOrWhiteSpace(postId))
-                    return true;
-
-                if (attempt < maxAttempts)
-                {
-                    _log.LogWarning("Facebook image send returned no post id, retrying ({Attempt}/{MaxAttempts}): {Text}", attempt, maxAttempts, plan.PostText);
-                    await Task.Delay(retryDelayMs);
-                    continue;
-                }
-
-                _log.LogWarning("Facebook image send returned no post id after retries: {Text}", plan.PostText);
-                return false;
-            }
-            catch (Exception ex)
-            {
-                if (attempt < maxAttempts)
-                {
-                    _log.LogWarning(ex, "Facebook image send failed (attempt {Attempt}/{MaxAttempts}), retrying: {Text}", attempt, maxAttempts, plan.PostText);
-                    await Task.Delay(retryDelayMs);
-                    continue;
-                }
-
-                _log.LogError(ex, "Facebook image send failed after retries: {Text}", plan.PostText);
-                return false;
-            }
-        }
-
-        return false;
+        return await SocialPostRetry.TrySendAsync(
+            () => _facebook.SendPhotoPostAsync(plan.PostText, imageAsset.Value.PublicUrl),
+            _log,
+            "Facebook image send",
+            plan.PostText,
+            retryMissingPostId: true);
     }
 
     public string? TryBuildMessage(EventType type, string rawText, string? eventId = null, bool visibleOnWebsite = true)

--- a/LongevityWorldCup.Website/Business/SocialPostRetry.cs
+++ b/LongevityWorldCup.Website/Business/SocialPostRetry.cs
@@ -1,0 +1,52 @@
+namespace LongevityWorldCup.Website.Business;
+
+internal static class SocialPostRetry
+{
+    internal static async Task<bool> TrySendAsync(
+        Func<Task<string?>> send,
+        ILogger logger,
+        string operation,
+        string text,
+        bool retryMissingPostId)
+    {
+        const int maxAttempts = 2;
+        const int retryDelayMs = 750;
+
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            try
+            {
+                if (!string.IsNullOrWhiteSpace(await send()))
+                    return true;
+
+                if (!retryMissingPostId)
+                {
+                    logger.LogWarning("{Operation} returned no post id: {Text}", operation, text);
+                    return false;
+                }
+
+                if (attempt == maxAttempts)
+                {
+                    logger.LogWarning("{Operation} returned no post id after retries: {Text}", operation, text);
+                    return false;
+                }
+
+                logger.LogWarning("{Operation} returned no post id, retrying ({Attempt}/{MaxAttempts}): {Text}", operation, attempt, maxAttempts, text);
+            }
+            catch (Exception ex)
+            {
+                if (attempt == maxAttempts)
+                {
+                    logger.LogError(ex, "{Operation} failed after retries: {Text}", operation, text);
+                    return false;
+                }
+
+                logger.LogWarning(ex, "{Operation} failed (attempt {Attempt}/{MaxAttempts}), retrying: {Text}", operation, attempt, maxAttempts, text);
+            }
+
+            await Task.Delay(retryDelayMs);
+        }
+
+        return false;
+    }
+}

--- a/LongevityWorldCup.Website/Business/ThreadsEventService.cs
+++ b/LongevityWorldCup.Website/Business/ThreadsEventService.cs
@@ -43,72 +43,28 @@ public class ThreadsEventService
         _ = await TrySendAsync(text);
     }
 
-    public async Task<bool> TrySendAsync(string text)
+    public Task<bool> TrySendAsync(string text)
     {
-        const int maxAttempts = 2;
-        const int retryDelayMs = 750;
-
-        for (var attempt = 1; attempt <= maxAttempts; attempt++)
-        {
-            try
-            {
-                var postId = await _threads.SendPostAsync(text);
-                if (!string.IsNullOrWhiteSpace(postId))
-                    return true;
-
-                _log.LogWarning("Threads send returned no post id: {Text}", text);
-                return false;
-            }
-            catch (Exception ex)
-            {
-                if (attempt < maxAttempts)
-                {
-                    _log.LogWarning(ex, "Threads send failed (attempt {Attempt}/{MaxAttempts}), retrying: {Text}", attempt, maxAttempts, text);
-                    await Task.Delay(retryDelayMs);
-                    continue;
-                }
-
-                _log.LogError(ex, "Threads send failed after retries: {Text}", text);
-                return false;
-            }
-        }
-
-        return false;
+        // The client owns container/publish retries; a missing id must not restart the post.
+        return SocialPostRetry.TrySendAsync(
+            () => _threads.SendPostAsync(text),
+            _log,
+            "Threads send",
+            text,
+            retryMissingPostId: false);
     }
 
-    public async Task<bool> TrySendImageAsync(string text, string imageUrl)
+    public Task<bool> TrySendImageAsync(string text, string imageUrl)
     {
-        const int maxAttempts = 2;
-        const int retryDelayMs = 750;
         text ??= "";
         imageUrl = imageUrl?.Trim() ?? "";
 
-        for (var attempt = 1; attempt <= maxAttempts; attempt++)
-        {
-            try
-            {
-                var postId = await _threads.SendImagePostAsync(text, imageUrl);
-                if (!string.IsNullOrWhiteSpace(postId))
-                    return true;
-
-                _log.LogWarning("Threads image send returned no post id: {Text}", text);
-                return false;
-            }
-            catch (Exception ex)
-            {
-                if (attempt < maxAttempts)
-                {
-                    _log.LogWarning(ex, "Threads image send failed (attempt {Attempt}/{MaxAttempts}), retrying: {Text}", attempt, maxAttempts, text);
-                    await Task.Delay(retryDelayMs);
-                    continue;
-                }
-
-                _log.LogError(ex, "Threads image send failed after retries: {Text}", text);
-                return false;
-            }
-        }
-
-        return false;
+        return SocialPostRetry.TrySendAsync(
+            () => _threads.SendImagePostAsync(text, imageUrl),
+            _log,
+            "Threads image send",
+            text,
+            retryMissingPostId: false);
     }
 
     public async Task SendEventAsync(EventType type, string rawText)

--- a/LongevityWorldCup.Website/Business/XEventService.cs
+++ b/LongevityWorldCup.Website/Business/XEventService.cs
@@ -43,49 +43,19 @@ public class XEventService
         _ = await TrySendAsync(text, mediaIds);
     }
 
-    public async Task<bool> TrySendAsync(string text)
+    public Task<bool> TrySendAsync(string text)
     {
-        return await TrySendAsync(text, null);
+        return TrySendAsync(text, null);
     }
 
-    public async Task<bool> TrySendAsync(string text, IReadOnlyList<string>? mediaIds)
+    public Task<bool> TrySendAsync(string text, IReadOnlyList<string>? mediaIds)
     {
-        const int maxAttempts = 2;
-        const int retryDelayMs = 750;
-
-        for (var attempt = 1; attempt <= maxAttempts; attempt++)
-        {
-            try
-            {
-                var tweetId = await _x.SendTweetAsync(text, mediaIds, null, true);
-                if (!string.IsNullOrWhiteSpace(tweetId))
-                    return true;
-
-                if (attempt < maxAttempts)
-                {
-                    _log.LogWarning("X send returned no tweet id, retrying ({Attempt}/{MaxAttempts}): {Text}", attempt, maxAttempts, text);
-                    await Task.Delay(retryDelayMs);
-                    continue;
-                }
-
-                _log.LogWarning("X send returned no tweet id after retries: {Text}", text);
-                return false;
-            }
-            catch (Exception ex)
-            {
-                if (attempt < maxAttempts)
-                {
-                    _log.LogWarning(ex, "X send failed (attempt {Attempt}/{MaxAttempts}), retrying: {Text}", attempt, maxAttempts, text);
-                    await Task.Delay(retryDelayMs);
-                    continue;
-                }
-
-                _log.LogError(ex, "X send failed after retries: {Text}", text);
-                return false;
-            }
-        }
-
-        return false;
+        return SocialPostRetry.TrySendAsync(
+            () => _x.SendTweetAsync(text, mediaIds, null, true),
+            _log,
+            "X send",
+            text,
+            retryMissingPostId: true);
     }
 
     public async Task SendEventAsync(EventType type, string rawText)


### PR DESCRIPTION
Five social-post send paths repeated the same retry loop. They now share `SocialPostRetry`, retaining two attempts and a 750 ms delay. X and Facebook still retry a missing post ID; Threads stops because its API client already owns container and publish retries. Rendering, media upload, token refresh, and post payloads keep their existing behavior.

The shared logs retain each service's logger category, severity, exception, and caption, and add a structured operation field. X's missing-ID log now uses the common term "post id".

Validation: all 1,344 tests pass in full .NET CI with coverage, and all PR checks are green, including CodeQL, dependency review, automated review, and the Node-free publish contract. Locally, 57 focused tests pass, including 19 new cases for request counts, text/image payload preservation, permanent Threads failures, shared retry limits, and exception logging. The normal build also passes frontend type checking and output verification.
