### PR TITLE
Improve timezone selection in signup and profiles

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -23,6 +23,7 @@ Keep reusable product decisions here; omit implementation history and one-off po
 ## Controls and Layout
 
 - Related controls share inherited fonts, height, modest radius, light borders, and visible focus. Aim for 44px direct-tap targets where space allows.
+- Searchable timezone choices expand within the form. Keep the text cursor in the search field during arrow navigation, expose the active option to assistive technology, and let Tab or Escape leave without changing the selected timezone.
 - Fields distinguish filled (teal boundary), read-only (muted neutral), invalid (danger boundary plus nearby explanation), and disabled (readable text, non-interactive cursor) states without relying on placeholders.
 - Profile field errors appear beside the field without interrupting the next edit. Submission shows all invalid fields and focuses the first; correcting or restoring a value clears its feedback while keeping the draft intact.
 - Profile drafts persist quietly, stay tied to the selected athlete, and clear after successful submission. Offer Reset all with Undo without a summary panel or repeated field links. Show save feedback only when storage fails and the user needs to keep the page open; protect that unsaved work when leaving.

--- a/LongevityWorldCup.Tests/LongevitymaxxingChallengeBrowserTests.TimeZonePicker.cs
+++ b/LongevityWorldCup.Tests/LongevitymaxxingChallengeBrowserTests.TimeZonePicker.cs
@@ -1,0 +1,183 @@
+using System.Text.Json;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace LongevityWorldCup.Tests;
+
+public sealed partial class LongevitymaxxingChallengeBrowserTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task TimeZonePicker_TabLeavesInOneStepWithoutChangingTheValue(bool profile)
+    {
+        await using var context = await NewTimeZoneContextAsync();
+        var (page, id) = await PrepareTimeZonePickerAsync(context, profile);
+        var button = page.Locator("#" + id + "Button");
+        var search = page.Locator("#" + id + "Search");
+        var original = await page.Locator("#" + id).InputValueAsync();
+        await button.ClickAsync();
+        await Assertions.Expect(search).ToBeFocusedAsync();
+        await search.PressAsync("ArrowDown");
+        await search.PressAsync("Tab");
+        await Assertions.Expect(button).ToHaveAttributeAsync("aria-expanded", "false");
+        var next = page.Locator(profile ? "#lmxProfilePictureButton" : "#lmxSignupForm button[type=submit]");
+        await Assertions.Expect(next).ToBeFocusedAsync();
+        Assert.Equal(original, await page.Locator("#" + id).InputValueAsync());
+
+        await button.PressAsync("Enter");
+        await Assertions.Expect(search).ToBeFocusedAsync();
+        await search.PressAsync("Shift+Tab");
+        await Assertions.Expect(button).ToBeFocusedAsync();
+        await Assertions.Expect(button).ToHaveAttributeAsync("aria-expanded", "false");
+        Assert.Equal(original, await page.Locator("#" + id).InputValueAsync());
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task TimeZonePicker_EscapeWorksFromEveryPartAndPointerCanToggleItClosed(bool profile)
+    {
+        await using var context = await NewTimeZoneContextAsync();
+        var (page, id) = await PrepareTimeZonePickerAsync(context, profile);
+        var button = page.Locator("#" + id + "Button");
+        var original = await page.Locator("#" + id).InputValueAsync();
+        foreach (var target in new[] { "Search", "option", "Button" })
+        {
+            await button.ClickAsync();
+            var search = page.Locator("#" + id + "Search");
+            await Assertions.Expect(search).ToBeFocusedAsync();
+            await search.FillAsync("London");
+            var focused = target == "option"
+                ? page.Locator("#" + id + "List [role=option]").First
+                : page.Locator("#" + id + target);
+            await focused.FocusAsync();
+            await focused.PressAsync("Escape");
+            await Assertions.Expect(button).ToHaveAttributeAsync("aria-expanded", "false");
+            await Assertions.Expect(button).ToBeFocusedAsync();
+            Assert.Equal(original, await page.Locator("#" + id).InputValueAsync());
+        }
+
+        await button.ClickAsync();
+        await Assertions.Expect(page.Locator("#" + id + "Search")).ToBeFocusedAsync();
+        await button.ClickAsync();
+        await Assertions.Expect(button).ToHaveAttributeAsync("aria-expanded", "false");
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task TimeZonePicker_AnnouncesKeyboardSelectionAndAcceptsItWithoutSubmitting(bool profile)
+    {
+        await using var context = await NewTimeZoneContextAsync();
+        var (page, id) = await PrepareTimeZonePickerAsync(context, profile);
+        var button = page.Locator("#" + id + "Button");
+        var search = page.Locator("#" + id + "Search");
+        var original = await page.Locator("#" + id).InputValueAsync();
+        await button.PressAsync("ArrowDown");
+        await Assertions.Expect(search).ToBeFocusedAsync();
+        await Assertions.Expect(search).ToHaveAttributeAsync("role", "combobox");
+        await search.FillAsync("United States");
+        for (var i = 0; i < 12; i++) await search.PressAsync("ArrowDown");
+        var activeId = await search.GetAttributeAsync("aria-activedescendant");
+        Assert.False(string.IsNullOrEmpty(activeId));
+        var active = page.Locator("#" + activeId);
+        await Assertions.Expect(active).ToHaveAttributeAsync("aria-selected", "true");
+        Assert.Equal(1, await page.Locator("#" + id + "List [aria-selected=true]").CountAsync());
+        await Assertions.Expect(search).ToBeFocusedAsync();
+        Assert.Equal(original, await page.Locator("#" + id).InputValueAsync());
+        var selectedZone = await active.GetAttributeAsync("data-time-zone");
+        var activeBounds = await active.BoundingBoxAsync();
+        var listBounds = await page.Locator("#" + id + "List").BoundingBoxAsync();
+        Assert.NotNull(activeBounds);
+        Assert.NotNull(listBounds);
+        Assert.True(activeBounds.Y >= listBounds.Y && activeBounds.Y + activeBounds.Height <= listBounds.Y + listBounds.Height + 1);
+        await search.PressAsync("Enter");
+        Assert.Equal(selectedZone, await page.Locator("#" + id).InputValueAsync());
+        await Assertions.Expect(button).ToBeFocusedAsync();
+        await Assertions.Expect(button).ToHaveAttributeAsync("aria-expanded", "false");
+        Assert.Equal(0, await page.EvaluateAsync<int>("window.__timezoneSubmits"));
+
+        await button.ClickAsync();
+        await search.FillAsync("NoSuchTimezone123");
+        Assert.Equal(0, await page.Locator("#" + id + "List [role=option]").CountAsync());
+        Assert.Null(await search.GetAttributeAsync("aria-activedescendant"));
+        await search.PressAsync("ArrowDown");
+        await search.PressAsync("ArrowUp");
+        await search.PressAsync("Enter");
+        Assert.Equal(selectedZone, await page.Locator("#" + id).InputValueAsync());
+        Assert.Equal(0, await page.EvaluateAsync<int>("window.__timezoneSubmits"));
+        await search.FillAsync("London");
+        await search.PressAsync("Enter");
+        Assert.Equal("Europe/London", await page.Locator("#" + id).InputValueAsync());
+    }
+
+    [Theory]
+    [InlineData(320, false)]
+    [InlineData(1280, true)]
+    public async Task TimeZonePicker_ExpansionKeepsTheNextControlClearAndAcceptsPointerSelection(int width, bool dark)
+    {
+        await using var context = await NewTimeZoneContextAsync(width, dark, touch: width == 320);
+        var (page, id) = await PrepareTimeZonePickerAsync(context, profile: false);
+        await page.Locator("#" + id + "Button").ClickAsync();
+        var search = page.Locator("#" + id + "Search");
+        await Assertions.Expect(search).ToBeFocusedAsync();
+        await search.FillAsync("London");
+        var popup = page.Locator("[data-select-id='" + id + "'] .lmx-timezone-popover");
+        var popupBounds = await popup.BoundingBoxAsync();
+        var nextBounds = await page.Locator("#lmxSignupForm button[type=submit]").BoundingBoxAsync();
+        Assert.NotNull(popupBounds);
+        Assert.NotNull(nextBounds);
+        Assert.True(popupBounds.Y + popupBounds.Height <= nextBounds.Y, "Timezone choices cover Sign up.");
+        if (width == 320) await page.SetViewportSizeAsync(width, 440);
+        await search.FillAsync("");
+        await search.PressAsync("ArrowUp");
+        var active = page.Locator("#" + await search.GetAttributeAsync("aria-activedescendant"));
+        await Assertions.Expect(active).ToBeInViewportAsync();
+        await search.FillAsync("London");
+        var option = page.Locator("#" + id + "List [data-time-zone='Europe/London']");
+        if (width == 320) await option.TapAsync();
+        else await option.ClickAsync();
+        Assert.Equal("Europe/London", await page.Locator("#" + id).InputValueAsync());
+        await Assertions.Expect(page.Locator("#" + id + "Button")).ToHaveAttributeAsync("aria-expanded", "false");
+        Assert.False(await page.EvaluateAsync<bool>("document.documentElement.scrollWidth > innerWidth"));
+        Assert.Equal(0, await page.EvaluateAsync<int>("window.__timezoneSubmits"));
+    }
+
+    private Task<IBrowserContext> NewTimeZoneContextAsync(int width = 390, bool dark = false, bool touch = false)
+        => Browser.NewContextAsync(new()
+        {
+            BaseURL = App.BaseAddress.ToString(), ViewportSize = new() { Width = width, Height = 844 },
+            TimezoneId = "Asia/Bangkok", ReducedMotion = ReducedMotion.Reduce,
+            ColorScheme = dark ? ColorScheme.Dark : ColorScheme.Light, HasTouch = touch, IsMobile = touch
+        });
+
+    private static async Task<(IPage Page, string Id)> PrepareTimeZonePickerAsync(IBrowserContext context, bool profile)
+    {
+        await BrowserTestApp.RouteExternalResourcesAsync(context);
+        if (profile) await context.AddInitScriptAsync("localStorage.setItem('lmxAccessToken','browser-token')");
+        var page = await context.NewPageAsync();
+        await page.RouteAsync("**/api/longevitymaxxing/state", route => FulfillJsonAsync(route, JsonSerializer.Serialize(BuildPublicState())));
+        var participantState = JsonSerializer.SerializeToNode(BuildParticipantState(timeZoneId: "Asia/Bangkok"))!;
+        foreach (var day in participantState["eligibleDays"]!.AsArray()) day!["existing"] = SavedCheckIn("");
+        await page.RouteAsync("**/api/longevitymaxxing/participant", route => FulfillJsonAsync(route, participantState.ToJsonString()));
+        await page.GotoAsync("/longevitymaxxing", new() { WaitUntil = WaitUntilState.DOMContentLoaded });
+        if (profile) await page.Locator("#lmxProfileTab").ClickAsync();
+        else
+        {
+            await page.Locator("#lmxSignupEmail").FillAsync("timezone@example.test");
+            await page.Locator("#lmxSignupName").FillAsync("Timezone Tester");
+        }
+        var id = profile ? "lmxEditTimeZone" : "lmxSignupTimeZone";
+        await Assertions.Expect(page.Locator("[data-select-id='" + id + "']")).ToHaveAttributeAsync("data-wired", "true");
+        await page.Locator(profile ? "#lmxEditForm" : "#lmxSignupForm").EvaluateAsync("""
+            form => {
+                window.__timezoneSubmits = 0;
+                form.addEventListener('submit', event => {
+                    event.preventDefault(); event.stopImmediatePropagation(); window.__timezoneSubmits++;
+                }, true);
+            }
+            """);
+        return (page, id);
+    }
+}

--- a/LongevityWorldCup.Tests/LongevitymaxxingChallengeBrowserTests.TimeZonePicker.cs
+++ b/LongevityWorldCup.Tests/LongevitymaxxingChallengeBrowserTests.TimeZonePicker.cs
@@ -77,6 +77,8 @@ public sealed partial class LongevitymaxxingChallengeBrowserTests
         await button.PressAsync("ArrowDown");
         await Assertions.Expect(search).ToBeFocusedAsync();
         await Assertions.Expect(search).ToHaveAttributeAsync("role", "combobox");
+        await Assertions.Expect(search).ToHaveAccessibleNameAsync("Search city or timezone");
+        await Assertions.Expect(search).ToHaveAttributeAsync("aria-controls", id + "List");
         await search.FillAsync("United States");
         for (var i = 0; i < 12; i++) await search.PressAsync("ArrowDown");
         var activeId = await search.GetAttributeAsync("aria-activedescendant");
@@ -142,6 +144,44 @@ public sealed partial class LongevitymaxxingChallengeBrowserTests
         await Assertions.Expect(page.Locator("#" + id + "Button")).ToHaveAttributeAsync("aria-expanded", "false");
         Assert.False(await page.EvaluateAsync<bool>("document.documentElement.scrollWidth > innerWidth"));
         Assert.Equal(0, await page.EvaluateAsync<int>("window.__timezoneSubmits"));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task TimeZonePicker_PointerSelectionSurvivesBlurWithoutANewFocusTarget(bool profile)
+    {
+        await using var context = await NewTimeZoneContextAsync();
+        var (page, id) = await PrepareTimeZonePickerAsync(context, profile);
+        var button = page.Locator("#" + id + "Button");
+        var search = page.Locator("#" + id + "Search");
+        await button.ClickAsync();
+        await Assertions.Expect(search).ToBeFocusedAsync();
+        await search.FillAsync("London");
+        var option = page.Locator("#" + id + "List [data-time-zone='Europe/London']");
+        await option.EvaluateAsync("""
+            option => {
+                const search = option.closest('[data-timezone-picker]').querySelector('input');
+                window.__timezoneNullBlurs = 0;
+                search.addEventListener('focusout', event => {
+                    if (event.relatedTarget === null) window.__timezoneNullBlurs++;
+                });
+                // Reproduce a pointer blur without a focusable destination, as on WebKit.
+                option.addEventListener('mousedown', () => search.blur(), { once: true });
+            }
+            """);
+        await option.ClickAsync();
+        Assert.Equal(1, await page.EvaluateAsync<int>("window.__timezoneNullBlurs"));
+        Assert.Equal("Europe/London", await page.Locator("#" + id).InputValueAsync());
+        await Assertions.Expect(button).ToHaveAttributeAsync("aria-expanded", "false");
+        await Assertions.Expect(button).ToBeFocusedAsync();
+        Assert.Equal(0, await page.EvaluateAsync<int>("window.__timezoneSubmits"));
+
+        await button.ClickAsync();
+        await Assertions.Expect(search).ToBeFocusedAsync();
+        await page.Locator("h1").ClickAsync();
+        await Assertions.Expect(button).ToHaveAttributeAsync("aria-expanded", "false");
+        Assert.Equal("Europe/London", await page.Locator("#" + id).InputValueAsync());
     }
 
     private Task<IBrowserContext> NewTimeZoneContextAsync(int width = 390, bool dark = false, bool touch = false)

--- a/LongevityWorldCup.Tests/LongevitymaxxingChallengePageTests.cs
+++ b/LongevityWorldCup.Tests/LongevitymaxxingChallengePageTests.cs
@@ -316,8 +316,6 @@ public sealed class LongevitymaxxingChallengePageTests(TestWebApplicationFactory
         Assert.Contains("id=\"lmxProfilePictureInput\" type=\"file\" accept=\"image/*\"", html);
         Assert.Contains("id=\"lmxSignupTimeZoneLabel\">Timezone</span>", html);
         Assert.Contains("class=\"lmx-timezone-picker\" data-timezone-picker data-select-id=\"lmxSignupTimeZone\"", html);
-        Assert.Contains("<input id=\"lmxSignupTimeZoneSearch\" type=\"search\" autocomplete=\"off\" autocapitalize=\"none\" spellcheck=\"false\" placeholder=\"Search city or timezone\" aria-label=\"Search city or timezone\" aria-controls=\"lmxSignupTimeZoneList\">", html);
-        Assert.Contains("<input id=\"lmxEditTimeZoneSearch\" type=\"search\" autocomplete=\"off\" autocapitalize=\"none\" spellcheck=\"false\" placeholder=\"Search city or timezone\" aria-label=\"Search city or timezone\" aria-controls=\"lmxEditTimeZoneList\">", html);
         Assert.Contains("id=\"lmxSignupTimeZone\" class=\"lmx-timezone-native\" name=\"timeZoneId\" required", html);
         Assert.Contains("id=\"lmxEditTimeZone\" class=\"lmx-timezone-native\" required", html);
         Assert.DoesNotContain("Extra details", html);

--- a/LongevityWorldCup.Website/Frontend/longevitymaxxing.ts
+++ b/LongevityWorldCup.Website/Frontend/longevitymaxxing.ts
@@ -6711,7 +6711,12 @@ const TIME_ZONE_COUNTRY_DATA = "Europe/Andorra=AD|Asia/Dubai=AE|Asia/Kabul=AF|Am
 
             button?.addEventListener("click", () => toggleTimeZonePicker(picker));
             input?.addEventListener("input", () => renderTimeZoneOptions(picker, input.value));
-            input?.addEventListener("keydown", event => handleTimeZoneSearchKeydown(event, picker));
+            picker.addEventListener("keydown", event => handleTimeZonePickerKeydown(event, picker));
+            picker.addEventListener("focusout", event => {
+                if (!(event.relatedTarget instanceof Node) || !picker.contains(event.relatedTarget)) {
+                    closeTimeZonePicker(picker);
+                }
+            });
             select?.addEventListener("change", () => syncTimeZonePicker(picker));
             syncTimeZonePicker(picker);
         });
@@ -6745,11 +6750,13 @@ const TIME_ZONE_COUNTRY_DATA = "Europe/Andorra=AD|Asia/Dubai=AE|Asia/Kabul=AF|Am
         const popover = picker.querySelector<HTMLElement>(".lmx-timezone-popover");
         const input = picker.querySelector<HTMLInputElement>(".lmx-timezone-search input");
         button?.setAttribute("aria-expanded", "true");
+        input?.setAttribute("aria-expanded", "true");
         if (popover) popover.hidden = false;
         if (input) {
             input.value = "";
             renderTimeZoneOptions(picker, "");
             requestAnimationFrame(() => {
+                if (!picker.classList.contains("open")) return;
                 popover?.scrollIntoView({ block: "nearest" });
                 input.focus({ preventScroll: true });
             });
@@ -6759,6 +6766,9 @@ const TIME_ZONE_COUNTRY_DATA = "Europe/Andorra=AD|Asia/Dubai=AE|Asia/Kabul=AF|Am
     function closeTimeZonePicker(picker: HTMLElement): void {
         picker.classList.remove("open");
         picker.querySelector(".lmx-timezone-button")?.setAttribute("aria-expanded", "false");
+        const input = picker.querySelector(".lmx-timezone-search input");
+        input?.setAttribute("aria-expanded", "false");
+        input?.removeAttribute("aria-activedescendant");
         const popover = picker.querySelector<HTMLElement>(".lmx-timezone-popover");
         if (popover) popover.hidden = true;
     }
@@ -6785,19 +6795,30 @@ const TIME_ZONE_COUNTRY_DATA = "Europe/Andorra=AD|Asia/Dubai=AE|Asia/Kabul=AF|Am
             .sort((a, b) => b.score - a.score || a.zone.localeCompare(b.zone));
 
         list.innerHTML = matches.length
-            ? matches.map((item, index) => timeZoneOptionHtml(item.zone, selected, index === 0)).join("")
+            ? matches.map((item, index) => timeZoneOptionHtml(item.zone, `${list.id}-option-${index}`)).join("")
             : `<div class="lmx-timezone-empty">No timezone found</div>`;
 
         list.querySelectorAll<HTMLElement>(".lmx-timezone-option").forEach(option => {
             option.addEventListener("click", () => chooseTimeZone(picker, option.dataset.timeZone || "UTC"));
         });
+        setActiveTimeZoneOption(picker, list.querySelector<HTMLElement>(".lmx-timezone-option"));
     }
 
-    function timeZoneOptionHtml(zone: string, selected: string, active: boolean): string {
-        return `<button type="button" class="lmx-timezone-option${active ? " active" : ""}" role="option" data-time-zone="${escAttr(zone)}" aria-selected="${zone === selected ? "true" : "false"}">
+    function timeZoneOptionHtml(zone: string, id: string): string {
+        return `<button type="button" tabindex="-1" id="${escAttr(id)}" class="lmx-timezone-option" role="option" data-time-zone="${escAttr(zone)}" aria-selected="false">
             <span>${esc(timeZoneDisplayName(zone))}</span>
             <small>${esc(zone)} · ${esc(timeZoneOffsetLabel(zone))}</small>
         </button>`;
+    }
+
+    function setActiveTimeZoneOption(picker: HTMLElement, active: HTMLElement | null): void {
+        picker.querySelectorAll<HTMLElement>(".lmx-timezone-option").forEach(option => {
+            option.classList.toggle("active", option === active);
+            option.setAttribute("aria-selected", option === active ? "true" : "false");
+        });
+        const input = picker.querySelector(".lmx-timezone-search input");
+        if (active) input?.setAttribute("aria-activedescendant", active.id);
+        else input?.removeAttribute("aria-activedescendant");
     }
 
     function chooseTimeZone(picker: HTMLElement, zone: string): void {
@@ -6809,29 +6830,50 @@ const TIME_ZONE_COUNTRY_DATA = "Europe/Andorra=AD|Asia/Dubai=AE|Asia/Kabul=AF|Am
         picker.querySelector<HTMLButtonElement>(".lmx-timezone-button")?.focus();
     }
 
-    function handleTimeZoneSearchKeydown(event: KeyboardEvent, picker: HTMLElement): void {
-        const options = Array.from(picker.querySelectorAll<HTMLElement>(".lmx-timezone-option"));
-        if (event.key === "Escape") {
+    function handleTimeZonePickerKeydown(event: KeyboardEvent, picker: HTMLElement): void {
+        if (event.isComposing) return;
+        const button = picker.querySelector<HTMLButtonElement>(".lmx-timezone-button");
+        const input = picker.querySelector<HTMLInputElement>(".lmx-timezone-search input");
+        const isArrow = event.key === "ArrowDown" || event.key === "ArrowUp";
+        if (event.target === button && isArrow) {
             event.preventDefault();
-            closeTimeZonePicker(picker);
-            picker.querySelector<HTMLButtonElement>(".lmx-timezone-button")?.focus();
+            if (picker.classList.contains("open")) input?.focus({ preventScroll: true });
+            else openTimeZonePicker(picker);
             return;
         }
-        if (event.key === "Enter") {
+        if (!picker.classList.contains("open")) return;
+        if (event.key === "Escape") {
+            event.preventDefault();
+            event.stopPropagation();
+            closeTimeZonePicker(picker);
+            button?.focus();
+            return;
+        }
+        if (event.key === "Tab" && event.shiftKey && event.target === input) {
+            event.preventDefault();
+            closeTimeZonePicker(picker);
+            button?.focus();
+            return;
+        }
+        if (event.target === button) return;
+        const options = Array.from(picker.querySelectorAll<HTMLElement>(".lmx-timezone-option"));
+        if (event.key === "Enter" && event.target === input) {
             event.preventDefault();
             const active = picker.querySelector<HTMLElement>(".lmx-timezone-option.active") || options[0];
             if (active) chooseTimeZone(picker, active.dataset.timeZone || "UTC");
             return;
         }
-        if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
+        if (!isArrow) return;
         event.preventDefault();
         if (!options.length) return;
         const current = Math.max(0, options.findIndex(option => option.classList.contains("active")));
         const next = event.key === "ArrowDown"
             ? (current + 1) % options.length
             : (current - 1 + options.length) % options.length;
-        options.forEach((option, index) => option.classList.toggle("active", index === next));
-        options[next]?.scrollIntoView({ block: "nearest" });
+        const active = options[next] ?? null;
+        setActiveTimeZoneOption(picker, active);
+        input?.focus({ preventScroll: true });
+        active?.scrollIntoView({ block: "nearest" });
     }
 
     function getAvailableTimeZones(current: string): string[] {

--- a/LongevityWorldCup.Website/Frontend/longevitymaxxing.ts
+++ b/LongevityWorldCup.Website/Frontend/longevitymaxxing.ts
@@ -6713,7 +6713,8 @@ const TIME_ZONE_COUNTRY_DATA = "Europe/Andorra=AD|Asia/Dubai=AE|Asia/Kabul=AF|Am
             input?.addEventListener("input", () => renderTimeZoneOptions(picker, input.value));
             picker.addEventListener("keydown", event => handleTimeZonePickerKeydown(event, picker));
             picker.addEventListener("focusout", event => {
-                if (!(event.relatedTarget instanceof Node) || !picker.contains(event.relatedTarget)) {
+                // A pointer can blur the search without moving focus; let its click finish first.
+                if (event.relatedTarget instanceof Node && !picker.contains(event.relatedTarget)) {
                     closeTimeZonePicker(picker);
                 }
             });

--- a/LongevityWorldCup.Website/wwwroot/css/longevitymaxxing.css
+++ b/LongevityWorldCup.Website/wwwroot/css/longevitymaxxing.css
@@ -1635,18 +1635,14 @@
 }
 
 .lmx-timezone-popover {
-    position: absolute;
-    top: calc(100% + 0.35rem);
-    left: 0;
-    right: 0;
-    z-index: 24;
+    margin-top: 0.35rem;
     display: grid;
     gap: 0.35rem;
     padding: 0.35rem;
     border: 1px solid var(--lmx-border-strong);
     border-radius: 8px;
     background: var(--lmx-surface);
-    box-shadow: 0 12px 24px rgba(15, 23, 42, 0.16);
+    box-shadow: var(--lwc-shadow-sm);
 }
 
 .lmx-timezone-search {

--- a/LongevityWorldCup.Website/wwwroot/longevitymaxxing/longevitymaxxing.html
+++ b/LongevityWorldCup.Website/wwwroot/longevitymaxxing/longevitymaxxing.html
@@ -123,9 +123,9 @@
                                     <div class="lmx-timezone-popover" hidden>
                                         <div class="lmx-timezone-search">
                                             <i class="fas fa-magnifying-glass" aria-hidden="true"></i>
-                                            <input id="lmxSignupTimeZoneSearch" type="search" autocomplete="off" autocapitalize="none" spellcheck="false" placeholder="Search city or timezone" aria-label="Search city or timezone" aria-controls="lmxSignupTimeZoneList">
+                                            <input id="lmxSignupTimeZoneSearch" type="search" role="combobox" aria-autocomplete="list" aria-expanded="false" autocomplete="off" autocapitalize="none" spellcheck="false" placeholder="Search city or timezone" aria-label="Search city or timezone" aria-controls="lmxSignupTimeZoneList">
                                         </div>
-                                        <div id="lmxSignupTimeZoneList" class="lmx-timezone-list" role="listbox" aria-label="Timezones"></div>
+                                        <div id="lmxSignupTimeZoneList" class="lmx-timezone-list" role="listbox" tabindex="-1" aria-label="Timezones"></div>
                                     </div>
                                     <select id="lmxSignupTimeZone" class="lmx-timezone-native" name="timeZoneId" required tabindex="-1" aria-hidden="true"></select>
                                 </div>
@@ -212,9 +212,9 @@
                                 <div class="lmx-timezone-popover" hidden>
                                     <div class="lmx-timezone-search">
                                         <i class="fas fa-magnifying-glass" aria-hidden="true"></i>
-                                        <input id="lmxEditTimeZoneSearch" type="search" autocomplete="off" autocapitalize="none" spellcheck="false" placeholder="Search city or timezone" aria-label="Search city or timezone" aria-controls="lmxEditTimeZoneList">
+                                        <input id="lmxEditTimeZoneSearch" type="search" role="combobox" aria-autocomplete="list" aria-expanded="false" autocomplete="off" autocapitalize="none" spellcheck="false" placeholder="Search city or timezone" aria-label="Search city or timezone" aria-controls="lmxEditTimeZoneList">
                                     </div>
-                                    <div id="lmxEditTimeZoneList" class="lmx-timezone-list" role="listbox" aria-label="Timezones"></div>
+                                    <div id="lmxEditTimeZoneList" class="lmx-timezone-list" role="listbox" tabindex="-1" aria-label="Timezones"></div>
                                 </div>
                                 <select id="lmxEditTimeZone" class="lmx-timezone-native" required tabindex="-1" aria-hidden="true"></select>
                             </div>


### PR DESCRIPTION
The challenge timezone picker covers Sign up, keeps its popup open after Escape from an option, and puts every timezone into the Tab path. A real browser audit needed 420 Tab presses to get from an empty search to Sign up.

Choices now expand within the form, leaving the next control clear. Tab moves out in one step; Shift+Tab and Escape return to the picker button without changing the chosen timezone. Arrow navigation keeps the text cursor in the search field and exposes the highlighted option to assistive technology. Enter or a pointer selection accepts the timezone without submitting the form. This applies to signup and profile settings.

Validation: normal frontend/.NET build passes without warnings. All 45 focused checks pass, including ten new browser cases covering both forms, keyboard selection and dismissal, empty-result recovery, alias matching, touch selection, null-target pointer blur, and layouts at 320px and 1280px, including a reduced-height mobile viewport. Mouse and touch selection also pass in WebKit 26.5. The search controls are now checked through their browser semantics instead of two exact HTML-tag snapshots. [Full CI](https://github.com/nopara73/LongevityWorldCup/actions/runs/34039836113) passes all 1,528 tests; all seven checks are green and the automated review finding is resolved.

The combined before/after image uses genuine 390px browser captures of the same London search. Its source pixels are preserved. Screenshots are uploaded as an attachment and kept outside the repository.

<img width="840" height="940" alt="before-after" src="https://github.com/user-attachments/assets/8cac67d1-b8ef-418b-8d40-e6571eff2ae5" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches required signup/profile timezone fields and form keyboard focus order, but changes are front-end only and covered by new browser tests.
> 
> **Overview**
> Fixes signup and profile **timezone picker** behavior so the list no longer traps Tab focus or covers the next control.
> 
> The choice panel **expands in the form flow** (popover CSS drops absolute overlay positioning) so **Sign up** stays visible on mobile. Keyboard handling moves to the picker: **Tab** exits in one step without changing the value; **Shift+Tab** and **Escape** close and return focus to the trigger; **arrow keys** keep the caret in the search field while **`aria-activedescendant`** tracks the highlighted option; **Enter** commits a choice without submitting the form. Markup adds **combobox** semantics; **`focusout`** closes only when focus leaves the widget, preserving pointer selection on WebKit-style blurs.
> 
> **DESIGN.md** records these interaction rules. New **Playwright** coverage exercises signup and profile flows; server HTML tests stop asserting brittle search-input markup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f9342479858457b07fd801a92a9f028179afd2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



