### PR TITLE
Keep profile validation beside the fields

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -23,6 +23,7 @@ Keep reusable product decisions here; omit implementation history and one-off po
 
 - Related controls share inherited fonts, height, modest radius, light borders, and visible focus. Aim for 44px direct-tap targets where space allows.
 - Fields distinguish filled (teal boundary), read-only (muted neutral), invalid (danger boundary plus nearby explanation), and disabled (readable text, non-interactive cursor) states without relying on placeholders.
+- Profile field errors appear beside the field without interrupting the next edit. Submission shows all invalid fields and focuses the first; correcting or restoring a value clears its feedback while keeping the draft intact.
 - Informational, success, warning, and error messages share neutral surfaces, semantic leading edges, spacing, and recovery-action geometry. Blocking alerts retain dialog shells with the same palette, type, radius, and action hierarchy. Group helper, confirmation, validation, and empty-state copy in compact light panels when useful.
 - Frame file, proof, and profile previews; use `object-fit: contain` for variable aspect ratios. Autocomplete uses padded floating panels with clear hover/focus rows and must avoid covering the next mobile action.
 - Proof uploads show an ordered page grid with source filenames, a zoomable reader, and removal undo. Keep preparation progress beside the pages and disable submission while files are processing. Returning to the step retains the attached pages and checklist; background preparation must respect the active step's validation.

--- a/LongevityWorldCup.Tests/ProfileValidationBrowserTests.cs
+++ b/LongevityWorldCup.Tests/ProfileValidationBrowserTests.cs
@@ -1,0 +1,201 @@
+using System.Text.Json.Nodes;
+using Microsoft.Playwright;
+using Xunit;
+using static LongevityWorldCup.Tests.AestheticSystemBrowserTests;
+
+namespace LongevityWorldCup.Tests;
+
+[Collection(BrowserTestCollections.WorkloadB)]
+public sealed class ProfileValidationBrowserTests(
+    PlaywrightBrowserFixture browserFixture,
+    BrowserTestAppFixture appFixture)
+    : BrowserIntegrationTest(browserFixture, appFixture)
+{
+    [Theory]
+    [InlineData(390, false)]
+    [InlineData(320, true)]
+    [InlineData(1280, false)]
+    public async Task InvalidBlur_KeepsTheNextFieldFocusedAndPreservesTheDraft(int width, bool dark)
+    {
+        await using var context = await CreateContextAsync(width, dark);
+        var page = await OpenEditorAsync(context);
+        var link = page.Locator("#personalLinkInput");
+        var contact = page.Locator("#mediaContactInput");
+        await link.FillAsync("not a link");
+        await contact.ClickAsync();
+
+        await Assertions.Expect(contact).ToBeFocusedAsync();
+        await Assertions.Expect(link).ToHaveAttributeAsync("aria-invalid", "true");
+        await Assertions.Expect(link).ToHaveAttributeAsync("aria-describedby", "personalLinkInputError");
+        var feedback = page.Locator("#personalLinkInputError");
+        await Assertions.Expect(feedback).ToBeVisibleAsync();
+        await Assertions.Expect(page.Locator("#custom-alert")).ToBeHiddenAsync();
+        var fieldBox = await link.BoundingBoxAsync();
+        var feedbackBox = await feedback.BoundingBoxAsync();
+        var restoreBox = await page.Locator("#restorePersonalLinkBtn").BoundingBoxAsync();
+        Assert.NotNull(fieldBox);
+        Assert.NotNull(feedbackBox);
+        Assert.NotNull(restoreBox);
+        Assert.InRange(feedbackBox.X, 0, width - feedbackBox.Width + 1);
+        Assert.True(feedbackBox.Y >= fieldBox.Y + fieldBox.Height);
+        Assert.InRange(Math.Abs(fieldBox.Y - restoreBox.Y), 0, 2);
+        Assert.True(restoreBox.X >= fieldBox.X + fieldBox.Width);
+        Assert.True(restoreBox.Width >= 44 && restoreBox.Height >= 44);
+
+        await page.ReloadAsync();
+        await Assertions.Expect(link).ToHaveValueAsync("not a link");
+        await Assertions.Expect(contact).ToHaveValueAsync("press@example.com");
+        await Assertions.Expect(page.Locator("#submitButton")).ToBeEnabledAsync();
+        await link.FillAsync("example.com/new");
+        await contact.ClickAsync();
+        await Assertions.Expect(link).ToHaveValueAsync("https://example.com/new");
+        await Assertions.Expect(link).ToHaveAttributeAsync("aria-invalid", "false");
+        await Assertions.Expect(feedback).ToBeHiddenAsync();
+        await Assertions.Expect(contact).ToBeFocusedAsync();
+    }
+
+    [Theory]
+    [InlineData("flagDisplayInput", "restoreFlagBtn", "?", "United Kingdom")]
+    [InlineData("personalLinkInput", "restorePersonalLinkBtn", "not a link", "https://example.com")]
+    [InlineData("mediaContactInput", "restoreMediaContactBtn", "", "press@example.com")]
+    [InlineData("whyDisplayInput", "restoreWhyDisplayBtn", "", "Training for a longer, healthier life.")]
+    public async Task KeyboardRestore_ClearsTheErrorAndKeepsOtherEdits(string id, string restoreId, string invalid, string original)
+    {
+        await using var context = await CreateContextAsync(390);
+        var page = await OpenEditorAsync(context);
+        var otherId = id == "whyDisplayInput" ? "personalLinkInput" : "whyDisplayInput";
+        var otherValue = id == "whyDisplayInput" ? "https://example.com/new" : "An unfinished motivation draft.";
+        await page.Locator("#" + otherId).FillAsync(otherValue);
+        var input = page.Locator("#" + id);
+        await input.FillAsync(invalid);
+        await input.PressAsync("Tab");
+        await Assertions.Expect(input).ToHaveAttributeAsync("aria-invalid", "true");
+        await Assertions.Expect(page.Locator("#" + restoreId)).ToBeFocusedAsync();
+        await page.Keyboard.PressAsync("Enter");
+        await Assertions.Expect(input).ToHaveValueAsync(original);
+        await Assertions.Expect(input).ToBeFocusedAsync();
+        await Assertions.Expect(input).ToHaveAttributeAsync("aria-invalid", "false");
+        await Assertions.Expect(page.Locator("#" + id + "Error")).ToBeHiddenAsync();
+        await Assertions.Expect(page.Locator("#" + restoreId)).ToBeHiddenAsync();
+        await Assertions.Expect(page.Locator("#" + otherId)).ToHaveValueAsync(otherValue);
+        await Assertions.Expect(page.Locator("#custom-alert")).ToBeHiddenAsync();
+        await Assertions.Expect(page.Locator("#submitButton")).ToBeEnabledAsync();
+    }
+
+    [Fact]
+    public async Task PointerRestore_IsNotMovedAwayByThePreviousFieldsBlurError()
+    {
+        await using var context = await CreateContextAsync(390);
+        var page = await OpenEditorAsync(context);
+        await page.Locator("#whyDisplayInput").FillAsync("An unfinished motivation draft.");
+        await page.Locator("#mediaContactInput").FillAsync("");
+        await page.Locator("#restoreWhyDisplayBtn").ClickAsync();
+        await Assertions.Expect(page.Locator("#whyDisplayInput")).ToHaveValueAsync("Training for a longer, healthier life.");
+        await Assertions.Expect(page.Locator("#mediaContactInput")).ToHaveAttributeAsync("aria-invalid", "true");
+        await Assertions.Expect(page.Locator("#mediaContactInput")).ToHaveValueAsync("");
+        await Assertions.Expect(page.Locator("#custom-alert")).ToBeHiddenAsync();
+    }
+
+    [Fact]
+    public async Task Submit_ShowsEveryInvalidFieldAndFocusesTheFirstWithoutSending()
+    {
+        await using var context = await CreateContextAsync(390);
+        var requests = 0;
+        await context.RouteAsync("**/api/application/application", async route =>
+        {
+            requests++;
+            await route.FulfillAsync(new() { Status = 422, Body = "Unexpected submission" });
+        });
+        var page = await OpenEditorAsync(context);
+        await page.Locator("#flagDisplayInput").FillAsync("?");
+        await page.Locator("#personalLinkInput").FillAsync("not a link");
+        await page.Locator("#mediaContactInput").FillAsync("");
+        await page.Locator("#whyDisplayInput").FillAsync("");
+        await page.Locator("#submitButton").ClickAsync();
+        await Assertions.Expect(page.Locator("#editOptionsGroup [aria-invalid=true]")).ToHaveCountAsync(4);
+        await Assertions.Expect(page.Locator(".profile-field-error:visible")).ToHaveCountAsync(4);
+        var first = page.Locator("#flagDisplayInput");
+        await Assertions.Expect(first).ToBeFocusedAsync();
+        await Assertions.Expect(page.Locator("#custom-alert")).ToBeHiddenAsync();
+        Assert.Equal(0, requests);
+        var box = await first.BoundingBoxAsync();
+        var dock = await page.Locator(".edit-profile-actions").BoundingBoxAsync();
+        Assert.NotNull(box);
+        Assert.NotNull(dock);
+        Assert.InRange(box.Y, 0, dock.Y - box.Height);
+        Assert.Equal("not a link", await page.Locator("#personalLinkInput").InputValueAsync());
+    }
+
+    [Fact]
+    public async Task CorrectingFields_PreservesNormalizationAndFailedSubmissionRetry()
+    {
+        await using var context = await CreateContextAsync(390);
+        var submissions = new List<JsonObject>();
+        await context.RouteAsync("**/api/application/application", async route =>
+        {
+            submissions.Add(JsonNode.Parse(route.Request.PostData!)!.AsObject());
+            await route.FulfillAsync(new() { Status = 422, ContentType = "text/plain", Body = "The change request could not be accepted." });
+        });
+        var page = await OpenEditorAsync(context);
+        var link = page.Locator("#personalLinkInput");
+        await link.FillAsync("not a link");
+        await page.Locator("#mediaContactInput").ClickAsync();
+        await Assertions.Expect(link).ToHaveAttributeAsync("aria-invalid", "true");
+        // Personal links remain optional; media contacts still accept non-email handles.
+        await link.FillAsync("");
+        await Assertions.Expect(link).ToHaveAttributeAsync("aria-invalid", "false");
+        await page.Locator("#mediaContactInput").FillAsync("@alex");
+        await page.Locator("#flagDisplayInput").FillAsync("Cyberspace");
+        await page.Locator("#whyDisplayInput").FillAsync("A revised motivation.");
+        for (var attempt = 0; attempt < 2; attempt++)
+        {
+            await page.Locator("#submitButton").ClickAsync();
+            await Assertions.Expect(page.Locator("#custom-alert")).ToBeVisibleAsync();
+            await page.Locator("#custom-alert-close").ClickAsync();
+            await Assertions.Expect(page.Locator("#submitButton")).ToBeFocusedAsync();
+            await Assertions.Expect(page.Locator("#submitButton")).ToBeEnabledAsync();
+            await Assertions.Expect(page.Locator("#whyDisplayInput")).ToHaveValueAsync("A revised motivation.");
+            await Assertions.Expect(page.Locator(".profile-field-error:visible")).ToHaveCountAsync(0);
+        }
+        Assert.Equal(2, submissions.Count);
+        Assert.Null(submissions[0]["personalLink"]);
+        Assert.Equal("@alex", submissions[0]["mediaContact"]!.GetValue<string>());
+        Assert.Equal("Cyberspace", submissions[0]["flag"]!.GetValue<string>());
+        Assert.Equal(submissions[0]["submissionId"]!.GetValue<string>(), submissions[1]["submissionId"]!.GetValue<string>());
+    }
+
+    private async Task<IBrowserContext> CreateContextAsync(int width, bool dark = false)
+    {
+        var context = await NewContextAsync(Browser, App, new()
+        {
+            ViewportSize = new() { Width = width, Height = 900 },
+            ColorScheme = dark ? ColorScheme.Dark : ColorScheme.Light,
+            ReducedMotion = ReducedMotion.Reduce
+        });
+        await context.AddInitScriptAsync("""
+            if (!sessionStorage.getItem('selectedAthlete')) {
+                const athlete = {Name:'Alex Morgan', DisplayName:'Alex Morgan', ProfilePic:'/assets/content-images/headshot.jpg',
+                    Division:"Men's", Flag:'United Kingdom', PersonalLink:'https://example.com',
+                    MediaContact:'press@example.com', Why:'Training for a longer, healthier life.', Biomarkers:[]};
+                sessionStorage.setItem('selectedAthlete', JSON.stringify(athlete));
+                localStorage.setItem('selectedAthleteName', athlete.Name);
+                localStorage.setItem('hasApplication', 'true');
+            }
+            """);
+        await context.RouteAsync("**/api/application/submission-report", route => route.FulfillAsync(new() { Status = 204 }));
+        return context;
+    }
+
+    private static async Task<IPage> OpenEditorAsync(IBrowserContext context)
+    {
+        var page = await context.NewPageAsync();
+        await page.GotoAsync("/edit-profile");
+        await page.WaitForFunctionAsync("""
+            () => window.modulesReady && document.querySelector('#divisionDisplaySelect')?.value === "Men's"
+                && document.querySelector('#mediaContactInput')?.value === 'press@example.com'
+                && document.querySelector('#whyDisplayInput')?.value === 'Training for a longer, healthier life.'
+            """);
+        await page.EvaluateAsync("async()=>{await window.modulesReady;await document.fonts.ready}");
+        return page;
+    }
+}

--- a/LongevityWorldCup.Website/wwwroot/play/edit-profile.html
+++ b/LongevityWorldCup.Website/wwwroot/play/edit-profile.html
@@ -595,6 +595,27 @@
             background: var(--lwc-accent-soft);
             color: var(--lwc-accent);
         }
+        .edit-profile-main .inline-option-group > :is(input, select, textarea) {
+            flex: 1 1 0;
+            min-width: 0;
+        }
+        .profile-field-error {
+            flex: 0 0 100%;
+            margin: calc(-1 * var(--lwc-space-1)) 0 0;
+            color: var(--lwc-danger);
+            font-size: var(--lwc-type-sm);
+            line-height: 1.5;
+            text-align: left;
+            overflow-wrap: anywhere;
+        }
+        .profile-field-error[hidden] { display: none; }
+        .edit-profile-main #editOptionsGroup [aria-invalid="true"] {
+            border-color: var(--lwc-danger);
+        }
+        .edit-profile-main #editOptionsGroup [aria-invalid="true"]:focus {
+            outline-color: var(--lwc-danger);
+            box-shadow: 0 0 0 3px var(--lwc-danger-soft);
+        }
     </style>
 </head>
 <body class="play-flow-route">
@@ -634,6 +655,7 @@
                 <label for="flagDisplayInput" class="field-label">Flag <span class="field-requirement">(required)</span></label>
                 <input type="text"
                        id="flagDisplayInput"
+                       aria-describedby="flagDisplayInputError"
                        name="flagDisplay"
                        required
                        aria-required="true"
@@ -646,11 +668,13 @@
                 <button id="restoreFlagBtn" class="option-button icon-only" style="display:none" title="Restore flag" aria-label="Restore flag">
                     <i class="fas fa-undo" aria-hidden="true"></i>
                 </button>
+                <p id="flagDisplayInputError" class="profile-field-error" aria-live="polite" hidden></p>
             </div>
             <div class="niceInputFieldDisplayWrapper options-container inline-option-group">
                 <label for="personalLinkInput" class="field-label">Personal link <span class="field-requirement">(optional)</span></label>
                 <input type="text"
                        id="personalLinkInput"
+                       aria-describedby="personalLinkInputError"
                        name="personalLink"
                        inputmode="url"
                        autocomplete="url"
@@ -660,11 +684,13 @@
                 <button id="restorePersonalLinkBtn" class="option-button icon-only" style="display:none" title="Restore personal link" aria-label="Restore personal link">
                     <i class="fas fa-undo" aria-hidden="true"></i>
                 </button>
+                <p id="personalLinkInputError" class="profile-field-error" aria-live="polite" hidden></p>
             </div>
             <div class="niceInputFieldDisplayWrapper options-container inline-option-group">
                 <label for="mediaContactInput" class="field-label">Media contact <span class="field-requirement">(required)</span></label>
                 <input type="text"
                        id="mediaContactInput"
+                       aria-describedby="mediaContactInputError"
                        name="mediaContact"
                        required
                        aria-required="true"
@@ -676,10 +702,12 @@
                 <button id="restoreMediaContactBtn" class="option-button icon-only" style="display:none" title="Restore media contact" aria-label="Restore media contact">
                     <i class="fas fa-undo" aria-hidden="true"></i>
                 </button>
+                <p id="mediaContactInputError" class="profile-field-error" aria-live="polite" hidden></p>
             </div>
             <div class="niceInputFieldDisplayWrapper options-container inline-option-group">
                 <label for="whyDisplayInput" class="field-label">Motivation <span class="field-requirement">(required)</span></label>
                 <textarea id="whyDisplayInput"
+                          aria-describedby="whyDisplayInputError"
                           name="whyDisplay"
                           rows="3"
                           required
@@ -689,6 +717,7 @@
                 <button id="restoreWhyDisplayBtn" class="option-button icon-only" style="display:none" title="Restore your why" aria-label="Restore your why">
                     <i class="fas fa-undo" aria-hidden="true"></i>
                 </button>
+                <p id="whyDisplayInputError" class="profile-field-error" aria-live="polite" hidden></p>
             </div>
         </div>
         <div class="options-container edit-profile-actions flow-action-stack flow-action-stack--hide-disabled-primary" data-flow-dock="auto" data-aos="fade" data-aos-duration="700" data-aos-delay="400">
@@ -720,6 +749,7 @@
     <!--FOOTER-->
     <script>
         let isEditProfileSubmitting = false;
+        const pendingProfileFieldValidation = new Map();
 
         function setBrowserStorageItem(storageName, key, value) {
             try {
@@ -998,6 +1028,43 @@
             const personalLinkInput = document.getElementById('personalLinkInput');
             const whyDisplayInput = document.getElementById('whyDisplayInput');
 
+            const profileFields = [
+                [flagInput, validateFlagDisplay],
+                [personalLinkInput, validatePersonalLink],
+                [mediaContactInput, validateMediaContact],
+                [whyDisplayInput, validateWhyDisplay]
+            ];
+            let profilePointerDown = false;
+            document.addEventListener('pointerdown', event => {
+                if (event.isPrimary) profilePointerDown = true;
+            }, true);
+            const finishProfilePointer = event => {
+                if (event.isPrimary === false) return;
+                profilePointerDown = false;
+                // An error row must not move a click target between pointerdown
+                // and click. Commit blur feedback after the gesture finishes.
+                setTimeout(() => {
+                    if (profilePointerDown || !pendingProfileFieldValidation.size) return;
+                    const pending = [...pendingProfileFieldValidation];
+                    pendingProfileFieldValidation.clear();
+                    pending.forEach(([input, validate]) => validate(input.value));
+                    const focused = document.activeElement;
+                    if (profileFields.some(([input]) => input === focused)) keepEditedControlClearOfDock(focused);
+                }, 0);
+            };
+            document.addEventListener('pointerup', finishProfilePointer, true);
+            document.addEventListener('pointercancel', finishProfilePointer, true);
+            window.addEventListener('blur', finishProfilePointer);
+            profileFields.forEach(([input, validate]) => {
+                input.addEventListener('blur', () => {
+                    if (profilePointerDown) pendingProfileFieldValidation.set(input, validate);
+                    else validate(input.value);
+                });
+                input.addEventListener('input', () => {
+                    if (input.getAttribute('aria-invalid') === 'true') validate(input.value);
+                });
+            });
+
             [flagInput, personalLinkInput, mediaContactInput].forEach(input => {
                 input.addEventListener('keydown', e => {
                     if (e.key === 'Enter' && !e.defaultPrevented && !e.isComposing) {
@@ -1018,13 +1085,12 @@
             submitButton.addEventListener('click', async function () {
                 if (isEditProfileSubmitting || submitButton.disabled) return;
 
-                // click-guard: validate before submitting
-                if (
-                    !validateFlagDisplay(flagInput.value) ||
-                    !validatePersonalLink(personalLinkInput.value) ||
-                    !validateMediaContact(mediaContactInput.value) ||
-                    !validateWhyDisplay(whyDisplayInput.value)
-                ) {
+                pendingProfileFieldValidation.clear();
+                const invalidFields = profileFields.filter(([input, validate]) => !validate(input.value));
+                if (invalidFields.length) {
+                    const firstInvalidInput = invalidFields[0][0];
+                    firstInvalidInput.focus();
+                    keepEditedControlClearOfDock(firstInvalidInput);
                     return;
                 }
 
@@ -1156,62 +1222,18 @@
                 updateSubmitButtonState(whyDisplayInput);
             });
 
-            let skipFlagValidation = false;
-            restoreFlagBtn.addEventListener('mousedown', () => {
-                skipFlagValidation = true;
-            });
-
-            flagInput.addEventListener('blur', function () {
-                if (skipFlagValidation) {
-                    skipFlagValidation = false;
-                    return;
-                }
-                validateFlagDisplay(this.value);
-            });
-
-            // --- SKIP-ON-RESTORE FLAGS ---
-            let skipPersonalLinkValidation = false;
-            restorePersonalLinkBtn.addEventListener('mousedown', () => {
-                skipPersonalLinkValidation = true;
-            });
-
-            let skipMediaContactValidation = false;
-            restoreMediaContactBtn.addEventListener('mousedown', () => {
-                skipMediaContactValidation = true;
-            });
-
             // --- BLUR HANDLERS ---
             personalLinkInput.addEventListener('blur', function () {
-                if (skipPersonalLinkValidation) {
-                    skipPersonalLinkValidation = false;
-                    return;
-                }
                 const normalized = normalizeOptionalUrl(this.value);
                 if (isOptionalUrl(normalized)) {
                     this.value = normalized;
                 }
-                validatePersonalLink(this.value);
-                updateSubmitButtonState(this);
+                updateSubmitButtonState();
             });
 
             mediaContactInput.addEventListener('blur', function () {
-                if (skipMediaContactValidation) {
-                    skipMediaContactValidation = false;
-                    return;
-                }
                 this.value = normalizeMediaContact(this.value);
-                validateMediaContact(this.value);
-                updateSubmitButtonState(this);
-            });
-
-            let skipWhyValidation = false;
-            restoreWhyDisplayBtn.addEventListener('mousedown', () => { skipWhyValidation = true; });
-            whyDisplayInput.addEventListener('blur', function () {
-                if (skipWhyValidation) {
-                    skipWhyValidation = false;
-                    return;
-                }
-                validateWhyDisplay(this.value);
+                updateSubmitButtonState();
             });
 
             document.getElementById('restoreProfilePicButton')
@@ -1249,7 +1271,7 @@
             const restoreFlagBtn = document.getElementById('restoreFlagBtn');
             flagInput.value = originalAthlete.Flag;
             athlete.Flag = originalAthlete.Flag;
-            restoreFlagBtn.style.display = 'none';
+            restoreProfileFieldFeedback(flagInput, restoreFlagBtn);
             updateSubmitButtonState();
         }
 
@@ -1259,7 +1281,7 @@
             const originalPersonalLink = normalizeOptionalUrl(originalAthlete.PersonalLink);
             personalLinkInput.value = originalPersonalLink;
             athlete.PersonalLink = originalPersonalLink;
-            restorePersonalLinkBtn.style.display = 'none';
+            restoreProfileFieldFeedback(personalLinkInput, restorePersonalLinkBtn);
             updateSubmitButtonState();
         }
 
@@ -1269,7 +1291,7 @@
             const originalMediaContact = normalizeMediaContact(originalAthlete.MediaContact);
             mediaContactInput.value = originalMediaContact;
             athlete.MediaContact = originalMediaContact;
-            restoreMediaContactBtn.style.display = 'none';
+            restoreProfileFieldFeedback(mediaContactInput, restoreMediaContactBtn);
             updateSubmitButtonState();
         }
         function restoreWhyDisplayToOriginal() {
@@ -1278,7 +1300,7 @@
             const originalWhy = normalizeEditText(originalAthlete.Why);
             whyDisplayInput.value = originalWhy;
             athlete.Why = originalWhy;
-            restoreWhyDisplayBtn.style.display = 'none';
+            restoreProfileFieldFeedback(whyDisplayInput, restoreWhyDisplayBtn);
             updateSubmitButtonState();
         }
 
@@ -1601,20 +1623,32 @@
             }
         }
 
+        function setProfileFieldError(id, message) {
+            const input = document.getElementById(id);
+            const feedback = document.getElementById(id + 'Error');
+            input.setAttribute('aria-invalid', message ? 'true' : 'false');
+            feedback.hidden = !message;
+            if (feedback.textContent !== message) feedback.textContent = message;
+            return !message;
+        }
+
+        function restoreProfileFieldFeedback(input, restoreButton) {
+            pendingProfileFieldValidation.delete(input);
+            setProfileFieldError(input.id, '');
+            if (document.activeElement === restoreButton) input.focus({ preventScroll: true });
+            restoreButton.style.display = 'none';
+        }
+
         function validateFlagDisplay(value) {
             const trimmed = value.trim();
             const regex = /^[A-Za-zÀ-ÖØ-öø-ÿ][A-Za-zÀ-ÖØ-öø-ÿ0-9\s'(),.\-]{2,99}$/;
             if (trimmed.length < 3) {
-                customAlert('Flag must be at least 3 characters long.')
-                    .then(() => document.getElementById('flagDisplayInput')?.focus());
-                return false;
+                return setProfileFieldError('flagDisplayInput', 'Flag must be at least 3 characters long.');
             }
             if (!regex.test(trimmed)) {
-                customAlert('Flag contains invalid characters.')
-                    .then(() => document.getElementById('flagDisplayInput')?.focus());
-                return false;
+                return setProfileFieldError('flagDisplayInput', 'Flag contains invalid characters.');
             }
-            return true;
+            return setProfileFieldError('flagDisplayInput', '');
         }
 
         function isOptionalUrl(value) {
@@ -1650,30 +1684,18 @@
 
         function validatePersonalLink(value) {
             const v = value.trim();
-            if (!v) return true;                            // empty OK
-            if (!isOptionalUrl(v)) {
-                customAlert('Please enter a valid URL for your personal link.').then(() => document.getElementById('personalLinkInput')?.focus());
-                return false;
-            }
-            return true;
+            return setProfileFieldError('personalLinkInput', !v || isOptionalUrl(v)
+                ? '' : 'Enter a valid website address, such as example.com.');
         }
 
         function validateMediaContact(value) {
             const v = value.trim();
-            if (!v) {
-                customAlert('Media contact is required.').then(() => document.getElementById('mediaContactInput')?.focus());
-                return false;
-            }
-            return true;                                    // any non-empty string OK
+            return setProfileFieldError('mediaContactInput', v ? '' : 'Enter a media contact.');
         }
 
         function validateWhyDisplay(value) {
             const v = value.trim();
-            if (!v) {
-                customAlert('Your why is the light. Don’t leave us in the dark.').then(() => document.getElementById('whyDisplayInput')?.focus());
-                return false;
-            }
-            return true;
+            return setProfileFieldError('whyDisplayInput', v ? '' : 'Enter your motivation.');
         }
     </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/cropperjs/1.5.13/cropper.min.js" defer></script>


### PR DESCRIPTION
Entering an invalid personal link and moving to Media contact currently opens a modal and takes focus away from the next edit. Show errors beside Flag, Personal link, Media contact, and Motivation so editing can continue. Submit reveals every invalid field and focuses the first one.

- Keep Restore buttons beside their fields; restoring a value clears its feedback and retains keyboard focus and other draft edits.
- Apply blur feedback after pointer gestures finish so inserting an error cannot move a Restore button out from under a click.
- Preserve validation rules, optional personal links, URL normalization, saved drafts, and failed-submission retry behavior.

Validation: normal .NET/TypeScript build; all 1,468 tests passed locally and in CI with zero failures or skips. The 37 focused browser cases include ten new cases for mobile/dark mode, desktop, keyboard and pointer restoration, drafts, blocked invalid submissions, and retries. Rendered at 320px, 390px, and 1280px. All seven checks passed on 4b13b48a; both automated reviews completed without findings.

Related to #484's profile-editing journey; authenticated self-service remains separate.

Before and after: enter an invalid personal link, then click Media contact.

<img width="840" height="1000" alt="before-after" src="https://github.com/user-attachments/assets/1b925013-d9b7-48fd-9029-0b8eb8df56c0" />
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side UX and validation presentation on edit-profile only; submission rules and API payloads are preserved and covered by new browser tests.
> 
> **Overview**
> **Edit profile** no longer opens `custom-alert` modals for Flag, Personal link, Media contact, or Motivation validation. Errors render in new `.profile-field-error` rows under each field with `aria-invalid` / `aria-describedby`, danger styling, and live updates while the user keeps editing the next field.
> 
> Submit now validates every profile field at once, blocks the API call when any fail, focuses the first invalid control, and scrolls it clear of the action dock. Restore clears that field’s feedback and refocuses the input without dropping other draft edits. Blur validation is deferred until pointer gestures finish so error rows cannot shift Restore buttons mid-click.
> 
> `DESIGN.md` records the inline profile-error behavior. **Playwright** adds `ProfileValidationBrowserTests` for blur/focus, keyboard and pointer restore, multi-field submit, normalization, and retry identity across viewports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b13b48aaaf08024bfcf3fd5c4850f4490c3059c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->