### PR TITLE
Keep header branding clear of the Play action

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -15,6 +15,7 @@ Keep reusable product decisions here; omit implementation history and one-off po
 ## Motion
 
 - Use shared standard easing with 140ms transitions or 220ms state transitions. Avoid generic scroll entrances, looping decoration, delayed routine text, and unbounded particles in focused tasks.
+- Shared interaction transitions name their visual properties explicitly. Responsive widths, flex sizing, and gaps update immediately so neighboring controls keep their space during resizing.
 - First-visit game storytelling may pace existing text once; repeat visits fast-forward and reduced motion displays it immediately.
 - Important outcomes may combine shared durations into bounded choreography that explains the result. Publish semantic results and actions immediately, never gate progress on `animationend`, cap decoration, and provide an immediate reduced-motion state.
 - Render indefinite activities from aggregate state with bounded elements, never one image or DOM node per historical event.

--- a/LongevityWorldCup.Tests/HomepageChromeRegressionBrowserTests.PlayAction.cs
+++ b/LongevityWorldCup.Tests/HomepageChromeRegressionBrowserTests.PlayAction.cs
@@ -32,6 +32,8 @@ public sealed class HomepagePlayActionBrowserTests(
                              {
                                  new ViewportSize { Width = 320, Height = 720 },
                                  new ViewportSize { Width = 390, Height = 844 },
+                                 new ViewportSize { Width = 641, Height = 844 },
+                                 new ViewportSize { Width = 720, Height = 900 },
                                  new ViewportSize { Width = 667, Height = 375 },
                                  new ViewportSize { Width = 844, Height = 390 },
                                  new ViewportSize { Width = 900, Height = 450 },
@@ -73,6 +75,55 @@ public sealed class HomepagePlayActionBrowserTests(
                     await page.CloseAsync();
                 }
             });
+    }
+
+    [Theory]
+    [InlineData(ReducedMotion.NoPreference)]
+    [InlineData(ReducedMotion.Reduce)]
+    public async Task HeaderResize_KeepsTheBrandSeparateFromPlayThroughoutTheTransition(ReducedMotion motion)
+    {
+        await using var context = await NewContextAsync(Browser, App, motion);
+        var page = await context.NewPageAsync();
+        await page.SetViewportSizeAsync(900, 450);
+        await page.GotoAsync("/leaderboard");
+        await SettleLayoutAsync(page);
+        await page.EvaluateAsync(
+            """
+            () => {
+                window.headerResizeSamples = [];
+                window.headerResizeComplete = false;
+                window.addEventListener('resize', () => {
+                    let frames = 0;
+                    const sample = () => {
+                        const brand = document.querySelector('header[role="banner"] .header-link').getBoundingClientRect();
+                        const action = document.querySelector('header[role="banner"] .join-game:not(.scrolled-button)').getBoundingClientRect();
+                        window.headerResizeSamples.push({
+                            BrandRight: brand.right,
+                            ActionLeft: action.left,
+                            Overlap: action.left < brand.right && action.right > brand.left
+                                && action.top < brand.bottom && action.bottom > brand.top
+                        });
+                        if (++frames < 20) requestAnimationFrame(sample);
+                        else window.headerResizeComplete = true;
+                    };
+                    sample();
+                }, { once: true });
+            }
+            """);
+
+        await page.SetViewportSizeAsync(1026, 473);
+        await page.WaitForFunctionAsync("() => window.headerResizeComplete === true");
+        var samples = await page.EvaluateAsync<HeaderResizeSample[]>("() => window.headerResizeSamples");
+        Assert.NotEmpty(samples);
+        Assert.All(samples, sample => Assert.False(sample.Overlap,
+            $"Brand ended at {sample.BrandRight:F1}px while Play began at {sample.ActionLeft:F1}px during resize."));
+    }
+
+    private sealed class HeaderResizeSample
+    {
+        public double BrandRight { get; set; }
+        public double ActionLeft { get; set; }
+        public bool Overlap { get; set; }
     }
 
     private static Task<ScrollPhaseDiagnostics> MeasureScrollPhasesAsync(IPage page)

--- a/LongevityWorldCup.Website/wwwroot/css/aesthetic-system.css
+++ b/LongevityWorldCup.Website/wwwroot/css/aesthetic-system.css
@@ -914,6 +914,11 @@ html body .leaderboard-view-switcher .view-badge {
     border-radius: 50%;
 }
 
+/* Set safe defaults while preserving each component's explicit transitions. */
+:where(button, a, input, select, textarea, .view-badge, .leaderboard table tbody tr) {
+    transition-property: background-color, border-color, color, box-shadow, opacity, transform;
+}
+
 /* Motion explains state without making the interface restless. */
 @media (prefers-reduced-motion: no-preference) {
     button,

--- a/LongevityWorldCup.Website/wwwroot/partials/header.html
+++ b/LongevityWorldCup.Website/wwwroot/partials/header.html
@@ -1084,6 +1084,12 @@
         outline-offset: 3px;
     }
 
+    @media (max-width: 932px) {
+        header[role="banner"] .tagline {
+            display: none;
+        }
+    }
+
     @media (max-width: 640px) {
         main {
             margin-top: var(--space-5);
@@ -1114,7 +1120,6 @@
             text-overflow: ellipsis;
         }
 
-        header[role="banner"] .tagline,
         .join-game-middle,
         .join-game-end {
             display: none;
@@ -1249,10 +1254,6 @@
             font-size: clamp(1rem, 3vw, 1.3rem);
             line-height: 1.05;
             text-overflow: ellipsis;
-        }
-
-        header[role="banner"] .tagline {
-            display: none;
         }
 
         header[role="banner"] .join-game:not(.scrolled-button) {


### PR DESCRIPTION
At mid-width portrait sizes, the header tagline ran beneath Play. Resizing from 900x450 to 1026x473 also briefly extended the brand link under the button: the shared transition duration implicitly animated flex sizing and gaps.

Limit default transitions to visual feedback, using a low-specificity rule that preserves components' explicit animations. Hide the secondary tagline through the existing 932px compact breakpoint so the brand and Play remain separate in portrait windows too. Related to #538.

Validation:

- Reproduced both failures on the baseline. New frame-by-frame resize checks failed with normal and reduced motion; the expanded existing header check failed at 641px portrait.
- Nine focused header checks passed. Rendered the shared routes from 320px to 1280px, including light/dark, portrait/landscape, and breakpoint transitions, with no remaining overlaps.
- Full local suite passed: 1,470 tests, zero failures or skips. All seven CI/review checks passed.

Before and after at a 641px viewport: genuine browser captures. The comparison is attached to this description and kept outside the repository.

<img width="1354" height="324" alt="before-after" src="https://github.com/user-attachments/assets/d9159cd5-a023-4ddb-8cdb-e75fa8f0109c" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to global transition defaults and header responsive CSS plus browser regression tests; no API or auth changes.
> 
> **Overview**
> Fixes header collisions where the brand link and **Play** CTA overlapped at mid-width portrait sizes and briefly during viewport resize (e.g. 900×450 → 1026×473), when shared transition timing was animating flex layout.
> 
> **CSS:** Adds a low-specificity `:where(...)` rule in `aesthetic-system.css` so default interaction transitions only cover visual properties (`background-color`, `border-color`, `color`, etc.), leaving responsive width/flex/gap to snap immediately. Hides the header **tagline** at `max-width: 932px` so portrait compact chrome stays a single brand row beside Play, instead of only hiding it in narrower rules.
> 
> **Docs:** `DESIGN.md` now states that shared transitions must name properties explicitly and layout must not animate on resize.
> 
> **Tests:** Extends Play-action regression viewports (641px, 720px portrait) and adds `HeaderResize_KeepsTheBrandSeparateFromPlayThroughoutTheTransition`, sampling ~20 frames during resize with and without `prefers-reduced-motion`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6070e88cf5e96840e9edd8a978cab2af69987d30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->